### PR TITLE
Refactor stage monitor with dynamic content routing

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -233,9 +233,6 @@ compose.desktop {
         }
 
         jvmArgs(
-            // Dev-only flag — deliberately NOT added to commonJvmArgs below, so packaged
-            // installers never get it. Gates dev-only testing features like simulated screens.
-            "-Dchurchpresenter.devMode=true",
             // Memory
             "-Xms512m",
             "-Xmx1536m",

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -233,6 +233,9 @@ compose.desktop {
         }
 
         jvmArgs(
+            // Dev-only flag — deliberately NOT added to commonJvmArgs below, so packaged
+            // installers never get it. Gates dev-only testing features like simulated screens.
+            "-Dchurchpresenter.devMode=true",
             // Memory
             "-Xms512m",
             "-Xmx1536m",

--- a/composeApp/src/jvmMain/composeResources/values-be/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-be/strings.xml
@@ -316,6 +316,8 @@
     <string name="tooltip_clear_schedule">Ачысціць праграму</string>
     <string name="tooltip_settings">Налады</string>
     <string name="tooltip_go_live">У эфір</string>
+    <string name="tooltip_send_to_stage_monitor">Даслаць на манітор сцэны</string>
+    <string name="tooltip_hide_from_stage_monitor">Схаваць аб\'яву</string>
     <string name="tooltip_remove">Выдаліць</string>
     <string name="tooltip_edit">Рэдагаваць</string>
     <string name="tooltip_edit_label">Рэдагаваць метку</string>
@@ -720,6 +722,13 @@
     <string name="timer_reset">Скінуць</string>
     <string name="timer_resume">Працягнуць</string>
     <string name="timer_seconds">сек</string>
+    <string name="timer_am">ДП</string>
+    <string name="timer_pm">ПП</string>
+    <string name="timer_clock_format">Фармат</string>
+    <string name="timer_clock_format_12h_sec">12-гадзінны (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12-гадзінны (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24-гадзінны (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24-гадзінны (HH:mm)</string>
     <string name="timer_start">Пачаць</string>
     <string name="timer_text_color">Колер таймера</string>
     <string name="timer_title">Таймер</string>
@@ -1103,7 +1112,16 @@
     <string name="stage_monitor_clock_show_seconds">Паказваць секунды</string>
     <string name="stage_monitor_clock_24h">24-гадзінны фармат</string>
     <string name="stage_monitor_no_extra_displays">Дадатковыя маніторы не выяўлены. Падключыце дадатковы манітор для выкарыстання маніторы сцэны.</string>
+    <string name="stage_monitor_layout_section">Раскладка экрана</string>
+    <string name="stage_monitor_zone_top_left">Уверсе злева</string>
+    <string name="stage_monitor_zone_top_right">Уверсе справа</string>
+    <string name="stage_monitor_zone_bottom_left">Унізе злева</string>
+    <string name="stage_monitor_zone_bottom_center">Унізе пасярэдзіне</string>
+    <string name="stage_monitor_zone_bottom_right">Унізе справа</string>
+    <string name="stage_monitor_zone_full_screen">Увесь экран</string>
+    <string name="stage_monitor_zone_none">Няма</string>
     <string name="stage_monitor_notes_from_presentation">Нататкі аўтаматычна адлюстроўваюцца з актыўнага слайда PowerPoint або Keynote.</string>
+    <string name="stage_monitor_content_section">Змест экрана</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Пытанні і адказы</string>

--- a/composeApp/src/jvmMain/composeResources/values-be/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-be/strings.xml
@@ -1122,6 +1122,13 @@
     <string name="stage_monitor_zone_none">Няма</string>
     <string name="stage_monitor_notes_from_presentation">Нататкі аўтаматычна адлюстроўваюцца з актыўнага слайда PowerPoint або Keynote.</string>
     <string name="stage_monitor_content_section">Змест экрана</string>
+    <string name="stage_monitor_metronome_position">Пазіцыя метранома</string>
+    <string name="stage_monitor_position_top_center">Уверсе пасярэдзіне</string>
+    <string name="stage_monitor_position_middle_left">Пасярэдзіне злева</string>
+    <string name="stage_monitor_position_center">Цэнтр</string>
+    <string name="stage_monitor_position_middle_right">Пасярэдзіне справа</string>
+    <string name="metronome_bpm_label">Тэмп метранома</string>
+    <string name="unit_bpm">удар/хв</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Пытанні і адказы</string>

--- a/composeApp/src/jvmMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-cs/strings.xml
@@ -295,6 +295,8 @@
     <string name="tooltip_add_label">Přidat štítek</string>
     <string name="tooltip_remove">Odebrat</string>
     <string name="tooltip_go_live">Zobrazit</string>
+    <string name="tooltip_send_to_stage_monitor">Odeslat na monitor scény</string>
+    <string name="tooltip_hide_from_stage_monitor">Skrýt oznámení</string>
 
     <!-- Bible Books (full list) -->
     <string name="bible_book_1">Genesis</string>
@@ -827,6 +829,13 @@
     <string name="timer_reset">Resetovat</string>
     <string name="timer_resume">Pokračovat</string>
     <string name="timer_seconds">sek</string>
+    <string name="timer_am">dop.</string>
+    <string name="timer_pm">odp.</string>
+    <string name="timer_clock_format">Formát</string>
+    <string name="timer_clock_format_12h_sec">12hodinový (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12hodinový (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24hodinový (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24hodinový (HH:mm)</string>
     <string name="timer_start">Spustit</string>
     <string name="timer_text_color">Barva časovače</string>
     <string name="timer_title">Časovač</string>
@@ -1207,7 +1216,16 @@
     <string name="stage_monitor_clock_show_seconds">Zobrazit sekundy</string>
     <string name="stage_monitor_clock_24h">24hodinový formát</string>
     <string name="stage_monitor_no_extra_displays">Žádný sekundární displej nebyl zjištěn. Připojte další monitor pro použití monitoru scény.</string>
+    <string name="stage_monitor_layout_section">Rozvržení obrazovky</string>
+    <string name="stage_monitor_zone_top_left">Vlevo nahoře</string>
+    <string name="stage_monitor_zone_top_right">Vpravo nahoře</string>
+    <string name="stage_monitor_zone_bottom_left">Vlevo dole</string>
+    <string name="stage_monitor_zone_bottom_center">Dole uprostřed</string>
+    <string name="stage_monitor_zone_bottom_right">Vpravo dole</string>
+    <string name="stage_monitor_zone_full_screen">Celá obrazovka</string>
+    <string name="stage_monitor_zone_none">Žádný</string>
     <string name="stage_monitor_notes_from_presentation">Poznámky jsou automaticky zobrazovány z aktivního snímku PowerPointu nebo Keynote.</string>
+    <string name="stage_monitor_content_section">Obsah obrazovky</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Otázky a odpovědi</string>

--- a/composeApp/src/jvmMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-cs/strings.xml
@@ -1226,6 +1226,13 @@
     <string name="stage_monitor_zone_none">Žádný</string>
     <string name="stage_monitor_notes_from_presentation">Poznámky jsou automaticky zobrazovány z aktivního snímku PowerPointu nebo Keynote.</string>
     <string name="stage_monitor_content_section">Obsah obrazovky</string>
+    <string name="stage_monitor_metronome_position">Pozice metronomu</string>
+    <string name="stage_monitor_position_top_center">Nahoře uprostřed</string>
+    <string name="stage_monitor_position_middle_left">Uprostřed vlevo</string>
+    <string name="stage_monitor_position_center">Uprostřed</string>
+    <string name="stage_monitor_position_middle_right">Uprostřed vpravo</string>
+    <string name="metronome_bpm_label">Tempo metronomu</string>
+    <string name="unit_bpm">úd/min</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Otázky a odpovědi</string>

--- a/composeApp/src/jvmMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-de/strings.xml
@@ -1122,6 +1122,13 @@
     <string name="stage_monitor_zone_none">Keine</string>
     <string name="stage_monitor_notes_from_presentation">Notizen werden automatisch aus der aktiven PowerPoint- oder Keynote-Folie angezeigt.</string>
     <string name="stage_monitor_content_section">Bildschirminhalt</string>
+    <string name="stage_monitor_metronome_position">Metronom-Position</string>
+    <string name="stage_monitor_position_top_center">Oben Mitte</string>
+    <string name="stage_monitor_position_middle_left">Mitte links</string>
+    <string name="stage_monitor_position_center">Mitte</string>
+    <string name="stage_monitor_position_middle_right">Mitte rechts</string>
+    <string name="metronome_bpm_label">Metronomtempo</string>
+    <string name="unit_bpm">Schl./Min</string>
 
     <!-- Q&amp;A Tab -->
     <string name="tab_qa">Fragen &amp; Antworten</string>

--- a/composeApp/src/jvmMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-de/strings.xml
@@ -316,6 +316,8 @@
     <string name="tooltip_clear_schedule">Programm löschen</string>
     <string name="tooltip_settings">Einstellungen</string>
     <string name="tooltip_go_live">Live gehen</string>
+    <string name="tooltip_send_to_stage_monitor">An Bühnenmonitor senden</string>
+    <string name="tooltip_hide_from_stage_monitor">Ankündigung ausblenden</string>
     <string name="tooltip_remove">Entfernen</string>
     <string name="tooltip_edit">Bearbeiten</string>
     <string name="tooltip_edit_label">Label bearbeiten</string>
@@ -720,6 +722,13 @@
     <string name="timer_reset">Zurücksetzen</string>
     <string name="timer_resume">Fortsetzen</string>
     <string name="timer_seconds">Sek</string>
+    <string name="timer_am">vorm.</string>
+    <string name="timer_pm">nachm.</string>
+    <string name="timer_clock_format">Format</string>
+    <string name="timer_clock_format_12h_sec">12-Stunden (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12-Stunden (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24-Stunden (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24-Stunden (HH:mm)</string>
     <string name="timer_start">Start</string>
     <string name="timer_text_color">Timer-Farbe</string>
     <string name="timer_title">Timer</string>
@@ -1103,7 +1112,16 @@
     <string name="stage_monitor_clock_show_seconds">Sekunden anzeigen</string>
     <string name="stage_monitor_clock_24h">24-Stunden-Format</string>
     <string name="stage_monitor_no_extra_displays">Kein zweiter Bildschirm erkannt. Schließen Sie einen zusätzlichen Monitor an, um den Bühnenmonitor zu verwenden.</string>
+    <string name="stage_monitor_layout_section">Bildschirmlayout</string>
+    <string name="stage_monitor_zone_top_left">Oben links</string>
+    <string name="stage_monitor_zone_top_right">Oben rechts</string>
+    <string name="stage_monitor_zone_bottom_left">Unten links</string>
+    <string name="stage_monitor_zone_bottom_center">Unten Mitte</string>
+    <string name="stage_monitor_zone_bottom_right">Unten rechts</string>
+    <string name="stage_monitor_zone_full_screen">Vollbild</string>
+    <string name="stage_monitor_zone_none">Keine</string>
     <string name="stage_monitor_notes_from_presentation">Notizen werden automatisch aus der aktiven PowerPoint- oder Keynote-Folie angezeigt.</string>
+    <string name="stage_monitor_content_section">Bildschirminhalt</string>
 
     <!-- Q&amp;A Tab -->
     <string name="tab_qa">Fragen &amp; Antworten</string>

--- a/composeApp/src/jvmMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-es/strings.xml
@@ -429,6 +429,8 @@
     <string name="tooltip_edit">Editar</string>
     <string name="tooltip_edit_label">Editar etiqueta</string>
     <string name="tooltip_go_live">Presentar en vivo</string>
+    <string name="tooltip_send_to_stage_monitor">Enviar al monitor de escenario</string>
+    <string name="tooltip_hide_from_stage_monitor">Ocultar anuncio</string>
     <string name="tooltip_add_label">Añadir etiqueta</string>
     <string name="tooltip_collapse_schedule">Colapsar programa</string>
     <string name="tooltip_expand_schedule">Expandir programa</string>
@@ -665,6 +667,13 @@
     <string name="timer_hours">h</string>
     <string name="timer_minutes">min</string>
     <string name="timer_seconds">seg</string>
+    <string name="timer_am">a. m.</string>
+    <string name="timer_pm">p. m.</string>
+    <string name="timer_clock_format">Formato</string>
+    <string name="timer_clock_format_12h_sec">12 horas (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12 horas (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24 horas (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24 horas (HH:mm)</string>
     <string name="timer_start">Iniciar</string>
     <string name="timer_pause">Pausar</string>
     <string name="timer_resume">Reanudar</string>
@@ -1179,7 +1188,16 @@
     <string name="stage_monitor_label_style_section">Estilo de etiqueta</string>
     <string name="stage_monitor_clock_show_seconds">Mostrar segundos</string>
     <string name="stage_monitor_clock_24h">Formato de 24 horas</string>
+    <string name="stage_monitor_layout_section">Diseño de pantalla</string>
+    <string name="stage_monitor_zone_top_left">Superior izquierda</string>
+    <string name="stage_monitor_zone_top_right">Superior derecha</string>
+    <string name="stage_monitor_zone_bottom_left">Inferior izquierda</string>
+    <string name="stage_monitor_zone_bottom_center">Inferior centro</string>
+    <string name="stage_monitor_zone_bottom_right">Inferior derecha</string>
+    <string name="stage_monitor_zone_full_screen">Pantalla completa</string>
+    <string name="stage_monitor_zone_none">Ninguno</string>
     <string name="stage_monitor_notes_from_presentation">Las notas se muestran automáticamente desde la diapositiva activa de PowerPoint o Keynote.</string>
+    <string name="stage_monitor_content_section">Contenido de pantalla</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Servidor no activo — inicie el servidor complementario en Configuración para habilitar P&amp;R</string>

--- a/composeApp/src/jvmMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-es/strings.xml
@@ -1198,6 +1198,13 @@
     <string name="stage_monitor_zone_none">Ninguno</string>
     <string name="stage_monitor_notes_from_presentation">Las notas se muestran automáticamente desde la diapositiva activa de PowerPoint o Keynote.</string>
     <string name="stage_monitor_content_section">Contenido de pantalla</string>
+    <string name="stage_monitor_metronome_position">Posición del metrónomo</string>
+    <string name="stage_monitor_position_top_center">Superior centro</string>
+    <string name="stage_monitor_position_middle_left">Centro izquierda</string>
+    <string name="stage_monitor_position_center">Centro</string>
+    <string name="stage_monitor_position_middle_right">Centro derecha</string>
+    <string name="metronome_bpm_label">Tempo del metrónomo</string>
+    <string name="unit_bpm">ppm</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Servidor no activo — inicie el servidor complementario en Configuración para habilitar P&amp;R</string>

--- a/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
@@ -429,6 +429,8 @@
     <string name="tooltip_edit">Modifier</string>
     <string name="tooltip_edit_label">Modifier l'étiquette</string>
     <string name="tooltip_go_live">Diffuser en direct</string>
+    <string name="tooltip_send_to_stage_monitor">Envoyer au moniteur de scène</string>
+    <string name="tooltip_hide_from_stage_monitor">Masquer l\'annonce</string>
     <string name="tooltip_add_label">Ajouter une étiquette</string>
     <string name="tooltip_collapse_schedule">Réduire le programme</string>
     <string name="tooltip_expand_schedule">Développer le programme</string>
@@ -665,6 +667,13 @@
     <string name="timer_hours">h</string>
     <string name="timer_minutes">min</string>
     <string name="timer_seconds">sec</string>
+    <string name="timer_am">AM</string>
+    <string name="timer_pm">PM</string>
+    <string name="timer_clock_format">Format</string>
+    <string name="timer_clock_format_12h_sec">12 heures (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12 heures (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24 heures (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24 heures (HH:mm)</string>
     <string name="timer_start">Démarrer</string>
     <string name="timer_pause">Pause</string>
     <string name="timer_resume">Reprendre</string>
@@ -1179,7 +1188,16 @@
     <string name="stage_monitor_label_style_section">Style d'étiquette</string>
     <string name="stage_monitor_clock_show_seconds">Afficher les secondes</string>
     <string name="stage_monitor_clock_24h">Format 24 heures</string>
+    <string name="stage_monitor_layout_section">Disposition de l\'écran</string>
+    <string name="stage_monitor_zone_top_left">Haut gauche</string>
+    <string name="stage_monitor_zone_top_right">Haut droite</string>
+    <string name="stage_monitor_zone_bottom_left">Bas gauche</string>
+    <string name="stage_monitor_zone_bottom_center">Bas centre</string>
+    <string name="stage_monitor_zone_bottom_right">Bas droite</string>
+    <string name="stage_monitor_zone_full_screen">Plein écran</string>
+    <string name="stage_monitor_zone_none">Aucun</string>
     <string name="stage_monitor_notes_from_presentation">Les notes sont automatiquement affichées depuis la diapositive active de PowerPoint ou Keynote.</string>
+    <string name="stage_monitor_content_section">Contenu de l\'écran</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Serveur non actif — démarrez le serveur compagnon dans Paramètres pour activer Q&amp;R</string>

--- a/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
@@ -1198,6 +1198,13 @@
     <string name="stage_monitor_zone_none">Aucun</string>
     <string name="stage_monitor_notes_from_presentation">Les notes sont automatiquement affichées depuis la diapositive active de PowerPoint ou Keynote.</string>
     <string name="stage_monitor_content_section">Contenu de l\'écran</string>
+    <string name="stage_monitor_metronome_position">Position du métronome</string>
+    <string name="stage_monitor_position_top_center">Haut centre</string>
+    <string name="stage_monitor_position_middle_left">Centre gauche</string>
+    <string name="stage_monitor_position_center">Centre</string>
+    <string name="stage_monitor_position_middle_right">Centre droite</string>
+    <string name="metronome_bpm_label">Tempo du métronome</string>
+    <string name="unit_bpm">b/min</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Serveur non actif — démarrez le serveur compagnon dans Paramètres pour activer Q&amp;R</string>

--- a/composeApp/src/jvmMain/composeResources/values-kk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-kk/strings.xml
@@ -316,6 +316,8 @@
     <string name="tooltip_clear_schedule">Бағдарламаны тазалау</string>
     <string name="tooltip_settings">Параметрлер</string>
     <string name="tooltip_go_live">Эфирге</string>
+    <string name="tooltip_send_to_stage_monitor">Сахна мониторына жіберу</string>
+    <string name="tooltip_hide_from_stage_monitor">Хабарландыруды жасыру</string>
     <string name="tooltip_remove">Жою</string>
     <string name="tooltip_edit">Өңдеу</string>
     <string name="tooltip_edit_label">Белгіні өңдеу</string>
@@ -720,6 +722,13 @@
     <string name="timer_reset">Қалпына келтіру</string>
     <string name="timer_resume">Жалғастыру</string>
     <string name="timer_seconds">сек</string>
+    <string name="timer_am">AM</string>
+    <string name="timer_pm">PM</string>
+    <string name="timer_clock_format">Пішім</string>
+    <string name="timer_clock_format_12h_sec">12 сағаттық (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12 сағаттық (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24 сағаттық (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24 сағаттық (HH:mm)</string>
     <string name="timer_start">Бастау</string>
     <string name="timer_text_color">Таймер түсі</string>
     <string name="timer_title">Таймер</string>
@@ -1103,7 +1112,16 @@
     <string name="stage_monitor_clock_show_seconds">Секундтарды көрсету</string>
     <string name="stage_monitor_clock_24h">24 сағаттық формат</string>
     <string name="stage_monitor_no_extra_displays">Қосымша дисплейлер анықталмады. Сахна мониторын пайдалану үшін қосымша монитор жалғаңыз.</string>
+    <string name="stage_monitor_layout_section">Экран орналасуы</string>
+    <string name="stage_monitor_zone_top_left">Жоғарғы сол жақ</string>
+    <string name="stage_monitor_zone_top_right">Жоғарғы оң жақ</string>
+    <string name="stage_monitor_zone_bottom_left">Төменгі сол жақ</string>
+    <string name="stage_monitor_zone_bottom_center">Төменгі орта</string>
+    <string name="stage_monitor_zone_bottom_right">Төменгі оң жақ</string>
+    <string name="stage_monitor_zone_full_screen">Толық экран</string>
+    <string name="stage_monitor_zone_none">Жоқ</string>
     <string name="stage_monitor_notes_from_presentation">Жазбалар белсенді PowerPoint немесе Keynote слайдынан автоматты түрде көрсетіледі.</string>
+    <string name="stage_monitor_content_section">Экран мазмұны</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Сұрақтар мен жауаптар</string>

--- a/composeApp/src/jvmMain/composeResources/values-kk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-kk/strings.xml
@@ -1122,6 +1122,13 @@
     <string name="stage_monitor_zone_none">Жоқ</string>
     <string name="stage_monitor_notes_from_presentation">Жазбалар белсенді PowerPoint немесе Keynote слайдынан автоматты түрде көрсетіледі.</string>
     <string name="stage_monitor_content_section">Экран мазмұны</string>
+    <string name="stage_monitor_metronome_position">Метроном орны</string>
+    <string name="stage_monitor_position_top_center">Жоғарғы орта</string>
+    <string name="stage_monitor_position_middle_left">Ортаңғы сол жақ</string>
+    <string name="stage_monitor_position_center">Орта</string>
+    <string name="stage_monitor_position_middle_right">Ортаңғы оң жақ</string>
+    <string name="metronome_bpm_label">Метроном қарқыны</string>
+    <string name="unit_bpm">соққы/мин</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Сұрақтар мен жауаптар</string>

--- a/composeApp/src/jvmMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-nl/strings.xml
@@ -429,6 +429,8 @@
     <string name="tooltip_edit">Bewerken</string>
     <string name="tooltip_edit_label">Label bewerken</string>
     <string name="tooltip_go_live">Live gaan</string>
+    <string name="tooltip_send_to_stage_monitor">Naar stage monitor sturen</string>
+    <string name="tooltip_hide_from_stage_monitor">Aankondiging verbergen</string>
     <string name="tooltip_add_label">Label toevoegen</string>
     <string name="tooltip_collapse_schedule">Programma inklappen</string>
     <string name="tooltip_expand_schedule">Programma uitklappen</string>
@@ -665,6 +667,13 @@
     <string name="timer_hours">uur</string>
     <string name="timer_minutes">min</string>
     <string name="timer_seconds">sec</string>
+    <string name="timer_am">a.m.</string>
+    <string name="timer_pm">p.m.</string>
+    <string name="timer_clock_format">Formaat</string>
+    <string name="timer_clock_format_12h_sec">12-uurs (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12-uurs (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24-uurs (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24-uurs (HH:mm)</string>
     <string name="timer_start">Starten</string>
     <string name="timer_pause">Pauzeren</string>
     <string name="timer_resume">Hervatten</string>
@@ -1179,7 +1188,16 @@
     <string name="stage_monitor_label_style_section">Labelstijl</string>
     <string name="stage_monitor_clock_show_seconds">Seconden tonen</string>
     <string name="stage_monitor_clock_24h">24-uursnotatie</string>
+    <string name="stage_monitor_layout_section">Schermindeling</string>
+    <string name="stage_monitor_zone_top_left">Linksboven</string>
+    <string name="stage_monitor_zone_top_right">Rechtsboven</string>
+    <string name="stage_monitor_zone_bottom_left">Linksonder</string>
+    <string name="stage_monitor_zone_bottom_center">Onder midden</string>
+    <string name="stage_monitor_zone_bottom_right">Rechtsonder</string>
+    <string name="stage_monitor_zone_full_screen">Volledig scherm</string>
+    <string name="stage_monitor_zone_none">Geen</string>
     <string name="stage_monitor_notes_from_presentation">Notities worden automatisch getoond vanuit de actieve PowerPoint- of Keynote-dia.</string>
+    <string name="stage_monitor_content_section">Scherminhoud</string>
 
     <!-- Q&amp;A Tab -->
     <string name="qa_server_not_running">Server niet actief — start de companion server in Instellingen om V&amp;A in te schakelen</string>

--- a/composeApp/src/jvmMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-nl/strings.xml
@@ -1198,6 +1198,13 @@
     <string name="stage_monitor_zone_none">Geen</string>
     <string name="stage_monitor_notes_from_presentation">Notities worden automatisch getoond vanuit de actieve PowerPoint- of Keynote-dia.</string>
     <string name="stage_monitor_content_section">Scherminhoud</string>
+    <string name="stage_monitor_metronome_position">Metronoompositie</string>
+    <string name="stage_monitor_position_top_center">Boven midden</string>
+    <string name="stage_monitor_position_middle_left">Midden links</string>
+    <string name="stage_monitor_position_center">Midden</string>
+    <string name="stage_monitor_position_middle_right">Midden rechts</string>
+    <string name="metronome_bpm_label">Metronoomtempo</string>
+    <string name="unit_bpm">sl/min</string>
 
     <!-- Q&amp;A Tab -->
     <string name="qa_server_not_running">Server niet actief — start de companion server in Instellingen om V&amp;A in te schakelen</string>

--- a/composeApp/src/jvmMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-pl/strings.xml
@@ -316,6 +316,8 @@
     <string name="tooltip_clear_schedule">Wyczyść program</string>
     <string name="tooltip_settings">Ustawienia</string>
     <string name="tooltip_go_live">Na żywo</string>
+    <string name="tooltip_send_to_stage_monitor">Wyślij do monitora sceny</string>
+    <string name="tooltip_hide_from_stage_monitor">Ukryj ogłoszenie</string>
     <string name="tooltip_remove">Usuń</string>
     <string name="tooltip_edit">Edytuj</string>
     <string name="tooltip_edit_label">Edytuj etykietę</string>
@@ -719,6 +721,13 @@
     <string name="timer_reset">Resetuj</string>
     <string name="timer_resume">Wznów</string>
     <string name="timer_seconds">sek</string>
+    <string name="timer_am">AM</string>
+    <string name="timer_pm">PM</string>
+    <string name="timer_clock_format">Format</string>
+    <string name="timer_clock_format_12h_sec">12-godzinny (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12-godzinny (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24-godzinny (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24-godzinny (HH:mm)</string>
     <string name="timer_start">Start</string>
     <string name="timer_text_color">Kolor minutnika</string>
     <string name="timer_title">Minutnik</string>
@@ -1102,7 +1111,16 @@
     <string name="stage_monitor_clock_show_seconds">Pokaż sekundy</string>
     <string name="stage_monitor_clock_24h">Format 24-godzinny</string>
     <string name="stage_monitor_no_extra_displays">Nie wykryto dodatkowych wyświetlaczy. Podłącz dodatkowy monitor, aby korzystać z monitora sceny.</string>
+    <string name="stage_monitor_layout_section">Układ ekranu</string>
+    <string name="stage_monitor_zone_top_left">Góra lewa</string>
+    <string name="stage_monitor_zone_top_right">Góra prawa</string>
+    <string name="stage_monitor_zone_bottom_left">Dół lewa</string>
+    <string name="stage_monitor_zone_bottom_center">Dół środek</string>
+    <string name="stage_monitor_zone_bottom_right">Dół prawa</string>
+    <string name="stage_monitor_zone_full_screen">Pełny ekran</string>
+    <string name="stage_monitor_zone_none">Brak</string>
     <string name="stage_monitor_notes_from_presentation">Notatki są automatycznie wyświetlane z aktywnego slajdu PowerPoint lub Keynote.</string>
+    <string name="stage_monitor_content_section">Zawartość ekranu</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Pytania i odpowiedzi</string>

--- a/composeApp/src/jvmMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-pl/strings.xml
@@ -1121,6 +1121,13 @@
     <string name="stage_monitor_zone_none">Brak</string>
     <string name="stage_monitor_notes_from_presentation">Notatki są automatycznie wyświetlane z aktywnego slajdu PowerPoint lub Keynote.</string>
     <string name="stage_monitor_content_section">Zawartość ekranu</string>
+    <string name="stage_monitor_metronome_position">Pozycja metronomu</string>
+    <string name="stage_monitor_position_top_center">Góra środek</string>
+    <string name="stage_monitor_position_middle_left">Środek lewa</string>
+    <string name="stage_monitor_position_center">Środek</string>
+    <string name="stage_monitor_position_middle_right">Środek prawa</string>
+    <string name="metronome_bpm_label">Tempo metronomu</string>
+    <string name="unit_bpm">ud/min</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Pytania i odpowiedzi</string>

--- a/composeApp/src/jvmMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-pt/strings.xml
@@ -429,6 +429,8 @@
     <string name="tooltip_edit">Editar</string>
     <string name="tooltip_edit_label">Editar Rótulo</string>
     <string name="tooltip_go_live">Transmitir</string>
+    <string name="tooltip_send_to_stage_monitor">Enviar para Monitor de Palco</string>
+    <string name="tooltip_hide_from_stage_monitor">Ocultar Anúncio</string>
     <string name="tooltip_add_label">Adicionar Rótulo</string>
     <string name="tooltip_collapse_schedule">Recolher Roteiro</string>
     <string name="tooltip_expand_schedule">Expandir Roteiro</string>
@@ -665,6 +667,13 @@
     <string name="timer_hours">h</string>
     <string name="timer_minutes">min</string>
     <string name="timer_seconds">seg</string>
+    <string name="timer_am">AM</string>
+    <string name="timer_pm">PM</string>
+    <string name="timer_clock_format">Formato</string>
+    <string name="timer_clock_format_12h_sec">12 horas (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12 horas (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24 horas (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24 horas (HH:mm)</string>
     <string name="timer_start">Iniciar</string>
     <string name="timer_pause">Pausar</string>
     <string name="timer_resume">Retomar</string>
@@ -1179,7 +1188,16 @@
     <string name="stage_monitor_label_style_section">Estilo de Rótulo</string>
     <string name="stage_monitor_clock_show_seconds">Mostrar Segundos</string>
     <string name="stage_monitor_clock_24h">Formato de 24 Horas</string>
+    <string name="stage_monitor_layout_section">Layout da Tela</string>
+    <string name="stage_monitor_zone_top_left">Superior Esquerda</string>
+    <string name="stage_monitor_zone_top_right">Superior Direita</string>
+    <string name="stage_monitor_zone_bottom_left">Inferior Esquerda</string>
+    <string name="stage_monitor_zone_bottom_center">Inferior Centro</string>
+    <string name="stage_monitor_zone_bottom_right">Inferior Direita</string>
+    <string name="stage_monitor_zone_full_screen">Tela Cheia</string>
+    <string name="stage_monitor_zone_none">Nenhum</string>
     <string name="stage_monitor_notes_from_presentation">As notas são exibidas automaticamente a partir do slide ativo do PowerPoint ou Keynote.</string>
+    <string name="stage_monitor_content_section">Conteúdo da Tela</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Servidor não está em execução — inicie o servidor companion em Configurações para habilitar P&amp;R</string>

--- a/composeApp/src/jvmMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-pt/strings.xml
@@ -1198,6 +1198,13 @@
     <string name="stage_monitor_zone_none">Nenhum</string>
     <string name="stage_monitor_notes_from_presentation">As notas são exibidas automaticamente a partir do slide ativo do PowerPoint ou Keynote.</string>
     <string name="stage_monitor_content_section">Conteúdo da Tela</string>
+    <string name="stage_monitor_metronome_position">Posição do Metrônomo</string>
+    <string name="stage_monitor_position_top_center">Superior Centro</string>
+    <string name="stage_monitor_position_middle_left">Centro Esquerda</string>
+    <string name="stage_monitor_position_center">Centro</string>
+    <string name="stage_monitor_position_middle_right">Centro Direita</string>
+    <string name="metronome_bpm_label">Tempo do Metrônomo</string>
+    <string name="unit_bpm">bat/min</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Servidor não está em execução — inicie o servidor companion em Configurações para habilitar P&amp;R</string>

--- a/composeApp/src/jvmMain/composeResources/values-ro/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-ro/strings.xml
@@ -1224,6 +1224,13 @@
     <string name="stage_monitor_zone_none">Niciunul</string>
     <string name="stage_monitor_notes_from_presentation">Notele sunt afișate automat din slide-ul activ PowerPoint sau Keynote.</string>
     <string name="stage_monitor_content_section">Conținut Ecran</string>
+    <string name="stage_monitor_metronome_position">Poziția Metronomului</string>
+    <string name="stage_monitor_position_top_center">Sus Centru</string>
+    <string name="stage_monitor_position_middle_left">Centru Stânga</string>
+    <string name="stage_monitor_position_center">Centru</string>
+    <string name="stage_monitor_position_middle_right">Centru Dreapta</string>
+    <string name="metronome_bpm_label">Tempo Metronom</string>
+    <string name="unit_bpm">băt/min</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Serverul nu rulează — porniți serverul companion din Setări pentru a activa Î&amp;R</string>

--- a/composeApp/src/jvmMain/composeResources/values-ro/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-ro/strings.xml
@@ -444,6 +444,8 @@
     <string name="tooltip_edit">Editează</string>
     <string name="tooltip_edit_label">Editează Etichetă</string>
     <string name="tooltip_go_live">Proiectează</string>
+    <string name="tooltip_send_to_stage_monitor">Trimite la Monitorul de Scenă</string>
+    <string name="tooltip_hide_from_stage_monitor">Ascunde Anunțul</string>
     <string name="tooltip_add_label">Adaugă Etichetă</string>
     <string name="tooltip_collapse_schedule">Restrânge Programul</string>
     <string name="tooltip_expand_schedule">Extinde Programul</string>
@@ -684,6 +686,13 @@
     <string name="timer_hours">ore</string>
     <string name="timer_minutes">min</string>
     <string name="timer_seconds">sec</string>
+    <string name="timer_am">a.m.</string>
+    <string name="timer_pm">p.m.</string>
+    <string name="timer_clock_format">Format</string>
+    <string name="timer_clock_format_12h_sec">12 ore (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12 ore (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24 ore (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24 ore (HH:mm)</string>
     <string name="timer_start">Pornește</string>
     <string name="timer_pause">Pauză</string>
     <string name="timer_resume">Reia</string>
@@ -1205,7 +1214,16 @@
     <string name="stage_monitor_label_style_section">Stil Etichetă</string>
     <string name="stage_monitor_clock_show_seconds">Afișează Secunde</string>
     <string name="stage_monitor_clock_24h">Format 24 de Ore</string>
+    <string name="stage_monitor_layout_section">Aspect Ecran</string>
+    <string name="stage_monitor_zone_top_left">Sus Stânga</string>
+    <string name="stage_monitor_zone_top_right">Sus Dreapta</string>
+    <string name="stage_monitor_zone_bottom_left">Jos Stânga</string>
+    <string name="stage_monitor_zone_bottom_center">Jos Centru</string>
+    <string name="stage_monitor_zone_bottom_right">Jos Dreapta</string>
+    <string name="stage_monitor_zone_full_screen">Ecran Complet</string>
+    <string name="stage_monitor_zone_none">Niciunul</string>
     <string name="stage_monitor_notes_from_presentation">Notele sunt afișate automat din slide-ul activ PowerPoint sau Keynote.</string>
+    <string name="stage_monitor_content_section">Conținut Ecran</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Serverul nu rulează — porniți serverul companion din Setări pentru a activa Î&amp;R</string>

--- a/composeApp/src/jvmMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-ru/strings.xml
@@ -1150,6 +1150,13 @@
     <string name="stage_monitor_zone_none">Нет</string>
     <string name="stage_monitor_notes_from_presentation">Заметки автоматически отображаются из активного слайда PowerPoint или Keynote.</string>
     <string name="stage_monitor_content_section">Содержимое экрана</string>
+    <string name="stage_monitor_metronome_position">Позиция метронома</string>
+    <string name="stage_monitor_position_top_center">Вверху по центру</string>
+    <string name="stage_monitor_position_middle_left">Посередине слева</string>
+    <string name="stage_monitor_position_center">Центр</string>
+    <string name="stage_monitor_position_middle_right">Посередине справа</string>
+    <string name="metronome_bpm_label">Темп метронома</string>
+    <string name="unit_bpm">уд/мин</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Вопросы и ответы</string>

--- a/composeApp/src/jvmMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-ru/strings.xml
@@ -331,6 +331,8 @@
     <string name="tooltip_clear_schedule">Очистить программу</string>
     <string name="tooltip_settings">Настройки</string>
     <string name="tooltip_go_live">В эфир</string>
+    <string name="tooltip_send_to_stage_monitor">Отправить на монитор сцены</string>
+    <string name="tooltip_hide_from_stage_monitor">Скрыть объявление</string>
     <string name="tooltip_remove">Удалить</string>
     <string name="tooltip_edit">Редактировать</string>
     <string name="tooltip_edit_label">Редактировать ярлык</string>
@@ -742,6 +744,13 @@
     <string name="timer_reset">Сброс</string>
     <string name="timer_resume">Продолжить</string>
     <string name="timer_seconds">сек</string>
+    <string name="timer_am">ДП</string>
+    <string name="timer_pm">ПП</string>
+    <string name="timer_clock_format">Формат</string>
+    <string name="timer_clock_format_12h_sec">12-часовой (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12-часовой (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24-часовой (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24-часовой (HH:mm)</string>
     <string name="timer_start">Старт</string>
     <string name="timer_text_color">Цвет таймера</string>
     <string name="timer_title">Таймер</string>
@@ -1131,7 +1140,16 @@
     <string name="stage_monitor_clock_show_seconds">Показывать секунды</string>
     <string name="stage_monitor_clock_24h">24-часовой формат</string>
     <string name="stage_monitor_no_extra_displays">Дополнительные мониторы не обнаружены. Подключите дополнительный монитор для использования монитора сцены.</string>
+    <string name="stage_monitor_layout_section">Раскладка экрана</string>
+    <string name="stage_monitor_zone_top_left">Вверху слева</string>
+    <string name="stage_monitor_zone_top_right">Вверху справа</string>
+    <string name="stage_monitor_zone_bottom_left">Внизу слева</string>
+    <string name="stage_monitor_zone_bottom_center">Внизу по центру</string>
+    <string name="stage_monitor_zone_bottom_right">Внизу справа</string>
+    <string name="stage_monitor_zone_full_screen">Весь экран</string>
+    <string name="stage_monitor_zone_none">Нет</string>
     <string name="stage_monitor_notes_from_presentation">Заметки автоматически отображаются из активного слайда PowerPoint или Keynote.</string>
+    <string name="stage_monitor_content_section">Содержимое экрана</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Вопросы и ответы</string>

--- a/composeApp/src/jvmMain/composeResources/values-sk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-sk/strings.xml
@@ -1198,6 +1198,13 @@
     <string name="stage_monitor_zone_none">Žiadne</string>
     <string name="stage_monitor_notes_from_presentation">Poznámky sa automaticky zobrazujú z aktívneho snímku PowerPoint alebo Keynote.</string>
     <string name="stage_monitor_content_section">Obsah obrazovky</string>
+    <string name="stage_monitor_metronome_position">Pozícia metronómu</string>
+    <string name="stage_monitor_position_top_center">Hore v strede</string>
+    <string name="stage_monitor_position_middle_left">V strede vľavo</string>
+    <string name="stage_monitor_position_center">V strede</string>
+    <string name="stage_monitor_position_middle_right">V strede vpravo</string>
+    <string name="metronome_bpm_label">Tempo metronómu</string>
+    <string name="unit_bpm">úd/min</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Server nebeží — spustite sprievodný server v Nastaveniach na povolenie Q&amp;A</string>

--- a/composeApp/src/jvmMain/composeResources/values-sk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-sk/strings.xml
@@ -429,6 +429,8 @@
     <string name="tooltip_edit">Upraviť</string>
     <string name="tooltip_edit_label">Upraviť štítok</string>
     <string name="tooltip_go_live">Spustiť naživo</string>
+    <string name="tooltip_send_to_stage_monitor">Odoslať na monitor javiska</string>
+    <string name="tooltip_hide_from_stage_monitor">Skryť oznámenie</string>
     <string name="tooltip_add_label">Pridať štítok</string>
     <string name="tooltip_collapse_schedule">Zbaliť program</string>
     <string name="tooltip_expand_schedule">Rozbaliť program</string>
@@ -665,6 +667,13 @@
     <string name="timer_hours">hod</string>
     <string name="timer_minutes">min</string>
     <string name="timer_seconds">sek</string>
+    <string name="timer_am">dop.</string>
+    <string name="timer_pm">pop.</string>
+    <string name="timer_clock_format">Formát</string>
+    <string name="timer_clock_format_12h_sec">12-hodinový (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12-hodinový (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24-hodinový (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24-hodinový (HH:mm)</string>
     <string name="timer_start">Spustiť</string>
     <string name="timer_pause">Pozastaviť</string>
     <string name="timer_resume">Pokračovať</string>
@@ -1179,7 +1188,16 @@
     <string name="stage_monitor_label_style_section">Štýl štítku</string>
     <string name="stage_monitor_clock_show_seconds">Zobraziť sekundy</string>
     <string name="stage_monitor_clock_24h">24-hodinový formát</string>
+    <string name="stage_monitor_layout_section">Rozloženie obrazovky</string>
+    <string name="stage_monitor_zone_top_left">Vľavo hore</string>
+    <string name="stage_monitor_zone_top_right">Vpravo hore</string>
+    <string name="stage_monitor_zone_bottom_left">Vľavo dole</string>
+    <string name="stage_monitor_zone_bottom_center">Dole v strede</string>
+    <string name="stage_monitor_zone_bottom_right">Vpravo dole</string>
+    <string name="stage_monitor_zone_full_screen">Celá obrazovka</string>
+    <string name="stage_monitor_zone_none">Žiadne</string>
     <string name="stage_monitor_notes_from_presentation">Poznámky sa automaticky zobrazujú z aktívneho snímku PowerPoint alebo Keynote.</string>
+    <string name="stage_monitor_content_section">Obsah obrazovky</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Server nebeží — spustite sprievodný server v Nastaveniach na povolenie Q&amp;A</string>

--- a/composeApp/src/jvmMain/composeResources/values-uk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-uk/strings.xml
@@ -316,6 +316,8 @@
     <string name="tooltip_clear_schedule">Очистити програму</string>
     <string name="tooltip_settings">Налаштування</string>
     <string name="tooltip_go_live">В ефір</string>
+    <string name="tooltip_send_to_stage_monitor">Надіслати на монітор сцени</string>
+    <string name="tooltip_hide_from_stage_monitor">Приховати оголошення</string>
     <string name="tooltip_remove">Видалити</string>
     <string name="tooltip_edit">Редагувати</string>
     <string name="tooltip_edit_label">Редагувати мітку</string>
@@ -725,6 +727,13 @@
     <string name="timer_reset">Скинути</string>
     <string name="timer_resume">Продовжити</string>
     <string name="timer_seconds">сек</string>
+    <string name="timer_am">дп</string>
+    <string name="timer_pm">пп</string>
+    <string name="timer_clock_format">Формат</string>
+    <string name="timer_clock_format_12h_sec">12-годинний (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12-годинний (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24-годинний (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24-годинний (HH:mm)</string>
     <string name="timer_start">Старт</string>
     <string name="timer_text_color">Колір таймера</string>
     <string name="timer_title">Таймер</string>
@@ -1108,7 +1117,16 @@
     <string name="stage_monitor_clock_show_seconds">Показувати секунди</string>
     <string name="stage_monitor_clock_24h">24-годинний формат</string>
     <string name="stage_monitor_no_extra_displays">Додаткові монітори не виявлено. Підключіть додатковий монітор для використання монітора сцени.</string>
+    <string name="stage_monitor_layout_section">Розкладка екрана</string>
+    <string name="stage_monitor_zone_top_left">Вгорі зліва</string>
+    <string name="stage_monitor_zone_top_right">Вгорі справа</string>
+    <string name="stage_monitor_zone_bottom_left">Внизу зліва</string>
+    <string name="stage_monitor_zone_bottom_center">Внизу по центру</string>
+    <string name="stage_monitor_zone_bottom_right">Внизу справа</string>
+    <string name="stage_monitor_zone_full_screen">Весь екран</string>
+    <string name="stage_monitor_zone_none">Немає</string>
     <string name="stage_monitor_notes_from_presentation">Нотатки автоматично відображаються з активного слайда PowerPoint або Keynote.</string>
+    <string name="stage_monitor_content_section">Вміст екрана</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Запитання і відповіді</string>

--- a/composeApp/src/jvmMain/composeResources/values-uk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-uk/strings.xml
@@ -1127,6 +1127,13 @@
     <string name="stage_monitor_zone_none">Немає</string>
     <string name="stage_monitor_notes_from_presentation">Нотатки автоматично відображаються з активного слайда PowerPoint або Keynote.</string>
     <string name="stage_monitor_content_section">Вміст екрана</string>
+    <string name="stage_monitor_metronome_position">Позиція метронома</string>
+    <string name="stage_monitor_position_top_center">Вгорі по центру</string>
+    <string name="stage_monitor_position_middle_left">Посередині зліва</string>
+    <string name="stage_monitor_position_center">Центр</string>
+    <string name="stage_monitor_position_middle_right">Посередині справа</string>
+    <string name="metronome_bpm_label">Темп метронома</string>
+    <string name="unit_bpm">уд/хв</string>
 
     <!-- Q&A Tab -->
     <string name="tab_qa">Запитання і відповіді</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -465,6 +465,7 @@
     <string name="tooltip_edit">Edit</string>
     <string name="tooltip_edit_label">Edit Label</string>
     <string name="tooltip_go_live">Go Live</string>
+    <string name="tooltip_send_to_stage_monitor">Send to Stage Monitor</string>
     <string name="tooltip_add_label">Add Label</string>
     <string name="tooltip_collapse_schedule">Collapse Schedule</string>
     <string name="tooltip_expand_schedule">Expand Schedule</string>
@@ -1229,8 +1230,7 @@
     <string name="display_stage_monitor">Stage Monitor</string>
     <string name="stage_monitor_layout_quadrants">4-Quadrant Layout</string>
     <string name="stage_monitor_quadrant_current">Current Slide</string>
-    <string name="stage_monitor_quadrant_next">Next Slide</string>
-    <string name="stage_monitor_quadrant_timer">Countdown Timer</string>
+    <string name="stage_monitor_quadrant_next">Next</string>
     <string name="stage_monitor_quadrant_clock">Clock</string>
     <string name="stage_monitor_quadrant_notes">Presenter Notes</string>
     <string name="stage_monitor_layout_section">Screen Layout</string>
@@ -1243,8 +1243,6 @@
     <string name="stage_monitor_zone_none">None</string>
     <string name="stage_monitor_notes_from_presentation">Notes are automatically shown from the active PowerPoint or Keynote slide.</string>
     <string name="stage_monitor_content_section">Screen Content</string>
-    <string name="stage_monitor_content_duration_timer">Duration Timer</string>
-    <string name="stage_monitor_content_specific_time">Specific Time</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Server not running — start the companion server in Settings to enable Q&amp;A</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -544,6 +544,10 @@
     <string name="screen_col_label">Screen %1$d</string>
     <string name="detected_screens">Detected screens: %1$d</string>
     <string name="presenter_windows_count">Presenter windows: %1$d</string>
+    <string name="simulate_screens_section">Simulate Screens (Dev Only)</string>
+    <string name="simulate_screens_count">Simulated Screens</string>
+    <string name="simulate_screens_help">Opens real test windows tiled next to your primary display, without needing extra physical monitors. Only available in development builds.</string>
+    <string name="simulated_screen_label">Simulated Screen %1$d</string>
     <string name="content_bible">Bible</string>
     <string name="content_songs">Songs</string>
     <string name="content_pictures">Pictures/Presentation</string>
@@ -1239,11 +1243,12 @@
     <string name="stage_monitor_zone_bottom_left">Bottom-Left</string>
     <string name="stage_monitor_zone_bottom_center">Bottom-Center</string>
     <string name="stage_monitor_zone_bottom_right">Bottom-Right</string>
-    <string name="stage_monitor_show_label">Show Song/Bible Label</string>
-    <string name="stage_monitor_label_style_section">Label Style</string>
-    <string name="stage_monitor_clock_show_seconds">Show Seconds</string>
-    <string name="stage_monitor_clock_24h">24-Hour Format</string>
+    <string name="stage_monitor_zone_full_screen">Full Screen</string>
+    <string name="stage_monitor_zone_none">None</string>
     <string name="stage_monitor_notes_from_presentation">Notes are automatically shown from the active PowerPoint or Keynote slide.</string>
+    <string name="stage_monitor_content_section">Screen Content</string>
+    <string name="stage_monitor_content_duration_timer">Duration Timer</string>
+    <string name="stage_monitor_content_specific_time">Specific Time</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Server not running — start the companion server in Settings to enable Q&amp;A</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -544,10 +544,6 @@
     <string name="screen_col_label">Screen %1$d</string>
     <string name="detected_screens">Detected screens: %1$d</string>
     <string name="presenter_windows_count">Presenter windows: %1$d</string>
-    <string name="simulate_screens_section">Simulate Screens (Dev Only)</string>
-    <string name="simulate_screens_count">Simulated Screens</string>
-    <string name="simulate_screens_help">Opens real test windows tiled next to your primary display, without needing extra physical monitors. Only available in development builds.</string>
-    <string name="simulated_screen_label">Simulated Screen %1$d</string>
     <string name="content_bible">Bible</string>
     <string name="content_songs">Songs</string>
     <string name="content_pictures">Pictures/Presentation</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -1248,6 +1248,13 @@
     <string name="stage_monitor_zone_none">None</string>
     <string name="stage_monitor_notes_from_presentation">Notes are automatically shown from the active PowerPoint or Keynote slide.</string>
     <string name="stage_monitor_content_section">Screen Content</string>
+    <string name="stage_monitor_metronome_position">Metronome Position</string>
+    <string name="stage_monitor_position_top_center">Top-Center</string>
+    <string name="stage_monitor_position_middle_left">Middle-Left</string>
+    <string name="stage_monitor_position_center">Center</string>
+    <string name="stage_monitor_position_middle_right">Middle-Right</string>
+    <string name="metronome_bpm_label">Metronome BPM</string>
+    <string name="unit_bpm">BPM</string>
 
     <!-- Q&A Tab -->
     <string name="qa_server_not_running">Server not running — start the companion server in Settings to enable Q&amp;A</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -466,6 +466,7 @@
     <string name="tooltip_edit_label">Edit Label</string>
     <string name="tooltip_go_live">Go Live</string>
     <string name="tooltip_send_to_stage_monitor">Send to Stage Monitor</string>
+    <string name="tooltip_hide_from_stage_monitor">Hide Announcement</string>
     <string name="tooltip_add_label">Add Label</string>
     <string name="tooltip_collapse_schedule">Collapse Schedule</string>
     <string name="tooltip_expand_schedule">Expand Schedule</string>
@@ -711,6 +712,10 @@
     <string name="timer_am">AM</string>
     <string name="timer_pm">PM</string>
     <string name="timer_clock_format">Format</string>
+    <string name="timer_clock_format_12h_sec">12-Hour (h:mm:ss AM/PM)</string>
+    <string name="timer_clock_format_12h">12-Hour (h:mm AM/PM)</string>
+    <string name="timer_clock_format_24h_sec">24-Hour (HH:mm:ss)</string>
+    <string name="timer_clock_format_24h">24-Hour (HH:mm)</string>
     <string name="timer_start">Start</string>
     <string name="timer_pause">Pause</string>
     <string name="timer_resume">Resume</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
@@ -370,6 +370,14 @@ fun MainDesktop(
 
     val presentingMode by presenterManager.presentingMode
 
+    // Keep the Stage Monitor's "Next" verse in sync with whatever is currently selected —
+    // recomputes automatically whenever the underlying Bible selection changes, from any source
+    // (manual click, auto-follow, remote API), since nextVerses is a derived state.
+    val nextVerses by bibleViewModel.nextVerses
+    LaunchedEffect(nextVerses) {
+        presenterManager.setNextVerses(nextVerses)
+    }
+
     // When Bible is live and the user is on a different tab, keep the presenter in sync with
     // new auto-follow detections. BibleTab is inside AnimatedContent and leaves the composition
     // on tab switch, so its own LaunchedEffect can't fire while the user is away.
@@ -631,6 +639,11 @@ fun MainDesktop(
                         keyEvent.key == Key.Escape -> {
                             mediaViewModel?.pause()
                             presenterManager.requestClearDisplay()
+                            // Also release any "Send to Stage Monitor" lock (e.g. from Announcements)
+                            // so the stage monitor goes back to following the main presenting mode.
+                            appSettings.projectionSettings.screenAssignments.indices
+                                .filter { appSettings.projectionSettings.screenAssignments[it].displayMode == Constants.DISPLAY_MODE_STAGE_MONITOR }
+                                .forEach { presenterManager.setScreenLock(it, null) }
                             true
                         }
                         keyEvent.key == Key.F6 -> { selectTab(Tabs.BIBLE); true }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
@@ -2,18 +2,16 @@ package org.churchpresenter.app.churchpresenter
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
@@ -24,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -40,16 +39,22 @@ import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
-import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorContent
+import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorContentType
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorSettings
+import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorStyleZone
+import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorZone
+import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorZoneStyle
+import org.churchpresenter.app.churchpresenter.data.settings.toStyleZone
 import org.churchpresenter.app.churchpresenter.models.LyricSection
 import org.churchpresenter.app.churchpresenter.models.SelectedVerse
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.utils.Utils
 import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
 import org.churchpresenter.app.churchpresenter.utils.Utils.systemFontFamilyOrDefault
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.composables.SoftwareVideoPlayer
 import org.churchpresenter.app.churchpresenter.viewmodel.LocalMediaViewModel
+import org.churchpresenter.app.churchpresenter.viewmodel.MediaViewModel
 import org.jetbrains.skia.Image as SkiaImage
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import java.io.File
@@ -57,29 +62,25 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 /**
- * Full-screen stage monitor layout — a fixed 5-zone grid whose content is assigned per zone via
- * settings (sm.topLeftContent, etc.), rather than hardcoded to a specific content type:
+ * Full-screen stage monitor layout — 5 quadrant zones plus a full-screen zone, whose content is
+ * routed per content type via settings (sm.contentZones), rather than hardcoded to a specific zone:
  *   ┌───────────────────┬───────────────────┐
  *   │  Top-Left         │  Top-Right        │
  *   ├─────────┬─────────┴───────────────────┤
- *   │ Bot-Left│   Bot-Center  │  Bot-Right  │
+ *   │ Bot-Left│   Bot-Middle  │  Bot-Right  │
  *   └─────────┴───────────────┴─────────────┘
+ * If a content type is routed to Full Screen, it takes over the entire monitor instead.
  */
 @Composable
 fun StageMonitorScreen(
     sm: StageMonitorSettings,
     presentingMode: Presenting,
     currentLyricSection: LyricSection,
-    allLyricSections: List<LyricSection>,
-    songDisplaySectionIndex: Int,
     displayedVerses: List<SelectedVerse>,
     timerRemainingSeconds: Int,
     timerRunning: Boolean,
     displayedImagePath: String? = null,
-    nextImagePath: String? = null,
     displayedSlide: ImageBitmap? = null,
-    nextSlide: ImageBitmap? = null,
-    announcementText: String = "",
     presenterNotes: String = "",
     modifier: Modifier = Modifier
 ) {
@@ -93,403 +94,279 @@ fun StageMonitorScreen(
                 "$ref\n${v.verseText}"
             } else ""
         }
-        Presenting.ANNOUNCEMENTS -> announcementText
         else -> ""
     }
 
-    // Derive next text (songs only)
-    val nextText: String = when (presentingMode) {
-        Presenting.LYRICS -> {
-            val nextIdx = songDisplaySectionIndex + 1
-            allLyricSections.getOrNull(nextIdx)?.lines?.joinToString("\n") ?: ""
-        }
-        else -> ""
-    }
-
-    // Label text (song title or song+section header)
-    val currentLabel: String = when (presentingMode) {
-        Presenting.LYRICS -> {
-            val title = currentLyricSection.title.ifBlank { null }
-            val header = currentLyricSection.header?.removePrefix("[")?.removePrefix("{")
-                ?.removeSuffix("]")?.removeSuffix("}")?.trim()?.ifBlank { null }
-            listOfNotNull(title, header).joinToString(" – ")
-        }
-        Presenting.BIBLE -> ""
-        else -> ""
-    }
-
-    // Load image bitmaps for PICTURES mode
+    // Load image bitmap for PICTURES mode
     var currentImageBitmap by remember(displayedImagePath) { mutableStateOf<ImageBitmap?>(null) }
-    var nextImageBitmap by remember(nextImagePath) { mutableStateOf<ImageBitmap?>(null) }
-
     LaunchedEffect(displayedImagePath) {
         currentImageBitmap = loadImageBitmapFromPath(displayedImagePath)
     }
-    LaunchedEffect(nextImagePath) {
-        nextImageBitmap = loadImageBitmapFromPath(nextImagePath)
-    }
 
     // Clock state — ticks every second
-    var clockText by remember { mutableStateOf(formatClock(sm)) }
-    LaunchedEffect(sm.clockFormat24h, sm.clockShowSeconds) {
+    var clockText by remember { mutableStateOf(formatClock()) }
+    LaunchedEffect(Unit) {
         while (true) {
-            clockText = formatClock(sm)
+            clockText = formatClock()
             delay(1000L)
         }
     }
 
-    // Timer text
-    val timerText = formatTimer(timerRemainingSeconds)
+    // Timer text (shared by the Duration/Countdown/Specific-Time content types)
+    val timerText = if (timerRunning || timerRemainingSeconds > 0) formatTimer(timerRemainingSeconds) else "--:--"
 
     val mediaViewModel = LocalMediaViewModel.current
 
     val renderData = ZoneRenderData(
-        presentingMode = presentingMode,
         currentText = currentText,
-        currentLabel = currentLabel,
         currentImageBitmap = currentImageBitmap,
         displayedSlide = displayedSlide,
-        nextText = nextText,
-        nextImageBitmap = nextImageBitmap,
-        nextSlide = nextSlide,
-        timerText = timerText,
-        timerRunning = timerRunning,
-        timerRemainingSeconds = timerRemainingSeconds,
         clockText = clockText,
+        timerText = timerText,
         presenterNotes = presenterNotes
     )
+
+    // Which content type is "active" for the current presenting mode. Clock is always available
+    // as a fallback so a zone assigned both a live type and Clock shows the clock when idle.
+    val activeTypes: Set<StageMonitorContentType> = when (presentingMode) {
+        Presenting.BIBLE -> setOf(StageMonitorContentType.BIBLE)
+        Presenting.LYRICS -> setOf(StageMonitorContentType.SONGS)
+        Presenting.PRESENTATION -> setOf(StageMonitorContentType.PRESENTATION, StageMonitorContentType.PRESENTATION_NOTES)
+        Presenting.PICTURES -> setOf(StageMonitorContentType.PICTURES)
+        Presenting.MEDIA -> setOf(StageMonitorContentType.MEDIA)
+        Presenting.LOWER_THIRD -> setOf(StageMonitorContentType.LOWER_THIRD)
+        Presenting.WEBSITE -> setOf(StageMonitorContentType.WEB)
+        Presenting.STT -> setOf(StageMonitorContentType.STT)
+        Presenting.CANVAS -> setOf(StageMonitorContentType.CANVAS)
+        Presenting.QA -> setOf(StageMonitorContentType.QA)
+        Presenting.DICTIONARY -> setOf(StageMonitorContentType.DICTIONARY)
+        // The announcement timer's exact mode (duration/countdown/specific-time) isn't surfaced
+        // here yet, so all three routes are treated as active and resolved by whichever zone
+        // each was routed to.
+        Presenting.ANNOUNCEMENTS -> setOf(
+            StageMonitorContentType.DURATION_TIMER,
+            StageMonitorContentType.COUNTDOWN_TIMER,
+            StageMonitorContentType.SPECIFIC_TIME
+        )
+        Presenting.NONE -> emptySet()
+    }
+
+    fun contentFor(zone: StageMonitorZone): StageMonitorContentType? {
+        val assigned = StageMonitorContentType.entries.filter { sm.zoneFor(it) == zone }
+        if (assigned.isEmpty()) return null
+        assigned.firstOrNull { it in activeTypes }?.let { return it }
+        if (StageMonitorContentType.CLOCK in assigned) return StageMonitorContentType.CLOCK
+        return null
+    }
+
+    val fullScreenContent = contentFor(StageMonitorZone.FULL_SCREEN)
 
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(Color.Black)
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            // ── TOP ROW ───────────────────────────────────────────────────
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
+        if (fullScreenContent != null) {
+            val style = sm.styleFor(StageMonitorStyleZone.FULL_SCREEN)
+            Box(
+                modifier = Modifier.fillMaxSize().background(parseHexColor(style.bgColor)).padding(12.dp),
+                contentAlignment = zoneContentAlignment(style)
             ) {
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .background(zoneBackgroundColor(sm.topLeftContent, sm))
-                        .padding(12.dp),
-                    contentAlignment = zoneContentAlignment(sm.topLeftContent)
-                ) {
-                    ZoneContent(sm.topLeftContent, sm, renderData)
-                }
-                VerticalDivider(color = Color.DarkGray, thickness = 1.dp)
-                Box(
-                    modifier = Modifier
-                        .weight(0.45f)
-                        .fillMaxHeight()
-                        .background(zoneBackgroundColor(sm.topRightContent, sm))
-                        .padding(12.dp),
-                    contentAlignment = zoneContentAlignment(sm.topRightContent)
-                ) {
-                    ZoneContent(sm.topRightContent, sm, renderData)
-                }
+                ZoneContent(fullScreenContent, style, renderData, mediaViewModel)
             }
-
-            HorizontalDivider(color = Color.DarkGray, thickness = 1.dp)
-
-            // ── BOTTOM ROW ────────────────────────────────────────────────
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(0.6f)
-            ) {
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .background(zoneBackgroundColor(sm.bottomLeftContent, sm))
-                        .padding(12.dp),
-                    contentAlignment = zoneContentAlignment(sm.bottomLeftContent)
-                ) {
-                    ZoneContent(sm.bottomLeftContent, sm, renderData)
+        } else {
+            Column(modifier = Modifier.fillMaxSize()) {
+                // ── TOP ROW ───────────────────────────────────────────────────
+                Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                    StageZoneBox(sm, StageMonitorZone.TOP_LEFT, renderData, mediaViewModel, ::contentFor, Modifier.weight(1f))
+                    VerticalDivider(color = Color.DarkGray, thickness = 1.dp)
+                    StageZoneBox(sm, StageMonitorZone.TOP_RIGHT, renderData, mediaViewModel, ::contentFor, Modifier.weight(0.45f))
                 }
-                VerticalDivider(color = Color.DarkGray, thickness = 1.dp)
-                Box(
-                    modifier = Modifier
-                        .weight(0.8f)
-                        .fillMaxHeight()
-                        .background(zoneBackgroundColor(sm.bottomCenterContent, sm))
-                        .padding(12.dp),
-                    contentAlignment = zoneContentAlignment(sm.bottomCenterContent)
-                ) {
-                    ZoneContent(sm.bottomCenterContent, sm, renderData)
-                }
-                VerticalDivider(color = Color.DarkGray, thickness = 1.dp)
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight()
-                        .background(zoneBackgroundColor(sm.bottomRightContent, sm))
-                        .padding(12.dp),
-                    contentAlignment = zoneContentAlignment(sm.bottomRightContent)
-                ) {
-                    ZoneContent(sm.bottomRightContent, sm, renderData)
+
+                HorizontalDivider(color = Color.DarkGray, thickness = 1.dp)
+
+                // ── BOTTOM ROW ────────────────────────────────────────────────
+                Row(modifier = Modifier.fillMaxWidth().weight(0.6f)) {
+                    StageZoneBox(sm, StageMonitorZone.BOTTOM_LEFT, renderData, mediaViewModel, ::contentFor, Modifier.weight(1f))
+                    VerticalDivider(color = Color.DarkGray, thickness = 1.dp)
+                    StageZoneBox(sm, StageMonitorZone.BOTTOM_MIDDLE, renderData, mediaViewModel, ::contentFor, Modifier.weight(0.8f))
+                    VerticalDivider(color = Color.DarkGray, thickness = 1.dp)
+                    StageZoneBox(sm, StageMonitorZone.BOTTOM_RIGHT, renderData, mediaViewModel, ::contentFor, Modifier.weight(1f))
                 }
             }
         }
+    }
+}
 
-        // ── MEDIA overlay: when playing media, cover the full stage monitor ──
-        if (presentingMode == Presenting.MEDIA && mediaViewModel != null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.Black),
-                contentAlignment = Alignment.Center
-            ) {
-                if (mediaViewModel.isLoaded && !mediaViewModel.isAudioFile) {
-                    SoftwareVideoPlayer(
-                        viewModel = mediaViewModel,
-                        modifier = Modifier.fillMaxSize(),
-                        audioEnabled = false // audio is handled by the main output
-                    )
-                }
-            }
+@Composable
+private fun StageZoneBox(
+    sm: StageMonitorSettings,
+    zone: StageMonitorZone,
+    data: ZoneRenderData,
+    mediaViewModel: MediaViewModel?,
+    contentFor: (StageMonitorZone) -> StageMonitorContentType?,
+    modifier: Modifier
+) {
+    val styleZone = zone.toStyleZone() ?: return
+    val style = sm.styleFor(styleZone)
+    val content = contentFor(zone)
+    Box(
+        modifier = modifier
+            .fillMaxHeight()
+            .background(parseHexColor(style.bgColor))
+            .padding(12.dp),
+        contentAlignment = zoneContentAlignment(style)
+    ) {
+        if (content != null) {
+            ZoneContent(content, style, data, mediaViewModel)
         }
     }
 }
 
 /** Bundles the derived per-frame state so it can be passed to whichever zone needs it. */
 private data class ZoneRenderData(
-    val presentingMode: Presenting,
     val currentText: String,
-    val currentLabel: String,
     val currentImageBitmap: ImageBitmap?,
     val displayedSlide: ImageBitmap?,
-    val nextText: String,
-    val nextImageBitmap: ImageBitmap?,
-    val nextSlide: ImageBitmap?,
-    val timerText: String,
-    val timerRunning: Boolean,
-    val timerRemainingSeconds: Int,
     val clockText: String,
+    val timerText: String,
     val presenterNotes: String
 )
 
-private fun zoneBackgroundColor(content: StageMonitorContent, sm: StageMonitorSettings): Color = when (content) {
-    StageMonitorContent.CURRENT_SLIDE -> parseHexColor(sm.currentBgColor)
-    StageMonitorContent.NEXT_SLIDE -> parseHexColor(sm.nextBgColor)
-    StageMonitorContent.TIMER -> parseHexColor(sm.timerBgColor)
-    StageMonitorContent.CLOCK -> parseHexColor(sm.clockBgColor)
-    StageMonitorContent.NOTES -> parseHexColor(sm.notesBgColor)
-}
-
-private fun zoneContentAlignment(content: StageMonitorContent): Alignment = when (content) {
-    StageMonitorContent.TIMER, StageMonitorContent.CLOCK -> Alignment.Center
-    else -> Alignment.TopStart
+private fun zoneContentAlignment(style: StageMonitorZoneStyle): Alignment {
+    val vertical = when (style.verticalAlignment) {
+        Constants.BOTTOM -> 1f
+        Constants.MIDDLE -> 0f
+        else -> -1f
+    }
+    val horizontal = when (style.horizontalAlignment) {
+        Constants.RIGHT -> 1f
+        Constants.CENTER -> 0f
+        else -> -1f
+    }
+    return BiasAlignment(horizontal, vertical)
 }
 
 @Composable
-private fun ZoneContent(content: StageMonitorContent, sm: StageMonitorSettings, data: ZoneRenderData) {
+private fun ZoneContent(
+    content: StageMonitorContentType,
+    style: StageMonitorZoneStyle,
+    data: ZoneRenderData,
+    mediaViewModel: MediaViewModel?
+) {
     when (content) {
-        StageMonitorContent.CURRENT_SLIDE -> CurrentSlideContent(sm, data)
-        StageMonitorContent.NEXT_SLIDE -> NextSlideContent(sm, data)
-        StageMonitorContent.TIMER -> TimerContent(sm, data)
-        StageMonitorContent.CLOCK -> ClockContent(sm, data)
-        StageMonitorContent.NOTES -> NotesContent(sm, data)
+        StageMonitorContentType.BIBLE,
+        StageMonitorContentType.SONGS -> TextContent(style, data.currentText)
+        StageMonitorContentType.PRESENTATION -> SlideContent(data.displayedSlide)
+        StageMonitorContentType.PRESENTATION_NOTES -> ScrollingTextContent(style, data.presenterNotes)
+        StageMonitorContentType.PICTURES -> SlideContent(data.currentImageBitmap)
+        StageMonitorContentType.MEDIA -> {
+            if (mediaViewModel != null && mediaViewModel.isLoaded && !mediaViewModel.isAudioFile) {
+                SoftwareVideoPlayer(
+                    viewModel = mediaViewModel,
+                    modifier = Modifier.fillMaxSize(),
+                    audioEnabled = false // audio is handled by the main output
+                )
+            }
+        }
+        StageMonitorContentType.CLOCK -> CenteredText(data.clockText, style)
+        StageMonitorContentType.DURATION_TIMER,
+        StageMonitorContentType.COUNTDOWN_TIMER,
+        StageMonitorContentType.SPECIFIC_TIME -> CenteredText(data.timerText, style)
+        // No live data is plumbed through to the stage monitor for these yet.
+        StageMonitorContentType.LOWER_THIRD,
+        StageMonitorContentType.WEB,
+        StageMonitorContentType.STT,
+        StageMonitorContentType.CANVAS,
+        StageMonitorContentType.QA,
+        StageMonitorContentType.DICTIONARY -> {}
     }
 }
 
 @Composable
-private fun CurrentSlideContent(sm: StageMonitorSettings, data: ZoneRenderData) {
-    when (data.presentingMode) {
-        Presenting.PICTURES -> {
-            val bmp = data.currentImageBitmap
-            if (bmp != null) {
-                Image(
-                    bitmap = bmp,
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxSize()
-                )
-            }
-        }
-        Presenting.PRESENTATION -> {
-            val bmp = data.displayedSlide
-            if (bmp != null) {
-                Image(
-                    bitmap = bmp,
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxSize()
-                )
-            }
-        }
-        else -> {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = resolveColumnVerticalArrangement(sm.currentVerticalAlignment),
-                horizontalAlignment = resolveColumnHorizontalAlignment(sm.currentHorizontalAlignment)
-            ) {
-                if (sm.showSongBibleLabel && data.currentLabel.isNotBlank()) {
-                    Text(
-                        text = data.currentLabel,
-                        style = buildTextStyle(
-                            fontType = sm.labelFontType,
-                            fontSize = sm.labelFontSize,
-                            color = parseHexColor(sm.labelColor),
-                            bold = sm.labelBold,
-                            italic = sm.labelItalic
-                        ),
-                        maxLines = 1
-                    )
-                    Spacer(Modifier.height(6.dp))
-                }
-                Text(
-                    text = data.currentText,
-                    style = buildTextStyle(
-                        fontType = sm.currentFontType,
-                        fontSize = sm.currentFontSize,
-                        color = parseHexColor(sm.currentColor),
-                        bold = sm.currentBold,
-                        italic = sm.currentItalic,
-                        underline = sm.currentUnderline,
-                        shadow = sm.currentShadow,
-                        shadowColor = parseHexColor(sm.currentShadowColor),
-                        shadowSize = sm.currentShadowSize,
-                        shadowOpacity = sm.currentShadowOpacity
-                    ),
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = resolveTextAlign(sm.currentHorizontalAlignment)
-                )
-            }
-        }
+private fun TextContent(style: StageMonitorZoneStyle, text: String) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = resolveColumnVerticalArrangement(style.verticalAlignment),
+        horizontalAlignment = resolveColumnHorizontalAlignment(style.horizontalAlignment)
+    ) {
+        Text(
+            text = text,
+            style = buildTextStyle(
+                fontType = style.fontType,
+                fontSize = style.fontSize,
+                color = parseHexColor(style.color),
+                bold = style.bold,
+                italic = style.italic,
+                underline = style.underline,
+                shadow = style.shadow,
+                shadowColor = parseHexColor(style.shadowColor),
+                shadowSize = style.shadowSize,
+                shadowOpacity = style.shadowOpacity
+            ),
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = resolveTextAlign(style.horizontalAlignment)
+        )
     }
 }
 
 @Composable
-private fun NextSlideContent(sm: StageMonitorSettings, data: ZoneRenderData) {
-    when (data.presentingMode) {
-        Presenting.PICTURES -> {
-            val bmp = data.nextImageBitmap
-            if (bmp != null) {
-                Image(
-                    bitmap = bmp,
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxSize()
-                )
-            }
-        }
-        Presenting.PRESENTATION -> {
-            val bmp = data.nextSlide
-            if (bmp != null) {
-                Image(
-                    bitmap = bmp,
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier.fillMaxSize()
-                )
-            }
-        }
-        else -> {
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = resolveColumnVerticalArrangement(sm.nextVerticalAlignment),
-                horizontalAlignment = resolveColumnHorizontalAlignment(sm.nextHorizontalAlignment)
-            ) {
-                Text(
-                    text = data.nextText,
-                    style = buildTextStyle(
-                        fontType = sm.nextFontType,
-                        fontSize = sm.nextFontSize,
-                        color = parseHexColor(sm.nextColor),
-                        bold = sm.nextBold,
-                        italic = sm.nextItalic,
-                        underline = sm.nextUnderline,
-                        shadow = sm.nextShadow,
-                        shadowColor = parseHexColor(sm.nextShadowColor),
-                        shadowSize = sm.nextShadowSize,
-                        shadowOpacity = sm.nextShadowOpacity
-                    ),
-                    modifier = Modifier.fillMaxWidth(),
-                    textAlign = resolveTextAlign(sm.nextHorizontalAlignment)
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun TimerContent(sm: StageMonitorSettings, data: ZoneRenderData) {
-    Text(
-        text = if (data.timerRunning || data.timerRemainingSeconds > 0) data.timerText else "--:--",
-        style = buildTextStyle(
-            fontType = sm.timerFontType,
-            fontSize = sm.timerFontSize,
-            color = parseHexColor(sm.timerColor),
-            bold = sm.timerBold,
-            italic = sm.timerItalic,
-            underline = sm.timerUnderline,
-            shadow = sm.timerShadow,
-            shadowColor = parseHexColor(sm.timerShadowColor),
-            shadowSize = sm.timerShadowSize,
-            shadowOpacity = sm.timerShadowOpacity
-        ),
-        textAlign = TextAlign.Center
-    )
-}
-
-@Composable
-private fun ClockContent(sm: StageMonitorSettings, data: ZoneRenderData) {
-    Text(
-        text = data.clockText,
-        style = buildTextStyle(
-            fontType = sm.clockFontType,
-            fontSize = sm.clockFontSize,
-            color = parseHexColor(sm.clockColor),
-            bold = sm.clockBold,
-            italic = sm.clockItalic,
-            underline = sm.clockUnderline,
-            shadow = sm.clockShadow,
-            shadowColor = parseHexColor(sm.clockShadowColor),
-            shadowSize = sm.clockShadowSize,
-            shadowOpacity = sm.clockShadowOpacity
-        ),
-        textAlign = TextAlign.Center
-    )
-}
-
-@Composable
-private fun NotesContent(sm: StageMonitorSettings, data: ZoneRenderData) {
+private fun ScrollingTextContent(style: StageMonitorZoneStyle, text: String) {
     val scrollState = rememberScrollState()
     Text(
-        text = data.presenterNotes,
+        text = text,
         style = buildTextStyle(
-            fontType = sm.notesFontType,
-            fontSize = sm.notesFontSize,
-            color = parseHexColor(sm.notesColor),
-            bold = sm.notesBold,
-            italic = sm.notesItalic,
-            underline = sm.notesUnderline,
-            shadow = sm.notesShadow,
-            shadowColor = parseHexColor(sm.notesShadowColor),
-            shadowSize = sm.notesShadowSize,
-            shadowOpacity = sm.notesShadowOpacity
+            fontType = style.fontType,
+            fontSize = style.fontSize,
+            color = parseHexColor(style.color),
+            bold = style.bold,
+            italic = style.italic,
+            underline = style.underline,
+            shadow = style.shadow,
+            shadowColor = parseHexColor(style.shadowColor),
+            shadowSize = style.shadowSize,
+            shadowOpacity = style.shadowOpacity
         ),
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(scrollState)
+        modifier = Modifier.fillMaxSize().verticalScroll(scrollState),
+        textAlign = resolveTextAlign(style.horizontalAlignment)
     )
 }
 
-private fun formatClock(sm: StageMonitorSettings): String {
-    val now = LocalTime.now()
-    val pattern = when {
-        sm.clockFormat24h && sm.clockShowSeconds -> "HH:mm:ss"
-        sm.clockFormat24h -> "HH:mm"
-        sm.clockShowSeconds -> "hh:mm:ss a"
-        else -> "hh:mm a"
+@Composable
+private fun SlideContent(bitmap: ImageBitmap?) {
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap,
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.fillMaxSize()
+        )
     }
-    return now.format(DateTimeFormatter.ofPattern(pattern))
+}
+
+@Composable
+private fun CenteredText(text: String, style: StageMonitorZoneStyle) {
+    Text(
+        text = text,
+        style = buildTextStyle(
+            fontType = style.fontType,
+            fontSize = style.fontSize,
+            color = parseHexColor(style.color),
+            bold = style.bold,
+            italic = style.italic,
+            underline = style.underline,
+            shadow = style.shadow,
+            shadowColor = parseHexColor(style.shadowColor),
+            shadowSize = style.shadowSize,
+            shadowOpacity = style.shadowOpacity
+        ),
+        textAlign = TextAlign.Center
+    )
+}
+
+private fun formatClock(): String {
+    val pattern = if (Utils.isSystemUsing24HourFormat()) "HH:mm:ss" else "hh:mm:ss a"
+    return LocalTime.now().format(DateTimeFormatter.ofPattern(pattern))
 }
 
 private fun formatTimer(totalSeconds: Int): String {
@@ -538,7 +415,6 @@ private suspend fun loadImageBitmapFromPath(path: String?): ImageBitmap? {
         }
     }
 }
-
 
 private fun resolveTextAlign(horizontal: String): TextAlign {
     return when (horizontal) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
@@ -39,6 +39,9 @@ import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import org.churchpresenter.app.churchpresenter.data.StrongsEntry
+import org.churchpresenter.app.churchpresenter.data.settings.DictionarySettings
+import org.churchpresenter.app.churchpresenter.data.settings.QASettings
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorContentType
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorSettings
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorStyleZone
@@ -46,8 +49,13 @@ import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorZone
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorZoneStyle
 import org.churchpresenter.app.churchpresenter.data.settings.toStyleZone
 import org.churchpresenter.app.churchpresenter.models.LyricSection
+import org.churchpresenter.app.churchpresenter.models.Question
+import org.churchpresenter.app.churchpresenter.models.Scene
 import org.churchpresenter.app.churchpresenter.models.SelectedVerse
+import org.churchpresenter.app.churchpresenter.presenter.DictionaryPresenter
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.presenter.QAPresenter
+import org.churchpresenter.app.churchpresenter.presenter.ScenePresenter
 import org.churchpresenter.app.churchpresenter.utils.Utils
 import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
 import org.churchpresenter.app.churchpresenter.utils.Utils.systemFontFamilyOrDefault
@@ -76,12 +84,19 @@ fun StageMonitorScreen(
     sm: StageMonitorSettings,
     presentingMode: Presenting,
     currentLyricSection: LyricSection,
+    allLyricSections: List<LyricSection> = emptyList(),
+    songDisplaySectionIndex: Int = 0,
     displayedVerses: List<SelectedVerse>,
-    timerRemainingSeconds: Int,
-    timerRunning: Boolean,
+    nextVerses: List<SelectedVerse> = emptyList(),
+    announcementText: String = "",
     displayedImagePath: String? = null,
     displayedSlide: ImageBitmap? = null,
     presenterNotes: String = "",
+    activeScene: Scene? = null,
+    displayedQuestion: Question? = null,
+    qaSettings: QASettings = QASettings(),
+    displayedDictionaryEntry: StrongsEntry? = null,
+    dictionarySettings: DictionarySettings = DictionarySettings(),
     modifier: Modifier = Modifier
 ) {
     // Derive current text
@@ -89,6 +104,23 @@ fun StageMonitorScreen(
         Presenting.LYRICS -> currentLyricSection.lines.joinToString("\n")
         Presenting.BIBLE -> {
             val v = displayedVerses.firstOrNull()
+            if (v != null) {
+                val ref = "${v.bookName} ${v.chapter}:${v.verseRange.ifEmpty { v.verseNumber.toString() }}"
+                "$ref\n${v.verseText}"
+            } else ""
+        }
+        else -> ""
+    }
+
+    // Next Bible verse (a dedicated lookahead, not the secondary language of the current verse)
+    // or next song line/section.
+    val nextText: String = when (presentingMode) {
+        Presenting.LYRICS -> {
+            val nextIdx = songDisplaySectionIndex + 1
+            allLyricSections.getOrNull(nextIdx)?.lines?.joinToString("\n") ?: ""
+        }
+        Presenting.BIBLE -> {
+            val v = nextVerses.firstOrNull()
             if (v != null) {
                 val ref = "${v.bookName} ${v.chapter}:${v.verseRange.ifEmpty { v.verseNumber.toString() }}"
                 "$ref\n${v.verseText}"
@@ -112,25 +144,34 @@ fun StageMonitorScreen(
         }
     }
 
-    // Timer text (shared by the Duration/Countdown/Specific-Time content types)
-    val timerText = if (timerRunning || timerRemainingSeconds > 0) formatTimer(timerRemainingSeconds) else "--:--"
+    // Timer text (shared by the Duration/Countdown/Specific-Time content types) — reuses the
+    // same pre-formatted string the real Announcements output shows, since that's already
+    // mode-aware (duration countdown, open-ended stopwatch, or live clock display) and there's
+    // no separate per-mode state to distinguish them here.
+    val timerText = announcementText.ifBlank { "--:--" }
 
     val mediaViewModel = LocalMediaViewModel.current
 
     val renderData = ZoneRenderData(
         currentText = currentText,
+        nextText = nextText,
         currentImageBitmap = currentImageBitmap,
         displayedSlide = displayedSlide,
         clockText = clockText,
         timerText = timerText,
-        presenterNotes = presenterNotes
+        presenterNotes = presenterNotes,
+        activeScene = activeScene,
+        displayedQuestion = displayedQuestion,
+        qaSettings = qaSettings,
+        displayedDictionaryEntry = displayedDictionaryEntry,
+        dictionarySettings = dictionarySettings
     )
 
     // Which content type is "active" for the current presenting mode. Clock is always available
     // as a fallback so a zone assigned both a live type and Clock shows the clock when idle.
     val activeTypes: Set<StageMonitorContentType> = when (presentingMode) {
-        Presenting.BIBLE -> setOf(StageMonitorContentType.BIBLE)
-        Presenting.LYRICS -> setOf(StageMonitorContentType.SONGS)
+        Presenting.BIBLE -> setOf(StageMonitorContentType.BIBLE, StageMonitorContentType.NEXT)
+        Presenting.LYRICS -> setOf(StageMonitorContentType.SONGS, StageMonitorContentType.NEXT)
         Presenting.PRESENTATION -> setOf(StageMonitorContentType.PRESENTATION, StageMonitorContentType.PRESENTATION_NOTES)
         Presenting.PICTURES -> setOf(StageMonitorContentType.PICTURES)
         Presenting.MEDIA -> setOf(StageMonitorContentType.MEDIA)
@@ -140,14 +181,7 @@ fun StageMonitorScreen(
         Presenting.CANVAS -> setOf(StageMonitorContentType.CANVAS)
         Presenting.QA -> setOf(StageMonitorContentType.QA)
         Presenting.DICTIONARY -> setOf(StageMonitorContentType.DICTIONARY)
-        // The announcement timer's exact mode (duration/countdown/specific-time) isn't surfaced
-        // here yet, so all three routes are treated as active and resolved by whichever zone
-        // each was routed to.
-        Presenting.ANNOUNCEMENTS -> setOf(
-            StageMonitorContentType.DURATION_TIMER,
-            StageMonitorContentType.COUNTDOWN_TIMER,
-            StageMonitorContentType.SPECIFIC_TIME
-        )
+        Presenting.ANNOUNCEMENTS -> setOf(StageMonitorContentType.ANNOUNCEMENT_TEXT)
         Presenting.NONE -> emptySet()
     }
 
@@ -226,11 +260,17 @@ private fun StageZoneBox(
 /** Bundles the derived per-frame state so it can be passed to whichever zone needs it. */
 private data class ZoneRenderData(
     val currentText: String,
+    val nextText: String,
     val currentImageBitmap: ImageBitmap?,
     val displayedSlide: ImageBitmap?,
     val clockText: String,
     val timerText: String,
-    val presenterNotes: String
+    val presenterNotes: String,
+    val activeScene: Scene?,
+    val displayedQuestion: Question?,
+    val qaSettings: QASettings,
+    val displayedDictionaryEntry: StrongsEntry?,
+    val dictionarySettings: DictionarySettings
 )
 
 private fun zoneContentAlignment(style: StageMonitorZoneStyle): Alignment {
@@ -270,16 +310,15 @@ private fun ZoneContent(
             }
         }
         StageMonitorContentType.CLOCK -> CenteredText(data.clockText, style)
-        StageMonitorContentType.DURATION_TIMER,
-        StageMonitorContentType.COUNTDOWN_TIMER,
-        StageMonitorContentType.SPECIFIC_TIME -> CenteredText(data.timerText, style)
+        StageMonitorContentType.ANNOUNCEMENT_TEXT -> CenteredText(data.timerText, style)
+        StageMonitorContentType.CANVAS -> ScenePresenter(modifier = Modifier.fillMaxSize(), scene = data.activeScene)
+        StageMonitorContentType.QA -> QAPresenter(question = data.displayedQuestion, qaSettings = data.qaSettings)
+        StageMonitorContentType.DICTIONARY -> DictionaryPresenter(entry = data.displayedDictionaryEntry, dictionarySettings = data.dictionarySettings)
+        StageMonitorContentType.NEXT -> TextContent(style, data.nextText)
         // No live data is plumbed through to the stage monitor for these yet.
         StageMonitorContentType.LOWER_THIRD,
         StageMonitorContentType.WEB,
-        StageMonitorContentType.STT,
-        StageMonitorContentType.CANVAS,
-        StageMonitorContentType.QA,
-        StageMonitorContentType.DICTIONARY -> {}
+        StageMonitorContentType.STT -> {}
     }
 }
 
@@ -367,13 +406,6 @@ private fun CenteredText(text: String, style: StageMonitorZoneStyle) {
 private fun formatClock(): String {
     val pattern = if (Utils.isSystemUsing24HourFormat()) "HH:mm:ss" else "hh:mm:ss a"
     return LocalTime.now().format(DateTimeFormatter.ofPattern(pattern))
-}
-
-private fun formatTimer(totalSeconds: Int): String {
-    val h = totalSeconds / 3600
-    val m = (totalSeconds % 3600) / 60
-    val s = totalSeconds % 60
-    return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%02d:%02d".format(m, s)
 }
 
 private fun buildTextStyle(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
@@ -176,17 +176,17 @@ fun StageMonitorScreen(
             }
         } else {
             Column(modifier = Modifier.fillMaxSize()) {
-                // ── TOP ROW ───────────────────────────────────────────────────
-                Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                // ── TOP ROW (fixed 2:1 against bottom = 67%; left/right split evenly 50/50) ──
+                Row(modifier = Modifier.fillMaxWidth().weight(2f)) {
                     StageZoneBox(sm, StageMonitorZone.TOP_LEFT, renderData, mediaViewModel, ::contentFor, Modifier.weight(1f))
                     VerticalDivider(color = Color.DarkGray, thickness = 1.dp)
-                    StageZoneBox(sm, StageMonitorZone.TOP_RIGHT, renderData, mediaViewModel, ::contentFor, Modifier.weight(0.45f))
+                    StageZoneBox(sm, StageMonitorZone.TOP_RIGHT, renderData, mediaViewModel, ::contentFor, Modifier.weight(1f))
                 }
 
                 HorizontalDivider(color = Color.DarkGray, thickness = 1.dp)
 
-                // ── BOTTOM ROW ────────────────────────────────────────────────
-                Row(modifier = Modifier.fillMaxWidth().weight(0.6f)) {
+                // ── BOTTOM ROW (fixed at 33% of total height, regardless of content) ──
+                Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
                     StageZoneBox(sm, StageMonitorZone.BOTTOM_LEFT, renderData, mediaViewModel, ::contentFor, Modifier.weight(1f))
                     VerticalDivider(color = Color.DarkGray, thickness = 1.dp)
                     StageZoneBox(sm, StageMonitorZone.BOTTOM_MIDDLE, renderData, mediaViewModel, ::contentFor, Modifier.weight(0.8f))

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
@@ -60,7 +60,9 @@ import org.churchpresenter.app.churchpresenter.utils.Utils
 import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
 import org.churchpresenter.app.churchpresenter.utils.Utils.systemFontFamilyOrDefault
 import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.composables.MetronomeDot
 import org.churchpresenter.app.churchpresenter.composables.SoftwareVideoPlayer
+import org.churchpresenter.app.churchpresenter.composables.toAlignment
 import org.churchpresenter.app.churchpresenter.viewmodel.LocalMediaViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.MediaViewModel
 import org.jetbrains.skia.Image as SkiaImage
@@ -238,6 +240,17 @@ fun StageMonitorScreen(
                     StageZoneBox(sm, StageMonitorZone.BOTTOM_RIGHT, renderData, mediaViewModel, ::contentFor, Modifier.weight(1f))
                 }
             }
+        }
+
+        // Metronome — a silent flash dot, only while a song is actually projected.
+        val metronomeAlignment = sm.metronomePosition.toAlignment()
+        if (metronomeAlignment != null && presentingMode == Presenting.LYRICS && currentLyricSection.bpm > 0) {
+            MetronomeDot(
+                bpm = currentLyricSection.bpm,
+                active = true,
+                size = 36.dp,
+                modifier = Modifier.align(metronomeAlignment).padding(24.dp)
+            )
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
@@ -83,6 +83,12 @@ import java.time.format.DateTimeFormatter
 fun StageMonitorScreen(
     sm: StageMonitorSettings,
     presentingMode: Presenting,
+    // True when an announcement has been routed to this stage monitor — either because it's what's
+    // actually live everywhere (presentingMode == ANNOUNCEMENTS), or because Announcements was sent
+    // here specifically via its own "Send to Stage Monitor" toggle. Kept independent of
+    // [presentingMode] so the Bible/Song/etc. zones below keep tracking whatever is really live on
+    // the main output instead of being blanked out by an announcement overlay.
+    announcementActive: Boolean = presentingMode == Presenting.ANNOUNCEMENTS,
     currentLyricSection: LyricSection,
     allLyricSections: List<LyricSection> = emptyList(),
     songDisplaySectionIndex: Int = 0,
@@ -169,20 +175,24 @@ fun StageMonitorScreen(
 
     // Which content type is "active" for the current presenting mode. Clock is always available
     // as a fallback so a zone assigned both a live type and Clock shows the clock when idle.
-    val activeTypes: Set<StageMonitorContentType> = when (presentingMode) {
-        Presenting.BIBLE -> setOf(StageMonitorContentType.BIBLE, StageMonitorContentType.NEXT)
-        Presenting.LYRICS -> setOf(StageMonitorContentType.SONGS, StageMonitorContentType.NEXT)
-        Presenting.PRESENTATION -> setOf(StageMonitorContentType.PRESENTATION, StageMonitorContentType.PRESENTATION_NOTES)
-        Presenting.PICTURES -> setOf(StageMonitorContentType.PICTURES)
-        Presenting.MEDIA -> setOf(StageMonitorContentType.MEDIA)
-        Presenting.LOWER_THIRD -> setOf(StageMonitorContentType.LOWER_THIRD)
-        Presenting.WEBSITE -> setOf(StageMonitorContentType.WEB)
-        Presenting.STT -> setOf(StageMonitorContentType.STT)
-        Presenting.CANVAS -> setOf(StageMonitorContentType.CANVAS)
-        Presenting.QA -> setOf(StageMonitorContentType.QA)
-        Presenting.DICTIONARY -> setOf(StageMonitorContentType.DICTIONARY)
-        Presenting.ANNOUNCEMENTS -> setOf(StageMonitorContentType.ANNOUNCEMENT_TEXT)
-        Presenting.NONE -> emptySet()
+    // The announcement zone is additive (see [announcementActive]) rather than exclusive, so it
+    // can be shown alongside whatever else is actually live on the main output.
+    val activeTypes: Set<StageMonitorContentType> = buildSet {
+        when (presentingMode) {
+            Presenting.BIBLE -> { add(StageMonitorContentType.BIBLE); add(StageMonitorContentType.NEXT) }
+            Presenting.LYRICS -> { add(StageMonitorContentType.SONGS); add(StageMonitorContentType.NEXT) }
+            Presenting.PRESENTATION -> { add(StageMonitorContentType.PRESENTATION); add(StageMonitorContentType.PRESENTATION_NOTES) }
+            Presenting.PICTURES -> add(StageMonitorContentType.PICTURES)
+            Presenting.MEDIA -> add(StageMonitorContentType.MEDIA)
+            Presenting.LOWER_THIRD -> add(StageMonitorContentType.LOWER_THIRD)
+            Presenting.WEBSITE -> add(StageMonitorContentType.WEB)
+            Presenting.STT -> add(StageMonitorContentType.STT)
+            Presenting.CANVAS -> add(StageMonitorContentType.CANVAS)
+            Presenting.QA -> add(StageMonitorContentType.QA)
+            Presenting.DICTIONARY -> add(StageMonitorContentType.DICTIONARY)
+            Presenting.ANNOUNCEMENTS, Presenting.NONE -> {}
+        }
+        if (announcementActive) add(StageMonitorContentType.ANNOUNCEMENT_TEXT)
     }
 
     fun contentFor(zone: StageMonitorZone): StageMonitorContentType? {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LivePreviewPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LivePreviewPanel.kt
@@ -232,13 +232,36 @@ private fun SingleDisplayPreview(
         label = "border_color"
     )
 
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .aspectRatio(presenterAspectRatio())
-            .clip(RoundedCornerShape(6.dp))
-            .border(1.dp, borderColor, RoundedCornerShape(6.dp))
-    ) {
+    val isStageMonitor = screenAssignment.displayMode == Constants.DISPLAY_MODE_STAGE_MONITOR
+    val displayModeChipLabel = when (screenAssignment.displayMode) {
+        Constants.DISPLAY_MODE_STAGE_MONITOR -> stringResource(Res.string.display_stage_monitor)
+        Constants.DISPLAY_MODE_LOWER_THIRD -> stringResource(Res.string.display_lower_third)
+        else -> null
+    }
+
+    Column(modifier = modifier) {
+        // Display mode chip (e.g. "Stage Monitor", "Lower Third") — sits above the preview so it
+        // never covers the content.
+        if (displayModeChipLabel != null) {
+            Text(
+                text = displayModeChipLabel,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 9.sp,
+                modifier = Modifier
+                    .padding(bottom = 4.dp)
+                    .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(3.dp))
+                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(3.dp))
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(presenterAspectRatio())
+                .clip(RoundedCornerShape(6.dp))
+                .border(1.dp, borderColor, RoundedCornerShape(6.dp))
+        ) {
         val primaryRole = screenAssignment.primaryOutputRole
 
         // ── Stage Monitor: dedicated presenter-confidence layout, not the normal presenter ──
@@ -246,7 +269,8 @@ private fun SingleDisplayPreview(
             ScaledPresenterContent {
                 StageMonitorScreen(
                     sm = appSettings.stageMonitorSettings,
-                    presentingMode = effectiveMode,
+                    presentingMode = presentingMode,
+                    announcementActive = effectiveMode == Presenting.ANNOUNCEMENTS,
                     currentLyricSection = displayedLyricSection,
                     allLyricSections = allLyricSections,
                     songDisplaySectionIndex = songDisplaySectionIndex,
@@ -431,75 +455,59 @@ private fun SingleDisplayPreview(
             )
         }
 
-        // LOCKED badge — shown when screen is locked to a specific tab
+        // LOCKED badge + lock toggle — not applicable to Stage Monitor screens, which route
+        // their own content dynamically and are never locked to a single tab.
         val lockedMode = screenLocks[screenIndex]
-        if (lockedMode != null) {
-            Text(
-                text = stringResource(Res.string.screen_locked_badge),
-                color = Color.White,
-                fontSize = 9.sp,
-                modifier = Modifier
-                    .align(Alignment.BottomStart)
-                    .padding(start = 4.dp, bottom = if (screenAssignment.hasKeyOutput) 24.dp else 4.dp)
-                    .background(Color(0xFFFFC107), RoundedCornerShape(3.dp))
-                    .padding(horizontal = 5.dp, vertical = 2.dp)
-            )
-        }
-
-        // Lock toggle button — bottom-right corner
-        IconButton(
-            onClick = {
-                if (lockedMode != null) {
-                    presenterManager.setScreenLock(screenIndex, null)
-                } else {
-                    presenterManager.setScreenLock(screenIndex, effectiveMode)
-                }
-            },
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(2.dp)
-                .size(24.dp),
-            colors = IconButtonDefaults.iconButtonColors(
-                contentColor = if (lockedMode != null) Color(0xFFFFC107) else Color.White.copy(alpha = 0.5f)
-            )
-        ) {
-            Icon(
-                imageVector = if (lockedMode != null) Icons.Filled.Lock else Icons.Filled.LockOpen,
-                contentDescription = if (lockedMode != null) stringResource(Res.string.unlock_screen) else stringResource(Res.string.lock_screen_to_tab),
-                modifier = Modifier.size(13.dp)
-            )
-        }
-
-        // Screen number label (+ display mode, when not the default fullscreen)
-        Column(
-            horizontalAlignment = Alignment.End,
-            modifier = Modifier.align(Alignment.TopEnd).padding(4.dp)
-        ) {
-            Text(
-                text = stringResource(Res.string.screen_number, screenIndex + 1),
-                color = Color.White.copy(alpha = 0.6f),
-                fontSize = 9.sp,
-                modifier = Modifier
-                    .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(3.dp))
-                    .padding(horizontal = 5.dp, vertical = 2.dp)
-            )
-            val modeLabel = when (screenAssignment.displayMode) {
-                Constants.DISPLAY_MODE_STAGE_MONITOR -> stringResource(Res.string.display_stage_monitor)
-                Constants.DISPLAY_MODE_LOWER_THIRD -> stringResource(Res.string.display_lower_third)
-                else -> null
-            }
-            if (modeLabel != null) {
+        if (!isStageMonitor) {
+            if (lockedMode != null) {
                 Text(
-                    text = modeLabel,
-                    color = Color.White.copy(alpha = 0.6f),
+                    text = stringResource(Res.string.screen_locked_badge),
+                    color = Color.White,
                     fontSize = 9.sp,
                     modifier = Modifier
-                        .padding(top = 2.dp)
-                        .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(3.dp))
+                        .align(Alignment.BottomStart)
+                        .padding(start = 4.dp, bottom = if (screenAssignment.hasKeyOutput) 24.dp else 4.dp)
+                        .background(Color(0xFFFFC107), RoundedCornerShape(3.dp))
                         .padding(horizontal = 5.dp, vertical = 2.dp)
                 )
             }
+
+            // Lock toggle button — bottom-right corner
+            IconButton(
+                onClick = {
+                    if (lockedMode != null) {
+                        presenterManager.setScreenLock(screenIndex, null)
+                    } else {
+                        presenterManager.setScreenLock(screenIndex, effectiveMode)
+                    }
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(2.dp)
+                    .size(24.dp),
+                colors = IconButtonDefaults.iconButtonColors(
+                    contentColor = if (lockedMode != null) Color(0xFFFFC107) else Color.White.copy(alpha = 0.5f)
+                )
+            ) {
+                Icon(
+                    imageVector = if (lockedMode != null) Icons.Filled.Lock else Icons.Filled.LockOpen,
+                    contentDescription = if (lockedMode != null) stringResource(Res.string.unlock_screen) else stringResource(Res.string.lock_screen_to_tab),
+                    modifier = Modifier.size(13.dp)
+                )
+            }
         }
+
+        // Screen number label
+        Text(
+            text = stringResource(Res.string.screen_number, screenIndex + 1),
+            color = Color.White.copy(alpha = 0.6f),
+            fontSize = 9.sp,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(4.dp)
+                .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(3.dp))
+                .padding(horizontal = 5.dp, vertical = 2.dp)
+        )
 
         // Animated audio indicator — only when presenting and media is playing
         if (effectiveMode != Presenting.NONE
@@ -514,6 +522,7 @@ private fun SingleDisplayPreview(
             ) {
                 AnimatedEqualizer()
             }
+        }
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LivePreviewPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LivePreviewPanel.kt
@@ -54,6 +54,8 @@ import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.ic_pause
 import churchpresenter.composeapp.generated.resources.ic_play
 import churchpresenter.composeapp.generated.resources.fill_badge
+import churchpresenter.composeapp.generated.resources.display_stage_monitor
+import churchpresenter.composeapp.generated.resources.display_lower_third
 import churchpresenter.composeapp.generated.resources.live_preview_nothing
 import churchpresenter.composeapp.generated.resources.live_preview_title
 import churchpresenter.composeapp.generated.resources.lock_screen_to_tab
@@ -63,6 +65,7 @@ import churchpresenter.composeapp.generated.resources.unlock_screen
 import churchpresenter.composeapp.generated.resources.pause
 import churchpresenter.composeapp.generated.resources.play
 import org.churchpresenter.app.churchpresenter.PresenterScreen
+import org.churchpresenter.app.churchpresenter.StageMonitorScreen
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
 import org.churchpresenter.app.churchpresenter.presenter.AnnouncementsPresenter
@@ -161,6 +164,7 @@ private fun SingleDisplayPreview(
     val screenLocks by presenterManager.screenLocks
     val effectiveMode = screenLocks[screenIndex] ?: presentingMode
     val displayedVerses by presenterManager.displayedVerses
+    val nextVerses by presenterManager.nextVerses
     val bibleTransitionAlpha by presenterManager.bibleTransitionAlpha
     val displayedLyricSection by presenterManager.displayedLyricSection
     val songTransitionAlpha by presenterManager.songTransitionAlpha
@@ -187,7 +191,9 @@ private fun SingleDisplayPreview(
     val websiteUrl by presenterManager.websiteUrl
     val webSnapshot by presenterManager.webSnapshot
     val activeScene by presenterManager.activeScene
+    val displayedQuestion by presenterManager.displayedQuestion
     val displayedDictionaryEntry by presenterManager.displayedDictionaryEntry
+    val presenterNotes by presenterManager.presenterNotes
     val mediaViewModel = LocalMediaViewModel.current
 
     val isLowerThird = screenAssignment.displayMode == Constants.DISPLAY_MODE_LOWER_THIRD
@@ -235,6 +241,30 @@ private fun SingleDisplayPreview(
     ) {
         val primaryRole = screenAssignment.primaryOutputRole
 
+        // ── Stage Monitor: dedicated presenter-confidence layout, not the normal presenter ──
+        if (screenAssignment.displayMode == Constants.DISPLAY_MODE_STAGE_MONITOR) {
+            ScaledPresenterContent {
+                StageMonitorScreen(
+                    sm = appSettings.stageMonitorSettings,
+                    presentingMode = effectiveMode,
+                    currentLyricSection = displayedLyricSection,
+                    allLyricSections = allLyricSections,
+                    songDisplaySectionIndex = songDisplaySectionIndex,
+                    displayedVerses = displayedVerses,
+                    nextVerses = nextVerses,
+                    announcementText = displayedAnnouncementText,
+                    displayedImagePath = displayedImagePath,
+                    displayedSlide = displayedSlide,
+                    presenterNotes = presenterNotes,
+                    activeScene = activeScene,
+                    displayedQuestion = displayedQuestion,
+                    qaSettings = appSettings.qaSettings,
+                    displayedDictionaryEntry = displayedDictionaryEntry,
+                    dictionarySettings = appSettings.dictionarySettings,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        } else
         // ── Scaled presenter content (all modes except WEBSITE) ───────────────
         // JavaFX/Swing heavyweight components cannot be scaled by Compose layout,
         // so WEBSITE is handled separately below at native size.
@@ -309,7 +339,6 @@ private fun SingleDisplayPreview(
                             Presenting.CANVAS ->
                                 ScenePresenter(scene = activeScene)
                             Presenting.QA -> {
-                                val displayedQuestion by presenterManager.displayedQuestion
                                 val showQRCode by presenterManager.showQRCodeOnDisplay
                                 if (showQRCode) {
                                     QAQRCodePresenter(url = "${qaDisplayUrl.ifEmpty { serverUrl }}/qa", qaSettings = appSettings.qaSettings)
@@ -349,7 +378,7 @@ private fun SingleDisplayPreview(
         // A second JFXPanel instance can't be scaled/clipped by Compose.
         // Instead, WebTab pushes a snapshot bitmap every 200ms via PresenterManager
         // so this panel shows a pixel-accurate mirror including scroll position.
-        if (effectiveMode == Presenting.WEBSITE) {
+        if (screenAssignment.displayMode != Constants.DISPLAY_MODE_STAGE_MONITOR && effectiveMode == Presenting.WEBSITE) {
             val snapshot = webSnapshot
             if (snapshot != null) {
                 Image(
@@ -441,17 +470,36 @@ private fun SingleDisplayPreview(
             )
         }
 
-        // Screen number label
-        Text(
-            text = stringResource(Res.string.screen_number, screenIndex + 1),
-            color = Color.White.copy(alpha = 0.6f),
-            fontSize = 9.sp,
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(4.dp)
-                .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(3.dp))
-                .padding(horizontal = 5.dp, vertical = 2.dp)
-        )
+        // Screen number label (+ display mode, when not the default fullscreen)
+        Column(
+            horizontalAlignment = Alignment.End,
+            modifier = Modifier.align(Alignment.TopEnd).padding(4.dp)
+        ) {
+            Text(
+                text = stringResource(Res.string.screen_number, screenIndex + 1),
+                color = Color.White.copy(alpha = 0.6f),
+                fontSize = 9.sp,
+                modifier = Modifier
+                    .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(3.dp))
+                    .padding(horizontal = 5.dp, vertical = 2.dp)
+            )
+            val modeLabel = when (screenAssignment.displayMode) {
+                Constants.DISPLAY_MODE_STAGE_MONITOR -> stringResource(Res.string.display_stage_monitor)
+                Constants.DISPLAY_MODE_LOWER_THIRD -> stringResource(Res.string.display_lower_third)
+                else -> null
+            }
+            if (modeLabel != null) {
+                Text(
+                    text = modeLabel,
+                    color = Color.White.copy(alpha = 0.6f),
+                    fontSize = 9.sp,
+                    modifier = Modifier
+                        .padding(top = 2.dp)
+                        .background(Color.Black.copy(alpha = 0.5f), RoundedCornerShape(3.dp))
+                        .padding(horizontal = 5.dp, vertical = 2.dp)
+                )
+            }
+        }
 
         // Animated audio indicator — only when presenting and media is playing
         if (effectiveMode != Presenting.NONE

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/MetronomeDot.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/MetronomeDot.kt
@@ -1,0 +1,71 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import org.churchpresenter.app.churchpresenter.data.settings.MetronomePosition
+
+/** Maps a free 3x3 grid position to a screen [Alignment]; NONE means the metronome is disabled. */
+fun MetronomePosition.toAlignment(): Alignment? = when (this) {
+    MetronomePosition.NONE -> null
+    MetronomePosition.TOP_LEFT -> Alignment.TopStart
+    MetronomePosition.TOP_CENTER -> Alignment.TopCenter
+    MetronomePosition.TOP_RIGHT -> Alignment.TopEnd
+    MetronomePosition.MIDDLE_LEFT -> Alignment.CenterStart
+    MetronomePosition.CENTER -> Alignment.Center
+    MetronomePosition.MIDDLE_RIGHT -> Alignment.CenterEnd
+    MetronomePosition.BOTTOM_LEFT -> Alignment.BottomStart
+    MetronomePosition.BOTTOM_CENTER -> Alignment.BottomCenter
+    MetronomePosition.BOTTOM_RIGHT -> Alignment.BottomEnd
+}
+
+/**
+ * A silent visual metronome — a dot that flashes [bpm] times per minute while [active] is true.
+ * Each flash is a brief on-pulse followed by a dark gap, so the flash count matches the tempo
+ * exactly rather than a symmetric on/off blink (which would only flash at half the BPM).
+ */
+@Composable
+fun MetronomeDot(
+    bpm: Int,
+    active: Boolean,
+    modifier: Modifier = Modifier,
+    size: Dp = 18.dp,
+    color: Color = Color.White
+) {
+    var flashOn by remember { mutableStateOf(false) }
+    LaunchedEffect(bpm, active) {
+        if (!active || bpm <= 0) {
+            flashOn = false
+            return@LaunchedEffect
+        }
+        val periodMs = 60_000L / bpm
+        val flashMs = periodMs.coerceAtMost(150L).coerceAtLeast(30L)
+        while (isActive) {
+            flashOn = true
+            delay(flashMs)
+            flashOn = false
+            delay((periodMs - flashMs).coerceAtLeast(0L))
+        }
+    }
+    Box(
+        modifier = modifier
+            .size(size)
+            .graphicsLayer(alpha = if (flashOn) 1f else 0f)
+            .background(color, CircleShape)
+    )
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/AppSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/AppSettings.kt
@@ -43,6 +43,7 @@ data class AppSettings(
     val atemSettings: AtemSettings = AtemSettings(),
     val songFavorites: List<String> = emptyList(),
     val songFavoritesPanelHeightDp: Int = 120,
+    val songBpm: Map<String, Int> = emptyMap(), // songId -> metronome BPM (0 = off), not stored in the .song file
     val songColOrder: List<String> = emptyList(),
     val songHiddenCols: Set<String> = setOf("tune", "play_count", "author", "composer"),
     val setupWizardShown: Boolean = false,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ProjectionSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ProjectionSettings.kt
@@ -12,8 +12,6 @@ data class ProjectionSettings(
     val audioOutputDeviceId: String = "", // empty = system default
     val vlcPath: String = "", // custom VLC installation directory (empty = auto-detect)
     val lowerThirdHeightPercent: Int = 33, // 10-60, used by Bible & Song presenters
-    /** Dev-mode-only testing aid: number of synthetic (non-physical) screens to simulate. */
-    val simulatedScreenCount: Int = 0,
 ) {
     fun getAssignment(index: Int): ScreenAssignment =
         screenAssignments.getOrElse(index) { ScreenAssignment() }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ProjectionSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ProjectionSettings.kt
@@ -12,6 +12,8 @@ data class ProjectionSettings(
     val audioOutputDeviceId: String = "", // empty = system default
     val vlcPath: String = "", // custom VLC installation directory (empty = auto-detect)
     val lowerThirdHeightPercent: Int = 33, // 10-60, used by Bible & Song presenters
+    /** Dev-mode-only testing aid: number of synthetic (non-physical) screens to simulate. */
+    val simulatedScreenCount: Int = 0,
 ) {
     fun getAssignment(index: Int): ScreenAssignment =
         screenAssignments.getOrElse(index) { ScreenAssignment() }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ScreenAssignment.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ScreenAssignment.kt
@@ -6,7 +6,7 @@ import org.churchpresenter.app.churchpresenter.utils.Constants
 @Serializable
 data class ScreenAssignment(
     val targetDisplay: Int = -1,  // -1 = auto (resolved at runtime), -2 = none, 0+ = specific display (legacy)
-    val targetType: String = "screen",  // "screen", "decklink", or "simulated" (dev-mode testing screen)
+    val targetType: String = "screen",  // "screen" or "decklink"
     val targetBoundsX: Int = Int.MIN_VALUE,  // screen bounds for reliable mapping (MIN_VALUE = unset)
     val targetBoundsY: Int = Int.MIN_VALUE,
     val targetBoundsW: Int = 0,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ScreenAssignment.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ScreenAssignment.kt
@@ -6,7 +6,7 @@ import org.churchpresenter.app.churchpresenter.utils.Constants
 @Serializable
 data class ScreenAssignment(
     val targetDisplay: Int = -1,  // -1 = auto (resolved at runtime), -2 = none, 0+ = specific display (legacy)
-    val targetType: String = "screen",  // "screen" or "decklink"
+    val targetType: String = "screen",  // "screen", "decklink", or "simulated" (dev-mode testing screen)
     val targetBoundsX: Int = Int.MIN_VALUE,  // screen bounds for reliable mapping (MIN_VALUE = unset)
     val targetBoundsY: Int = Int.MIN_VALUE,
     val targetBoundsW: Int = 0,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/StageMonitorSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/StageMonitorSettings.kt
@@ -30,6 +30,15 @@ enum class StageMonitorStyleZone {
     TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_MIDDLE, BOTTOM_RIGHT, FULL_SCREEN
 }
 
+/** Where the metronome flash dot is anchored on the stage monitor screen — a free 3x3 grid, independent of the content zones above (no full-screen option since it's a small overlay). */
+@Serializable
+enum class MetronomePosition {
+    NONE,
+    TOP_LEFT, TOP_CENTER, TOP_RIGHT,
+    MIDDLE_LEFT, CENTER, MIDDLE_RIGHT,
+    BOTTOM_LEFT, BOTTOM_CENTER, BOTTOM_RIGHT
+}
+
 fun StageMonitorZone.toStyleZone(): StageMonitorStyleZone? = when (this) {
     StageMonitorZone.TOP_LEFT -> StageMonitorStyleZone.TOP_LEFT
     StageMonitorZone.TOP_RIGHT -> StageMonitorStyleZone.TOP_RIGHT
@@ -63,7 +72,10 @@ data class StageMonitorSettings(
     val contentZones: Map<StageMonitorContentType, StageMonitorZone> = defaultContentZones(),
 
     // Font/color/style/alignment for each of the 6 drawable zones.
-    val zoneStyles: Map<StageMonitorStyleZone, StageMonitorZoneStyle> = defaultZoneStyles()
+    val zoneStyles: Map<StageMonitorStyleZone, StageMonitorZoneStyle> = defaultZoneStyles(),
+
+    // Where the metronome flash dot is anchored; NONE = disabled (default).
+    val metronomePosition: MetronomePosition = MetronomePosition.NONE
 ) {
     /** Safe lookup that falls back to the built-in default zone for content types missing from older saved settings. */
     fun zoneFor(type: StageMonitorContentType): StageMonitorZone =

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/StageMonitorSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/StageMonitorSettings.kt
@@ -7,7 +7,15 @@ import org.churchpresenter.app.churchpresenter.utils.Constants
 @Serializable
 enum class StageMonitorContentType {
     BIBLE, SONGS, PRESENTATION, PRESENTATION_NOTES, PICTURES, MEDIA, LOWER_THIRD, WEB, STT, CANVAS, QA, DICTIONARY,
-    CLOCK, DURATION_TIMER, COUNTDOWN_TIMER, SPECIFIC_TIME
+    CLOCK,
+    /**
+     * Announcements text and all timer variants (Duration/Countdown/Specific Time) share one
+     * pre-formatted string with no way to tell them apart, so they're a single content type —
+     * having separate entries that all show identical text just duplicated it across zones.
+     */
+    ANNOUNCEMENT_TEXT,
+    /** Next Bible verse (when presenting Bible) or next song line/section (when presenting Songs). */
+    NEXT
 }
 
 /** Where a content type is routed to on the stage monitor screen. */
@@ -51,15 +59,15 @@ data class StageMonitorZoneStyle(
 
 @Serializable
 data class StageMonitorSettings(
-    // Which zone each content type is routed to; every type defaults to Full Screen.
+    // Which zone each content type is routed to; see defaultContentZones() for per-type defaults.
     val contentZones: Map<StageMonitorContentType, StageMonitorZone> = defaultContentZones(),
 
     // Font/color/style/alignment for each of the 6 drawable zones.
     val zoneStyles: Map<StageMonitorStyleZone, StageMonitorZoneStyle> = defaultZoneStyles()
 ) {
-    /** Safe lookup that falls back to Full Screen for content types missing from older saved settings. */
+    /** Safe lookup that falls back to the built-in default zone for content types missing from older saved settings. */
     fun zoneFor(type: StageMonitorContentType): StageMonitorZone =
-        contentZones[type] ?: StageMonitorZone.FULL_SCREEN
+        contentZones[type] ?: defaultContentZones().getValue(type)
 
     /** Safe lookup that falls back to the built-in default style for zones missing from older saved settings. */
     fun styleFor(zone: StageMonitorStyleZone): StageMonitorZoneStyle =
@@ -67,28 +75,34 @@ data class StageMonitorSettings(
 
     companion object {
         fun defaultContentZones(): Map<StageMonitorContentType, StageMonitorZone> =
-            StageMonitorContentType.entries.associateWith { StageMonitorZone.FULL_SCREEN }
+            StageMonitorContentType.entries.associateWith { StageMonitorZone.FULL_SCREEN } + mapOf(
+                StageMonitorContentType.BIBLE to StageMonitorZone.TOP_LEFT,
+                StageMonitorContentType.SONGS to StageMonitorZone.TOP_LEFT,
+                StageMonitorContentType.NEXT to StageMonitorZone.TOP_RIGHT,
+                StageMonitorContentType.CLOCK to StageMonitorZone.BOTTOM_MIDDLE,
+                StageMonitorContentType.ANNOUNCEMENT_TEXT to StageMonitorZone.BOTTOM_LEFT
+            )
 
         fun defaultZoneStyles(): Map<StageMonitorStyleZone, StageMonitorZoneStyle> = mapOf(
             StageMonitorStyleZone.TOP_LEFT to StageMonitorZoneStyle(
-                fontSize = 60, color = "#FFFFFF", bgColor = "#1A1A2E", shadow = true
+                fontSize = 35, color = "#FFFFFF", bgColor = "#000000", shadow = true
             ),
             StageMonitorStyleZone.TOP_RIGHT to StageMonitorZoneStyle(
-                fontSize = 80, color = "#00FF88", bgColor = "#0D1A0D", bold = true,
+                fontSize = 35, color = "#FFFFFF", bgColor = "#000000", bold = true,
                 verticalAlignment = Constants.MIDDLE, horizontalAlignment = Constants.CENTER
             ),
             StageMonitorStyleZone.BOTTOM_LEFT to StageMonitorZoneStyle(
-                fontSize = 40, color = "#AAAAAA", bgColor = "#0D0D1A", italic = true
+                fontSize = 35, color = "#FFFFFF", bgColor = "#000000", italic = true
             ),
             StageMonitorStyleZone.BOTTOM_MIDDLE to StageMonitorZoneStyle(
-                fontSize = 72, color = "#FFFFFF", bgColor = "#000000",
+                fontSize = 35, color = "#FFFFFF", bgColor = "#000000",
                 verticalAlignment = Constants.MIDDLE, horizontalAlignment = Constants.CENTER
             ),
             StageMonitorStyleZone.BOTTOM_RIGHT to StageMonitorZoneStyle(
-                fontSize = 36, color = "#DDDDDD", bgColor = "#111111"
+                fontSize = 35, color = "#FFFFFF", bgColor = "#000000"
             ),
             StageMonitorStyleZone.FULL_SCREEN to StageMonitorZoneStyle(
-                fontSize = 90, color = "#FFFFFF", bgColor = "#000000",
+                fontSize = 80, color = "#FFFFFF", bgColor = "#000000",
                 verticalAlignment = Constants.MIDDLE, horizontalAlignment = Constants.CENTER
             )
         )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/StageMonitorSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/StageMonitorSettings.kt
@@ -3,98 +3,94 @@ package org.churchpresenter.app.churchpresenter.data.settings
 import kotlinx.serialization.Serializable
 import org.churchpresenter.app.churchpresenter.utils.Constants
 
-/** What content is displayed in a given stage monitor screen zone. */
+/** A type of content that can be routed to a zone on the stage monitor screen. */
 @Serializable
-enum class StageMonitorContent {
-    CLOCK, TIMER, NOTES, CURRENT_SLIDE, NEXT_SLIDE
+enum class StageMonitorContentType {
+    BIBLE, SONGS, PRESENTATION, PRESENTATION_NOTES, PICTURES, MEDIA, LOWER_THIRD, WEB, STT, CANVAS, QA, DICTIONARY,
+    CLOCK, DURATION_TIMER, COUNTDOWN_TIMER, SPECIFIC_TIME
+}
+
+/** Where a content type is routed to on the stage monitor screen. */
+@Serializable
+enum class StageMonitorZone {
+    TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_MIDDLE, BOTTOM_RIGHT, FULL_SCREEN, NONE
+}
+
+/** The zones that are actually drawn and therefore have their own configurable style. */
+@Serializable
+enum class StageMonitorStyleZone {
+    TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_MIDDLE, BOTTOM_RIGHT, FULL_SCREEN
+}
+
+fun StageMonitorZone.toStyleZone(): StageMonitorStyleZone? = when (this) {
+    StageMonitorZone.TOP_LEFT -> StageMonitorStyleZone.TOP_LEFT
+    StageMonitorZone.TOP_RIGHT -> StageMonitorStyleZone.TOP_RIGHT
+    StageMonitorZone.BOTTOM_LEFT -> StageMonitorStyleZone.BOTTOM_LEFT
+    StageMonitorZone.BOTTOM_MIDDLE -> StageMonitorStyleZone.BOTTOM_MIDDLE
+    StageMonitorZone.BOTTOM_RIGHT -> StageMonitorStyleZone.BOTTOM_RIGHT
+    StageMonitorZone.FULL_SCREEN -> StageMonitorStyleZone.FULL_SCREEN
+    StageMonitorZone.NONE -> null
 }
 
 @Serializable
-data class StageMonitorSettings(
-    // Which content type appears in each screen zone
-    val topLeftContent: StageMonitorContent = StageMonitorContent.CURRENT_SLIDE,
-    val topRightContent: StageMonitorContent = StageMonitorContent.TIMER,
-    val bottomLeftContent: StageMonitorContent = StageMonitorContent.NEXT_SLIDE,
-    val bottomCenterContent: StageMonitorContent = StageMonitorContent.CLOCK,
-    val bottomRightContent: StageMonitorContent = StageMonitorContent.NOTES,
-
-    // Top-Left: Current slide
-    val currentFontSize: Int = 60,
-    val currentFontType: String = "Arial",
-    val currentColor: String = "#FFFFFF",
-    val currentBgColor: String = "#1A1A2E",
-    val currentBold: Boolean = false,
-    val currentItalic: Boolean = false,
-    val currentUnderline: Boolean = false,
-    val currentShadow: Boolean = true,
-    val currentShadowColor: String = "#000000",
-    val currentShadowSize: Int = 100,
-    val currentShadowOpacity: Int = 80,
-    val currentVerticalAlignment: String = Constants.TOP,
-    val currentHorizontalAlignment: String = Constants.LEFT,
-
-    // Bottom-Left: Next slide
-    val nextFontSize: Int = 40,
-    val nextFontType: String = "Arial",
-    val nextColor: String = "#AAAAAA",
-    val nextBgColor: String = "#0D0D1A",
-    val nextBold: Boolean = false,
-    val nextItalic: Boolean = true,
-    val nextUnderline: Boolean = false,
-    val nextShadow: Boolean = false,
-    val nextShadowColor: String = "#000000",
-    val nextShadowSize: Int = 100,
-    val nextShadowOpacity: Int = 80,
-    val nextVerticalAlignment: String = Constants.TOP,
-    val nextHorizontalAlignment: String = Constants.LEFT,
-
-    // Top-Right: Timer
-    val showTimer: Boolean = true,
-    val timerFontSize: Int = 80,
-    val timerFontType: String = "Arial",
-    val timerColor: String = "#00FF88",
-    val timerBgColor: String = "#0D1A0D",
-    val timerBold: Boolean = true,
-    val timerItalic: Boolean = false,
-    val timerUnderline: Boolean = false,
-    val timerShadow: Boolean = false,
-    val timerShadowColor: String = "#000000",
-    val timerShadowSize: Int = 100,
-    val timerShadowOpacity: Int = 80,
-    // Song/Bible label shown in top-right corner of current/next panels
-    val showSongBibleLabel: Boolean = true,
-    val labelFontSize: Int = 22,
-    val labelFontType: String = "Arial",
-    val labelColor: String = "#888888",
-    val labelBold: Boolean = false,
-    val labelItalic: Boolean = false,
-
-    // Bottom-Center: Clock
-    val showClock: Boolean = true,
-    val clockFontSize: Int = 72,
-    val clockFontType: String = "Arial",
-    val clockColor: String = "#FFFFFF",
-    val clockBgColor: String = "#000000",
-    val clockBold: Boolean = false,
-    val clockItalic: Boolean = false,
-    val clockUnderline: Boolean = false,
-    val clockShadow: Boolean = false,
-    val clockShadowColor: String = "#000000",
-    val clockShadowSize: Int = 100,
-    val clockShadowOpacity: Int = 80,
-    val clockShowSeconds: Boolean = true,
-    val clockFormat24h: Boolean = true,
-
-    // Bottom-Right: Presenter Notes
-    val notesFontSize: Int = 36,
-    val notesFontType: String = "Arial",
-    val notesColor: String = "#DDDDDD",
-    val notesBgColor: String = "#111111",
-    val notesBold: Boolean = false,
-    val notesItalic: Boolean = false,
-    val notesUnderline: Boolean = false,
-    val notesShadow: Boolean = false,
-    val notesShadowColor: String = "#000000",
-    val notesShadowSize: Int = 100,
-    val notesShadowOpacity: Int = 80
+data class StageMonitorZoneStyle(
+    val fontType: String = "Arial",
+    val fontSize: Int = 40,
+    val color: String = "#FFFFFF",
+    val bgColor: String = "#1A1A2E",
+    val bold: Boolean = false,
+    val italic: Boolean = false,
+    val underline: Boolean = false,
+    val shadow: Boolean = false,
+    val shadowColor: String = "#000000",
+    val shadowSize: Int = 100,
+    val shadowOpacity: Int = 80,
+    val verticalAlignment: String = Constants.TOP,
+    val horizontalAlignment: String = Constants.LEFT
 )
+
+@Serializable
+data class StageMonitorSettings(
+    // Which zone each content type is routed to; every type defaults to Full Screen.
+    val contentZones: Map<StageMonitorContentType, StageMonitorZone> = defaultContentZones(),
+
+    // Font/color/style/alignment for each of the 6 drawable zones.
+    val zoneStyles: Map<StageMonitorStyleZone, StageMonitorZoneStyle> = defaultZoneStyles()
+) {
+    /** Safe lookup that falls back to Full Screen for content types missing from older saved settings. */
+    fun zoneFor(type: StageMonitorContentType): StageMonitorZone =
+        contentZones[type] ?: StageMonitorZone.FULL_SCREEN
+
+    /** Safe lookup that falls back to the built-in default style for zones missing from older saved settings. */
+    fun styleFor(zone: StageMonitorStyleZone): StageMonitorZoneStyle =
+        zoneStyles[zone] ?: defaultZoneStyles().getValue(zone)
+
+    companion object {
+        fun defaultContentZones(): Map<StageMonitorContentType, StageMonitorZone> =
+            StageMonitorContentType.entries.associateWith { StageMonitorZone.FULL_SCREEN }
+
+        fun defaultZoneStyles(): Map<StageMonitorStyleZone, StageMonitorZoneStyle> = mapOf(
+            StageMonitorStyleZone.TOP_LEFT to StageMonitorZoneStyle(
+                fontSize = 60, color = "#FFFFFF", bgColor = "#1A1A2E", shadow = true
+            ),
+            StageMonitorStyleZone.TOP_RIGHT to StageMonitorZoneStyle(
+                fontSize = 80, color = "#00FF88", bgColor = "#0D1A0D", bold = true,
+                verticalAlignment = Constants.MIDDLE, horizontalAlignment = Constants.CENTER
+            ),
+            StageMonitorStyleZone.BOTTOM_LEFT to StageMonitorZoneStyle(
+                fontSize = 40, color = "#AAAAAA", bgColor = "#0D0D1A", italic = true
+            ),
+            StageMonitorStyleZone.BOTTOM_MIDDLE to StageMonitorZoneStyle(
+                fontSize = 72, color = "#FFFFFF", bgColor = "#000000",
+                verticalAlignment = Constants.MIDDLE, horizontalAlignment = Constants.CENTER
+            ),
+            StageMonitorStyleZone.BOTTOM_RIGHT to StageMonitorZoneStyle(
+                fontSize = 36, color = "#DDDDDD", bgColor = "#111111"
+            ),
+            StageMonitorStyleZone.FULL_SCREEN to StageMonitorZoneStyle(
+                fontSize = 90, color = "#FFFFFF", bgColor = "#000000",
+                verticalAlignment = Constants.MIDDLE, horizontalAlignment = Constants.CENTER
+            )
+        )
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
@@ -89,6 +89,10 @@ import churchpresenter.composeapp.generated.resources.screen_lang_bible_2
 import churchpresenter.composeapp.generated.resources.screen_lang_language_1
 import churchpresenter.composeapp.generated.resources.screen_lang_language_2
 import churchpresenter.composeapp.generated.resources.screen_lang_off
+import churchpresenter.composeapp.generated.resources.simulate_screens_count
+import churchpresenter.composeapp.generated.resources.simulate_screens_help
+import churchpresenter.composeapp.generated.resources.simulate_screens_section
+import churchpresenter.composeapp.generated.resources.simulated_screen_label
 import churchpresenter.composeapp.generated.resources.song_language_both
 import churchpresenter.composeapp.generated.resources.top
 import churchpresenter.composeapp.generated.resources.vlc_browse
@@ -241,6 +245,43 @@ fun ProjectionSettingsTab(
         }
         options.toList()
     }
+
+    // ── Dev-mode-only: simulated (synthetic) screens for testing without extra monitors ──
+    val simulatedScreenCount = if (Constants.isDevMode) proj.simulatedScreenCount else 0
+    LaunchedEffect(simulatedScreenCount, presenterWindowCount) {
+        if (!Constants.isDevMode) return@LaunchedEffect
+        val baseIndex = presenterWindowCount
+        val primaryBounds = primaryDevice.defaultConfiguration.bounds
+        val assignments = proj.screenAssignments.toMutableList()
+        var changed = false
+        val simWidth = 960
+        val simHeight = 540
+        val gap = 16
+        for (n in 0 until simulatedScreenCount) {
+            val idx = baseIndex + n
+            while (assignments.size <= idx) assignments.add(ScreenAssignment())
+            if (assignments[idx].targetType != Constants.TARGET_TYPE_SIMULATED) {
+                assignments[idx] = ScreenAssignment(
+                    targetDisplay = idx,
+                    targetType = Constants.TARGET_TYPE_SIMULATED,
+                    targetBoundsX = primaryBounds.x + primaryBounds.width + gap + n * (simWidth + gap),
+                    targetBoundsY = primaryBounds.y,
+                    targetBoundsW = simWidth,
+                    targetBoundsH = simHeight
+                )
+                changed = true
+            }
+        }
+        // Trim trailing simulated slots beyond the current count — never touches real/DeckLink slots.
+        while (assignments.size > baseIndex + simulatedScreenCount && assignments.lastOrNull()?.targetType == Constants.TARGET_TYPE_SIMULATED) {
+            assignments.removeAt(assignments.lastIndex)
+            changed = true
+        }
+        if (changed) {
+            onSettingsChange { s -> s.copy(projectionSettings = s.projectionSettings.copy(screenAssignments = assignments)) }
+        }
+    }
+    val simulatedAssignments = (0 until simulatedScreenCount).map { proj.getAssignment(presenterWindowCount + it) }
 
     Box(
         modifier = Modifier

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
@@ -89,10 +89,6 @@ import churchpresenter.composeapp.generated.resources.screen_lang_bible_2
 import churchpresenter.composeapp.generated.resources.screen_lang_language_1
 import churchpresenter.composeapp.generated.resources.screen_lang_language_2
 import churchpresenter.composeapp.generated.resources.screen_lang_off
-import churchpresenter.composeapp.generated.resources.simulate_screens_count
-import churchpresenter.composeapp.generated.resources.simulate_screens_help
-import churchpresenter.composeapp.generated.resources.simulate_screens_section
-import churchpresenter.composeapp.generated.resources.simulated_screen_label
 import churchpresenter.composeapp.generated.resources.song_language_both
 import churchpresenter.composeapp.generated.resources.top
 import churchpresenter.composeapp.generated.resources.vlc_browse
@@ -245,43 +241,6 @@ fun ProjectionSettingsTab(
         }
         options.toList()
     }
-
-    // ── Dev-mode-only: simulated (synthetic) screens for testing without extra monitors ──
-    val simulatedScreenCount = if (Constants.isDevMode) proj.simulatedScreenCount else 0
-    LaunchedEffect(simulatedScreenCount, presenterWindowCount) {
-        if (!Constants.isDevMode) return@LaunchedEffect
-        val baseIndex = presenterWindowCount
-        val primaryBounds = primaryDevice.defaultConfiguration.bounds
-        val assignments = proj.screenAssignments.toMutableList()
-        var changed = false
-        val simWidth = 960
-        val simHeight = 540
-        val gap = 16
-        for (n in 0 until simulatedScreenCount) {
-            val idx = baseIndex + n
-            while (assignments.size <= idx) assignments.add(ScreenAssignment())
-            if (assignments[idx].targetType != Constants.TARGET_TYPE_SIMULATED) {
-                assignments[idx] = ScreenAssignment(
-                    targetDisplay = idx,
-                    targetType = Constants.TARGET_TYPE_SIMULATED,
-                    targetBoundsX = primaryBounds.x + primaryBounds.width + gap + n * (simWidth + gap),
-                    targetBoundsY = primaryBounds.y,
-                    targetBoundsW = simWidth,
-                    targetBoundsH = simHeight
-                )
-                changed = true
-            }
-        }
-        // Trim trailing simulated slots beyond the current count — never touches real/DeckLink slots.
-        while (assignments.size > baseIndex + simulatedScreenCount && assignments.lastOrNull()?.targetType == Constants.TARGET_TYPE_SIMULATED) {
-            assignments.removeAt(assignments.lastIndex)
-            changed = true
-        }
-        if (changed) {
-            onSettingsChange { s -> s.copy(projectionSettings = s.projectionSettings.copy(screenAssignments = assignments)) }
-        }
-    }
-    val simulatedAssignments = (0 until simulatedScreenCount).map { proj.getAssignment(presenterWindowCount + it) }
 
     Box(
         modifier = Modifier
@@ -935,6 +894,7 @@ fun ProjectionSettingsTab(
         }
 
     }
+
     // ── Card 2: Audio Output ─────────────────────────────────────────────────
     SettingsSection(title = stringResource(Res.string.audio_output)) {
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTab.kt
@@ -28,6 +28,7 @@ import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.background_color
 import churchpresenter.composeapp.generated.resources.bible
 import churchpresenter.composeapp.generated.resources.color
+import churchpresenter.composeapp.generated.resources.content_announcements
 import churchpresenter.composeapp.generated.resources.font_size
 import churchpresenter.composeapp.generated.resources.font_type
 import churchpresenter.composeapp.generated.resources.media
@@ -37,12 +38,10 @@ import churchpresenter.composeapp.generated.resources.presentation
 import churchpresenter.composeapp.generated.resources.songs
 import churchpresenter.composeapp.generated.resources.horizontal_alignment
 import churchpresenter.composeapp.generated.resources.vertical_alignment
-import churchpresenter.composeapp.generated.resources.stage_monitor_content_duration_timer
 import churchpresenter.composeapp.generated.resources.stage_monitor_content_section
-import churchpresenter.composeapp.generated.resources.stage_monitor_content_specific_time
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_clock
+import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_next
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_notes
-import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_timer
 import churchpresenter.composeapp.generated.resources.shadow_settings
 import churchpresenter.composeapp.generated.resources.stage_monitor_layout_section
 import churchpresenter.composeapp.generated.resources.stage_monitor_zone_bottom_left
@@ -178,9 +177,8 @@ private fun contentTypeLabel(type: StageMonitorContentType): String = when (type
     StageMonitorContentType.QA -> stringResource(Res.string.tab_qa)
     StageMonitorContentType.DICTIONARY -> stringResource(Res.string.tab_dictionary)
     StageMonitorContentType.CLOCK -> stringResource(Res.string.stage_monitor_quadrant_clock)
-    StageMonitorContentType.DURATION_TIMER -> stringResource(Res.string.stage_monitor_content_duration_timer)
-    StageMonitorContentType.COUNTDOWN_TIMER -> stringResource(Res.string.stage_monitor_quadrant_timer)
-    StageMonitorContentType.SPECIFIC_TIME -> stringResource(Res.string.stage_monitor_content_specific_time)
+    StageMonitorContentType.ANNOUNCEMENT_TEXT -> stringResource(Res.string.content_announcements)
+    StageMonitorContentType.NEXT -> stringResource(Res.string.stage_monitor_quadrant_next)
 }
 
 @Composable
@@ -210,7 +208,10 @@ private fun StageMonitorContentSection(
     sm: StageMonitorSettings,
     update: (StageMonitorSettings.() -> StageMonitorSettings) -> Unit
 ) {
-    val zoneOptions = StageMonitorZone.entries.map { zoneLabel(it) }
+    // Bible/Songs/Next are always meant to share the screen with other zones, never take it over.
+    val noFullScreenTypes = setOf(StageMonitorContentType.BIBLE, StageMonitorContentType.SONGS, StageMonitorContentType.NEXT)
+    val allZones = StageMonitorZone.entries.map { zoneLabel(it) }
+    val zonesWithoutFullScreen = StageMonitorZone.entries.filter { it != StageMonitorZone.FULL_SCREEN }.map { zoneLabel(it) }
     val zoneByLabel = StageMonitorZone.entries.associateBy { zoneLabel(it) }
     val types = StageMonitorContentType.entries
     val columns = types.chunked((types.size + 3) / 4)
@@ -229,7 +230,7 @@ private fun StageMonitorContentSection(
                         DropdownSettingsField(
                             label = contentTypeLabel(type),
                             value = zoneLabel(sm.zoneFor(type)),
-                            options = zoneOptions,
+                            options = if (type in noFullScreenTypes) zonesWithoutFullScreen else allZones,
                             onValueChange = { picked ->
                                 zoneByLabel[picked]?.let { zone -> update { copy(contentZones = contentZones + (type to zone)) } }
                             },

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTab.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -16,8 +15,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.Switch
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -25,27 +22,41 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.background_color
+import churchpresenter.composeapp.generated.resources.bible
 import churchpresenter.composeapp.generated.resources.color
 import churchpresenter.composeapp.generated.resources.font_size
 import churchpresenter.composeapp.generated.resources.font_type
-import churchpresenter.composeapp.generated.resources.style
+import churchpresenter.composeapp.generated.resources.media
+import churchpresenter.composeapp.generated.resources.obs_mode_lower_third
+import churchpresenter.composeapp.generated.resources.pictures
+import churchpresenter.composeapp.generated.resources.presentation
+import churchpresenter.composeapp.generated.resources.songs
 import churchpresenter.composeapp.generated.resources.horizontal_alignment
 import churchpresenter.composeapp.generated.resources.vertical_alignment
-import churchpresenter.composeapp.generated.resources.stage_monitor_clock_24h
-import churchpresenter.composeapp.generated.resources.stage_monitor_clock_show_seconds
-import churchpresenter.composeapp.generated.resources.stage_monitor_label_style_section
-import churchpresenter.composeapp.generated.resources.stage_monitor_notes_from_presentation
+import churchpresenter.composeapp.generated.resources.stage_monitor_content_duration_timer
+import churchpresenter.composeapp.generated.resources.stage_monitor_content_section
+import churchpresenter.composeapp.generated.resources.stage_monitor_content_specific_time
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_clock
-import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_current
-import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_next
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_notes
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_timer
-import churchpresenter.composeapp.generated.resources.stage_monitor_show_label
 import churchpresenter.composeapp.generated.resources.shadow_settings
 import churchpresenter.composeapp.generated.resources.stage_monitor_layout_section
+import churchpresenter.composeapp.generated.resources.stage_monitor_zone_bottom_left
+import churchpresenter.composeapp.generated.resources.stage_monitor_zone_bottom_center
+import churchpresenter.composeapp.generated.resources.stage_monitor_zone_bottom_right
+import churchpresenter.composeapp.generated.resources.stage_monitor_zone_full_screen
+import churchpresenter.composeapp.generated.resources.stage_monitor_zone_none
+import churchpresenter.composeapp.generated.resources.stage_monitor_zone_top_left
+import churchpresenter.composeapp.generated.resources.stage_monitor_zone_top_right
+import churchpresenter.composeapp.generated.resources.tab_canvas
+import churchpresenter.composeapp.generated.resources.tab_dictionary
+import churchpresenter.composeapp.generated.resources.tab_qa
+import churchpresenter.composeapp.generated.resources.tab_stt
+import churchpresenter.composeapp.generated.resources.tab_web
 import org.churchpresenter.app.churchpresenter.composables.ColorPickerField
 import org.churchpresenter.app.churchpresenter.composables.DropdownSettingsField
 import org.churchpresenter.app.churchpresenter.composables.FontSettingsDropdown
@@ -59,8 +70,11 @@ import org.churchpresenter.app.churchpresenter.composables.TvScreenBox
 import org.churchpresenter.app.churchpresenter.composables.VerticalAlignmentButtons
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
-import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorContent
+import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorContentType
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorSettings
+import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorStyleZone
+import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorZone
+import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorZoneStyle
 import org.jetbrains.compose.resources.stringResource
 import java.awt.GraphicsEnvironment
 
@@ -92,227 +106,255 @@ fun StageMonitorSettingsTab(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-            // ── Left column: Current + Next ──────────────────────────────────────
-            Column(
-                modifier = Modifier.weight(1f).widthIn(min = 320.dp, max = 480.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-            SettingsSection(title = stringResource(Res.string.stage_monitor_quadrant_current)) {
-                QuadrantFontSettings(
-                    fontType = sm.currentFontType, fontSize = sm.currentFontSize,
-                    color = sm.currentColor, bgColor = sm.currentBgColor,
-                    bold = sm.currentBold, italic = sm.currentItalic,
-                    underline = sm.currentUnderline, shadow = sm.currentShadow,
-                    shadowColor = sm.currentShadowColor, shadowSize = sm.currentShadowSize, shadowOpacity = sm.currentShadowOpacity,
-                    availableFonts = availableFonts,
-                    onFontTypeChange = { update { copy(currentFontType = it) } },
-                    onFontSizeChange = { update { copy(currentFontSize = it) } },
-                    onColorChange = { update { copy(currentColor = it) } },
-                    onBgColorChange = { update { copy(currentBgColor = it) } },
-                    onBoldChange = { update { copy(currentBold = it) } },
-                    onItalicChange = { update { copy(currentItalic = it) } },
-                    onUnderlineChange = { update { copy(currentUnderline = it) } },
-                    onShadowChange = { update { copy(currentShadow = it) } },
-                    onShadowColorChange = { update { copy(currentShadowColor = it) } },
-                    onShadowSizeChange = { update { copy(currentShadowSize = it) } },
-                    onShadowOpacityChange = { update { copy(currentShadowOpacity = it) } }
-                )
-                Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(stringResource(Res.string.vertical_alignment), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
-                    VerticalAlignmentButtons(selectedAlignment = sm.currentVerticalAlignment, onAlignmentChange = { update { copy(currentVerticalAlignment = it) } }, topValue = Constants.TOP, middleValue = Constants.MIDDLE, bottomValue = Constants.BOTTOM)
-                }
-                Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(stringResource(Res.string.horizontal_alignment), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
-                    HorizontalAlignmentButtons(selectedAlignment = sm.currentHorizontalAlignment, onAlignmentChange = { update { copy(currentHorizontalAlignment = it) } }, leftValue = Constants.LEFT, centerValue = Constants.CENTER, rightValue = Constants.RIGHT)
-                }
+                // ── Left column: content assignment + Top-Left/Top-Right style ──────
+                Column(
+                    modifier = Modifier.weight(1f).widthIn(min = 320.dp, max = 480.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    StageMonitorContentSection(sm = sm, update = ::update)
 
-            }
-
-            SettingsSection(title = stringResource(Res.string.stage_monitor_quadrant_next)) {
-                QuadrantFontSettings(
-                    fontType = sm.nextFontType, fontSize = sm.nextFontSize,
-                    color = sm.nextColor, bgColor = sm.nextBgColor,
-                    bold = sm.nextBold, italic = sm.nextItalic,
-                    underline = sm.nextUnderline, shadow = sm.nextShadow,
-                    shadowColor = sm.nextShadowColor, shadowSize = sm.nextShadowSize, shadowOpacity = sm.nextShadowOpacity,
-                    availableFonts = availableFonts,
-                    onFontTypeChange = { update { copy(nextFontType = it) } },
-                    onFontSizeChange = { update { copy(nextFontSize = it) } },
-                    onColorChange = { update { copy(nextColor = it) } },
-                    onBgColorChange = { update { copy(nextBgColor = it) } },
-                    onBoldChange = { update { copy(nextBold = it) } },
-                    onItalicChange = { update { copy(nextItalic = it) } },
-                    onUnderlineChange = { update { copy(nextUnderline = it) } },
-                    onShadowChange = { update { copy(nextShadow = it) } },
-                    onShadowColorChange = { update { copy(nextShadowColor = it) } },
-                    onShadowSizeChange = { update { copy(nextShadowSize = it) } },
-                    onShadowOpacityChange = { update { copy(nextShadowOpacity = it) } }
-                )
-                Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(stringResource(Res.string.vertical_alignment), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
-                    VerticalAlignmentButtons(selectedAlignment = sm.nextVerticalAlignment, onAlignmentChange = { update { copy(nextVerticalAlignment = it) } }, topValue = Constants.TOP, middleValue = Constants.MIDDLE, bottomValue = Constants.BOTTOM)
-                }
-                Row(modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(stringResource(Res.string.horizontal_alignment), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
-                    HorizontalAlignmentButtons(selectedAlignment = sm.nextHorizontalAlignment, onAlignmentChange = { update { copy(nextHorizontalAlignment = it) } }, leftValue = Constants.LEFT, centerValue = Constants.CENTER, rightValue = Constants.RIGHT)
-                }
-            }
-                // Song/Bible Label Style card
-                SettingsSection(title = stringResource(Res.string.stage_monitor_label_style_section)) {
-                    SettingRow(stringResource(Res.string.stage_monitor_show_label)) {
-                        Switch(checked = sm.showSongBibleLabel, onCheckedChange = { update { copy(showSongBibleLabel = it) } })
-                    }
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        FontSettingsDropdown(
-                            label = stringResource(Res.string.font_type).removeSuffix(":"),
-                            value = sm.labelFontType,
-                            fonts = availableFonts,
-                            onValueChange = { update { copy(labelFontType = it) } }
-                        )
-                        NumberSettingsTextField(
-                            label = stringResource(Res.string.font_size).removeSuffix(":"),
-                            initialText = sm.labelFontSize,
-                            onValueChange = { update { copy(labelFontSize = it) } },
-                            range = 8..100
-                        )
-                        ColorPickerField(
-                            color = sm.labelColor,
-                            onColorChange = { update { copy(labelColor = it) } },
-                            label = stringResource(Res.string.color).removeSuffix(":"),
-                            modifier = Modifier.widthIn(max = 150.dp)
-                        )
-                    }
-                    SettingRow(stringResource(Res.string.style)) {
-                        TextStyleButtons(
-                            bold = sm.labelBold,
-                            italic = sm.labelItalic,
-                            underline = false,
-                            shadow = false,
-                            onBoldChange = { update { copy(labelBold = it) } },
-                            onItalicChange = { update { copy(labelItalic = it) } },
-                            onUnderlineChange = {},
-                            onShadowChange = {}
-                        )
-                    }
-                }
-            } // end left column
-
-            // ── Right column: Timer + Clock + Notes ──────────────────────────────
-            Column(
-                modifier = Modifier.weight(1f).widthIn(min = 320.dp, max = 480.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Timer card
-                SettingsSection(title = stringResource(Res.string.stage_monitor_quadrant_timer)) {
-                    QuadrantFontSettings(
-                        fontType = sm.timerFontType, fontSize = sm.timerFontSize,
-                        color = sm.timerColor, bgColor = sm.timerBgColor,
-                        bold = sm.timerBold, italic = sm.timerItalic,
-                        underline = sm.timerUnderline, shadow = sm.timerShadow,
-                        shadowColor = sm.timerShadowColor, shadowSize = sm.timerShadowSize, shadowOpacity = sm.timerShadowOpacity,
+                    ZoneStyleSection(
+                        title = styleZoneLabel(StageMonitorStyleZone.FULL_SCREEN),
+                        style = sm.styleFor(StageMonitorStyleZone.FULL_SCREEN),
                         availableFonts = availableFonts,
-                        onFontTypeChange = { update { copy(timerFontType = it) } },
-                        onFontSizeChange = { update { copy(timerFontSize = it) } },
-                        onColorChange = { update { copy(timerColor = it) } },
-                        onBgColorChange = { update { copy(timerBgColor = it) } },
-                        onBoldChange = { update { copy(timerBold = it) } },
-                        onItalicChange = { update { copy(timerItalic = it) } },
-                        onUnderlineChange = { update { copy(timerUnderline = it) } },
-                        onShadowChange = { update { copy(timerShadow = it) } },
-                        onShadowColorChange = { update { copy(timerShadowColor = it) } },
-                        onShadowSizeChange = { update { copy(timerShadowSize = it) } },
-                        onShadowOpacityChange = { update { copy(timerShadowOpacity = it) } }
-                    )
-                }
-
-                // Clock card
-                SettingsSection(title = stringResource(Res.string.stage_monitor_quadrant_clock)) {
-                    QuadrantFontSettings(
-                        fontType = sm.clockFontType, fontSize = sm.clockFontSize,
-                        color = sm.clockColor, bgColor = sm.clockBgColor,
-                        bold = sm.clockBold, italic = sm.clockItalic,
-                        underline = sm.clockUnderline, shadow = sm.clockShadow,
-                        shadowColor = sm.clockShadowColor, shadowSize = sm.clockShadowSize, shadowOpacity = sm.clockShadowOpacity,
-                        availableFonts = availableFonts,
-                        onFontTypeChange = { update { copy(clockFontType = it) } },
-                        onFontSizeChange = { update { copy(clockFontSize = it) } },
-                        onColorChange = { update { copy(clockColor = it) } },
-                        onBgColorChange = { update { copy(clockBgColor = it) } },
-                        onBoldChange = { update { copy(clockBold = it) } },
-                        onItalicChange = { update { copy(clockItalic = it) } },
-                        onUnderlineChange = { update { copy(clockUnderline = it) } },
-                        onShadowChange = { update { copy(clockShadow = it) } },
-                        onShadowColorChange = { update { copy(clockShadowColor = it) } },
-                        onShadowSizeChange = { update { copy(clockShadowSize = it) } },
-                        onShadowOpacityChange = { update { copy(clockShadowOpacity = it) } }
-                    )
-                    Spacer(Modifier.height(8.dp))
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Checkbox(
-                                checked = sm.clockShowSeconds,
-                                onCheckedChange = { update { copy(clockShowSeconds = it) } },
-                                modifier = Modifier.size(24.dp)
-                            )
-                            Text(
-                                text = stringResource(Res.string.stage_monitor_clock_show_seconds),
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.padding(start = 6.dp)
-                            )
+                        onStyleChange = { block ->
+                            update {
+                                copy(zoneStyles = zoneStyles + (StageMonitorStyleZone.FULL_SCREEN to styleFor(StageMonitorStyleZone.FULL_SCREEN).block()))
+                            }
                         }
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Checkbox(
-                                checked = sm.clockFormat24h,
-                                onCheckedChange = { update { copy(clockFormat24h = it) } },
-                                modifier = Modifier.size(24.dp)
-                            )
-                            Text(
-                                text = stringResource(Res.string.stage_monitor_clock_24h),
-                                style = MaterialTheme.typography.bodyMedium,
-                                modifier = Modifier.padding(start = 6.dp)
-                            )
-                        }
+                    )
+
+                    listOf(StageMonitorStyleZone.TOP_LEFT, StageMonitorStyleZone.TOP_RIGHT).forEach { zone ->
+                        ZoneStyleSection(
+                            title = styleZoneLabel(zone),
+                            style = sm.styleFor(zone),
+                            availableFonts = availableFonts,
+                            onStyleChange = { block ->
+                                update { copy(zoneStyles = zoneStyles + (zone to styleFor(zone).block())) }
+                            }
+                        )
                     }
                 }
 
-                // Presenter Notes card
-                SettingsSection(title = stringResource(Res.string.stage_monitor_quadrant_notes)) {
-                    Text(
-                        text = stringResource(Res.string.stage_monitor_notes_from_presentation),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    QuadrantFontSettings(
-                        fontType = sm.notesFontType, fontSize = sm.notesFontSize,
-                        color = sm.notesColor, bgColor = sm.notesBgColor,
-                        bold = sm.notesBold, italic = sm.notesItalic,
-                        underline = sm.notesUnderline, shadow = sm.notesShadow,
-                        shadowColor = sm.notesShadowColor, shadowSize = sm.notesShadowSize, shadowOpacity = sm.notesShadowOpacity,
-                        availableFonts = availableFonts,
-                        onFontTypeChange = { update { copy(notesFontType = it) } },
-                        onFontSizeChange = { update { copy(notesFontSize = it) } },
-                        onColorChange = { update { copy(notesColor = it) } },
-                        onBgColorChange = { update { copy(notesBgColor = it) } },
-                        onBoldChange = { update { copy(notesBold = it) } },
-                        onItalicChange = { update { copy(notesItalic = it) } },
-                        onUnderlineChange = { update { copy(notesUnderline = it) } },
-                        onShadowChange = { update { copy(notesShadow = it) } },
-                        onShadowColorChange = { update { copy(notesShadowColor = it) } },
-                        onShadowSizeChange = { update { copy(notesShadowSize = it) } },
-                        onShadowOpacityChange = { update { copy(notesShadowOpacity = it) } }
-                    )
-                }
+                // ── Right column: layout preview + remaining zone styles + clock ────
+                Column(
+                    modifier = Modifier.weight(1f).widthIn(min = 320.dp, max = 480.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    StageMonitorLayoutPreviewSection(sm = sm)
 
-                StageMonitorLayoutSection(sm = sm, update = ::update)
+                    listOf(
+                        StageMonitorStyleZone.BOTTOM_LEFT,
+                        StageMonitorStyleZone.BOTTOM_MIDDLE,
+                        StageMonitorStyleZone.BOTTOM_RIGHT
+                    ).forEach { zone ->
+                        ZoneStyleSection(
+                            title = styleZoneLabel(zone),
+                            style = sm.styleFor(zone),
+                            availableFonts = availableFonts,
+                            onStyleChange = { block ->
+                                update { copy(zoneStyles = zoneStyles + (zone to styleFor(zone).block())) }
+                            }
+                        )
+                    }
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun contentTypeLabel(type: StageMonitorContentType): String = when (type) {
+    StageMonitorContentType.BIBLE -> stringResource(Res.string.bible)
+    StageMonitorContentType.SONGS -> stringResource(Res.string.songs)
+    StageMonitorContentType.PRESENTATION -> stringResource(Res.string.presentation)
+    StageMonitorContentType.PRESENTATION_NOTES -> stringResource(Res.string.stage_monitor_quadrant_notes)
+    StageMonitorContentType.PICTURES -> stringResource(Res.string.pictures)
+    StageMonitorContentType.MEDIA -> stringResource(Res.string.media)
+    StageMonitorContentType.LOWER_THIRD -> stringResource(Res.string.obs_mode_lower_third)
+    StageMonitorContentType.WEB -> stringResource(Res.string.tab_web)
+    StageMonitorContentType.STT -> stringResource(Res.string.tab_stt)
+    StageMonitorContentType.CANVAS -> stringResource(Res.string.tab_canvas)
+    StageMonitorContentType.QA -> stringResource(Res.string.tab_qa)
+    StageMonitorContentType.DICTIONARY -> stringResource(Res.string.tab_dictionary)
+    StageMonitorContentType.CLOCK -> stringResource(Res.string.stage_monitor_quadrant_clock)
+    StageMonitorContentType.DURATION_TIMER -> stringResource(Res.string.stage_monitor_content_duration_timer)
+    StageMonitorContentType.COUNTDOWN_TIMER -> stringResource(Res.string.stage_monitor_quadrant_timer)
+    StageMonitorContentType.SPECIFIC_TIME -> stringResource(Res.string.stage_monitor_content_specific_time)
+}
+
+@Composable
+private fun zoneLabel(zone: StageMonitorZone): String = when (zone) {
+    StageMonitorZone.TOP_LEFT -> stringResource(Res.string.stage_monitor_zone_top_left)
+    StageMonitorZone.TOP_RIGHT -> stringResource(Res.string.stage_monitor_zone_top_right)
+    StageMonitorZone.BOTTOM_LEFT -> stringResource(Res.string.stage_monitor_zone_bottom_left)
+    StageMonitorZone.BOTTOM_MIDDLE -> stringResource(Res.string.stage_monitor_zone_bottom_center)
+    StageMonitorZone.BOTTOM_RIGHT -> stringResource(Res.string.stage_monitor_zone_bottom_right)
+    StageMonitorZone.FULL_SCREEN -> stringResource(Res.string.stage_monitor_zone_full_screen)
+    StageMonitorZone.NONE -> stringResource(Res.string.stage_monitor_zone_none)
+}
+
+@Composable
+private fun styleZoneLabel(zone: StageMonitorStyleZone): String = when (zone) {
+    StageMonitorStyleZone.TOP_LEFT -> stringResource(Res.string.stage_monitor_zone_top_left)
+    StageMonitorStyleZone.TOP_RIGHT -> stringResource(Res.string.stage_monitor_zone_top_right)
+    StageMonitorStyleZone.BOTTOM_LEFT -> stringResource(Res.string.stage_monitor_zone_bottom_left)
+    StageMonitorStyleZone.BOTTOM_MIDDLE -> stringResource(Res.string.stage_monitor_zone_bottom_center)
+    StageMonitorStyleZone.BOTTOM_RIGHT -> stringResource(Res.string.stage_monitor_zone_bottom_right)
+    StageMonitorStyleZone.FULL_SCREEN -> stringResource(Res.string.stage_monitor_zone_full_screen)
+}
+
+/** For every content type, a dropdown choosing which zone (or none) it is routed to. */
+@Composable
+private fun StageMonitorContentSection(
+    sm: StageMonitorSettings,
+    update: (StageMonitorSettings.() -> StageMonitorSettings) -> Unit
+) {
+    val zoneOptions = StageMonitorZone.entries.map { zoneLabel(it) }
+    val zoneByLabel = StageMonitorZone.entries.associateBy { zoneLabel(it) }
+    val types = StageMonitorContentType.entries
+    val columns = types.chunked((types.size + 3) / 4)
+
+    SettingsSection(title = stringResource(Res.string.stage_monitor_content_section)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            columns.forEach { column ->
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    column.forEach { type ->
+                        DropdownSettingsField(
+                            label = contentTypeLabel(type),
+                            value = zoneLabel(sm.zoneFor(type)),
+                            options = zoneOptions,
+                            onValueChange = { picked ->
+                                zoneByLabel[picked]?.let { zone -> update { copy(contentZones = contentZones + (type to zone)) } }
+                            },
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** Visual preview of the screen: shows which content types land in each zone, as labels. */
+@Composable
+private fun StageMonitorLayoutPreviewSection(sm: StageMonitorSettings) {
+    val labeledTypes = StageMonitorContentType.entries.map { it to contentTypeLabel(it) }
+    val byZone: Map<StageMonitorZone, List<String>> = labeledTypes
+        .groupBy({ sm.zoneFor(it.first) }, { it.second })
+    fun labelsFor(zone: StageMonitorZone): String = byZone[zone].orEmpty().joinToString(", ")
+
+    SettingsSection(title = stringResource(Res.string.stage_monitor_layout_section)) {
+        TvScreenBox(
+            modifier = Modifier.fillMaxWidth(0.9f).height(200.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                    ZoneLabelCell(text = labelsFor(StageMonitorZone.TOP_LEFT), modifier = Modifier.weight(1f))
+                    ZoneLabelCell(text = labelsFor(StageMonitorZone.TOP_RIGHT), modifier = Modifier.weight(1f))
+                }
+                Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                    ZoneLabelCell(text = labelsFor(StageMonitorZone.BOTTOM_LEFT), modifier = Modifier.weight(1f))
+                    ZoneLabelCell(text = labelsFor(StageMonitorZone.BOTTOM_MIDDLE), modifier = Modifier.weight(0.8f))
+                    ZoneLabelCell(text = labelsFor(StageMonitorZone.BOTTOM_RIGHT), modifier = Modifier.weight(1f))
+                }
+            }
+        }
+        SettingRow(label = stringResource(Res.string.stage_monitor_zone_full_screen)) {
+            Text(
+                text = labelsFor(StageMonitorZone.FULL_SCREEN).ifBlank { "—" },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        SettingRow(label = stringResource(Res.string.stage_monitor_zone_none)) {
+            Text(
+                text = labelsFor(StageMonitorZone.NONE).ifBlank { "—" },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ZoneLabelCell(
+    text: String,
+    modifier: Modifier = Modifier,
+    cellColor: Color = MaterialTheme.colorScheme.surfaceVariant
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(2.dp)
+            .background(cellColor, RoundedCornerShape(4.dp))
+            .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.4f), RoundedCornerShape(4.dp))
+            .padding(4.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = text.ifBlank { "—" },
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+/** Full font/color/style/alignment editor for one drawable zone. */
+@Composable
+private fun ZoneStyleSection(
+    title: String,
+    style: StageMonitorZoneStyle,
+    availableFonts: List<String>,
+    onStyleChange: (StageMonitorZoneStyle.() -> StageMonitorZoneStyle) -> Unit
+) {
+    SettingsSection(title = title) {
+        QuadrantFontSettings(
+            fontType = style.fontType, fontSize = style.fontSize,
+            color = style.color, bgColor = style.bgColor,
+            bold = style.bold, italic = style.italic,
+            underline = style.underline, shadow = style.shadow,
+            shadowColor = style.shadowColor, shadowSize = style.shadowSize, shadowOpacity = style.shadowOpacity,
+            availableFonts = availableFonts,
+            onFontTypeChange = { v -> onStyleChange { copy(fontType = v) } },
+            onFontSizeChange = { v -> onStyleChange { copy(fontSize = v) } },
+            onColorChange = { v -> onStyleChange { copy(color = v) } },
+            onBgColorChange = { v -> onStyleChange { copy(bgColor = v) } },
+            onBoldChange = { v -> onStyleChange { copy(bold = v) } },
+            onItalicChange = { v -> onStyleChange { copy(italic = v) } },
+            onUnderlineChange = { v -> onStyleChange { copy(underline = v) } },
+            onShadowChange = { v -> onStyleChange { copy(shadow = v) } },
+            onShadowColorChange = { v -> onStyleChange { copy(shadowColor = v) } },
+            onShadowSizeChange = { v -> onStyleChange { copy(shadowSize = v) } },
+            onShadowOpacityChange = { v -> onStyleChange { copy(shadowOpacity = v) } }
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(stringResource(Res.string.vertical_alignment), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+                VerticalAlignmentButtons(
+                    selectedAlignment = style.verticalAlignment,
+                    onAlignmentChange = { v -> onStyleChange { copy(verticalAlignment = v) } },
+                    topValue = Constants.TOP, middleValue = Constants.MIDDLE, bottomValue = Constants.BOTTOM
+                )
+            }
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(stringResource(Res.string.horizontal_alignment), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
+                HorizontalAlignmentButtons(
+                    selectedAlignment = style.horizontalAlignment,
+                    onAlignmentChange = { v -> onStyleChange { copy(horizontalAlignment = v) } },
+                    leftValue = Constants.LEFT, centerValue = Constants.CENTER, rightValue = Constants.RIGHT
+                )
             }
         }
     }
@@ -366,112 +408,16 @@ private fun QuadrantFontSettings(
             label = stringResource(Res.string.background_color).removeSuffix(":"),
             modifier = Modifier.widthIn(max = 150.dp)
         )
-    }
-    SettingRow(stringResource(Res.string.style)) {
         TextStyleButtons(
             bold = bold, italic = italic, underline = underline, shadow = shadow,
             onBoldChange = onBoldChange, onItalicChange = onItalicChange,
             onUnderlineChange = onUnderlineChange, onShadowChange = onShadowChange
         )
     }
-    if (shadow) {
-        SettingRow(stringResource(Res.string.shadow_settings)) {
-            ShadowDetailRow(
-                shadowColor = shadowColor, shadowSize = shadowSize, shadowOpacity = shadowOpacity,
-                onColorChange = onShadowColorChange, onSizeChange = onShadowSizeChange, onOpacityChange = onShadowOpacityChange
-            )
-        }
-    }
-}
-
-@Composable
-private fun StageMonitorLayoutSection(
-    sm: StageMonitorSettings,
-    update: (StageMonitorSettings.() -> StageMonitorSettings) -> Unit
-) {
-    val clockLabel = stringResource(Res.string.stage_monitor_quadrant_clock)
-    val timerLabel = stringResource(Res.string.stage_monitor_quadrant_timer)
-    val notesLabel = stringResource(Res.string.stage_monitor_quadrant_notes)
-    val currentLabel = stringResource(Res.string.stage_monitor_quadrant_current)
-    val nextLabel = stringResource(Res.string.stage_monitor_quadrant_next)
-
-    fun labelFor(content: StageMonitorContent): String = when (content) {
-        StageMonitorContent.CLOCK -> clockLabel
-        StageMonitorContent.TIMER -> timerLabel
-        StageMonitorContent.NOTES -> notesLabel
-        StageMonitorContent.CURRENT_SLIDE -> currentLabel
-        StageMonitorContent.NEXT_SLIDE -> nextLabel
-    }
-
-    val contentOptions = StageMonitorContent.entries.map { labelFor(it) }
-    val contentByLabel = StageMonitorContent.entries.associateBy { labelFor(it) }
-
-    SettingsSection(title = stringResource(Res.string.stage_monitor_layout_section)) {
-        TvScreenBox(
-            modifier = Modifier.fillMaxWidth(0.9f).height(240.dp)
-        ) {
-            Column(modifier = Modifier.fillMaxSize()) {
-                Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
-                    ZoneDropdownCell(
-                        value = labelFor(sm.topLeftContent),
-                        options = contentOptions,
-                        onValueChange = { picked -> contentByLabel[picked]?.let { update { copy(topLeftContent = it) } } },
-                        modifier = Modifier.weight(1f)
-                    )
-                    ZoneDropdownCell(
-                        value = labelFor(sm.topRightContent),
-                        options = contentOptions,
-                        onValueChange = { picked -> contentByLabel[picked]?.let { update { copy(topRightContent = it) } } },
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-                Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
-                    ZoneDropdownCell(
-                        value = labelFor(sm.bottomLeftContent),
-                        options = contentOptions,
-                        onValueChange = { picked -> contentByLabel[picked]?.let { update { copy(bottomLeftContent = it) } } },
-                        modifier = Modifier.weight(1f)
-                    )
-                    ZoneDropdownCell(
-                        value = labelFor(sm.bottomCenterContent),
-                        options = contentOptions,
-                        onValueChange = { picked -> contentByLabel[picked]?.let { update { copy(bottomCenterContent = it) } } },
-                        modifier = Modifier.weight(0.8f)
-                    )
-                    ZoneDropdownCell(
-                        value = labelFor(sm.bottomRightContent),
-                        options = contentOptions,
-                        onValueChange = { picked -> contentByLabel[picked]?.let { update { copy(bottomRightContent = it) } } },
-                        modifier = Modifier.weight(1f)
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ZoneDropdownCell(
-    value: String,
-    options: List<String>,
-    onValueChange: (String) -> Unit,
-    modifier: Modifier = Modifier,
-    cellColor: Color = MaterialTheme.colorScheme.surfaceVariant
-) {
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(2.dp)
-            .background(cellColor, RoundedCornerShape(4.dp))
-            .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.4f), RoundedCornerShape(4.dp))
-            .padding(4.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        DropdownSettingsField(
-            value = value,
-            options = options,
-            onValueChange = onValueChange
+    SettingRow(stringResource(Res.string.shadow_settings)) {
+        ShadowDetailRow(
+            shadowColor = shadowColor, shadowSize = shadowSize, shadowOpacity = shadowOpacity,
+            onColorChange = onShadowColorChange, onSizeChange = onShadowSizeChange, onOpacityChange = onShadowOpacityChange
         )
     }
 }
-

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTab.kt
@@ -37,6 +37,11 @@ import churchpresenter.composeapp.generated.resources.pictures
 import churchpresenter.composeapp.generated.resources.presentation
 import churchpresenter.composeapp.generated.resources.songs
 import churchpresenter.composeapp.generated.resources.stage_monitor_content_section
+import churchpresenter.composeapp.generated.resources.stage_monitor_metronome_position
+import churchpresenter.composeapp.generated.resources.stage_monitor_position_center
+import churchpresenter.composeapp.generated.resources.stage_monitor_position_middle_left
+import churchpresenter.composeapp.generated.resources.stage_monitor_position_middle_right
+import churchpresenter.composeapp.generated.resources.stage_monitor_position_top_center
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_clock
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_next
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_notes
@@ -58,6 +63,7 @@ import org.churchpresenter.app.churchpresenter.composables.ColorPickerField
 import org.churchpresenter.app.churchpresenter.composables.DropdownSettingsField
 import org.churchpresenter.app.churchpresenter.composables.FontSettingsDropdown
 import org.churchpresenter.app.churchpresenter.composables.HorizontalAlignmentButtons
+import org.churchpresenter.app.churchpresenter.composables.MetronomeDot
 import org.churchpresenter.app.churchpresenter.composables.NumberSettingsTextField
 import org.churchpresenter.app.churchpresenter.composables.SettingRow
 import org.churchpresenter.app.churchpresenter.composables.SettingsSection
@@ -65,8 +71,10 @@ import org.churchpresenter.app.churchpresenter.composables.ShadowDetailRow
 import org.churchpresenter.app.churchpresenter.composables.TextStyleButtons
 import org.churchpresenter.app.churchpresenter.composables.TvScreenBox
 import org.churchpresenter.app.churchpresenter.composables.VerticalAlignmentButtons
+import org.churchpresenter.app.churchpresenter.composables.toAlignment
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.MetronomePosition
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorContentType
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorSettings
 import org.churchpresenter.app.churchpresenter.data.settings.StageMonitorStyleZone
@@ -191,6 +199,20 @@ private fun zoneLabel(zone: StageMonitorZone): String = when (zone) {
 }
 
 @Composable
+private fun metronomePositionLabel(position: MetronomePosition): String = when (position) {
+    MetronomePosition.NONE -> stringResource(Res.string.stage_monitor_zone_none)
+    MetronomePosition.TOP_LEFT -> stringResource(Res.string.stage_monitor_zone_top_left)
+    MetronomePosition.TOP_CENTER -> stringResource(Res.string.stage_monitor_position_top_center)
+    MetronomePosition.TOP_RIGHT -> stringResource(Res.string.stage_monitor_zone_top_right)
+    MetronomePosition.MIDDLE_LEFT -> stringResource(Res.string.stage_monitor_position_middle_left)
+    MetronomePosition.CENTER -> stringResource(Res.string.stage_monitor_position_center)
+    MetronomePosition.MIDDLE_RIGHT -> stringResource(Res.string.stage_monitor_position_middle_right)
+    MetronomePosition.BOTTOM_LEFT -> stringResource(Res.string.stage_monitor_zone_bottom_left)
+    MetronomePosition.BOTTOM_CENTER -> stringResource(Res.string.stage_monitor_zone_bottom_center)
+    MetronomePosition.BOTTOM_RIGHT -> stringResource(Res.string.stage_monitor_zone_bottom_right)
+}
+
+@Composable
 private fun styleZoneLabel(zone: StageMonitorStyleZone): String = when (zone) {
     StageMonitorStyleZone.TOP_LEFT -> stringResource(Res.string.stage_monitor_zone_top_left)
     StageMonitorStyleZone.TOP_RIGHT -> stringResource(Res.string.stage_monitor_zone_top_right)
@@ -213,6 +235,9 @@ private fun StageMonitorContentSection(
     val zoneByLabel = StageMonitorZone.entries.associateBy { zoneLabel(it) }
     val types = StageMonitorContentType.entries
     val columns = types.chunked((types.size + 3) / 4)
+
+    val metronomeOptions = MetronomePosition.entries.map { metronomePositionLabel(it) }
+    val metronomeByLabel = MetronomePosition.entries.associateBy { metronomePositionLabel(it) }
 
     SettingsSection(title = stringResource(Res.string.stage_monitor_content_section)) {
         Row(
@@ -238,6 +263,15 @@ private fun StageMonitorContentSection(
                 }
             }
         }
+        DropdownSettingsField(
+            label = stringResource(Res.string.stage_monitor_metronome_position),
+            value = metronomePositionLabel(sm.metronomePosition),
+            options = metronomeOptions,
+            onValueChange = { picked ->
+                metronomeByLabel[picked]?.let { position -> update { copy(metronomePosition = position) } }
+            },
+            modifier = Modifier.padding(vertical = 4.dp)
+        )
     }
 }
 
@@ -264,6 +298,15 @@ private fun StageMonitorLayoutPreviewSection(sm: StageMonitorSettings) {
                     ZoneLabelCell(text = labelsFor(StageMonitorZone.BOTTOM_RIGHT), modifier = Modifier.weight(1f))
                 }
             }
+            // Preview of where the metronome dot will flash — demo rate, independent of the zone grid above.
+            sm.metronomePosition.toAlignment()?.let { alignment ->
+                MetronomeDot(
+                    bpm = 100,
+                    active = true,
+                    size = 24.dp,
+                    modifier = Modifier.align(alignment).padding(6.dp)
+                )
+            }
         }
         SettingRow(label = stringResource(Res.string.stage_monitor_zone_full_screen)) {
             Text(
@@ -275,6 +318,13 @@ private fun StageMonitorLayoutPreviewSection(sm: StageMonitorSettings) {
         SettingRow(label = stringResource(Res.string.stage_monitor_zone_none)) {
             Text(
                 text = labelsFor(StageMonitorZone.NONE).ifBlank { "—" },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        SettingRow(label = stringResource(Res.string.stage_monitor_metronome_position)) {
+            Text(
+                text = metronomePositionLabel(sm.metronomePosition),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTab.kt
@@ -36,8 +36,6 @@ import churchpresenter.composeapp.generated.resources.obs_mode_lower_third
 import churchpresenter.composeapp.generated.resources.pictures
 import churchpresenter.composeapp.generated.resources.presentation
 import churchpresenter.composeapp.generated.resources.songs
-import churchpresenter.composeapp.generated.resources.horizontal_alignment
-import churchpresenter.composeapp.generated.resources.vertical_alignment
 import churchpresenter.composeapp.generated.resources.stage_monitor_content_section
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_clock
 import churchpresenter.composeapp.generated.resources.stage_monitor_quadrant_next
@@ -320,18 +318,12 @@ private fun ZoneStyleSection(
         QuadrantFontSettings(
             fontType = style.fontType, fontSize = style.fontSize,
             color = style.color, bgColor = style.bgColor,
-            bold = style.bold, italic = style.italic,
-            underline = style.underline, shadow = style.shadow,
             shadowColor = style.shadowColor, shadowSize = style.shadowSize, shadowOpacity = style.shadowOpacity,
             availableFonts = availableFonts,
             onFontTypeChange = { v -> onStyleChange { copy(fontType = v) } },
             onFontSizeChange = { v -> onStyleChange { copy(fontSize = v) } },
             onColorChange = { v -> onStyleChange { copy(color = v) } },
             onBgColorChange = { v -> onStyleChange { copy(bgColor = v) } },
-            onBoldChange = { v -> onStyleChange { copy(bold = v) } },
-            onItalicChange = { v -> onStyleChange { copy(italic = v) } },
-            onUnderlineChange = { v -> onStyleChange { copy(underline = v) } },
-            onShadowChange = { v -> onStyleChange { copy(shadow = v) } },
             onShadowColorChange = { v -> onStyleChange { copy(shadowColor = v) } },
             onShadowSizeChange = { v -> onStyleChange { copy(shadowSize = v) } },
             onShadowOpacityChange = { v -> onStyleChange { copy(shadowOpacity = v) } }
@@ -339,24 +331,28 @@ private fun ZoneStyleSection(
         Row(
             modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(Res.string.vertical_alignment), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
-                VerticalAlignmentButtons(
-                    selectedAlignment = style.verticalAlignment,
-                    onAlignmentChange = { v -> onStyleChange { copy(verticalAlignment = v) } },
-                    topValue = Constants.TOP, middleValue = Constants.MIDDLE, bottomValue = Constants.BOTTOM
-                )
-            }
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(stringResource(Res.string.horizontal_alignment), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 1)
-                HorizontalAlignmentButtons(
-                    selectedAlignment = style.horizontalAlignment,
-                    onAlignmentChange = { v -> onStyleChange { copy(horizontalAlignment = v) } },
-                    leftValue = Constants.LEFT, centerValue = Constants.CENTER, rightValue = Constants.RIGHT
-                )
-            }
+            // Bold/Italic/Underline/Shadow moved here from the font settings row above, which was
+            // getting squeezed for room with the font/size/color pickers already in it. Alignment
+            // labels dropped too — each button already has its own tooltip.
+            TextStyleButtons(
+                bold = style.bold, italic = style.italic, underline = style.underline, shadow = style.shadow,
+                onBoldChange = { v -> onStyleChange { copy(bold = v) } },
+                onItalicChange = { v -> onStyleChange { copy(italic = v) } },
+                onUnderlineChange = { v -> onStyleChange { copy(underline = v) } },
+                onShadowChange = { v -> onStyleChange { copy(shadow = v) } }
+            )
+            VerticalAlignmentButtons(
+                selectedAlignment = style.verticalAlignment,
+                onAlignmentChange = { v -> onStyleChange { copy(verticalAlignment = v) } },
+                topValue = Constants.TOP, middleValue = Constants.MIDDLE, bottomValue = Constants.BOTTOM
+            )
+            HorizontalAlignmentButtons(
+                selectedAlignment = style.horizontalAlignment,
+                onAlignmentChange = { v -> onStyleChange { copy(horizontalAlignment = v) } },
+                leftValue = Constants.LEFT, centerValue = Constants.CENTER, rightValue = Constants.RIGHT
+            )
         }
     }
 }
@@ -365,17 +361,12 @@ private fun ZoneStyleSection(
 private fun QuadrantFontSettings(
     fontType: String, fontSize: Int,
     color: String, bgColor: String,
-    bold: Boolean, italic: Boolean, underline: Boolean, shadow: Boolean,
     shadowColor: String, shadowSize: Int, shadowOpacity: Int,
     availableFonts: List<String>,
     onFontTypeChange: (String) -> Unit,
     onFontSizeChange: (Int) -> Unit,
     onColorChange: (String) -> Unit,
     onBgColorChange: (String) -> Unit,
-    onBoldChange: (Boolean) -> Unit,
-    onItalicChange: (Boolean) -> Unit,
-    onUnderlineChange: (Boolean) -> Unit,
-    onShadowChange: (Boolean) -> Unit,
     onShadowColorChange: (String) -> Unit,
     onShadowSizeChange: (Int) -> Unit,
     onShadowOpacityChange: (Int) -> Unit
@@ -408,11 +399,6 @@ private fun QuadrantFontSettings(
             onColorChange = onBgColorChange,
             label = stringResource(Res.string.background_color).removeSuffix(":"),
             modifier = Modifier.widthIn(max = 150.dp)
-        )
-        TextStyleButtons(
-            bold = bold, italic = italic, underline = underline, shadow = shadow,
-            onBoldChange = onBoldChange, onItalicChange = onItalicChange,
-            onUnderlineChange = onUnderlineChange, onShadowChange = onShadowChange
         )
     }
     SettingRow(stringResource(Res.string.shadow_settings)) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -2507,6 +2507,7 @@ private fun PresenterWindows(
                     StageMonitorScreen(
                         sm = appSettings.stageMonitorSettings,
                         presentingMode = presentingMode,
+                        announcementActive = effectiveMode == Presenting.ANNOUNCEMENTS,
                         currentLyricSection = displayedLyricSection,
                         allLyricSections = allLyricSections,
                         songDisplaySectionIndex = songDisplaySectionIndex,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -2243,7 +2243,7 @@ private fun PresenterWindows(
                             }
                         Presenting.DICTIONARY ->
                             if (screenAssignment.showDictionary)
-                                DictionaryPresenter(
+                                DictzionaryPresenter(
                                     dictionarySettings = appSettings.dictionarySettings,
                                     entry = displayedDictionaryEntry,
                                     outputRole = Constants.OUTPUT_ROLE_KEY,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -1926,8 +1926,7 @@ private fun PresenterWindows(
     val availableScreens = screens.indices.filter { screens[it] != defaultDevice }
 
     val deckLinkDeviceCount = if (DeckLinkManager.isAvailable()) DeckLinkManager.listDevices().size else 0
-    val simulatedScreenCount = if (Constants.isDevMode) proj.simulatedScreenCount else 0
-    val windowCount = availableScreens.size + deckLinkDeviceCount + simulatedScreenCount
+    val windowCount = availableScreens.size + deckLinkDeviceCount
     for (i in 0 until windowCount) {
         val screenAssignment = proj.getAssignment(i)
         val effectiveMode = screenLocks[i] ?: presentingMode
@@ -2453,26 +2452,21 @@ private fun PresenterWindows(
 
         if (screenAssignment.targetDisplay == Constants.KEY_TARGET_NONE) continue
 
-        val isSimulated = screenAssignment.targetType == Constants.TARGET_TYPE_SIMULATED
+        // Resolve target display
+        val targetScreenIndex = findScreenIndexByBounds(
+            screens,
+            screenAssignment.targetBoundsX,
+            screenAssignment.targetBoundsY,
+            screenAssignment.targetBoundsW,
+            screenAssignment.targetBoundsH
+        ) ?: if (screenAssignment.targetDisplay >= 0 && screenAssignment.targetDisplay < screens.size) {
+            screenAssignment.targetDisplay
+        } else {
+            availableScreens.getOrNull(i) ?: continue
+        }
 
-        // Resolve target display — skipped for simulated screens, which carry their own
-        // synthetic bounds directly on the assignment rather than pointing at a real device.
-        val targetScreenIndex = if (!isSimulated) {
-            findScreenIndexByBounds(
-                screens,
-                screenAssignment.targetBoundsX,
-                screenAssignment.targetBoundsY,
-                screenAssignment.targetBoundsW,
-                screenAssignment.targetBoundsH
-            ) ?: if (screenAssignment.targetDisplay >= 0 && screenAssignment.targetDisplay < screens.size) {
-                screenAssignment.targetDisplay
-            } else {
-                availableScreens.getOrNull(i) ?: continue
-            }
-        } else -1
-
-        // Skip if the target screen doesn't exist (not applicable to simulated screens)
-        if (!isSimulated && (targetScreenIndex < 0 || targetScreenIndex >= screens.size)) continue
+        // Skip if the target screen doesn't exist
+        if (targetScreenIndex < 0 || targetScreenIndex >= screens.size) continue
 
         // Per-output background toggle
         val showBg = if (screenAssignment.displayMode == Constants.DISPLAY_MODE_LOWER_THIRD) screenAssignment.showLowerThirdBackground else screenAssignment.showFullscreenBackground
@@ -2481,30 +2475,19 @@ private fun PresenterWindows(
         val primaryRole = screenAssignment.primaryOutputRole
 
         val windowState = remember(i) {
-            if (isSimulated) {
-                WindowState(
-                    placement = WindowPlacement.Floating,
-                    position = WindowPosition(screenAssignment.targetBoundsX.dp, screenAssignment.targetBoundsY.dp),
-                    width = screenAssignment.targetBoundsW.dp,
-                    height = screenAssignment.targetBoundsH.dp
-                )
-            } else {
-                val b = screens[targetScreenIndex].defaultConfiguration.bounds
-                WindowState(
-                    placement = WindowPlacement.Floating,
-                    position = WindowPosition(b.x.dp, b.y.dp),
-                    width = b.width.dp,
-                    height = b.height.dp
-                )
-            }
+            val b = screens[targetScreenIndex].defaultConfiguration.bounds
+            WindowState(
+                placement = WindowPlacement.Floating,
+                position = WindowPosition(b.x.dp, b.y.dp),
+                width = b.width.dp,
+                height = b.height.dp
+            )
         }
 
-        if (!isSimulated) {
-            LaunchedEffect(targetScreenIndex) {
-                val b = screens[targetScreenIndex].defaultConfiguration.bounds
-                windowState.position = WindowPosition(b.x.dp, b.y.dp)
-                windowState.size = DpSize(b.width.dp, b.height.dp)
-            }
+        LaunchedEffect(targetScreenIndex) {
+            val b = screens[targetScreenIndex].defaultConfiguration.bounds
+            windowState.position = WindowPosition(b.x.dp, b.y.dp)
+            windowState.size = DpSize(b.width.dp, b.height.dp)
         }
 
         // Primary window (fill or normal)
@@ -2731,7 +2714,7 @@ private fun PresenterWindows(
             }
         }
 
-        // Key output window — spawned when a key target is configured (not for simulated slots)
+        // Key output window — spawned when a key target is configured
         if (screenAssignment.hasKeyOutput && screenAssignment.keyTargetType != "decklink") {
             val keyScreenIndex = findScreenIndexByBounds(
                 screens,
@@ -2937,7 +2920,7 @@ private fun PresenterWindows(
             }
         }
 
-        // Key output on DeckLink when primary is a regular screen (not for simulated slots)
+        // Key output on DeckLink when primary is a regular screen
         if (screenAssignment.targetType != "decklink" && screenAssignment.hasKeyOutput && screenAssignment.keyTargetType == "decklink" && screenAssignment.keyTargetDisplay >= 0) {
             if (showPresenterWindow) {
                 DeckLinkComposeOutput(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -1584,6 +1584,7 @@ private fun PresenterWindows(
     val screenLocks by presenterManager.screenLocks
     val selectedVerses by presenterManager.selectedVerses
     val displayedVerses by presenterManager.displayedVerses
+    val nextVerses by presenterManager.nextVerses
     val bibleTransitionAlpha by presenterManager.bibleTransitionAlpha
     val lyricSection by presenterManager.lyricSection
     val lyricSectionVersion by presenterManager.lyricSectionVersion
@@ -1628,8 +1629,6 @@ private fun PresenterWindows(
     val qaTransitionAlpha by presenterManager.qaTransitionAlpha
     val showQRCodeOnDisplay by presenterManager.showQRCodeOnDisplay
     val displayedDictionaryEntry by presenterManager.displayedDictionaryEntry
-    val timerRemainingSeconds by presenterManager.timerRemainingSeconds
-    val timerRunning by presenterManager.timerRunning
     val presenterNotes by presenterManager.presenterNotes
 
     val proj = appSettings.projectionSettings
@@ -2243,7 +2242,7 @@ private fun PresenterWindows(
                             }
                         Presenting.DICTIONARY ->
                             if (screenAssignment.showDictionary)
-                                DictzionaryPresenter(
+                                DictionaryPresenter(
                                     dictionarySettings = appSettings.dictionarySettings,
                                     entry = displayedDictionaryEntry,
                                     outputRole = Constants.OUTPUT_ROLE_KEY,
@@ -2509,12 +2508,19 @@ private fun PresenterWindows(
                         sm = appSettings.stageMonitorSettings,
                         presentingMode = presentingMode,
                         currentLyricSection = displayedLyricSection,
+                        allLyricSections = allLyricSections,
+                        songDisplaySectionIndex = songDisplaySectionIndex,
                         displayedVerses = displayedVerses,
-                        timerRemainingSeconds = timerRemainingSeconds,
-                        timerRunning = timerRunning,
+                        nextVerses = nextVerses,
+                        announcementText = displayedAnnouncementText,
                         displayedImagePath = displayedImagePath,
                         displayedSlide = displayedSlide,
                         presenterNotes = presenterNotes,
+                        activeScene = activeScene,
+                        displayedQuestion = displayedQuestion,
+                        qaSettings = appSettings.qaSettings,
+                        displayedDictionaryEntry = displayedDictionaryEntry,
+                        dictionarySettings = appSettings.dictionarySettings,
                         modifier = Modifier.fillMaxSize()
                     )
                 } else {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -1594,13 +1594,11 @@ private fun PresenterWindows(
     val songDisplaySectionIndex by presenterManager.songDisplaySectionIndex
     val selectedImagePath by presenterManager.selectedImagePath
     val displayedImagePath by presenterManager.displayedImagePath
-    val nextImagePath by presenterManager.nextImagePath
     val pictureTransitionAlpha by presenterManager.pictureTransitionAlpha
     val previousDisplayedImagePath by presenterManager.previousDisplayedImagePath
     val pictureSlideOffset by presenterManager.pictureSlideOffset
     val selectedSlide by presenterManager.selectedSlide
     val displayedSlide by presenterManager.displayedSlide
-    val nextSlide by presenterManager.nextSlide
     val slideTransitionAlpha by presenterManager.slideTransitionAlpha
     val previousDisplayedSlide by presenterManager.previousDisplayedSlide
     val slideSlideOffset by presenterManager.slideSlideOffset
@@ -1928,7 +1926,8 @@ private fun PresenterWindows(
     val availableScreens = screens.indices.filter { screens[it] != defaultDevice }
 
     val deckLinkDeviceCount = if (DeckLinkManager.isAvailable()) DeckLinkManager.listDevices().size else 0
-    val windowCount = availableScreens.size + deckLinkDeviceCount
+    val simulatedScreenCount = if (Constants.isDevMode) proj.simulatedScreenCount else 0
+    val windowCount = availableScreens.size + deckLinkDeviceCount + simulatedScreenCount
     for (i in 0 until windowCount) {
         val screenAssignment = proj.getAssignment(i)
         val effectiveMode = screenLocks[i] ?: presentingMode
@@ -2454,21 +2453,26 @@ private fun PresenterWindows(
 
         if (screenAssignment.targetDisplay == Constants.KEY_TARGET_NONE) continue
 
-        // Resolve target display
-        val targetScreenIndex = findScreenIndexByBounds(
-            screens,
-            screenAssignment.targetBoundsX,
-            screenAssignment.targetBoundsY,
-            screenAssignment.targetBoundsW,
-            screenAssignment.targetBoundsH
-        ) ?: if (screenAssignment.targetDisplay >= 0 && screenAssignment.targetDisplay < screens.size) {
-            screenAssignment.targetDisplay
-        } else {
-            availableScreens.getOrNull(i) ?: continue
-        }
+        val isSimulated = screenAssignment.targetType == Constants.TARGET_TYPE_SIMULATED
 
-        // Skip if the target screen doesn't exist
-        if (targetScreenIndex < 0 || targetScreenIndex >= screens.size) continue
+        // Resolve target display — skipped for simulated screens, which carry their own
+        // synthetic bounds directly on the assignment rather than pointing at a real device.
+        val targetScreenIndex = if (!isSimulated) {
+            findScreenIndexByBounds(
+                screens,
+                screenAssignment.targetBoundsX,
+                screenAssignment.targetBoundsY,
+                screenAssignment.targetBoundsW,
+                screenAssignment.targetBoundsH
+            ) ?: if (screenAssignment.targetDisplay >= 0 && screenAssignment.targetDisplay < screens.size) {
+                screenAssignment.targetDisplay
+            } else {
+                availableScreens.getOrNull(i) ?: continue
+            }
+        } else -1
+
+        // Skip if the target screen doesn't exist (not applicable to simulated screens)
+        if (!isSimulated && (targetScreenIndex < 0 || targetScreenIndex >= screens.size)) continue
 
         // Per-output background toggle
         val showBg = if (screenAssignment.displayMode == Constants.DISPLAY_MODE_LOWER_THIRD) screenAssignment.showLowerThirdBackground else screenAssignment.showFullscreenBackground
@@ -2477,19 +2481,30 @@ private fun PresenterWindows(
         val primaryRole = screenAssignment.primaryOutputRole
 
         val windowState = remember(i) {
-            val b = screens[targetScreenIndex].defaultConfiguration.bounds
-            WindowState(
-                placement = WindowPlacement.Floating,
-                position = WindowPosition(b.x.dp, b.y.dp),
-                width = b.width.dp,
-                height = b.height.dp
-            )
+            if (isSimulated) {
+                WindowState(
+                    placement = WindowPlacement.Floating,
+                    position = WindowPosition(screenAssignment.targetBoundsX.dp, screenAssignment.targetBoundsY.dp),
+                    width = screenAssignment.targetBoundsW.dp,
+                    height = screenAssignment.targetBoundsH.dp
+                )
+            } else {
+                val b = screens[targetScreenIndex].defaultConfiguration.bounds
+                WindowState(
+                    placement = WindowPlacement.Floating,
+                    position = WindowPosition(b.x.dp, b.y.dp),
+                    width = b.width.dp,
+                    height = b.height.dp
+                )
+            }
         }
 
-        LaunchedEffect(targetScreenIndex) {
-            val b = screens[targetScreenIndex].defaultConfiguration.bounds
-            windowState.position = WindowPosition(b.x.dp, b.y.dp)
-            windowState.size = DpSize(b.width.dp, b.height.dp)
+        if (!isSimulated) {
+            LaunchedEffect(targetScreenIndex) {
+                val b = screens[targetScreenIndex].defaultConfiguration.bounds
+                windowState.position = WindowPosition(b.x.dp, b.y.dp)
+                windowState.size = DpSize(b.width.dp, b.height.dp)
+            }
         }
 
         // Primary window (fill or normal)
@@ -2511,16 +2526,11 @@ private fun PresenterWindows(
                         sm = appSettings.stageMonitorSettings,
                         presentingMode = presentingMode,
                         currentLyricSection = displayedLyricSection,
-                        allLyricSections = allLyricSections,
-                        songDisplaySectionIndex = songDisplaySectionIndex,
                         displayedVerses = displayedVerses,
                         timerRemainingSeconds = timerRemainingSeconds,
                         timerRunning = timerRunning,
                         displayedImagePath = displayedImagePath,
-                        nextImagePath = nextImagePath,
                         displayedSlide = displayedSlide,
-                        nextSlide = nextSlide,
-                        announcementText = displayedAnnouncementText,
                         presenterNotes = presenterNotes,
                         modifier = Modifier.fillMaxSize()
                     )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/models/LyricSection.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/models/LyricSection.kt
@@ -10,4 +10,5 @@ data class LyricSection(
     val lines: List<String> = emptyList(),
     val secondaryLines: List<String> = emptyList(),
     val isLastSection: Boolean = false,
+    val bpm: Int = 0, // metronome tempo for this song (0 = off)
 )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTab.kt
@@ -97,6 +97,7 @@ import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.add_to_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_add_to_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_go_live
+import churchpresenter.composeapp.generated.resources.tooltip_send_to_stage_monitor
 import churchpresenter.composeapp.generated.resources.tooltip_announcement_show
 import churchpresenter.composeapp.generated.resources.tooltip_announcement_hide
 import churchpresenter.composeapp.generated.resources.anim_slide_from_bottom
@@ -123,6 +124,7 @@ import churchpresenter.composeapp.generated.resources.font_type
 import churchpresenter.composeapp.generated.resources.go_live
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Cast
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Tv
 import churchpresenter.composeapp.generated.resources.ic_playlist_add
@@ -194,6 +196,45 @@ fun AnnouncementsTab(
 
     val availableFonts = remember {
         GraphicsEnvironment.getLocalGraphicsEnvironment().availableFontFamilyNames.toList()
+    }
+
+    // Screens configured as Stage Monitor — locking them to Announcements shows this content
+    // there without disturbing whatever the main projection screen(s) are currently live with.
+    // The lock persists (even as other tabs go live elsewhere) until toggled off again or Escape
+    // is pressed (see MainDesktop.kt's global Escape handler).
+    // If Stage Monitor is the ONLY configured screen there's nothing else to protect from being
+    // locked out, so the button instead behaves as a plain Go Live (global presenting mode, no
+    // per-screen lock) — same visible result, without blocking Bible/Songs from ever showing.
+    val stageMonitorScreenIndices = remember(appSettings.projectionSettings) {
+        appSettings.projectionSettings.screenAssignments.indices.filter {
+            appSettings.projectionSettings.screenAssignments[it].displayMode == Constants.DISPLAY_MODE_STAGE_MONITOR
+        }
+    }
+    val hasSeparateMainScreen = stageMonitorScreenIndices.size < appSettings.projectionSettings.screenAssignments.size
+    val canSendToStageMonitor = stageMonitorScreenIndices.isNotEmpty()
+    val currentScreenLocks = presenterManager?.screenLocks?.value ?: emptyMap()
+    val isSentToStageMonitor = if (hasSeparateMainScreen) {
+        canSendToStageMonitor && stageMonitorScreenIndices.all { currentScreenLocks[it] == Presenting.ANNOUNCEMENTS }
+    } else {
+        presenterManager?.presentingMode?.value == Presenting.ANNOUNCEMENTS
+    }
+    fun toggleStageMonitor(text: String) {
+        if (presenterManager == null || !canSendToStageMonitor) return
+        if (!hasSeparateMainScreen) {
+            if (isSentToStageMonitor) {
+                presenterManager.requestClearDisplay()
+            } else {
+                presenterManager.setAnnouncementText(text)
+                presenterManager.setPresentingMode(Presenting.ANNOUNCEMENTS)
+            }
+            return
+        }
+        if (isSentToStageMonitor) {
+            stageMonitorScreenIndices.forEach { presenterManager.setScreenLock(it, null) }
+        } else {
+            presenterManager.setAnnouncementText(text)
+            stageMonitorScreenIndices.forEach { presenterManager.setScreenLock(it, Presenting.ANNOUNCEMENTS) }
+        }
     }
 
     val timerExpiredLabel = stringResource(Res.string.timer_expired)
@@ -378,6 +419,26 @@ fun AnnouncementsTab(
                         colors = IconButtonDefaults.iconButtonColors(containerColor = MaterialTheme.colorScheme.primary, contentColor = MaterialTheme.colorScheme.onPrimary, disabledContainerColor = MaterialTheme.colorScheme.outlineVariant, disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f))
                     ) {
                         Icon(Icons.Default.Tv, contentDescription = null, modifier = Modifier.size(16.dp))
+                    }
+                }
+                if (canSendToStageMonitor) {
+                    TooltipArea(
+                        tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.tooltip_send_to_stage_monitor), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
+                        tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
+                    ) {
+                        IconButton(
+                            onClick = { toggleStageMonitor(viewModel.text) },
+                            enabled = viewModel.text.isNotBlank() || isSentToStageMonitor,
+                            modifier = Modifier.size(34.dp),
+                            colors = IconButtonDefaults.iconButtonColors(
+                                containerColor = if (isSentToStageMonitor) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+                                contentColor = if (isSentToStageMonitor) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+                                disabledContainerColor = MaterialTheme.colorScheme.outlineVariant,
+                                disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            )
+                        ) {
+                            Icon(Icons.Default.Cast, contentDescription = null, modifier = Modifier.size(16.dp))
+                        }
                     }
                 }
             }
@@ -786,6 +847,24 @@ fun AnnouncementsTab(
                                         presenterManager.setPresentingMode(Presenting.ANNOUNCEMENTS)
                                     }, colors = IconButtonDefaults.iconButtonColors(containerColor = MaterialTheme.colorScheme.primary, contentColor = MaterialTheme.colorScheme.onPrimary, disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant, disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f))) {
                                         Icon(Icons.Default.Tv, contentDescription = stringResource(Res.string.go_live), modifier = Modifier.size(20.dp))
+                                    }
+                                }
+                            }
+                            // Stage Monitor already shows its own always-on clock, so the plain
+                            // "Clock" timer mode has nothing extra to send there.
+                            if (presenterManager != null && canSendToStageMonitor && viewModel.timerMode != Constants.TIMER_MODE_CLOCK) {
+                                ConditionalTooltipArea(tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.tooltip_send_to_stage_monitor), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } }) {
+                                    IconButton(
+                                        onClick = {
+                                            val liveText = if (viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY) viewModel.liveClockText else AnnouncementsViewModel.formatTimer(displayValue)
+                                            toggleStageMonitor(liveText)
+                                        },
+                                        colors = IconButtonDefaults.iconButtonColors(
+                                            containerColor = if (isSentToStageMonitor) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceVariant,
+                                            contentColor = if (isSentToStageMonitor) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    ) {
+                                        Icon(Icons.Default.Cast, contentDescription = stringResource(Res.string.tooltip_send_to_stage_monitor), modifier = Modifier.size(20.dp))
                                     }
                                 }
                             }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTab.kt
@@ -98,6 +98,7 @@ import churchpresenter.composeapp.generated.resources.add_to_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_add_to_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_go_live
 import churchpresenter.composeapp.generated.resources.tooltip_send_to_stage_monitor
+import churchpresenter.composeapp.generated.resources.tooltip_hide_from_stage_monitor
 import churchpresenter.composeapp.generated.resources.tooltip_announcement_show
 import churchpresenter.composeapp.generated.resources.tooltip_announcement_hide
 import churchpresenter.composeapp.generated.resources.anim_slide_from_bottom
@@ -125,6 +126,7 @@ import churchpresenter.composeapp.generated.resources.go_live
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Cast
+import androidx.compose.material.icons.filled.CastConnected
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Tv
 import churchpresenter.composeapp.generated.resources.ic_playlist_add
@@ -132,9 +134,14 @@ import churchpresenter.composeapp.generated.resources.ic_refresh
 import churchpresenter.composeapp.generated.resources.ic_pause
 import churchpresenter.composeapp.generated.resources.ic_play
 import churchpresenter.composeapp.generated.resources.position_on_screen
+import churchpresenter.composeapp.generated.resources.text_color
 import churchpresenter.composeapp.generated.resources.canvas_source_clock
 import churchpresenter.composeapp.generated.resources.timer_am
 import churchpresenter.composeapp.generated.resources.timer_clock_format
+import churchpresenter.composeapp.generated.resources.timer_clock_format_12h_sec
+import churchpresenter.composeapp.generated.resources.timer_clock_format_12h
+import churchpresenter.composeapp.generated.resources.timer_clock_format_24h_sec
+import churchpresenter.composeapp.generated.resources.timer_clock_format_24h
 import churchpresenter.composeapp.generated.resources.timer_pm
 import churchpresenter.composeapp.generated.resources.timer_expired
 import churchpresenter.composeapp.generated.resources.timer_expired_text_hint
@@ -245,45 +252,32 @@ fun AnnouncementsTab(
     val minLabel          = stringResource(Res.string.timer_minutes)
     val secLabel          = stringResource(Res.string.timer_seconds)
 
-    // Auto-start timer when triggered from the schedule panel
+    // Auto-start timer when triggered from the schedule panel. The actual ticking (and pushing to
+    // the live output/Stage Monitor) now happens on presenterManager itself — see
+    // PresenterManager.startAnnouncementCountdown/CountUp/SpecificTime/ClockDisplay — so it keeps
+    // running even after this tab is switched away from.
     LaunchedEffect(scheduleTimerVersion) {
         if (scheduleTimerVersion == 0) return@LaunchedEffect
         viewModel.syncFromSettings(appSettings.announcementsSettings)
-        viewModel.resetTimer()
-        val startDisplayValue = if (viewModel.timerMode == Constants.TIMER_MODE_COUNT_UP) viewModel.countUpElapsed else viewModel.timerRemaining
-        val anyScreenOnAnnouncements = presenterManager?.presentingMode?.value == Presenting.ANNOUNCEMENTS
-            || presenterManager?.screenLocks?.value?.values?.any { it == Presenting.ANNOUNCEMENTS } == true
-        if (presenterManager != null && anyScreenOnAnnouncements) {
-            presenterManager.setAnnouncementText(AnnouncementsViewModel.formatTimer(startDisplayValue))
+        if (presenterManager == null) return@LaunchedEffect
+        when (viewModel.timerMode) {
+            Constants.TIMER_MODE_COUNT_UP -> presenterManager.startAnnouncementCountUp(viewModel.countUpElapsed)
+            Constants.TIMER_MODE_CLOCK -> presenterManager.startAnnouncementSpecificTime(viewModel.targetHour, viewModel.targetMinute, viewModel.targetSecond)
+            Constants.TIMER_MODE_CLOCK_DISPLAY -> presenterManager.startAnnouncementClockDisplay(viewModel.liveClockFormat)
+            else -> presenterManager.startAnnouncementCountdown(viewModel.timerRemaining, viewModel.timerExpiredText.ifBlank { timerExpiredLabel })
         }
-        presenterManager?.setTimerState(startDisplayValue, true)
-        viewModel.startPauseTimer(
-            onTick = { remaining ->
-                val anyScreen = presenterManager?.presentingMode?.value == Presenting.ANNOUNCEMENTS
-                    || presenterManager?.screenLocks?.value?.values?.any { it == Presenting.ANNOUNCEMENTS } == true
-                if (presenterManager != null && anyScreen)
-                    presenterManager.setAnnouncementText(AnnouncementsViewModel.formatTimer(remaining))
-                presenterManager?.setTimerState(remaining, true)
-            },
-            onExpired = { expiredMsg ->
-                if (presenterManager != null) {
-                    presenterManager.setAnnouncementText(expiredMsg.ifBlank { timerExpiredLabel })
-                    presenterManager.setPresentingMode(Presenting.ANNOUNCEMENTS)
-                    presenterManager.setTimerState(0, false)
-                }
-            }
-        )
     }
 
-    // The live clock has no Start/tick callback of its own, so keep the output screen in sync
-    // with it directly whenever it ticks (every second) while it's the mode being shown live.
-    LaunchedEffect(viewModel.liveClockText) {
-        if (viewModel.timerMode != Constants.TIMER_MODE_CLOCK_DISPLAY) return@LaunchedEffect
-        val anyScreenOnAnnouncements = presenterManager?.presentingMode?.value == Presenting.ANNOUNCEMENTS
-            || presenterManager?.screenLocks?.value?.values?.any { it == Presenting.ANNOUNCEMENTS } == true
-        if (presenterManager != null && anyScreenOnAnnouncements) {
-            presenterManager.setAnnouncementText(viewModel.liveClockText)
-        }
+    // Duration/Count-up now tick on presenterManager (see above), so "is it running" and "what's
+    // the current value" must be read from there rather than from the tab's own ViewModel, which
+    // may have been recreated since the countdown was actually started.
+    val isDurationOrCountUp = viewModel.timerMode == Constants.TIMER_MODE_DURATION || viewModel.timerMode == Constants.TIMER_MODE_COUNT_UP
+    val isTimerRunning = isDurationOrCountUp && presenterManager?.timerRunning?.value == true
+    val isTimerExpired = viewModel.timerMode == Constants.TIMER_MODE_DURATION && presenterManager?.announcementTimerExpired?.value == true
+    val timerDisplayValue = when {
+        isTimerRunning -> presenterManager!!.timerRemainingSeconds.value
+        viewModel.timerMode == Constants.TIMER_MODE_COUNT_UP -> viewModel.countUpElapsed
+        else -> viewModel.timerRemaining
     }
 
     val density = LocalDensity.current
@@ -386,7 +380,7 @@ fun AnnouncementsTab(
                 }
             }
             if (presenterManager != null) {
-                val announcementTextIsLive = presenterManager.presentingMode.value == Presenting.ANNOUNCEMENTS && !viewModel.timerRunning
+                val announcementTextIsLive = presenterManager.presentingMode.value == Presenting.ANNOUNCEMENTS && !isTimerRunning
                 TooltipArea(
                     tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(if (announcementTextIsLive) Res.string.tooltip_announcement_hide else Res.string.tooltip_announcement_show), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
                     tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
@@ -394,7 +388,7 @@ fun AnnouncementsTab(
                     IconButton(
                         onClick = {
                             if (announcementTextIsLive) presenterManager.requestClearDisplay()
-                            else { if (viewModel.timerRunning) viewModel.pauseTimer(); presenterManager.setAnnouncementText(viewModel.text); presenterManager.setPresentingMode(Presenting.ANNOUNCEMENTS) }
+                            else { viewModel.pauseTimer(presenterManager); presenterManager.setAnnouncementText(viewModel.text); presenterManager.setPresentingMode(Presenting.ANNOUNCEMENTS) }
                         },
                         enabled = viewModel.text.isNotBlank() || announcementTextIsLive,
                         modifier = Modifier.size(34.dp),
@@ -423,7 +417,7 @@ fun AnnouncementsTab(
                 }
                 if (canSendToStageMonitor) {
                     TooltipArea(
-                        tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.tooltip_send_to_stage_monitor), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
+                        tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(if (isSentToStageMonitor) stringResource(Res.string.tooltip_hide_from_stage_monitor) else stringResource(Res.string.tooltip_send_to_stage_monitor), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
                         tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
                     ) {
                         IconButton(
@@ -437,7 +431,7 @@ fun AnnouncementsTab(
                                 disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                             )
                         ) {
-                            Icon(Icons.Default.Cast, contentDescription = null, modifier = Modifier.size(16.dp))
+                            Icon(if (isSentToStageMonitor) Icons.Default.CastConnected else Icons.Default.Cast, contentDescription = null, modifier = Modifier.size(16.dp))
                         }
                     }
                 }
@@ -455,7 +449,7 @@ fun AnnouncementsTab(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            ColorPickerField(color = viewModel.textColor, onColorChange = { viewModel.setTextColor(it); viewModel.saveToSettings(onSettingsChange) }, modifier = Modifier.width(120.dp))
+            ColorPickerField(label = stringResource(Res.string.text_color), color = viewModel.textColor, onColorChange = { viewModel.setTextColor(it); viewModel.saveToSettings(onSettingsChange) }, modifier = Modifier.width(120.dp))
             HorizontalDivider(modifier = Modifier.height(22.dp).width(1.dp), color = MaterialTheme.colorScheme.outlineVariant)
             TextStyleButtons(
                 bold = viewModel.bold, italic = viewModel.italic, underline = viewModel.underline, shadow = viewModel.shadow,
@@ -624,6 +618,9 @@ fun AnnouncementsTab(
                                 ),
                                 selectedValue = viewModel.timerMode,
                                 onValueChange = { mode ->
+                                    // Switching modes makes whatever was ticking on presenterManager stale
+                                    // (it's counting down/up for a mode that's no longer selected) — stop it.
+                                    presenterManager?.pauseAnnouncementTimer(0)
                                     viewModel.setTimerMode(mode)
                                     viewModel.saveToSettings(onSettingsChange)
                                 },
@@ -636,13 +633,12 @@ fun AnnouncementsTab(
                         // Countdown / count-up / live clock display
                         Text(
                             text = when {
-                                viewModel.timerExpired -> viewModel.timerExpiredText.ifBlank { timerExpiredLabel }
-                                viewModel.timerMode == Constants.TIMER_MODE_COUNT_UP -> AnnouncementsViewModel.formatTimer(viewModel.countUpElapsed)
+                                isTimerExpired -> viewModel.timerExpiredText.ifBlank { timerExpiredLabel }
                                 viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY -> viewModel.liveClockText
-                                else -> AnnouncementsViewModel.formatTimer(viewModel.timerRemaining)
+                                else -> AnnouncementsViewModel.formatTimer(timerDisplayValue)
                             },
                             style = MaterialTheme.typography.displayMedium,
-                            color = if (viewModel.timerExpired) MaterialTheme.colorScheme.error
+                            color = if (isTimerExpired) MaterialTheme.colorScheme.error
                                     else MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.fillMaxWidth(),
                             textAlign = TextAlign.Center
@@ -762,10 +758,19 @@ fun AnnouncementsTab(
                                 }
                             }
                         } else if (viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY) {
+                            val clockFormatLabels = mapOf(
+                                "h:mm:ss a" to stringResource(Res.string.timer_clock_format_12h_sec),
+                                "h:mm a" to stringResource(Res.string.timer_clock_format_12h),
+                                "HH:mm:ss" to stringResource(Res.string.timer_clock_format_24h_sec),
+                                "HH:mm" to stringResource(Res.string.timer_clock_format_24h)
+                            )
+                            val patternForLabel = clockFormatLabels.entries.associate { (pattern, label) -> label to pattern }
                             DropdownSettingsField(
-                                value = viewModel.liveClockFormat,
-                                options = listOf("h:mm:ss a", "h:mm a", "HH:mm:ss", "HH:mm"),
-                                onValueChange = { viewModel.setLiveClockFormat(it); viewModel.saveToSettings(onSettingsChange) },
+                                value = clockFormatLabels[viewModel.liveClockFormat] ?: viewModel.liveClockFormat,
+                                options = clockFormatLabels.values.toList(),
+                                onValueChange = { picked ->
+                                    patternForLabel[picked]?.let { viewModel.setLiveClockFormat(it); viewModel.saveToSettings(onSettingsChange) }
+                                },
                                 label = stringResource(Res.string.timer_clock_format),
                                 modifier = Modifier.fillMaxWidth()
                             )
@@ -781,44 +786,24 @@ fun AnnouncementsTab(
                         ) {
                             val total = viewModel.timerHours * 3600 + viewModel.timerMinutes * 60 + viewModel.timerSeconds
                             val isClockDisplay = viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY
-                            val displayValue = if (viewModel.timerMode == Constants.TIMER_MODE_COUNT_UP) viewModel.countUpElapsed else viewModel.timerRemaining
-                            val displayText = if (isClockDisplay) viewModel.liveClockText else AnnouncementsViewModel.formatTimer(displayValue)
                             // Only Timer/Duration have a real play/pause concept. Specific Time and the
                             // live Clock always track automatically — "Go Live" is enough to push them.
                             val hasPlayPause = viewModel.timerMode == Constants.TIMER_MODE_DURATION || viewModel.timerMode == Constants.TIMER_MODE_COUNT_UP
                             if (hasPlayPause) {
-                                ConditionalTooltipArea(tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(if (viewModel.timerRunning) pauseLabel else startLabel, color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } }) {
+                                ConditionalTooltipArea(tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(if (isTimerRunning) pauseLabel else startLabel, color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } }) {
                                     IconButton(
                                         onClick = {
                                             viewModel.saveToSettings(onSettingsChange)
-                                            val anyScreenOnAnnouncements = presenterManager?.presentingMode?.value == Presenting.ANNOUNCEMENTS || presenterManager?.screenLocks?.value?.values?.any { it == Presenting.ANNOUNCEMENTS } == true
-                                            if (!viewModel.timerRunning && presenterManager != null && anyScreenOnAnnouncements) {
-                                                presenterManager.setAnnouncementText(displayText)
-                                            }
-                                            presenterManager?.setTimerState(displayValue, !viewModel.timerRunning)
-                                            viewModel.startPauseTimer(
-                                                onTick = { remaining ->
-                                                    val anyScreenOnAnnouncements = presenterManager?.presentingMode?.value == Presenting.ANNOUNCEMENTS || presenterManager?.screenLocks?.value?.values?.any { it == Presenting.ANNOUNCEMENTS } == true
-                                                    if (presenterManager != null && anyScreenOnAnnouncements) presenterManager.setAnnouncementText(AnnouncementsViewModel.formatTimer(remaining))
-                                                    presenterManager?.setTimerState(remaining, true)
-                                                },
-                                                onExpired = { expiredMsg ->
-                                                    if (presenterManager != null) {
-                                                        presenterManager.setAnnouncementText(expiredMsg.ifBlank { timerExpiredLabel })
-                                                        presenterManager.setPresentingMode(Presenting.ANNOUNCEMENTS)
-                                                        presenterManager.setTimerState(0, false)
-                                                    }
-                                                }
-                                            )
+                                            viewModel.startPauseTimer(presenterManager)
                                         },
-                                        enabled = viewModel.timerMode != Constants.TIMER_MODE_DURATION || total > 0 || viewModel.timerRunning,
+                                        enabled = viewModel.timerMode != Constants.TIMER_MODE_DURATION || total > 0 || isTimerRunning,
                                         colors = IconButtonDefaults.iconButtonColors(
-                                            containerColor = if (viewModel.timerRunning) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.primaryContainer,
+                                            containerColor = if (isTimerRunning) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.primaryContainer,
                                             disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
                                             disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                                         )
                                     ) {
-                                        Icon(painter = painterResource(if (viewModel.timerRunning) Res.drawable.ic_pause else Res.drawable.ic_play), contentDescription = if (viewModel.timerRunning) pauseLabel else startLabel, tint = if (viewModel.timerRunning) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onPrimaryContainer)
+                                        Icon(painter = painterResource(if (isTimerRunning) Res.drawable.ic_pause else Res.drawable.ic_play), contentDescription = if (isTimerRunning) pauseLabel else startLabel, tint = if (isTimerRunning) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onPrimaryContainer)
                                     }
                                 }
                             }
@@ -827,7 +812,7 @@ fun AnnouncementsTab(
                             // clock automatically — there's nothing to reset back to.
                             if (hasPlayPause) {
                                 ConditionalTooltipArea(tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(resetLabel, color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } }) {
-                                    IconButton(onClick = { viewModel.resetTimer(); val resetValue = if (viewModel.timerMode == Constants.TIMER_MODE_COUNT_UP) viewModel.countUpElapsed else viewModel.timerRemaining; presenterManager?.setTimerState(resetValue, false) }, colors = IconButtonDefaults.iconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceVariant, contentColor = MaterialTheme.colorScheme.onSurfaceVariant)) {
+                                    IconButton(onClick = { viewModel.resetTimer(presenterManager) }, colors = IconButtonDefaults.iconButtonColors(containerColor = MaterialTheme.colorScheme.surfaceVariant, contentColor = MaterialTheme.colorScheme.onSurfaceVariant)) {
                                         Icon(painter = painterResource(Res.drawable.ic_refresh), contentDescription = resetLabel, modifier = Modifier.size(20.dp))
                                     }
                                 }
@@ -842,7 +827,14 @@ fun AnnouncementsTab(
                             if (presenterManager != null) {
                                 ConditionalTooltipArea(tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.tooltip_go_live), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } }) {
                                     IconButton(onClick = {
-                                        val liveText = if (viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY) viewModel.liveClockText else AnnouncementsViewModel.formatTimer(displayValue)
+                                        // Specific Time / Clock Display have no Start button of their own —
+                                        // Go Live is what kicks off their always-on ticking.
+                                        when (viewModel.timerMode) {
+                                            Constants.TIMER_MODE_CLOCK -> presenterManager.startAnnouncementSpecificTime(viewModel.targetHour, viewModel.targetMinute, viewModel.targetSecond)
+                                            Constants.TIMER_MODE_CLOCK_DISPLAY -> presenterManager.startAnnouncementClockDisplay(viewModel.liveClockFormat)
+                                            else -> {}
+                                        }
+                                        val liveText = if (viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY) viewModel.liveClockText else AnnouncementsViewModel.formatTimer(timerDisplayValue)
                                         presenterManager.setAnnouncementText(liveText)
                                         presenterManager.setPresentingMode(Presenting.ANNOUNCEMENTS)
                                     }, colors = IconButtonDefaults.iconButtonColors(containerColor = MaterialTheme.colorScheme.primary, contentColor = MaterialTheme.colorScheme.onPrimary, disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant, disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f))) {
@@ -852,11 +844,16 @@ fun AnnouncementsTab(
                             }
                             // Stage Monitor already shows its own always-on clock, so the plain
                             // "Clock" timer mode has nothing extra to send there.
-                            if (presenterManager != null && canSendToStageMonitor && viewModel.timerMode != Constants.TIMER_MODE_CLOCK) {
-                                ConditionalTooltipArea(tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.tooltip_send_to_stage_monitor), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } }) {
+                            if (presenterManager != null && canSendToStageMonitor && viewModel.timerMode != Constants.TIMER_MODE_CLOCK_DISPLAY) {
+                                ConditionalTooltipArea(tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(if (isSentToStageMonitor) stringResource(Res.string.tooltip_hide_from_stage_monitor) else stringResource(Res.string.tooltip_send_to_stage_monitor), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } }) {
                                     IconButton(
                                         onClick = {
-                                            val liveText = if (viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY) viewModel.liveClockText else AnnouncementsViewModel.formatTimer(displayValue)
+                                            // Specific Time has no Start button of its own — sending it to
+                                            // Stage Monitor is what kicks off its always-on ticking.
+                                            if (!isSentToStageMonitor && viewModel.timerMode == Constants.TIMER_MODE_CLOCK) {
+                                                presenterManager.startAnnouncementSpecificTime(viewModel.targetHour, viewModel.targetMinute, viewModel.targetSecond)
+                                            }
+                                            val liveText = AnnouncementsViewModel.formatTimer(timerDisplayValue)
                                             toggleStageMonitor(liveText)
                                         },
                                         colors = IconButtonDefaults.iconButtonColors(
@@ -864,7 +861,7 @@ fun AnnouncementsTab(
                                             contentColor = if (isSentToStageMonitor) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.onSurfaceVariant
                                         )
                                     ) {
-                                        Icon(Icons.Default.Cast, contentDescription = stringResource(Res.string.tooltip_send_to_stage_monitor), modifier = Modifier.size(20.dp))
+                                        Icon(if (isSentToStageMonitor) Icons.Default.CastConnected else Icons.Default.Cast, contentDescription = if (isSentToStageMonitor) stringResource(Res.string.tooltip_hide_from_stage_monitor) else stringResource(Res.string.tooltip_send_to_stage_monitor), modifier = Modifier.size(20.dp))
                                     }
                                 }
                             }
@@ -932,21 +929,19 @@ fun AnnouncementsTab(
                     // preview the counter while actively running, and otherwise fall back to the
                     // expired message or plain announcement text.
                     val previewText = when {
-                        viewModel.timerExpired -> viewModel.timerExpiredText.ifBlank { timerExpiredLabel }
+                        isTimerExpired -> viewModel.timerExpiredText.ifBlank { timerExpiredLabel }
                         viewModel.timerMode == Constants.TIMER_MODE_CLOCK -> AnnouncementsViewModel.formatTimer(viewModel.timerRemaining)
                         viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY -> viewModel.liveClockText
-                        viewModel.timerRunning -> AnnouncementsViewModel.formatTimer(
-                            if (viewModel.timerMode == Constants.TIMER_MODE_COUNT_UP) viewModel.countUpElapsed else viewModel.timerRemaining
-                        )
+                        isTimerRunning -> AnnouncementsViewModel.formatTimer(timerDisplayValue)
                         else -> viewModel.text
                     }
                     // A live timer/clock value changes every second and must stay legible, so skip the
                     // configured entrance animation in the preview (it would otherwise cycle the value
                     // fully off-screen on every animation loop, looking like it froze or went dark).
-                    val isShowingLiveTimerValue = viewModel.timerExpired ||
+                    val isShowingLiveTimerValue = isTimerExpired ||
                         viewModel.timerMode == Constants.TIMER_MODE_CLOCK ||
                         viewModel.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY ||
-                        viewModel.timerRunning
+                        isTimerRunning
                     var previewWidthPx by remember { mutableStateOf(0) }
                     var previewHeightPx by remember { mutableStateOf(0) }
                     val scaleFactor = if (previewWidthPx > 0)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -455,7 +455,10 @@ fun BibleTab(
         }
     }
 
-    // Auto-pause when user navigates to a different chapter or book while presenting
+    // Auto-pause when user navigates to a different chapter or book while presenting — except
+    // when it's just a sequential chapter advance (Left/Right arrow-key continuation, including
+    // rolling past a chapter's last verse), which is a deliberate continuation of what's live,
+    // not browsing away from it.
     val prevBookRef = remember { mutableStateOf(selectedBookIndex) }
     val prevChapterRef = remember { mutableStateOf(selectedChapter) }
     LaunchedEffect(selectedBookIndex, selectedChapter) {
@@ -463,7 +466,8 @@ fun BibleTab(
         val chapterChanged = selectedChapter != prevChapterRef.value
         prevBookRef.value = selectedBookIndex
         prevChapterRef.value = selectedChapter
-        if ((bookChanged || chapterChanged) && !splitBrowseMode && currentIsPresenting) {
+        val wasSequentialAdvance = viewModel.consumeSequentialChapterAdvance()
+        if ((bookChanged || chapterChanged) && !splitBrowseMode && currentIsPresenting && !wasSequentialAdvance) {
             presenterManager?.setBibleHold(true)
         }
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
@@ -56,7 +56,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -104,6 +107,9 @@ import churchpresenter.composeapp.generated.resources.songs_no_db_hint
 import churchpresenter.composeapp.generated.resources.songs_no_db_step
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
 import kotlinx.coroutines.delay
 import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.add_to_favorites
@@ -116,6 +122,9 @@ import churchpresenter.composeapp.generated.resources.back_to_live
 import churchpresenter.composeapp.generated.resources.go_live
 import churchpresenter.composeapp.generated.resources.ic_add
 import churchpresenter.composeapp.generated.resources.line_navigation_hint
+import churchpresenter.composeapp.generated.resources.metronome_bpm_label
+import churchpresenter.composeapp.generated.resources.unit_bpm
+import churchpresenter.composeapp.generated.resources.ok
 import churchpresenter.composeapp.generated.resources.new_song
 import churchpresenter.composeapp.generated.resources.ic_arrow_down
 import churchpresenter.composeapp.generated.resources.ic_arrow_up
@@ -240,12 +249,13 @@ fun SongsTab(
         onAllSectionsChanged(viewModel.getLyricSections())
         onSectionIndexChanged(viewModel.selectedSectionIndex.value)
         onLineIndexChanged(viewModel.selectedLineIndex.value)
-        viewModel.getSelectedLyricSection()?.let { onSongItemSelected(it) }
+        val idx = viewModel.selectedSongIndex.value
+        val items = viewModel.filteredSongItems.value
+        val bpm = items.getOrNull(idx)?.let { appSettings.songBpm[it.songId] } ?: 0
+        viewModel.getSelectedLyricSection()?.let { onSongItemSelected(it.copy(bpm = bpm)) }
         // Record song display for statistics — only when the song is actually live
         // (or being sent live), and only when a different song is presented.
-        val idx = viewModel.selectedSongIndex.value
         if ((goLive || isPresenting) && idx != liveSongIndex) {
-            val items = viewModel.filteredSongItems.value
             if (idx in items.indices) {
                 val song = items[idx]
                 statisticsManager?.recordSongDisplay(
@@ -1360,12 +1370,80 @@ fun SongsTab(
             val addScheduleStr = stringResource(Res.string.add_to_schedule)
 
             val hasSongSelected = selectedSongIndex >= 0 && selectedSongIndex < filteredSongs.size && selectedSectionIndex >= 0
+            val hasStageMonitorScreen = appSettings.projectionSettings.screenAssignments.any {
+                it.displayMode == Constants.DISPLAY_MODE_STAGE_MONITOR
+            }
             @OptIn(ExperimentalLayoutApi::class)
             FlowRow(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
                 horizontalArrangement = Arrangement.End,
                 verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
+                if (hasStageMonitorScreen && selectedSongIndex >= 0 && selectedSongIndex < filteredSongs.size) {
+                    val selectedSong = filteredSongs[selectedSongIndex]
+                    val metronomeBpmStr = stringResource(Res.string.metronome_bpm_label)
+                    val bpmUnitStr = stringResource(Res.string.unit_bpm)
+                    val currentBpm = appSettings.songBpm[selectedSong.songId] ?: 0
+                    var editingBpm by remember { mutableStateOf(false) }
+                    var bpmInput by remember(selectedSong.songId) { mutableStateOf(currentBpm.toString()) }
+
+                    Column(
+                        modifier = Modifier
+                            .height(42.dp)
+                            .width(90.dp)
+                            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+                            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+                            .clickable { bpmInput = currentBpm.toString(); editingBpm = true }
+                            .padding(start = 11.dp, end = 11.dp, top = 0.dp, bottom = 6.dp),
+                        verticalArrangement = Arrangement.Center
+                    ) {
+                        Text(
+                            text = metronomeBpmStr.uppercase(),
+                            fontSize = TextUnit(8f, TextUnitType.Sp),
+                            lineHeight = TextUnit(9f, TextUnitType.Sp),
+                            fontWeight = FontWeight.SemiBold,
+                            letterSpacing = 0.9.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+                            maxLines = 1
+                        )
+                        Text(
+                            text = "$currentBpm $bpmUnitStr",
+                            style = MaterialTheme.typography.bodySmall.copy(fontSize = 12.sp, fontWeight = FontWeight.Medium),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1
+                        )
+                    }
+
+                    if (editingBpm) {
+                        AlertDialog(
+                            onDismissRequest = { editingBpm = false },
+                            title = { Text(metronomeBpmStr) },
+                            text = {
+                                OutlinedTextField(
+                                    value = bpmInput,
+                                    onValueChange = { bpmInput = it.filter { c -> c.isDigit() }.take(3) },
+                                    suffix = { Text(bpmUnitStr) },
+                                    singleLine = true,
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+                                )
+                            },
+                            confirmButton = {
+                                TextButton(
+                                    shape = RoundedCornerShape(6.dp),
+                                    onClick = {
+                                        val bpmValue = bpmInput.toIntOrNull()?.coerceIn(0, 300) ?: 0
+                                        onSettingsChangeState.value { s -> s.copy(songBpm = s.songBpm + (selectedSong.songId to bpmValue)) }
+                                        editingBpm = false
+                                    }
+                                ) { Text(stringResource(Res.string.ok)) }
+                            },
+                            dismissButton = {
+                                TextButton(shape = RoundedCornerShape(6.dp), onClick = { editingBpm = false }) { Text(stringResource(Res.string.cancel)) }
+                            }
+                        )
+                    }
+                }
+
                 if (selectedSongIndex >= 0 && selectedSongIndex < filteredSongs.size) {
                     TooltipArea(
                         tooltip = {
@@ -1578,7 +1656,8 @@ fun SongsTab(
                                 lines = buildList {
                                     add(titleLine)
                                     if (creditLine.isNotBlank()) add(creditLine)
-                                }
+                                },
+                                bpm = appSettings.songBpm[currentSong.songId] ?: 0
                             )
 
                             fun sendTitleSlide() {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
@@ -82,6 +82,13 @@ object Constants {
     /** Localhost port used to enforce single-instance via ServerSocket lock. */
     const val SINGLE_INSTANCE_PORT = 47632
 
+    /**
+     * True only when launched via `./gradlew :composeApp:run` (see build.gradle.kts'
+     * `application.jvmArgs`) — never set for packaged installers. Gates dev-only testing
+     * features (e.g. simulated screens) out of production builds entirely.
+     */
+    val isDevMode: Boolean by lazy { System.getProperty("churchpresenter.devMode") == "true" }
+
     const val TIMER_MODE_DURATION = "duration"
     const val TIMER_MODE_CLOCK    = "clock"
     /** Open-ended stopwatch: counts up from zero, no h:m:s configuration. */
@@ -212,6 +219,12 @@ object Constants {
     const val DISPLAY_MODE_FULLSCREEN = "fullscreen"
     const val DISPLAY_MODE_LOWER_THIRD = "lower_third"
     const val DISPLAY_MODE_STAGE_MONITOR = "stage_monitor"
+
+    // Screen assignment target types
+    const val TARGET_TYPE_SCREEN = "screen"
+    const val TARGET_TYPE_DECKLINK = "decklink"
+    /** Dev-mode-only synthetic screen — not backed by a real GraphicsDevice. */
+    const val TARGET_TYPE_SIMULATED = "simulated"
 
     // Output Role (fill+key for video mixers)
     const val OUTPUT_ROLE_NORMAL = "normal"

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
@@ -82,13 +82,6 @@ object Constants {
     /** Localhost port used to enforce single-instance via ServerSocket lock. */
     const val SINGLE_INSTANCE_PORT = 47632
 
-    /**
-     * True only when launched via `./gradlew :composeApp:run` (see build.gradle.kts'
-     * `application.jvmArgs`) — never set for packaged installers. Gates dev-only testing
-     * features (e.g. simulated screens) out of production builds entirely.
-     */
-    val isDevMode: Boolean by lazy { System.getProperty("churchpresenter.devMode") == "true" }
-
     const val TIMER_MODE_DURATION = "duration"
     const val TIMER_MODE_CLOCK    = "clock"
     /** Open-ended stopwatch: counts up from zero, no h:m:s configuration. */
@@ -223,8 +216,6 @@ object Constants {
     // Screen assignment target types
     const val TARGET_TYPE_SCREEN = "screen"
     const val TARGET_TYPE_DECKLINK = "decklink"
-    /** Dev-mode-only synthetic screen — not backed by a real GraphicsDevice. */
-    const val TARGET_TYPE_SIMULATED = "simulated"
 
     // Output Role (fill+key for video mixers)
     const val OUTPUT_ROLE_NORMAL = "normal"

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/AnnouncementsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/AnnouncementsViewModel.kt
@@ -74,16 +74,11 @@ class AnnouncementsViewModel {
     private val _timerSeconds = mutableStateOf(0)
     val timerSeconds: Int get() = _timerSeconds.value
 
-    /** Remaining time in whole seconds while the timer is running */
+    /** Configured/local-preview remaining time — the live value while actually running lives on
+     *  PresenterManager instead (see startPauseTimer), since it must survive this ViewModel being
+     *  recreated when the Announcements tab is switched away from and back. */
     private val _timerRemaining = mutableStateOf(0)
     val timerRemaining: Int get() = _timerRemaining.value
-
-    private val _timerRunning = mutableStateOf(false)
-    val timerRunning: Boolean get() = _timerRunning.value
-
-    /** true once the countdown has reached 0 */
-    private val _timerExpired = mutableStateOf(false)
-    val timerExpired: Boolean get() = _timerExpired.value
 
     /** Message to show on screen when the timer expires */
     private val _timerExpiredText = mutableStateOf("")
@@ -122,16 +117,10 @@ class AnnouncementsViewModel {
     val liveClockText: String get() = _liveClockText.value
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-    private var timerJob: Job? = null
     /** Ticks every second in clock mode while the timer is not running, keeping the display current. */
     private var clockPreviewJob: Job? = null
     /** Ticks every second while TIMER_MODE_CLOCK_DISPLAY is active, keeping [liveClockText] current. */
     private var liveClockJob: Job? = null
-    /** Absolute epoch-second the running timer reaches 0 at. Remaining time is always derived from
-     *  this minus "now" rather than decremented, so it can't drift and self-corrects after any gap. */
-    private var timerEndEpochSecond: Long = 0L
-    /** Absolute epoch-second the count-up stopwatch started at (adjusted on resume). */
-    private var countUpStartEpochSecond: Long = 0L
 
     // ── Sync from settings ───────────────────────────────────────────
     fun syncFromSettings(settings: AnnouncementsSettings) {
@@ -162,12 +151,10 @@ class AnnouncementsViewModel {
         _targetMinute.value = settings.targetMinute
         _targetSecond.value = settings.targetSecond
         _liveClockFormat.value = settings.liveClockFormat
-        if (!_timerRunning.value) {
-            _countUpElapsed.value = 0
-            _timerRemaining.value = if (settings.timerMode == Constants.TIMER_MODE_CLOCK) secondsUntilTarget() else totalSeconds()
-            if (settings.timerMode == Constants.TIMER_MODE_CLOCK) startClockPreview()
-            if (settings.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY) startLiveClockPreview()
-        }
+        _countUpElapsed.value = 0
+        _timerRemaining.value = if (settings.timerMode == Constants.TIMER_MODE_CLOCK) secondsUntilTarget() else totalSeconds()
+        if (settings.timerMode == Constants.TIMER_MODE_CLOCK) startClockPreview()
+        if (settings.timerMode == Constants.TIMER_MODE_CLOCK_DISPLAY) startLiveClockPreview()
     }
 
     // ── Mutations ────────────────────────────────────────────────────
@@ -191,9 +178,11 @@ class AnnouncementsViewModel {
 
     /**
      * Applies a change to the configured H/M/S duration fields and carries the *delta* over to
-     * the live remaining time (and the running end time), instead of recomputing remaining from
-     * the raw fields. That way, editing hours/minutes/seconds while paused or running extends or
-     * shortens the countdown instead of snapping it back to the full configured duration.
+     * the live remaining time, instead of recomputing remaining from the raw fields. That way,
+     * editing hours/minutes/seconds while paused extends or shortens the countdown instead of
+     * snapping it back to the full configured duration. (Duration now actually ticks on
+     * PresenterManager once started — see startPauseTimer — so this only affects the local,
+     * not-yet-live preview; editing the fields while a countdown is already live doesn't nudge it.)
      */
     private inline fun applyDurationDelta(mutate: () -> Unit) {
         val oldTotal = totalSeconds()
@@ -202,9 +191,6 @@ class AnnouncementsViewModel {
         if (delta == 0) return
         if (_timerMode.value != Constants.TIMER_MODE_DURATION) return
         _timerRemaining.value = (_timerRemaining.value + delta).coerceAtLeast(0)
-        if (_timerRunning.value) {
-            timerEndEpochSecond += delta
-        }
     }
 
     fun setTimerHours(value: Int) = applyDurationDelta { _timerHours.value = value.coerceAtLeast(0) }
@@ -269,7 +255,7 @@ class AnnouncementsViewModel {
         clockPreviewJob = scope.launch {
             while (true) {
                 delay(1000L)
-                if (!_timerRunning.value && _timerMode.value == Constants.TIMER_MODE_CLOCK) {
+                if (_timerMode.value == Constants.TIMER_MODE_CLOCK) {
                     _timerRemaining.value = secondsUntilTarget()
                 }
             }
@@ -308,20 +294,6 @@ class AnnouncementsViewModel {
         val previousMode = _timerMode.value
         if (previousMode == value) return
         val enteringClockMode = value == Constants.TIMER_MODE_CLOCK
-        // Count-up and the live clock display are different paradigms (open-ended stopwatch /
-        // always-on clock, vs. a countdown to zero), so switching to/from either while running
-        // just stops the timer instead of carrying state over.
-        val stopsActiveTimer = value == Constants.TIMER_MODE_COUNT_UP || previousMode == Constants.TIMER_MODE_COUNT_UP ||
-            value == Constants.TIMER_MODE_CLOCK_DISPLAY || previousMode == Constants.TIMER_MODE_CLOCK_DISPLAY
-
-        if (stopsActiveTimer && _timerRunning.value) {
-            timerJob?.cancel()
-            timerJob = null
-            _timerRunning.value = false
-        }
-        // A stale "expired" flag from a previous mode must not leak into the new mode — otherwise
-        // the next Start press just silently resets it instead of actually starting anything.
-        _timerExpired.value = false
 
         _timerMode.value = value
         stopClockPreview()
@@ -342,15 +314,11 @@ class AnnouncementsViewModel {
                     _targetMinute.value = now.minute
                     _targetSecond.value = now.second
                 }
-                val remaining = secondsUntilTarget()
-                _timerRemaining.value = remaining
-                if (_timerRunning.value) timerEndEpochSecond = java.time.Instant.now().epochSecond + remaining
+                _timerRemaining.value = secondsUntilTarget()
                 startClockPreview()
             }
             else -> {
-                val remaining = totalSeconds()
-                _timerRemaining.value = remaining
-                if (_timerRunning.value) timerEndEpochSecond = java.time.Instant.now().epochSecond + remaining
+                _timerRemaining.value = totalSeconds()
             }
         }
     }
@@ -363,15 +331,11 @@ class AnnouncementsViewModel {
         return if (diff > 0) diff else diff + 86400
     }
 
-    /** Applies a change to the target clock time and keeps the live countdown (running or not) in sync. */
+    /** Applies a change to the target clock time and keeps the local preview in sync. */
     private inline fun applyTargetChange(mutate: () -> Unit) {
         mutate()
         if (_timerMode.value != Constants.TIMER_MODE_CLOCK) return
-        val remaining = secondsUntilTarget()
-        _timerRemaining.value = remaining
-        if (_timerRunning.value) {
-            timerEndEpochSecond = java.time.Instant.now().epochSecond + remaining
-        }
+        _timerRemaining.value = secondsUntilTarget()
     }
 
     fun setTargetHour(value: Int) = applyTargetChange { _targetHour.value = value.coerceIn(0, 23) }
@@ -410,91 +374,51 @@ class AnnouncementsViewModel {
     }
 
     // ── Timer control ────────────────────────────────────────────────
-    fun startPauseTimer(
-        onTick: ((remaining: Int) -> Unit)? = null,
-        onExpired: (String) -> Unit
-    ) {
-        // The live clock display is always on — nothing to start, pause, or resume.
-        if (_timerMode.value == Constants.TIMER_MODE_CLOCK_DISPLAY) return
+    // Duration/Count-up/Specific-Time actually tick on [presenterManager] now (not here), so the
+    // countdown survives switching away from the Announcements tab — see PresenterManager's
+    // startAnnouncementCountdown/startAnnouncementCountUp/startAnnouncementSpecificTime. This
+    // ViewModel just tells it what to do and reads its state back for the UI.
 
-        if (_timerMode.value == Constants.TIMER_MODE_COUNT_UP) {
-            if (_timerRunning.value) {
-                timerJob?.cancel()
-                timerJob = null
-                _timerRunning.value = false
-            } else {
-                countUpStartEpochSecond = java.time.Instant.now().epochSecond - _countUpElapsed.value
-                _timerRunning.value = true
-                timerJob = scope.launch {
-                    while (true) {
-                        val elapsed = (java.time.Instant.now().epochSecond - countUpStartEpochSecond).toInt().coerceAtLeast(0)
-                        _countUpElapsed.value = elapsed
-                        onTick?.invoke(elapsed)
-                        delay(1000L)
-                    }
+    /** Starts, pauses, or resumes the live timer/clock for the current [timerMode]. */
+    fun startPauseTimer(presenterManager: PresenterManager?) {
+        if (presenterManager == null) return
+        when (_timerMode.value) {
+            // The live clock display is always on — nothing to start, pause, or resume.
+            Constants.TIMER_MODE_CLOCK_DISPLAY -> {}
+            // Specific Time has no pause concept either — it always tracks the wall clock.
+            Constants.TIMER_MODE_CLOCK -> presenterManager.startAnnouncementSpecificTime(_targetHour.value, _targetMinute.value, _targetSecond.value)
+            Constants.TIMER_MODE_COUNT_UP -> {
+                if (presenterManager.timerRunning.value) {
+                    presenterManager.pauseAnnouncementTimer(presenterManager.timerRemainingSeconds.value)
+                } else {
+                    presenterManager.startAnnouncementCountUp(presenterManager.timerRemainingSeconds.value)
                 }
             }
-            return
-        }
-
-        if (_timerExpired.value) {
-            resetTimer()
-            return
-        }
-        if (_timerRunning.value) {
-            // Pause
-            timerJob?.cancel()
-            timerJob = null
-            _timerRunning.value = false
-            if (_timerMode.value == Constants.TIMER_MODE_CLOCK) startClockPreview()
-        } else {
-            // Start / resume
-            stopClockPreview()
-            if (_timerRemaining.value <= 0) {
-                val total = if (_timerMode.value == Constants.TIMER_MODE_CLOCK) secondsUntilTarget() else totalSeconds()
-                if (total <= 0) return
-                _timerRemaining.value = total
-            }
-            timerEndEpochSecond = java.time.Instant.now().epochSecond + _timerRemaining.value
-            _timerRunning.value = true
-            _timerExpired.value = false
-            timerJob = scope.launch {
-                while (true) {
-                    val remaining = (timerEndEpochSecond - java.time.Instant.now().epochSecond).toInt()
-                    if (remaining <= 0) break
-                    _timerRemaining.value = remaining
-                    onTick?.invoke(remaining)
-                    delay(1000L)
+            else -> { // TIMER_MODE_DURATION
+                if (presenterManager.timerRunning.value) {
+                    presenterManager.pauseAnnouncementTimer(presenterManager.timerRemainingSeconds.value)
+                } else {
+                    val remaining = presenterManager.timerRemainingSeconds.value.takeIf { it > 0 } ?: totalSeconds()
+                    if (remaining <= 0) return
+                    presenterManager.startAnnouncementCountdown(remaining, _timerExpiredText.value)
                 }
-                _timerRemaining.value = 0
-                _timerRunning.value = false
-                _timerExpired.value = true
-                if (_timerMode.value == Constants.TIMER_MODE_CLOCK) startClockPreview()
-                onExpired(_timerExpiredText.value)
             }
         }
     }
 
-    fun pauseTimer() {
-        if (_timerRunning.value) {
-            timerJob?.cancel()
-            timerJob = null
-            _timerRunning.value = false
-            if (_timerMode.value == Constants.TIMER_MODE_CLOCK) startClockPreview()
+    fun pauseTimer(presenterManager: PresenterManager?) {
+        if (presenterManager != null && presenterManager.timerRunning.value) {
+            presenterManager.pauseAnnouncementTimer(presenterManager.timerRemainingSeconds.value)
         }
     }
 
-    fun resetTimer() {
-        timerJob?.cancel()
-        timerJob = null
-        _timerRunning.value = false
-        if (_timerMode.value == Constants.TIMER_MODE_COUNT_UP) {
-            _countUpElapsed.value = 0
-            return
+    fun resetTimer(presenterManager: PresenterManager?) {
+        when (_timerMode.value) {
+            Constants.TIMER_MODE_COUNT_UP -> presenterManager?.pauseAnnouncementTimer(0)
+            // Specific Time always auto-tracks the wall clock — nothing to reset back to.
+            Constants.TIMER_MODE_CLOCK -> {}
+            else -> presenterManager?.pauseAnnouncementTimer(totalSeconds())
         }
-        _timerExpired.value = false
-        _timerRemaining.value = if (_timerMode.value == Constants.TIMER_MODE_CLOCK) secondsUntilTarget() else totalSeconds()
-        if (_timerMode.value == Constants.TIMER_MODE_CLOCK) startClockPreview()
     }
 
     fun dispose() {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
@@ -964,34 +964,65 @@ class BibleViewModel(
     }
 
     fun navigateNextVerse(): Boolean {
-        if (_verses.value.isNotEmpty() && _selectedVerseIndex.value < _verses.value.size - 1) {
+        if (_verses.value.isEmpty()) return false
+        if (_selectedVerseIndex.value < _verses.value.size - 1) {
             _selectedVerseIndices.clear()
             _multiVerseEnabled.value = false
             _selectedVerseIndex.value++
             _verseSelectionToken.value++
             return true
         }
-        return false
+        // At the last verse of the chapter — roll into the next chapter, and into the next book
+        // if this was the book's last chapter, instead of silently doing nothing (mirrors the
+        // rollover getNextVerses() already does for the Stage Monitor lookahead).
+        val bible = _primaryBible.value ?: return false
+        var nextBookIndex = _selectedBookIndex.value
+        var nextChapter = _selectedChapter.value + 1
+        if (nextChapter > bible.getChapterCount(nextBookIndex)) {
+            nextBookIndex += 1
+            nextChapter = 1
+            if (nextBookIndex >= _books.value.size) return false // past the last book
+        }
+        _sequentialChapterAdvance = true
+        _selectedVerseIndices.clear()
+        _multiVerseEnabled.value = false
+        loadChapter(nextBookIndex, nextChapter)
+        return true
     }
 
     fun navigatePreviousChapter(): Boolean {
         if (_selectedChapter.value > 1) {
+            _sequentialChapterAdvance = true
             selectChapter(_selectedChapter.value - 1)
             return true
         }
         return false
     }
 
+    // Set right before a sequential chapter advance (next or previous) and consumed by
+    // BibleTab's auto-hold check, so stepping through the Bible via the </> chapter arrows
+    // doesn't get treated as browsing away from what's live (unlike jumping to an arbitrary
+    // chapter/book, which should still engage Hold).
+    private var _sequentialChapterAdvance = false
+
     fun navigateNextChapter(): Boolean {
         _primaryBible.value?.let { bible ->
             // getChapterCount expects 0-based book index
             val maxChapter = bible.getChapterCount(_selectedBookIndex.value)
             if (_selectedChapter.value < maxChapter) {
+                _sequentialChapterAdvance = true
                 selectChapter(_selectedChapter.value + 1)
                 return true
             }
         }
         return false
+    }
+
+    /** Returns true if the most recent chapter change was a sequential "next chapter" advance, clearing the flag. */
+    fun consumeSequentialChapterAdvance(): Boolean {
+        val wasSequentialAdvance = _sequentialChapterAdvance
+        _sequentialChapterAdvance = false
+        return wasSequentialAdvance
     }
 
     private fun refreshFilteredLists() {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
@@ -1,6 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
 import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import kotlinx.coroutines.CancellationException
@@ -867,6 +868,82 @@ class BibleViewModel(
 
         return verseList
     }
+
+    /**
+     * Returns the verse(s) immediately after whatever [getSelectedVerses] currently returns —
+     * same shape (primary, then secondary if bilingual) but read-only: never mutates selection
+     * state. Rolls into the next chapter, and into the next book if that was the last chapter.
+     */
+    fun getNextVerses(): List<SelectedVerse> {
+        if (_verses.value.isEmpty()) return emptyList()
+
+        val referenceIndex = if (_multiVerseEnabled.value && _selectedVerseIndices.isNotEmpty()) {
+            _selectedVerseIndices.max()
+        } else {
+            _selectedVerseIndex.value.coerceIn(0, _verses.value.size - 1)
+        }
+
+        val bookId = _primaryBible.value?.getBookId(_selectedBookIndex.value) ?: (_selectedBookIndex.value + 1)
+
+        // Next verse is in the same chapter.
+        if (referenceIndex < _verses.value.size - 1) {
+            val verse = _verses.value[referenceIndex + 1]
+            val verseNumber = verse.substringBefore(". ").toIntOrNull() ?: return emptyList()
+            return buildNextVerseList(bookId, _selectedChapter.value, verseNumber, verse.substringAfter(". "))
+        }
+
+        // Roll into the next chapter, and into the next book if this was the last chapter.
+        val bible = _primaryBible.value ?: return emptyList()
+        var nextBookIndex = _selectedBookIndex.value
+        var nextChapter = _selectedChapter.value + 1
+        if (nextChapter > bible.getChapterCount(nextBookIndex)) {
+            nextBookIndex += 1
+            nextChapter = 1
+            if (nextBookIndex >= _books.value.size) return emptyList() // past the last book
+        }
+        val nextBookId = bible.getBookId(nextBookIndex)
+        val firstVerse = bible.getChapter(nextBookId, nextChapter).verses.firstOrNull() ?: return emptyList()
+        val verseNumber = firstVerse.substringBefore(". ").toIntOrNull() ?: return emptyList()
+        return buildNextVerseList(nextBookId, nextChapter, verseNumber, firstVerse.substringAfter(". "))
+    }
+
+    /** Builds primary (+ secondary, if bilingual) [SelectedVerse] entries for one verse, by book id. */
+    private fun buildNextVerseList(bookId: Int, chapter: Int, verseNumber: Int, verseText: String): List<SelectedVerse> {
+        val verseList = mutableListOf<SelectedVerse>()
+        if (verseText.isNotEmpty()) {
+            verseList.add(
+                SelectedVerse(
+                    bibleAbbreviation = _primaryBible.value?.getBibleAbbreviation() ?: "",
+                    bibleName = _primaryBible.value?.getBibleTitle() ?: "",
+                    bookName = _primaryBible.value?.getBookName(bookId) ?: "",
+                    chapter = chapter,
+                    verseNumber = verseNumber,
+                    verseText = verseText
+                )
+            )
+        }
+        val codeRef = _primaryBible.value?.getCodeReference(bookId, chapter, verseNumber)
+        val secBook = codeRef?.first ?: bookId
+        val secChapter = codeRef?.second ?: chapter
+        val secVerse = codeRef?.third ?: verseNumber
+        _secondaryBible.value?.takeIf { it.getVerseCount() > 0 }
+            ?.getVerseDetailsByCode(secBook, secChapter, secVerse)?.let { result ->
+            verseList.add(
+                SelectedVerse(
+                    bibleAbbreviation = _secondaryBible.value?.getBibleAbbreviation() ?: "",
+                    bibleName = _secondaryBible.value?.getBibleTitle() ?: "",
+                    bookName = result.bookName,
+                    chapter = result.displayChapter,
+                    verseNumber = result.displayVerse,
+                    verseText = result.verseText
+                )
+            )
+        }
+        return verseList
+    }
+
+    /** Reactively recomputes whenever the underlying selection state changes — for Stage Monitor. */
+    val nextVerses: State<List<SelectedVerse>> = derivedStateOf { getNextVerses() }
 
     /** Returns verse numbers currently selected in multi-verse mode. */
     fun getSelectedVerseNumbers(): List<Int> {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresenterManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresenterManager.kt
@@ -44,6 +44,11 @@ class PresenterManager {
     private val _displayedVerses = mutableStateOf<List<SelectedVerse>>(emptyList())
     val displayedVerses: State<List<SelectedVerse>> = _displayedVerses
 
+    // Next Bible verse after whatever is currently displayed — for Stage Monitor's "Next" zone.
+    // Distinct from displayedVerses, which pairs primary+secondary *language* of the same verse.
+    private val _nextVerses = mutableStateOf<List<SelectedVerse>>(emptyList())
+    val nextVerses: State<List<SelectedVerse>> = _nextVerses
+
     private val _bibleTransitionAlpha = mutableStateOf(1f)
     val bibleTransitionAlpha: State<Float> = _bibleTransitionAlpha
 
@@ -213,6 +218,10 @@ class PresenterManager {
 
     fun setDisplayedVerses(verses: List<SelectedVerse>) {
         _displayedVerses.value = verses
+    }
+
+    fun setNextVerses(verses: List<SelectedVerse>) {
+        _nextVerses.value = verses
     }
 
     fun setBibleTransitionAlpha(alpha: Float) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresenterManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresenterManager.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.churchpresenter.app.churchpresenter.models.AnimationType
@@ -453,16 +454,107 @@ class PresenterManager {
         _activeScene.value = scene
     }
 
-    // Announcements countdown timer — mirrored here so stage monitor can observe it
+    // ── Announcements timer/clock ───────────────────────────────────────────
+    // Ticks here — not in the Announcements tab's ViewModel — so switching to another tab (e.g.
+    // to present a Bible verse) doesn't kill the coroutine and freeze the countdown. Stage
+    // Monitor and the live output both observe timerRemainingSeconds/timerRunning directly.
     private val _timerRemainingSeconds = mutableStateOf(0)
     val timerRemainingSeconds: State<Int> = _timerRemainingSeconds
 
     private val _timerRunning = mutableStateOf(false)
     val timerRunning: State<Boolean> = _timerRunning
 
-    fun setTimerState(remainingSeconds: Int, running: Boolean) {
+    // True once a Duration countdown has run out — the authoritative signal the Announcements tab
+    // uses to show the expired message/color, since it (unlike this manager) may have been
+    // recreated since the countdown actually finished.
+    private val _announcementTimerExpired = mutableStateOf(false)
+    val announcementTimerExpired: State<Boolean> = _announcementTimerExpired
+
+    private var announcementTickerJob: Job? = null
+
+    /** Duration/Countdown — ticks down from [remainingSeconds] and shows [expiredText] on reaching zero. */
+    fun startAnnouncementCountdown(remainingSeconds: Int, expiredText: String) {
+        announcementTickerJob?.cancel()
+        if (remainingSeconds <= 0) return
+        val endEpochSecond = java.time.Instant.now().epochSecond + remainingSeconds
         _timerRemainingSeconds.value = remainingSeconds
-        _timerRunning.value = running
+        _timerRunning.value = true
+        _announcementTimerExpired.value = false
+        announcementTickerJob = preRenderScope.launch {
+            while (true) {
+                val remaining = (endEpochSecond - java.time.Instant.now().epochSecond).toInt()
+                if (remaining <= 0) break
+                _timerRemainingSeconds.value = remaining
+                pushAnnouncementTextIfLive(AnnouncementsViewModel.formatTimer(remaining))
+                delay(1000L)
+            }
+            _timerRemainingSeconds.value = 0
+            _timerRunning.value = false
+            _announcementTimerExpired.value = true
+            pushAnnouncementTextIfLive(expiredText)
+            setPresentingMode(Presenting.ANNOUNCEMENTS)
+        }
+    }
+
+    /** Count-up — an open-ended stopwatch starting from [initialElapsedSeconds]. */
+    fun startAnnouncementCountUp(initialElapsedSeconds: Int) {
+        announcementTickerJob?.cancel()
+        val startEpochSecond = java.time.Instant.now().epochSecond - initialElapsedSeconds
+        _timerRemainingSeconds.value = initialElapsedSeconds
+        _timerRunning.value = true
+        _announcementTimerExpired.value = false
+        announcementTickerJob = preRenderScope.launch {
+            while (true) {
+                val elapsed = (java.time.Instant.now().epochSecond - startEpochSecond).toInt().coerceAtLeast(0)
+                _timerRemainingSeconds.value = elapsed
+                pushAnnouncementTextIfLive(AnnouncementsViewModel.formatTimer(elapsed))
+                delay(1000L)
+            }
+        }
+    }
+
+    /** Specific Time — always-on countdown to the next occurrence of [targetHour]:[targetMinute]:[targetSecond]. */
+    fun startAnnouncementSpecificTime(targetHour: Int, targetMinute: Int, targetSecond: Int) {
+        announcementTickerJob?.cancel()
+        _timerRunning.value = false
+        announcementTickerJob = preRenderScope.launch {
+            while (true) {
+                val nowSec = java.time.LocalTime.now().toSecondOfDay()
+                val targetSec = targetHour * 3600 + targetMinute * 60 + targetSecond
+                val diff = targetSec - nowSec
+                val remaining = if (diff > 0) diff else diff + 86400
+                _timerRemainingSeconds.value = remaining
+                pushAnnouncementTextIfLive(AnnouncementsViewModel.formatTimer(remaining))
+                delay(1000L)
+            }
+        }
+    }
+
+    /** Clock Display — always-on live wall clock formatted with [formatPattern]. */
+    fun startAnnouncementClockDisplay(formatPattern: String) {
+        announcementTickerJob?.cancel()
+        _timerRunning.value = false
+        announcementTickerJob = preRenderScope.launch {
+            while (true) {
+                val text = java.time.LocalTime.now().format(java.time.format.DateTimeFormatter.ofPattern(formatPattern))
+                pushAnnouncementTextIfLive(text)
+                delay(1000L)
+            }
+        }
+    }
+
+    /** Pauses/stops whichever announcement ticker is active, optionally pinning the mirrored remaining value (e.g. on Reset). */
+    fun pauseAnnouncementTimer(remainingSeconds: Int? = null) {
+        announcementTickerJob?.cancel()
+        _timerRunning.value = false
+        _announcementTimerExpired.value = false
+        if (remainingSeconds != null) _timerRemainingSeconds.value = remainingSeconds
+    }
+
+    private fun pushAnnouncementTextIfLive(text: String) {
+        val anyScreenOnAnnouncements = _presentingMode.value == Presenting.ANNOUNCEMENTS ||
+            _screenLocks.value.values.any { it == Presenting.ANNOUNCEMENTS }
+        if (anyScreenOnAnnouncements) setAnnouncementText(text)
     }
 
     // Q&A display state


### PR DESCRIPTION
Redesign stage monitor architecture to route content types to zones flexibly rather than using hardcoded per-zone assignment. Zones now have independent styles configured via a unified StageMonitorZoneStyle data class. Simplified screen parameters and enabled media/canvas/QA/etc. support in the monitor. Added dev-mode-only simulated screens for testing multiple outputs without extra physical displays (gated by -Dchurchpresenter.devMode=true).