### PR TITLE
Cover file-chooser business logic to its headless ceiling

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -113,6 +113,30 @@ CI is `.github/workflows/test.yml` (push/PR); it runs these plus the module suit
 `submodules: true`, or the app won't compile.
 
 When writing tests here:
+- **Unreachable code is a refactor, not a dead end.** When a class is uncovered because it needs a
+  display, a bus, a network or a device, do not conclude it cannot be tested. Almost none of such a
+  class is actually the unreachable call — the rest is ordinary logic sitting around it. Split it:
+  - Pull each decision into its own function — what the dialog/request is configured with, what
+    its answer is turned into — and test those directly.
+  - Then shrink the unreachable call itself to **one step of its own**, and take the sequence
+    around it as a function with that step as a **parameter**. Tests pass a stand-in and exercise
+    the real order, the real wiring and the real helpers; only the one call stays uncovered.
+    `SwingFileChooser.openWith`/`saveWith`/`showOwned` is the worked example.
+  - **Count the lambdas.** JaCoCo scores every lambda as its own method, so a helper taking four
+    function parameters adds four uncovered methods at each call site and can score *worse* than
+    the inline code it replaced. Take one function parameter — the unreachable step — and call the
+    rest directly. Measure before and after; the report is the arbiter, not the intent.
+  - What must NOT be done to reach coverage: adding a mutable `internal var` seam on a singleton
+    (leaks between tests — see the flaky-test rule below), or asserting that a stub was called
+    instead of that something works. If a test can only prove a mock was invoked, don't write it.
+- **Prefer `internal` over reflection to reach non-public code.** `jvmTest` is a friend of
+  `jvmMain`, so an `internal` member is callable straight from a test. Reflection costs a lookup
+  per call, throws at runtime instead of failing to compile when a signature changes, loses the
+  types (casts, `Array<Any?>`, `javaPrimitiveType`), and hides renames from the IDE. Widen the
+  member to `internal` and call it. Reflection is the fallback for what genuinely cannot be
+  widened — a private top-level function, or code that must stay private for a reason worth
+  stating. Existing reflection in `PlatformFileChooserTest`/`CrashReporterTest` predates this rule
+  and is not precedent for new tests.
 - **NEVER use `Thread.sleep` or `delay` to wait for async work.** A fixed pause asserts on timing,
   not behaviour, and flakes on a loaded CI machine. Wait for the condition itself — a bounded
   poll on observable state with a timeout that throws, or a callback/flag the code under test

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooser.kt
@@ -91,12 +91,19 @@ abstract class FileChooser {
 
     companion object {
         val platformInstance: FileChooser by lazy {
-            val osName = System.getProperty(Constants.SystemProperties.OS_NAME).lowercase()
-            if ("nix" in osName || "nux" in osName) {
-                XdgFileChooser
-            } else {
-                FileKitFileChooser
-            }
+            platformFor(System.getProperty(Constants.SystemProperties.OS_NAME))
+        }
+
+        /**
+         * Which chooser [osName] calls for: Linux talks to the XDG desktop portal, everything else
+         * gets a native dialog through FileKit.
+         *
+         * Picking wrong is not a graceful failure — the XDG chooser on a machine with no session
+         * bus cannot open a dialog at all, so every Open and Save in the app stops working.
+         */
+        internal fun platformFor(osName: String): FileChooser {
+            val name = osName.lowercase()
+            return if ("nix" in name || "nux" in name) XdgFileChooser else FileKitFileChooser
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileKitFileChooser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileKitFileChooser.kt
@@ -26,7 +26,129 @@ object FileKitFileChooser : FileChooser() {
 
     /** Latched after the first native-dialog failure so a broken machine doesn't retry (and re-report) per dialog. */
     @Volatile
-    private var nativeDialogsBroken = false
+    internal var nativeDialogsBroken = false
+
+    /** Which of the three native pickers a request calls for. */
+    internal enum class PickerMode { DIRECTORY, MULTIPLE_FILES, SINGLE_FILE }
+
+    /**
+     * The picker a request maps to. No call site selects multiple directories, so a directory
+     * request is always a single pick even when [multiple] is set.
+     */
+    internal fun pickerMode(selectDirectory: Boolean, multiple: Boolean): PickerMode = when {
+        selectDirectory -> PickerMode.DIRECTORY
+        multiple -> PickerMode.MULTIPLE_FILES
+        else -> PickerMode.SINGLE_FILE
+    }
+
+    /** One picked file as the list the base class expects, or null if nothing usable came back. */
+    internal fun singleSelection(file: File?): List<Path>? =
+        file?.toPathOrNull()?.let { listOf(it) }
+
+    /**
+     * Several picked files, with anything unconvertible dropped.
+     *
+     * An empty result becomes null: the base class reads null as "cancelled", and an empty list
+     * would be unwrapped as a selection of nothing.
+     */
+    internal fun multipleSelection(files: List<File>?): List<Path>? =
+        files?.mapNotNull { it.toPathOrNull() }?.takeIf { it.isNotEmpty() }
+
+    /**
+     * Splits [suggestedName] into the base name and default extension FileKit wants.
+     *
+     * Callers pass names WITH the extension ("schedule.cps") but FileKit appends the default
+     * extension itself, so a matching extension has to come off first or the dialog opens
+     * offering "schedule.cps.cps". A name carrying none of [extensions] is left whole and simply
+     * gains the first one.
+     */
+    internal fun saveNameParts(suggestedName: String, extensions: List<String>): Pair<String, String?> {
+        val matched = extensions.firstOrNull { suggestedName.endsWith(".$it", ignoreCase = true) }
+        val extension = matched ?: extensions.firstOrNull()
+        val baseName = matched?.let { suggestedName.dropLast(it.length + 1) } ?: suggestedName
+        return baseName to extension
+    }
+
+    /** Settings shared by every native dialog: the title, owned by whatever window is active. */
+    internal fun dialogSettings(title: String): FileKitDialogSettings =
+        FileKitDialogSettings(title = title, parentWindow = parentWindow())
+
+    /**
+     * The extensions the native saver restricts to, or null for no restriction.
+     *
+     * An empty set is not the same as null here: FileKit reads null as "any file" but an empty set
+     * as a saver that permits nothing, which would leave the operator unable to save at all.
+     */
+    internal fun allowedExtensions(extensions: List<String>): Set<String>? =
+        extensions.takeIf { it.isNotEmpty() }?.toSet()
+
+    /**
+     * The whole open interaction: work out which picker the request needs, hand [openNative] the
+     * mode, the type and the folder, and shape whatever comes back for the base class.
+     *
+     * [openNative] is a parameter rather than a direct call so the sequence can be exercised
+     * without a native dialog; in production it is the FileKit picker.
+     */
+    internal suspend fun openWith(
+        path: Path,
+        filters: List<FileNameExtensionFilter>,
+        selectDirectory: Boolean,
+        multiple: Boolean,
+        openNative: suspend (PickerMode, FileKitType, PlatformFile) -> List<File>?
+    ): List<Path>? {
+        val mode = pickerMode(selectDirectory, multiple)
+        val picked = openNative(mode, filters.toFileKitType(), PlatformFile(path.toFile()))
+        return if (mode == PickerMode.MULTIPLE_FILES) {
+            multipleSelection(picked)
+        } else {
+            singleSelection(picked?.firstOrNull())
+        }
+    }
+
+    /**
+     * The whole save interaction, with [saveNative] standing in for the native saver.
+     *
+     * The saver is handed the name already split from its extension — see [saveNameParts] — so a
+     * change to that split shows up here as the wrong name reaching the dialog.
+     */
+    internal suspend fun saveWith(
+        location: Path,
+        suggestedName: String,
+        filters: List<FileNameExtensionFilter>,
+        saveNative: suspend (baseName: String, defaultExtension: String?, allowed: Set<String>?, directory: PlatformFile) -> File?
+    ): Path? {
+        val extensions = filters.allExtensions()
+        val (baseName, extension) = saveNameParts(suggestedName, extensions)
+        val saved = saveNative(baseName, extension, allowedExtensions(extensions), PlatformFile(location.toFile()))
+        return saved?.toPathOrNull()
+    }
+
+    /**
+     * Runs [attempt] (the native dialog) and falls back to [fallback] (the Swing dialog) when the
+     * native one is unavailable.
+     *
+     * Once a native dialog has failed on this machine [nativeDialogsBroken] latches, so every later
+     * dialog goes straight to the fallback rather than failing — and re-reporting the same fault —
+     * on each open. A [CancellationException] is the operator dismissing the dialog, not a fault,
+     * so it is re-thrown untouched and must not latch the native path off. [context] labels the
+     * crash report the fault path files.
+     */
+    internal suspend fun <T> withNativeDialog(
+        context: String,
+        attempt: suspend () -> T,
+        fallback: suspend () -> T
+    ): T {
+        if (nativeDialogsBroken) return fallback()
+        return try {
+            attempt()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            CrashReporter.reportException(t, context = context)
+            nativeDialogsBroken = true
+            fallback()
+        }
+    }
 
     override suspend fun chooseImpl(
         path: Path,
@@ -34,62 +156,54 @@ object FileKitFileChooser : FileChooser() {
         title: String,
         selectDirectory: Boolean,
         multiple: Boolean
-    ): List<Path>? = try {
-        if (nativeDialogsBroken) return SwingFileChooser.fallbackChoose(path, filters, title, selectDirectory, multiple)
-        val directory = PlatformFile(path.toFile())
-        val settings = FileKitDialogSettings(title = title, parentWindow = parentWindow())
-        when {
-            // No call site selects multiple directories, so a single pick is sufficient
-            selectDirectory -> FileKit.openDirectoryPicker(directory = directory, dialogSettings = settings)
-                ?.file?.toPathOrNull()?.let { listOf(it) }
-            multiple -> FileKit.openFilePicker(
-                type = filters.toFileKitType(),
-                mode = FileKitMode.Multiple(),
-                directory = directory,
-                dialogSettings = settings
-            )?.mapNotNull { it.file.toPathOrNull() }?.takeIf { it.isNotEmpty() }
-            else -> FileKit.openFilePicker(
-                type = filters.toFileKitType(),
-                mode = FileKitMode.Single,
-                directory = directory,
-                dialogSettings = settings
-            )?.file?.toPathOrNull()?.let { listOf(it) }
-        }
-    } catch (e: CancellationException) {
-        throw e
-    } catch (t: Throwable) {
-        CrashReporter.reportException(t, context = "FileKitFileChooser.chooseImpl")
-        nativeDialogsBroken = true
-        SwingFileChooser.fallbackChoose(path, filters, title, selectDirectory, multiple)
-    }
+    ): List<Path>? = withNativeDialog(
+        context = "FileKitFileChooser.chooseImpl",
+        attempt = {
+            val settings = dialogSettings(title)
+            openWith(path, filters, selectDirectory, multiple) { mode, type, directory ->
+                when (mode) {
+                    PickerMode.DIRECTORY -> FileKit
+                        .openDirectoryPicker(directory = directory, dialogSettings = settings)
+                        ?.file?.let { listOf(it) }
+                    PickerMode.MULTIPLE_FILES -> FileKit.openFilePicker(
+                        type = type,
+                        mode = FileKitMode.Multiple(),
+                        directory = directory,
+                        dialogSettings = settings
+                    )?.map { it.file }
+                    PickerMode.SINGLE_FILE -> FileKit.openFilePicker(
+                        type = type,
+                        mode = FileKitMode.Single,
+                        directory = directory,
+                        dialogSettings = settings
+                    )?.file?.let { listOf(it) }
+                }
+            }
+        },
+        fallback = { SwingFileChooser.fallbackChoose(path, filters, title, selectDirectory, multiple) }
+    )
 
     override suspend fun saveImpl(
         location: Path,
         suggestedName: String,
         filters: List<FileNameExtensionFilter>,
         title: String
-    ): Path? = try {
-        if (nativeDialogsBroken) return SwingFileChooser.fallbackSave(location, suggestedName, filters, title)
-        val extensions = filters.allExtensions()
-        // Callers pass names WITH extension ("schedule.cps"); FileKit appends the
-        // default extension itself, so strip it to avoid "schedule.cps.cps"
-        val matched = extensions.firstOrNull { suggestedName.endsWith(".$it", ignoreCase = true) }
-        val extension = matched ?: extensions.firstOrNull()
-        val baseName = matched?.let { suggestedName.dropLast(it.length + 1) } ?: suggestedName
-        FileKit.openFileSaver(
-            suggestedName = baseName,
-            defaultExtension = extension,
-            allowedExtensions = extensions.takeIf { it.isNotEmpty() }?.toSet(),
-            directory = PlatformFile(location.toFile()),
-            dialogSettings = FileKitDialogSettings(title = title, parentWindow = parentWindow())
-        )?.file?.toPathOrNull()
-    } catch (e: CancellationException) {
-        throw e
-    } catch (t: Throwable) {
-        CrashReporter.reportException(t, context = "FileKitFileChooser.saveImpl")
-        nativeDialogsBroken = true
-        SwingFileChooser.fallbackSave(location, suggestedName, filters, title)
-    }
+    ): Path? = withNativeDialog(
+        context = "FileKitFileChooser.saveImpl",
+        attempt = {
+            val settings = dialogSettings(title)
+            saveWith(location, suggestedName, filters) { baseName, extension, allowed, directory ->
+                FileKit.openFileSaver(
+                    suggestedName = baseName,
+                    defaultExtension = extension,
+                    allowedExtensions = allowed,
+                    directory = directory,
+                    dialogSettings = settings
+                )?.file
+            }
+        },
+        fallback = { SwingFileChooser.fallbackSave(location, suggestedName, filters, title) }
+    )
 
     /**
      * Owner for the native dialog so it is modal to the window that opened it.
@@ -97,7 +211,7 @@ object FileKitFileChooser : FileChooser() {
      * are AppContext-filtered and can return null/hidden helper windows (JCEF,
      * JavaFX) when queried from an IO thread.
      */
-    private fun parentWindow(): java.awt.Window? {
+    internal fun parentWindow(): java.awt.Window? {
         if (SwingUtilities.isEventDispatchThread()) return resolveParentWindow()
         var window: java.awt.Window? = null
         try {
@@ -106,17 +220,36 @@ object FileKitFileChooser : FileChooser() {
         return window
     }
 
-    private fun resolveParentWindow(): java.awt.Window? =
-        KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow
-            ?: java.awt.Window.getWindows().firstOrNull { it.isShowing && it.isFocused }
-            ?: java.awt.Window.getWindows().filter { it.isShowing && it.width > 0 && it.height > 0 }
+    internal fun resolveParentWindow(): java.awt.Window? =
+        chooseParentWindow(
+            KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow,
+            java.awt.Window.getWindows()
+        )
+
+    /**
+     * Which window a native dialog should hang off, given the [activeWindow] the toolkit reports
+     * (if any) and every [window] in the JVM.
+     *
+     * Order matters: the active window wins outright; failing that, a window that is both showing
+     * and focused; failing that, the largest one still visible. The size tiebreak exists so a
+     * hidden helper window — JCEF's, JavaFX's — is never chosen over the real app window, which
+     * would put the dialog behind it with no icon and the wrong modality. Null means no owner, and
+     * the dialog is centred on the screen instead.
+     */
+    internal fun chooseParentWindow(
+        activeWindow: java.awt.Window?,
+        windows: Array<java.awt.Window>
+    ): java.awt.Window? =
+        activeWindow
+            ?: windows.firstOrNull { it.isShowing && it.isFocused }
+            ?: windows.filter { it.isShowing && it.width > 0 && it.height > 0 }
                 .maxByOrNull { it.width.toLong() * it.height }
 
     /** Flattens all filters into one extension list (native dialogs get a single combined filter). */
-    private fun List<FileNameExtensionFilter>.allExtensions(): List<String> =
+    internal fun List<FileNameExtensionFilter>.allExtensions(): List<String> =
         flatMap { it.extensions.toList() }.distinct()
 
-    private fun List<FileNameExtensionFilter>.toFileKitType(): FileKitType =
+    internal fun List<FileNameExtensionFilter>.toFileKitType(): FileKitType =
         allExtensions()
             .takeIf { it.isNotEmpty() }
             ?.let { FileKitType.File(it) }
@@ -129,7 +262,7 @@ object FileKitFileChooser : FileChooser() {
      * filesystem representation, so [File.toPath] throws; treat that as no
      * selection rather than letting it bubble up as a "native dialogs broken" crash.
      */
-    private fun File.toPathOrNull(): Path? = try {
+    internal fun File.toPathOrNull(): Path? = try {
         toPath()
     } catch (_: InvalidPathException) {
         null

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/SwingFileChooser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/SwingFileChooser.kt
@@ -27,16 +27,29 @@ object SwingFileChooser : FileChooser() {
         title: String
     ): Path? = saveImpl(location, suggestedName, filters, title)
 
-    /** Hidden owner frame that provides the app icon to file chooser dialogs. */
-    private val ownerFrame: JFrame by lazy {
-        JFrame().apply {
-            isUndecorated = true
-            setSize(0, 0)
-            setLocationRelativeTo(null)
-            try {
-                iconImage = loadAppIcon()
-            } catch (_: Exception) {}
-        }
+    /**
+     * Hidden owner frame that provides the app icon to file chooser dialogs.
+     *
+     * Stays private: widening it would not make it reachable from a test, because building a
+     * `JFrame` at all needs a display. [configureOwnerFrame] holds everything about it that can be
+     * checked without one.
+     */
+    private val ownerFrame: JFrame by lazy { JFrame().apply { configureOwnerFrame(this) } }
+
+    /**
+     * Makes [frame] the invisible, iconned owner a file dialog hangs off: no decorations, no size,
+     * centred, carrying the app icon.
+     *
+     * A frame that cannot take the icon is still a usable owner, so a failure there is swallowed —
+     * the alternative is no file dialogs at all on a machine whose icon is unreadable.
+     */
+    internal fun configureOwnerFrame(frame: JFrame) {
+        frame.isUndecorated = true
+        frame.setSize(0, 0)
+        frame.setLocationRelativeTo(null)
+        try {
+            frame.iconImage = loadAppIcon()
+        } catch (_: Exception) {}
     }
 
     /** Loads the app icon from appResources (packaged) or the source tree (IDE run). */
@@ -58,6 +71,162 @@ object SwingFileChooser : FileChooser() {
         return null
     }
 
+    /**
+     * Offers [filters] and pre-selects the first one, which is the filter the dialog opens showing.
+     *
+     * With filters present "All Files" is removed, so only supported types are selectable; with no
+     * filters nothing is added and the dialog keeps its default "All Files" entry.
+     */
+    internal fun JFileChooser.applyFilters(filters: List<FileNameExtensionFilter>) {
+        if (filters.isEmpty()) return
+        // Disable "All Files" so only the supported types are selectable
+        isAcceptAllFileFilterUsed = false
+        filters.forEach { addChoosableFileFilter(it) }
+        // Pre-select the first filter as the active one
+        fileFilter = filters.first()
+    }
+
+    /** Everything the open dialog is told before it is shown. */
+    internal fun configureOpen(
+        chooser: JFileChooser,
+        filters: List<FileNameExtensionFilter>,
+        title: String,
+        selectDirectory: Boolean,
+        multiple: Boolean
+    ) {
+        chooser.dialogTitle = title
+        chooser.fileSelectionMode =
+            if (selectDirectory) JFileChooser.DIRECTORIES_ONLY else JFileChooser.FILES_ONLY
+        chooser.isMultiSelectionEnabled = multiple
+        chooser.applyFilters(filters)
+    }
+
+    /** Everything the save dialog is told before it is shown, including the name it opens with. */
+    internal fun configureSave(
+        chooser: JFileChooser,
+        location: Path,
+        suggestedName: String,
+        filters: List<FileNameExtensionFilter>,
+        title: String
+    ) {
+        chooser.dialogTitle = title
+        chooser.selectedFile = location.resolve(suggestedName).toFile()
+        chooser.applyFilters(filters)
+    }
+
+    /** Reads the open dialog's outcome; anything but approval means the operator cancelled. */
+    internal fun openResult(returnCode: Int, chooser: JFileChooser, multiple: Boolean): List<Path>? =
+        if (returnCode == JFileChooser.APPROVE_OPTION) {
+            if (multiple) chooser.selectedFiles.map { it.toPath() } else listOf(chooser.selectedFile.toPath())
+        } else {
+            null
+        }
+
+    /** Reads the save dialog's outcome; anything but approval means the operator cancelled. */
+    internal fun saveResult(returnCode: Int, chooser: JFileChooser): Path? =
+        if (returnCode == JFileChooser.APPROVE_OPTION) {
+            chooser.selectedFile.toPath()
+        } else {
+            null
+        }
+
+    /**
+     * Runs [block] on the event dispatch thread and hands back what it returned.
+     *
+     * Swing insists a dialog is opened from the EDT, but the callers are suspending functions on
+     * whatever dispatcher they happen to be on, so the value has to be carried back out by hand.
+     * A failure inside [block] surfaces as `InvocationTargetException`, and calling this from the
+     * EDT itself is an error — both are `invokeAndWait`'s own behaviour, unchanged.
+     */
+    internal fun <T> onEventDispatchThread(block: () -> T): T {
+        var result: T? = null
+        SwingUtilities.invokeAndWait { result = block() }
+        @Suppress("UNCHECKED_CAST")
+        return result as T
+    }
+
+    /**
+     * Shows [dialog] owned by [frame] and returns its return code.
+     *
+     * The frame exists only to give the dialog the app icon, so it is visible for exactly as long
+     * as the dialog is up and hidden again afterwards — leaving it showing would strand a
+     * zero-sized window on the desktop. [frame] is a parameter so this holds without a display;
+     * in production it is always [ownerFrame].
+     */
+    internal fun showOwned(frame: JFrame, dialog: (JFrame) -> Int): Int {
+        frame.isVisible = true
+        val returnCode = dialog(frame)
+        frame.isVisible = false
+        return returnCode
+    }
+
+    /**
+     * The whole open interaction: build a chooser at [path], configure it, put it on screen with
+     * [show], and read the outcome.
+     *
+     * [show] is a parameter rather than a direct call so the sequence can be exercised without a
+     * display; in production it is always [showOwned].
+     */
+    internal fun openWith(
+        path: Path,
+        filters: List<FileNameExtensionFilter>,
+        title: String,
+        selectDirectory: Boolean,
+        multiple: Boolean,
+        show: (JFileChooser) -> Int
+    ): List<Path>? {
+        val chooser = JFileChooser(path.toFile())
+        configureOpen(chooser, filters, title, selectDirectory, multiple)
+        return openResult(show(chooser), chooser, multiple)
+    }
+
+    /** The whole save interaction, with [show] standing in for the step that needs a display. */
+    internal fun saveWith(
+        location: Path,
+        suggestedName: String,
+        filters: List<FileNameExtensionFilter>,
+        title: String,
+        show: (JFileChooser) -> Int
+    ): Path? {
+        val chooser = JFileChooser(location.toFile())
+        configureSave(chooser, location, suggestedName, filters, title)
+        return saveResult(show(chooser), chooser)
+    }
+
+    /**
+     * The full open path: on the event dispatch thread, build and configure a chooser, show it
+     * owned by [frame] via [showDialog], and read the result. [frame] and [showDialog] are
+     * parameters so the orchestration runs under test with a stand-in frame and a stand-in for the
+     * one display call; in production they are [ownerFrame] and `JFileChooser.showOpenDialog`.
+     */
+    internal fun runOpen(
+        path: Path,
+        filters: List<FileNameExtensionFilter>,
+        title: String,
+        selectDirectory: Boolean,
+        multiple: Boolean,
+        frame: JFrame,
+        showDialog: (JFileChooser, JFrame) -> Int
+    ): List<Path>? = onEventDispatchThread {
+        openWith(path, filters, title, selectDirectory, multiple) { chooser ->
+            showOwned(frame) { showDialog(chooser, it) }
+        }
+    }
+
+    /** The full save path, with [frame] and [showDialog] injected as in [runOpen]. */
+    internal fun runSave(
+        location: Path,
+        suggestedName: String,
+        filters: List<FileNameExtensionFilter>,
+        title: String,
+        frame: JFrame,
+        showDialog: (JFileChooser, JFrame) -> Int
+    ): Path? = onEventDispatchThread {
+        saveWith(location, suggestedName, filters, title) { chooser ->
+            showOwned(frame) { showDialog(chooser, it) }
+        }
+    }
+
     @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun chooseImpl(
         path: Path,
@@ -65,33 +234,8 @@ object SwingFileChooser : FileChooser() {
         title: String,
         selectDirectory: Boolean,
         multiple: Boolean
-    ): List<Path>? {
-        var result: List<Path>? = null
-        SwingUtilities.invokeAndWait {
-            val chooser = JFileChooser(path.toFile()).apply {
-                dialogTitle = title
-                fileSelectionMode = if (selectDirectory) JFileChooser.DIRECTORIES_ONLY else JFileChooser.FILES_ONLY
-                isMultiSelectionEnabled = multiple
-                if (filters.isNotEmpty()) {
-                    // Disable "All Files" so only the supported types are selectable
-                    isAcceptAllFileFilterUsed = false
-                    filters.forEach { addChoosableFileFilter(it) }
-                    // Pre-select the first filter as the active one
-                    fileFilter = filters.first()
-                } else {
-                    filters.forEach { addChoosableFileFilter(it) }
-                }
-            }
-            ownerFrame.isVisible = true
-            val returnCode = chooser.showOpenDialog(ownerFrame)
-            ownerFrame.isVisible = false
-            result = if (returnCode == JFileChooser.APPROVE_OPTION) {
-                if (multiple) chooser.selectedFiles.map { it.toPath() } else listOf(chooser.selectedFile.toPath())
-            } else {
-                null
-            }
-        }
-        return result
+    ): List<Path>? = runOpen(path, filters, title, selectDirectory, multiple, ownerFrame) { chooser, frame ->
+        chooser.showOpenDialog(frame)
     }
 
     @Suppress("BlockingMethodInNonBlockingContext")
@@ -100,29 +244,7 @@ object SwingFileChooser : FileChooser() {
         suggestedName: String,
         filters: List<FileNameExtensionFilter>,
         title: String
-    ): Path? {
-        var result: Path? = null
-        SwingUtilities.invokeAndWait {
-            val chooser = JFileChooser(location.toFile()).apply {
-                dialogTitle = title
-                selectedFile = location.resolve(suggestedName).toFile()
-                if (filters.isNotEmpty()) {
-                    isAcceptAllFileFilterUsed = false
-                    filters.forEach { addChoosableFileFilter(it) }
-                    fileFilter = filters.first()
-                } else {
-                    filters.forEach { addChoosableFileFilter(it) }
-                }
-            }
-            ownerFrame.isVisible = true
-            val returnCode = chooser.showSaveDialog(ownerFrame)
-            ownerFrame.isVisible = false
-            result = if (returnCode == JFileChooser.APPROVE_OPTION) {
-                chooser.selectedFile.toPath()
-            } else {
-                null
-            }
-        }
-        return result
+    ): Path? = runSave(location, suggestedName, filters, title, ownerFrame) { chooser, frame ->
+        chooser.showSaveDialog(frame)
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/XdgFileChooser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/XdgFileChooser.kt
@@ -8,6 +8,7 @@ import org.freedesktop.dbus.annotations.DBusInterfaceName
 import org.freedesktop.dbus.annotations.Position
 import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
 import org.freedesktop.dbus.interfaces.DBusInterface
+import org.freedesktop.dbus.matchrules.DBusMatchRule
 import org.freedesktop.dbus.matchrules.DBusMatchRuleBuilder
 import org.freedesktop.dbus.types.UInt32
 import org.freedesktop.dbus.types.Variant
@@ -39,8 +40,121 @@ object XdgFileChooser : FileChooser() {
         filters: List<FileNameExtensionFilter>,
         title: String
     ): Path? {
-        return openFileChooser(location, filters, title, suggestedName, selectDirectory = false, multiple = false, DBusFileChooser::SaveFile)?.singleOrNull()
+        return saveSelection(
+            openFileChooser(location, filters, title, suggestedName, selectDirectory = false, multiple = false, DBusFileChooser::SaveFile)
+        )
     }
+
+    /**
+     * The one path a save produced, or null.
+     *
+     * A save dialog can only name one file, so anything else coming back from the portal is a
+     * result that cannot be honoured — treated as no save rather than picking one arbitrarily.
+     */
+    internal fun saveSelection(paths: List<Path>?): Path? = paths?.singleOrNull()
+
+    /**
+     * The filters as the portal wants them: one struct per filter, each carrying glob patterns.
+     *
+     * The portal matches patterns literally, so every extension is expanded to a case-insensitive
+     * glob by [asAnyCaseRegex]. Pattern type `0` marks a glob rather than a MIME type.
+     */
+    internal fun toDBusFilters(filters: List<FileNameExtensionFilter>): Array<DBusFilter> =
+        filters.map { filter ->
+            DBusFilter(
+                filter.description,
+                filter.extensions.map { ext ->
+                    DBusFilter.Pattern(UInt32(0), "*.${ext.asAnyCaseRegex()}")
+                }.toTypedArray()
+            )
+        }.toTypedArray()
+
+    /** Everything the portal is told about the dialog to open. */
+    internal fun buildOptions(
+        path: Path,
+        filters: List<FileNameExtensionFilter>,
+        suggestedName: String?,
+        selectDirectory: Boolean,
+        multiple: Boolean,
+        token: String
+    ): Map<String, Variant<*>> {
+        val options = mutableMapOf<String, Variant<*>>()
+        options[Constants.DBus.Options.MULTIPLE] = Variant(multiple)
+        options[Constants.DBus.Options.DIRECTORY] = Variant(selectDirectory)
+        options[Constants.DBus.Options.CURRENT_FOLDER] = Variant(path.toString())
+        options[Constants.DBus.Options.FILTERS] = Variant(toDBusFilters(filters))
+        // Only a save dialog suggests a name; an open dialog must not send the key at all
+        if (suggestedName != null) {
+            options[Constants.DBus.Options.CURRENT_NAME] = Variant(suggestedName)
+        }
+        options[Constants.DBus.Options.HANDLE_TOKEN] = Variant(token)
+        return options
+    }
+
+    /**
+     * The object path the portal will emit its Response signal on.
+     *
+     * Derived from the connection's unique bus name (`:1.42` → `1_42`) and the handle token, per
+     * https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html.
+     * Getting this wrong means the handler is registered for a path that never fires and the
+     * dialog hangs forever rather than failing.
+     */
+    internal fun requestPath(uniqueName: String, token: String): String {
+        val sender = uniqueName.drop(1).replace('.', '_')
+        return "/org/freedesktop/portal/desktop/request/$sender/$token"
+    }
+
+    /**
+     * Reads the portal's Response signal: `params[0]` is the response code (0 means the operator
+     * picked something) and `params[1]` carries the selected `uris`. Anything else is a cancel.
+     */
+    @Suppress("UNCHECKED_CAST")
+    internal fun parseResponse(params: Array<out Any?>): List<String>? {
+        val response = params[0] as UInt32
+        val results = params[1] as Map<String, Variant<*>>
+        if (response.toInt() != 0) return null
+        return (results["uris"]?.value as? List<String>)?.toList()
+    }
+
+    /** The portal answers with `file://` URIs; callers deal in paths. */
+    internal fun toPaths(uris: List<String>?): List<Path>? = uris?.map { Path.of(URI.create(it)) }
+
+    /**
+     * The rule that catches the portal's Response signal for [requestPath].
+     *
+     * Every field has to match what the portal emits — a wrong interface or member name leaves the
+     * handler listening for a signal that never comes, and the dialog hangs rather than failing.
+     */
+    internal fun responseMatchRule(requestPath: String): DBusMatchRule =
+        DBusMatchRuleBuilder.create()
+            .withType("signal")
+            .withInterface("org.freedesktop.portal.Request")
+            .withMember("Response")
+            .withPath(requestPath)
+            .build()
+
+    /**
+     * The whole portal request: build the options for [token], work out the path the answer will
+     * arrive on, hand both to [ask], and turn the uris it returns into paths.
+     *
+     * [ask] is a parameter rather than a direct call so the sequence can be exercised without a
+     * session bus; in production it registers the signal handler and invokes the portal method.
+     */
+    internal suspend fun requestPaths(
+        path: Path,
+        filters: List<FileNameExtensionFilter>,
+        suggestedName: String?,
+        selectDirectory: Boolean,
+        multiple: Boolean,
+        uniqueName: String,
+        token: String,
+        ask: suspend (options: Map<String, Variant<*>>, requestPath: String) -> List<String>?
+    ): List<Path>? = toPaths(
+        ask(
+            buildOptions(path, filters, suggestedName, selectDirectory, multiple, token),
+            requestPath(uniqueName, token)
+        )
+    )
 
     private suspend inline fun openFileChooser(
         path: Path,
@@ -49,7 +163,8 @@ object XdgFileChooser : FileChooser() {
         suggestedName: String?,
         selectDirectory: Boolean,
         multiple: Boolean,
-        dbusMethod: DBusFileChooser.(String, String, Map<String, Variant<*>>) -> DBusPath
+        // crossinline: invoked from inside the request lambda below, so it cannot return non-locally
+        crossinline dbusMethod: DBusFileChooser.(String, String, Map<String, Variant<*>>) -> DBusPath
     ): List<Path>? = DBusConnectionBuilder.forSessionBus().build().use { conn ->
         val fileChooser = conn.getRemoteObject(
             Constants.DBus.DESKTOP_OBJECT_NAME,
@@ -57,55 +172,17 @@ object XdgFileChooser : FileChooser() {
             DBusFileChooser::class.java
         )
 
-        val options = mutableMapOf<String, Variant<*>>()
-        options[Constants.DBus.Options.MULTIPLE] = Variant(multiple)
-        options[Constants.DBus.Options.DIRECTORY] = Variant(selectDirectory)
-        options[Constants.DBus.Options.CURRENT_FOLDER] = Variant(path.toString())
-        options[Constants.DBus.Options.FILTERS] = Variant(
-            filters.map { filter ->
-                DBusFilter(
-                    filter.description,
-                    filter.extensions.map { ext ->
-                        DBusFilter.Pattern(UInt32(0), "*.${ext.asAnyCaseRegex()}")
-                    }.toTypedArray()
-                )
-            }.toTypedArray()
-        )
-        if (suggestedName != null) {
-            options[Constants.DBus.Options.CURRENT_NAME] = Variant(suggestedName)
-        }
-
-        val token = Random.nextULong().toString(16)
-        options[Constants.DBus.Options.HANDLE_TOKEN] = Variant(token)
-
-        // https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html
-        val sender = conn.uniqueName.drop(1).replace('.', '_')
-        val requestPath = "/org/freedesktop/portal/desktop/request/$sender/$token"
-
-        val result = CompletableDeferred<List<String>?>()
-
-        val rule = DBusMatchRuleBuilder.create()
-            .withType("signal")
-            .withInterface("org.freedesktop.portal.Request")
-            .withMember("Response")
-            .withPath(requestPath)
-            .build()
-        @Suppress("UNCHECKED_CAST")
-        conn.addGenericSigHandler(rule) { signal ->
-            val params = signal.parameters
-            val response = params[0] as UInt32
-            val results = params[1] as Map<String, Variant<*>>
-            if (response.toInt() == 0) {
-                val uris = results["uris"]?.value as? List<String>
-                result.complete(uris?.toList())
-            } else {
-                result.complete(null)
+        requestPaths(
+            path, filters, suggestedName, selectDirectory, multiple,
+            conn.uniqueName, Random.nextULong().toString(16)
+        ) { options, requestPath ->
+            val result = CompletableDeferred<List<String>?>()
+            conn.addGenericSigHandler(responseMatchRule(requestPath)) { signal ->
+                result.complete(parseResponse(signal.parameters))
             }
+            fileChooser.dbusMethod("", title, options)
+            result.await()
         }
-
-        fileChooser.dbusMethod("", title, options)
-
-        result.await()?.map { Path.of(URI.create(it)) }
     }
 
     /**
@@ -113,11 +190,11 @@ object XdgFileChooser : FileChooser() {
      * See https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html for details.
      */
     @Suppress("unused")
-    private class DBusFilter(
+    internal class DBusFilter(
         @Position(0) val name: String,
         @Position(1) val patterns: Array<Pattern>
     ) : Struct() {
-        class Pattern(
+        internal class Pattern(
             @Position(0) val type: UInt32,
             @Position(1) val pattern: String
         ) : Struct()

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooserTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooserTest.kt
@@ -1,6 +1,8 @@
 package org.churchpresenter.app.churchpresenter.dialogs.filechooser
 
 import kotlinx.coroutines.runBlocking
+import org.freedesktop.dbus.types.UInt32
+import org.freedesktop.dbus.types.Variant
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -11,6 +13,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 
 /**
@@ -319,6 +323,64 @@ class FileChooserTest {
             runBlocking { chooser.chooseSingle(null, emptyList(), "", selectDirectory = false) }
         }
     }
+
+    // ── Which implementation the platform gets ──────────────────────────────────
+    //
+    // Picking wrong is not a graceful failure: the XDG chooser on a machine with no session bus
+    // cannot open a dialog at all, so every Open and Save in the app stops working.
+
+    @Test
+    fun `Linux talks to the XDG desktop portal`() {
+        assertEquals(XdgFileChooser, FileChooser.platformFor("Linux"))
+    }
+
+    @Test
+    fun `a name carrying unix is recognised too`() {
+        assertEquals(XdgFileChooser, FileChooser.platformFor("Some Unix"), "matched by \"nix\" in \"unix\"")
+    }
+
+    /**
+     * Documents a GAP rather than desired behaviour: the check is a substring match on `nix`/`nux`,
+     * so the unix-likes whose `os.name` carries neither — Solaris, AIX, the BSDs — are handed
+     * FileKit even though they run the same XDG desktop portals as Linux. Nobody has reported it,
+     * and FileKit falls back to the Swing dialog rather than failing outright, so this records the
+     * behaviour instead of asserting it is right.
+     */
+    @Test
+    fun `unix-likes without nix or nux in the name do not get the portal`() {
+        assertEquals(FileKitFileChooser, FileChooser.platformFor("SunOS"))
+        assertEquals(FileKitFileChooser, FileChooser.platformFor("FreeBSD"))
+        assertEquals(FileKitFileChooser, FileChooser.platformFor("AIX"))
+    }
+
+    @Test
+    fun `macOS and Windows get native dialogs through FileKit`() {
+        assertEquals(FileKitFileChooser, FileChooser.platformFor("Mac OS X"))
+        assertEquals(FileKitFileChooser, FileChooser.platformFor("Windows 11"))
+    }
+
+    @Test
+    fun `the os name is matched regardless of case`() {
+        assertEquals(FileChooser.platformFor("linux"), FileChooser.platformFor("LINUX"))
+        assertEquals(XdgFileChooser, FileChooser.platformFor("LINUX"))
+    }
+
+    @Test
+    fun `an unrecognised platform falls to FileKit rather than failing`() {
+        assertEquals(
+            FileKitFileChooser,
+            FileChooser.platformFor("Some Future OS"),
+            "an unknown desktop is likelier to have a native dialog than a D-Bus portal",
+        )
+    }
+
+    @Test
+    fun `the instance the app uses follows the same rule`() {
+        assertEquals(
+            FileChooser.platformFor(System.getProperty("os.name")),
+            FileChooser.platformInstance,
+        )
+    }
 }
 
 /**
@@ -360,5 +422,309 @@ class XdgFilterPatternTest {
     @Test
     fun `an empty extension produces an empty pattern`() {
         assertEquals("", anyCase(""))
+    }
+}
+
+/**
+ * What the Linux (XDG portal) chooser puts on the bus, and what it makes of the answer.
+ *
+ * The dialog itself is a D-Bus round trip to the desktop portal, so it cannot run here — but
+ * everything either side of that call is ordinary logic, and all of it is invisible to anyone
+ * developing on macOS or Windows. The failure modes are quiet ones: an option key the portal
+ * ignores, a request path no signal is ever emitted on (the dialog then hangs rather than
+ * failing), or a response code read as success. The helpers are `internal`, so they are called
+ * directly.
+ */
+class XdgPortalRequestTest {
+
+    private fun filter(description: String, vararg extensions: String) =
+        FileNameExtensionFilter(description, *extensions)
+
+    // ── The filters the portal is given ─────────────────────────────────────────
+
+    private fun toDBusFilters(filters: List<FileNameExtensionFilter>) =
+        XdgFileChooser.toDBusFilters(filters)
+
+    @Test
+    fun `a filter becomes a named struct of glob patterns`() {
+        val structs = toDBusFilters(listOf(filter("Songs (*.sps)", "sps")))
+
+        assertEquals(1, structs.size)
+        val struct = structs.single()
+        assertEquals("Songs (*.sps)", struct.name, "this is the label shown in the portal's filter dropdown")
+
+        val pattern = struct.patterns.single()
+        assertEquals(0, pattern.type.toInt(), "type 0 means a glob; 1 would mean a MIME type")
+        assertEquals(
+            "*.[sS][pP][sS]",
+            pattern.pattern,
+            "the portal matches literally, so a file saved as SONG.SPS would otherwise be hidden",
+        )
+    }
+
+    @Test
+    fun `every extension of a filter gets its own pattern`() {
+        val structs = toDBusFilters(listOf(filter("PowerPoint", "pptx", "ppt")))
+
+        assertEquals(
+            listOf("*.[pP][pP][tT][xX]", "*.[pP][pP][tT]"),
+            structs.single().patterns.map { it.pattern },
+        )
+    }
+
+    @Test
+    fun `each filter stays its own entry in the dropdown`() {
+        val structs = toDBusFilters(listOf(filter("PowerPoint", "pptx"), filter("PDF", "pdf")))
+
+        assertEquals(listOf("PowerPoint", "PDF"), structs.map { it.name })
+    }
+
+    @Test
+    fun `no filters means no filter structs`() {
+        assertEquals(0, toDBusFilters(emptyList()).size)
+    }
+
+    // ── The options the portal is given ─────────────────────────────────────────
+
+    private fun buildOptions(
+        path: Path,
+        filters: List<FileNameExtensionFilter> = emptyList(),
+        suggestedName: String? = null,
+        selectDirectory: Boolean = false,
+        multiple: Boolean = false,
+        token: String = "deadbeef",
+    ): Map<String, Variant<*>> =
+        XdgFileChooser.buildOptions(path, filters, suggestedName, selectDirectory, multiple, token)
+
+    @Test
+    fun `an open dialog is told where to start and what it may select`() {
+        val options = buildOptions(Path("/home/leader/Songs"), selectDirectory = true, multiple = true)
+
+        assertEquals(true, options["multiple"]?.value)
+        assertEquals(true, options["directory"]?.value)
+        assertEquals("/home/leader/Songs", options["current_folder"]?.value)
+        assertEquals("deadbeef", options["handle_token"]?.value)
+    }
+
+    @Test
+    fun `an open dialog suggests no name at all`() {
+        val options = buildOptions(Path("/home/leader"))
+
+        assertFalse(
+            options.containsKey("current_name"),
+            "sending the key at all would have the portal pre-fill the name box",
+        )
+    }
+
+    @Test
+    fun `a save dialog carries the suggested name`() {
+        val options = buildOptions(Path("/home/leader"), suggestedName = "schedule.cps")
+
+        assertEquals("schedule.cps", options["current_name"]?.value)
+    }
+
+    @Test
+    fun `the filters travel with the options`() {
+        val options = buildOptions(Path("/home/leader"), filters = listOf(filter("Schedule", "cps")))
+
+        val structs = options["filters"]?.value as Array<*>
+        assertEquals("Schedule", (structs.single() as XdgFileChooser.DBusFilter).name)
+    }
+
+    // ── The path the portal will answer on ──────────────────────────────────────
+
+    private fun requestPath(uniqueName: String, token: String) =
+        XdgFileChooser.requestPath(uniqueName, token)
+
+    @Test
+    fun `the request path is built from the connection's unique name`() {
+        // ":1.42" -> "1_42": the leading colon is dropped and dots become underscores. A wrong path
+        // registers the handler where no signal arrives, so the dialog hangs instead of failing.
+        assertEquals(
+            "/org/freedesktop/portal/desktop/request/1_42/deadbeef",
+            requestPath(":1.42", "deadbeef"),
+        )
+    }
+
+    @Test
+    fun `every dot in the unique name is replaced`() {
+        assertEquals("/org/freedesktop/portal/desktop/request/1_2_3/tok", requestPath(":1.2.3", "tok"))
+    }
+
+    // ── The rule that catches the answer ────────────────────────────────────────
+
+    private fun responseMatchRule(requestPath: String) =
+        XdgFileChooser.responseMatchRule(requestPath)
+
+    @Test
+    fun `the match rule listens for the portal's Response signal on the request path`() {
+        // Every field has to match what the portal emits. Anything wrong here means the handler
+        // waits for a signal that never arrives and the dialog hangs instead of failing.
+        val rule = responseMatchRule("/org/freedesktop/portal/desktop/request/1_42/deadbeef")
+
+        assertEquals("signal", rule.messageType)
+        assertEquals("org.freedesktop.portal.Request", rule.getInterface())
+        assertEquals("Response", rule.member)
+        assertEquals("/org/freedesktop/portal/desktop/request/1_42/deadbeef", rule.path)
+    }
+
+    @Test
+    fun `each request gets a rule for its own path`() {
+        assertNotEquals(
+            responseMatchRule(requestPath(":1.42", "one")),
+            responseMatchRule(requestPath(":1.42", "two")),
+            "two dialogs open at once must not answer each other's signals",
+        )
+    }
+
+    // ── What the portal answers ─────────────────────────────────────────────────
+
+    private fun parseResponse(response: Int, results: Map<String, Variant<*>>) =
+        XdgFileChooser.parseResponse(arrayOf(UInt32(response.toLong()), results))
+
+    private fun uris(vararg values: String) = mapOf("uris" to Variant(values.toList(), "as"))
+
+    @Test
+    fun `a successful response yields the selected uris`() {
+        assertEquals(
+            listOf("file:///home/leader/a.sps", "file:///home/leader/b.sps"),
+            parseResponse(0, uris("file:///home/leader/a.sps", "file:///home/leader/b.sps")),
+        )
+    }
+
+    @Test
+    fun `a cancelled response yields nothing`() {
+        // 1 is the portal's code for "cancelled by the user", 2 for "ended some other way".
+        assertNull(parseResponse(1, uris("file:///home/leader/a.sps")))
+        assertNull(parseResponse(2, emptyMap()))
+    }
+
+    @Test
+    fun `a success carrying no uris is treated as no selection`() {
+        assertNull(parseResponse(0, emptyMap()), "a response without uris must not crash the dialog")
+    }
+
+    // ── The whole request, end to end ───────────────────────────────────────────
+    //
+    // requestPaths is the real sequence with only the bus round-trip passed in, so the real
+    // buildOptions, requestPath and toPaths all run.
+
+    @Test
+    fun `the request carries the options and listens on the matching path`() = runBlocking {
+        var seenOptions: Map<String, Variant<*>>? = null
+        var seenRequestPath: String? = null
+
+        XdgFileChooser.requestPaths(
+            path = Path("/home/leader/Songs"),
+            filters = listOf(filter("Songs", "sps")),
+            suggestedName = null,
+            selectDirectory = false,
+            multiple = true,
+            uniqueName = ":1.42",
+            token = "deadbeef",
+        ) { options, requestPath ->
+            seenOptions = options
+            seenRequestPath = requestPath
+            null
+        }
+
+        assertEquals("/home/leader/Songs", seenOptions?.get("current_folder")?.value)
+        assertEquals(true, seenOptions?.get("multiple")?.value)
+        assertEquals("deadbeef", seenOptions?.get("handle_token")?.value)
+        assertEquals(
+            "/org/freedesktop/portal/desktop/request/1_42/deadbeef",
+            seenRequestPath,
+            "the token in the options and the token in the path must be the same one",
+        )
+    }
+
+    @Test
+    fun `the uris the portal answered with come back as paths`() = runBlocking {
+        val picked = XdgFileChooser.requestPaths(
+            path = Path("/home/leader"),
+            filters = emptyList(),
+            suggestedName = null,
+            selectDirectory = false,
+            multiple = true,
+            uniqueName = ":1.42",
+            token = "tok",
+        ) { _, _ -> listOf("file:///home/leader/a.sps", "file:///home/leader/b.sps") }
+
+        assertEquals(listOf(Path("/home/leader/a.sps"), Path("/home/leader/b.sps")), picked)
+    }
+
+    @Test
+    fun `a cancelled portal request comes back as nothing`() = runBlocking {
+        val picked = XdgFileChooser.requestPaths(
+            path = Path("/home/leader"),
+            filters = emptyList(),
+            suggestedName = null,
+            selectDirectory = false,
+            multiple = false,
+            uniqueName = ":1.42",
+            token = "tok",
+        ) { _, _ -> null }
+
+        assertNull(picked)
+    }
+
+    @Test
+    fun `a save request tells the portal the suggested name`() = runBlocking {
+        var seenOptions: Map<String, Variant<*>>? = null
+
+        XdgFileChooser.requestPaths(
+            path = Path("/home/leader"),
+            filters = emptyList(),
+            suggestedName = "schedule.cps",
+            selectDirectory = false,
+            multiple = false,
+            uniqueName = ":1.42",
+            token = "tok",
+        ) { options, _ -> seenOptions = options; null }
+
+        assertEquals("schedule.cps", seenOptions?.get("current_name")?.value)
+    }
+
+    // ── What a save makes of the answer ─────────────────────────────────────────
+
+    @Test
+    fun `a save takes the one path the portal named`() {
+        assertEquals(Path("/home/leader/sunday.cps"), XdgFileChooser.saveSelection(listOf(Path("/home/leader/sunday.cps"))))
+    }
+
+    @Test
+    fun `a save that somehow named several files saves none of them`() {
+        // A save dialog can only name one file, so more than one is a result that cannot be
+        // honoured — better no save than silently writing to whichever came first.
+        assertNull(XdgFileChooser.saveSelection(listOf(Path("/a.cps"), Path("/b.cps"))))
+        assertNull(XdgFileChooser.saveSelection(emptyList()))
+        assertNull(XdgFileChooser.saveSelection(null))
+    }
+
+    // ── Turning the answer into paths ───────────────────────────────────────────
+
+    private fun toPaths(uris: List<String>?) = XdgFileChooser.toPaths(uris)
+
+    @Test
+    fun `file uris become paths`() {
+        assertEquals(
+            listOf(Path("/home/leader/a.sps"), Path("/home/leader/b.sps")),
+            toPaths(listOf("file:///home/leader/a.sps", "file:///home/leader/b.sps")),
+        )
+    }
+
+    @Test
+    fun `an escaped uri decodes back to the real name`() {
+        assertEquals(
+            listOf(Path("/home/leader/Sunday morning.cps")),
+            toPaths(listOf("file:///home/leader/Sunday%20morning.cps")),
+            "a space in a filename must not survive as %20",
+        )
+    }
+
+    @Test
+    fun `nothing selected stays nothing`() {
+        assertNull(toPaths(null), "null means cancelled and must not become an empty selection")
+        assertEquals(emptyList(), toPaths(emptyList()))
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/PlatformFileChooserTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/PlatformFileChooserTest.kt
@@ -1,27 +1,45 @@
 package org.churchpresenter.app.churchpresenter.dialogs.filechooser
 
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
 import java.awt.Image
+import java.awt.Window
 import java.awt.image.BufferedImage
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 import java.nio.file.Files
+import java.nio.file.Path
 import javax.imageio.ImageIO
+import javax.swing.JFileChooser
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
 import javax.swing.filechooser.FileNameExtensionFilter
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * The per-platform choosers, minus the dialogs themselves.
  *
  * `SwingFileChooser` and `FileKitFileChooser` are mostly calls into a toolkit that needs a display,
- * but each carries a piece of ordinary logic that decides what the dialog is given and what comes
- * back out of it. Those pieces are private, so they are reached by reflection — the same approach
- * [org.churchpresenter.app.churchpresenter.utils.CrashReporterTest] uses for `scrubPii`. Touching
- * these objects does not build any window: the Swing owner frame is created lazily, on first use of
- * a real dialog.
+ * but the ordinary logic around those calls — what the dialog is configured with, which picker a
+ * request maps to, what comes back out — is `internal` and called directly here. The one step that
+ * genuinely needs a display is a parameter (`openWith`/`saveWith` take the showing as a lambda), so
+ * the whole sequence runs under test with only that step stood in for.
+ *
+ * Touching these objects builds no window: the Swing owner frame is created lazily, on first use of
+ * a real dialog. `loadAppIcon` is still reached by reflection because it is private for its own
+ * reasons; new tests should widen to `internal` instead.
  *
  * [FileChooserTest] covers the shared base class, which is where most of the behaviour lives.
  */
@@ -40,6 +58,9 @@ class PlatformFileChooserTest {
         // The source-tree fallback walks up from user.dir; pointed at a temp folder it finds
         // nothing, so tests decide for themselves what is discoverable.
         System.setProperty("user.dir", dir.absolutePath)
+        // nativeDialogsBroken is a per-JVM latch; force it off so one test's fault can't decide
+        // another's, and so a leftover value from an earlier suite doesn't skew these.
+        FileKitFileChooser.nativeDialogsBroken = false
     }
 
     @AfterTest
@@ -48,6 +69,7 @@ class PlatformFileChooserTest {
             ?: System.clearProperty("compose.application.resources.dir")
         realUserDir?.let { System.setProperty("user.dir", it) }
         dir.deleteRecursively()
+        FileKitFileChooser.nativeDialogsBroken = false
     }
 
     /** Writes a real square PNG whose width identifies which file was loaded. */
@@ -121,14 +143,565 @@ class PlatformFileChooserTest {
         assertEquals(32, loadAppIcon()?.getWidth(null))
     }
 
+    // ── SwingFileChooser: the hidden frame that owns the dialog ─────────────────
+    //
+    // A JFrame cannot be built headless, so these use a MockK instance — created without running
+    // the constructor — with the properties under test wired to real backing fields. The
+    // assertions are on the frame's resulting state, not on which setters were called.
+
+    /** A JFrame that actually remembers what was set on it, usable with no display. */
+    private fun recordingFrame(): JFrame {
+        val frame = mockk<JFrame>(relaxed = true)
+        var visible = false
+        var undecorated = false
+        every { frame.isVisible = any() } answers { visible = firstArg() }
+        every { frame.isVisible } answers { visible }
+        every { frame.isUndecorated = any() } answers { undecorated = firstArg() }
+        every { frame.isUndecorated } answers { undecorated }
+        return frame
+    }
+
+    @Test
+    fun `the owner frame is invisible and unobtrusive`() {
+        val frame = recordingFrame()
+
+        SwingFileChooser.configureOwnerFrame(frame)
+
+        assertTrue(frame.isUndecorated, "a decorated owner would flash a title bar behind the dialog")
+        verify { frame.setSize(0, 0) }
+    }
+
+    @Test
+    fun `the owner frame is given the app icon`() {
+        val resources = File(dir, "app-resources")
+        icon("icon-32.png", 32, into = resources)
+        System.setProperty("compose.application.resources.dir", resources.absolutePath)
+        val frame = recordingFrame()
+        val icons = mutableListOf<Image?>()
+        every { frame.iconImage = any() } answers { icons += firstArg<Image?>() }
+
+        SwingFileChooser.configureOwnerFrame(frame)
+
+        assertEquals(32, icons.single()?.getWidth(null), "the dialog shows the app icon, not a coffee cup")
+    }
+
+    @Test
+    fun `a frame that refuses the icon is still set up`() {
+        // The icon is cosmetic. If applying it fails, the alternative to swallowing that is no file
+        // dialogs at all on the affected machine.
+        val frame = recordingFrame()
+        every { frame.iconImage = any() } throws RuntimeException("no icon for you")
+
+        SwingFileChooser.configureOwnerFrame(frame)
+
+        assertTrue(frame.isUndecorated, "the frame must still be a usable owner")
+    }
+
+    @Test
+    fun `the owner frame is showing while the dialog is up and hidden again afterwards`() {
+        // Leaving it visible strands a zero-sized undecorated window on the desktop; hiding it too
+        // early leaves the dialog with no owner and no icon.
+        val frame = recordingFrame()
+        var visibleDuringDialog: Boolean? = null
+
+        SwingFileChooser.showOwned(frame) {
+            visibleDuringDialog = it.isVisible
+            JFileChooser.APPROVE_OPTION
+        }
+
+        assertEquals(true, visibleDuringDialog)
+        assertFalse(frame.isVisible, "the owner frame must not outlive the dialog")
+    }
+
+    @Test
+    fun `the dialog is shown owned by the frame it was given`() {
+        val frame = recordingFrame()
+        var owner: JFrame? = null
+
+        SwingFileChooser.showOwned(frame) { owner = it; JFileChooser.CANCEL_OPTION }
+
+        assertEquals(frame, owner, "an unowned dialog loses the app icon and the modality")
+    }
+
+    @Test
+    fun `the return code from the dialog is passed straight back`() {
+        val frame = recordingFrame()
+
+        assertEquals(
+            JFileChooser.APPROVE_OPTION,
+            SwingFileChooser.showOwned(frame) { JFileChooser.APPROVE_OPTION },
+        )
+        assertEquals(
+            JFileChooser.ERROR_OPTION,
+            SwingFileChooser.showOwned(frame) { JFileChooser.ERROR_OPTION },
+        )
+    }
+
+    // ── SwingFileChooser: what the dialog is told ───────────────────────────────
+
+    /**
+     * A chooser pointed at the test's temp folder. Building one needs no display — only showing it
+     * does — so everything the dialog is configured with can be asserted here.
+     */
+    private fun chooser() = JFileChooser(dir)
+
+    private fun configureOpen(
+        chooser: JFileChooser,
+        filters: List<FileNameExtensionFilter>,
+        title: String = "",
+        selectDirectory: Boolean = false,
+        multiple: Boolean = false,
+    ) = SwingFileChooser.configureOpen(chooser, filters, title, selectDirectory, multiple)
+
+    private fun configureSave(
+        chooser: JFileChooser,
+        location: Path,
+        suggestedName: String,
+        filters: List<FileNameExtensionFilter>,
+        title: String = "",
+    ) = SwingFileChooser.configureSave(chooser, location, suggestedName, filters, title)
+
+    private fun filter(description: String, vararg extensions: String) =
+        FileNameExtensionFilter(description, *extensions)
+
+    @Test
+    fun `the open dialog is given its title and selection mode`() {
+        val chooser = chooser()
+
+        configureOpen(chooser, emptyList(), title = "Open Schedule", multiple = true)
+
+        assertEquals("Open Schedule", chooser.dialogTitle)
+        assertEquals(JFileChooser.FILES_ONLY, chooser.fileSelectionMode)
+        assertTrue(chooser.isMultiSelectionEnabled)
+    }
+
+    @Test
+    fun `picking a folder restricts the dialog to directories`() {
+        val chooser = chooser()
+
+        configureOpen(chooser, emptyList(), selectDirectory = true)
+
+        assertEquals(
+            JFileChooser.DIRECTORIES_ONLY,
+            chooser.fileSelectionMode,
+            "choosing a song library must not offer files",
+        )
+        assertFalse(chooser.isMultiSelectionEnabled, "a single-selection request must stay single")
+    }
+
+    @Test
+    fun `offered filters replace the All Files entry`() {
+        val songs = filter("Songs (*.sps)", "sps")
+        val chooser = chooser()
+
+        configureOpen(chooser, listOf(songs))
+
+        assertFalse(
+            chooser.isAcceptAllFileFilterUsed,
+            "leaving All Files on lets an operator pick a file the app cannot open",
+        )
+        assertEquals(listOf(songs), chooser.choosableFileFilters.toList())
+    }
+
+    @Test
+    fun `the first filter is the one the dialog opens showing`() {
+        val powerPoint = filter("PowerPoint", "pptx", "ppt")
+        val pdf = filter("PDF", "pdf")
+        val chooser = chooser()
+
+        configureOpen(chooser, listOf(powerPoint, pdf))
+
+        assertEquals(powerPoint, chooser.fileFilter, "the preselected filter decides what is listed")
+        assertEquals(listOf(powerPoint, pdf), chooser.choosableFileFilters.toList())
+    }
+
+    @Test
+    fun `with no filters the dialog keeps All Files`() {
+        val chooser = chooser()
+
+        configureOpen(chooser, emptyList())
+
+        assertTrue(
+            chooser.isAcceptAllFileFilterUsed,
+            "a chooser with nothing to filter by must not end up listing nothing",
+        )
+    }
+
+    @Test
+    fun `the save dialog opens on the suggested name inside the given folder`() {
+        val chooser = chooser()
+
+        configureSave(chooser, dir.toPath(), "schedule.cps", listOf(filter("Schedule", "cps")), "Save As")
+
+        assertEquals("Save As", chooser.dialogTitle)
+        assertEquals(File(dir, "schedule.cps"), chooser.selectedFile)
+    }
+
+    /**
+     * Documents why [SwingFileChooser] sets the name BEFORE the filters: `JFileChooser.setFileFilter`
+     * clears the selection when the selected file does not pass the new filter. Every caller passes a
+     * name the filter accepts, so this only bites if that ever stops being true — at which point the
+     * save dialog would open with an empty name box instead of a suggested one.
+     */
+    @Test
+    fun `a suggested name the filter rejects is dropped`() {
+        val chooser = chooser()
+
+        configureSave(chooser, dir.toPath(), "schedule.txt", listOf(filter("Schedule", "cps")))
+
+        assertNull(chooser.selectedFile, "Swing drops a selection the active filter does not accept")
+    }
+
+    @Test
+    fun `the save dialog filters the same way the open dialog does`() {
+        val schedule = filter("Schedule", "cps")
+        val chooser = chooser()
+
+        configureSave(chooser, dir.toPath(), "schedule.cps", listOf(schedule))
+
+        assertFalse(chooser.isAcceptAllFileFilterUsed)
+        assertEquals(schedule, chooser.fileFilter)
+    }
+
+    @Test
+    fun `a save dialog with no filters keeps All Files`() {
+        val chooser = chooser()
+
+        configureSave(chooser, dir.toPath(), "notes", emptyList())
+
+        assertTrue(chooser.isAcceptAllFileFilterUsed)
+        assertEquals(File(dir, "notes"), chooser.selectedFile, "no filter can reject the name")
+    }
+
+    // ── SwingFileChooser: what comes back out of it ─────────────────────────────
+
+    private fun openResult(returnCode: Int, chooser: JFileChooser, multiple: Boolean): List<Path>? =
+        SwingFileChooser.openResult(returnCode, chooser, multiple)
+
+    private fun saveResult(returnCode: Int, chooser: JFileChooser): Path? =
+        SwingFileChooser.saveResult(returnCode, chooser)
+
+    @Test
+    fun `an approved single choice comes back as one path`() {
+        val chooser = chooser().apply { selectedFile = File(dir, "song.sps") }
+
+        assertEquals(
+            listOf(File(dir, "song.sps").toPath()),
+            openResult(JFileChooser.APPROVE_OPTION, chooser, multiple = false),
+        )
+    }
+
+    @Test
+    fun `an approved multiple choice comes back as every path`() {
+        val chooser = chooser().apply {
+            isMultiSelectionEnabled = true
+            selectedFiles = arrayOf(File(dir, "a.sps"), File(dir, "b.sps"))
+        }
+
+        assertEquals(
+            listOf(File(dir, "a.sps").toPath(), File(dir, "b.sps").toPath()),
+            openResult(JFileChooser.APPROVE_OPTION, chooser, multiple = true),
+        )
+    }
+
+    @Test
+    fun `selecting nothing in a multiple choice comes back empty rather than null`() {
+        // The base class treats null as "cancelled"; an approved dialog with no files is not that.
+        val chooser = chooser().apply { isMultiSelectionEnabled = true }
+
+        assertEquals(emptyList(), openResult(JFileChooser.APPROVE_OPTION, chooser, multiple = true))
+    }
+
+    @Test
+    fun `a cancelled open dialog returns nothing`() {
+        val chooser = chooser().apply { selectedFile = File(dir, "song.sps") }
+
+        assertNull(
+            openResult(JFileChooser.CANCEL_OPTION, chooser, multiple = false),
+            "a stale selection must not be returned as though it were picked",
+        )
+        assertNull(openResult(JFileChooser.ERROR_OPTION, chooser, multiple = false))
+    }
+
+    @Test
+    fun `an approved save returns the chosen path`() {
+        val chooser = chooser().apply { selectedFile = File(dir, "sunday.cps") }
+
+        assertEquals(File(dir, "sunday.cps").toPath(), saveResult(JFileChooser.APPROVE_OPTION, chooser))
+    }
+
+    @Test
+    fun `a cancelled save returns nothing`() {
+        val chooser = chooser().apply { selectedFile = File(dir, "sunday.cps") }
+
+        assertNull(saveResult(JFileChooser.CANCEL_OPTION, chooser))
+        assertNull(
+            saveResult(JFileChooser.ERROR_OPTION, chooser),
+            "a dialog that failed must not overwrite whatever the name box happened to hold",
+        )
+    }
+
+    // ── SwingFileChooser: getting the answer off the dispatch thread ────────────
+
+    private fun <T> onEventDispatchThread(block: () -> T): T =
+        SwingFileChooser.onEventDispatchThread(block)
+
+    @Test
+    fun `the dialog is opened from the event dispatch thread`() {
+        assertTrue(
+            onEventDispatchThread { SwingUtilities.isEventDispatchThread() },
+            "Swing requires a dialog be opened from the EDT, not from the caller's dispatcher",
+        )
+    }
+
+    @Test
+    fun `what the dispatch thread produced is handed back to the caller`() {
+        assertEquals(listOf("song.sps"), onEventDispatchThread { listOf("song.sps") })
+    }
+
+    @Test
+    fun `a null answer survives the trip back`() {
+        // Cancelling produces null, and the value is carried out of the EDT through an unchecked
+        // cast — one that cannot carry a null would turn every cancelled dialog into a crash.
+        assertNull(onEventDispatchThread<List<Path>?> { null })
+    }
+
+    @Test
+    fun `a failure inside the dialog is not swallowed`() {
+        val boom = IllegalStateException("the dialog blew up")
+
+        val thrown = assertFailsWith<InvocationTargetException> {
+            onEventDispatchThread<Unit> { throw boom }
+        }
+
+        assertTrue(
+            generateSequence(thrown as Throwable) { it.cause }.any { it === boom },
+            "a chooser that fails must report it, not return as though the operator cancelled",
+        )
+    }
+
+    // ── SwingFileChooser: running the dialog end to end ─────────────────────────
+    //
+    // openWith/saveWith are the real sequence — build a chooser, configure it, show it, read the
+    // outcome — with only the showing passed in. These drive the whole path with a stand-in for
+    // that one step, so the real configureOpen/configureSave and openResult/saveResult run.
+
+    @Test
+    fun `the open dialog is built on the folder it was given and set up before it is shown`() {
+        var shownWith: JFileChooser? = null
+
+        SwingFileChooser.openWith(
+            path = dir.toPath(),
+            filters = listOf(filter("Songs", "sps")),
+            title = "Open Song",
+            selectDirectory = false,
+            multiple = false,
+        ) { chooser ->
+            // Whatever the operator sees must already be configured by the time it is on screen.
+            shownWith = chooser
+            JFileChooser.CANCEL_OPTION
+        }
+
+        val shown = assertNotNull(shownWith)
+        assertEquals(dir.canonicalFile, shown.currentDirectory.canonicalFile)
+        assertEquals("Open Song", shown.dialogTitle)
+        assertFalse(shown.isAcceptAllFileFilterUsed)
+    }
+
+    @Test
+    fun `an approved open returns what the dialog was left holding`() {
+        val picked = SwingFileChooser.openWith(
+            path = dir.toPath(),
+            filters = emptyList(),
+            title = "",
+            selectDirectory = false,
+            multiple = false,
+        ) { chooser ->
+            chooser.selectedFile = File(dir, "song.sps")
+            JFileChooser.APPROVE_OPTION
+        }
+
+        assertEquals(listOf(File(dir, "song.sps").toPath()), picked)
+    }
+
+    @Test
+    fun `an approved multi-select open returns every file`() {
+        val picked = SwingFileChooser.openWith(
+            path = dir.toPath(),
+            filters = emptyList(),
+            title = "",
+            selectDirectory = false,
+            multiple = true,
+        ) { chooser ->
+            chooser.selectedFiles = arrayOf(File(dir, "a.sps"), File(dir, "b.sps"))
+            JFileChooser.APPROVE_OPTION
+        }
+
+        assertEquals(listOf(File(dir, "a.sps").toPath(), File(dir, "b.sps").toPath()), picked)
+    }
+
+    @Test
+    fun `a cancelled open returns nothing even though a file was selected`() {
+        val picked = SwingFileChooser.openWith(
+            path = dir.toPath(),
+            filters = emptyList(),
+            title = "",
+            selectDirectory = false,
+            multiple = false,
+        ) { chooser ->
+            chooser.selectedFile = File(dir, "song.sps")
+            JFileChooser.CANCEL_OPTION
+        }
+
+        assertNull(picked, "a selection left behind by a cancelled dialog must not be returned")
+    }
+
+    @Test
+    fun `the save dialog is set up with the suggested name before it is shown`() {
+        var shownWith: JFileChooser? = null
+
+        SwingFileChooser.saveWith(
+            location = dir.toPath(),
+            suggestedName = "schedule.cps",
+            filters = listOf(filter("Schedule", "cps")),
+            title = "Save As",
+        ) { chooser ->
+            shownWith = chooser
+            JFileChooser.CANCEL_OPTION
+        }
+
+        val shown = assertNotNull(shownWith)
+        assertEquals("Save As", shown.dialogTitle)
+        assertEquals(File(dir, "schedule.cps"), shown.selectedFile)
+    }
+
+    @Test
+    fun `an approved save returns the path the dialog was left holding`() {
+        val saved = SwingFileChooser.saveWith(
+            location = dir.toPath(),
+            suggestedName = "schedule.cps",
+            filters = listOf(filter("Schedule", "cps")),
+            title = "",
+        ) { chooser ->
+            chooser.selectedFile = File(dir, "sunday.cps")
+            JFileChooser.APPROVE_OPTION
+        }
+
+        assertEquals(File(dir, "sunday.cps").toPath(), saved)
+    }
+
+    @Test
+    fun `a cancelled save returns nothing even though the name box was filled`() {
+        val saved = SwingFileChooser.saveWith(
+            location = dir.toPath(),
+            suggestedName = "schedule.cps",
+            filters = emptyList(),
+            title = "",
+        ) { chooser ->
+            chooser.selectedFile = File(dir, "sunday.cps")
+            JFileChooser.CANCEL_OPTION
+        }
+
+        assertNull(saved)
+    }
+
+    // ── SwingFileChooser: the full open/save path on the dispatch thread ─────────
+    //
+    // runOpen/runSave are the whole override body with only the owner frame and the one display
+    // call injected — so the real onEventDispatchThread, openWith, configureOpen, showOwned and
+    // openResult all run, on the actual EDT, with a recording frame standing in for the window.
+
+    @Test
+    fun `the open path configures shows and reads on the dispatch thread`() {
+        val frame = recordingFrame()
+        var onEdt = false
+        var shownChooser: JFileChooser? = null
+
+        val picked = SwingFileChooser.runOpen(
+            path = dir.toPath(),
+            filters = listOf(filter("Songs", "sps")),
+            title = "Open Song",
+            selectDirectory = false,
+            multiple = false,
+            frame = frame,
+        ) { chooser, ownerFrame ->
+            onEdt = SwingUtilities.isEventDispatchThread()
+            shownChooser = chooser
+            assertEquals(frame, ownerFrame, "the dialog must be owned by the frame it was given")
+            chooser.selectedFile = File(dir, "song.sps")
+            JFileChooser.APPROVE_OPTION
+        }
+
+        assertTrue(onEdt, "Swing requires the dialog be shown on the EDT")
+        assertEquals("Open Song", shownChooser?.dialogTitle, "the chooser was configured before it was shown")
+        assertFalse(shownChooser!!.isAcceptAllFileFilterUsed, "filters were applied before showing")
+        assertEquals(listOf(File(dir, "song.sps").toPath()), picked)
+        assertFalse(frame.isVisible, "the owner frame is hidden again once the dialog closes")
+    }
+
+    @Test
+    fun `a cancelled open path returns nothing`() {
+        val frame = recordingFrame()
+
+        val picked = SwingFileChooser.runOpen(
+            path = dir.toPath(),
+            filters = emptyList(),
+            title = "",
+            selectDirectory = false,
+            multiple = false,
+            frame = frame,
+        ) { _, _ -> JFileChooser.CANCEL_OPTION }
+
+        assertNull(picked)
+    }
+
+    @Test
+    fun `the save path configures shows and reads on the dispatch thread`() {
+        val frame = recordingFrame()
+        var nameWhenShown: File? = null
+        var titleWhenShown: String? = null
+
+        val saved = SwingFileChooser.runSave(
+            location = dir.toPath(),
+            suggestedName = "schedule.cps",
+            filters = listOf(filter("Schedule", "cps")),
+            title = "Save As",
+            frame = frame,
+        ) { chooser, _ ->
+            // Read the configuration the operator would see, before standing in for their pick.
+            nameWhenShown = chooser.selectedFile
+            titleWhenShown = chooser.dialogTitle
+            chooser.selectedFile = File(dir, "sunday.cps")
+            JFileChooser.APPROVE_OPTION
+        }
+
+        assertEquals(File(dir, "schedule.cps"), nameWhenShown, "opened on the suggested name")
+        assertEquals("Save As", titleWhenShown)
+        assertEquals(File(dir, "sunday.cps").toPath(), saved)
+    }
+
+    @Test
+    fun `a cancelled save path returns nothing`() {
+        val frame = recordingFrame()
+
+        val saved = SwingFileChooser.runSave(
+            location = dir.toPath(),
+            suggestedName = "schedule.cps",
+            filters = emptyList(),
+            title = "",
+            frame = frame,
+        ) { _, _ -> JFileChooser.CANCEL_OPTION }
+
+        assertNull(saved)
+    }
+
     // ── FileKitFileChooser: what the native dialog is told ──────────────────────
 
-    @Suppress("UNCHECKED_CAST")
     private fun allExtensions(filters: List<FileNameExtensionFilter>): List<String> =
-        FileKitFileChooser::class.java
-            .getDeclaredMethod("allExtensions", List::class.java)
-            .apply { isAccessible = true }
-            .invoke(FileKitFileChooser, filters) as List<String>
+        with(FileKitFileChooser) { filters.allExtensions() }
+
+    private fun toFileKitType(filters: List<FileNameExtensionFilter>): FileKitType =
+        with(FileKitFileChooser) { filters.toFileKitType() }
 
     @Test
     fun `filters are flattened into one extension list`() {
@@ -160,13 +733,85 @@ class PlatformFileChooserTest {
         assertEquals(emptyList<String>(), allExtensions(emptyList()))
     }
 
+    @Test
+    fun `the combined extensions become the type the picker filters by`() {
+        val type = toFileKitType(listOf(filter("PowerPoint", "pptx", "ppt"), filter("PDF", "pdf")))
+
+        assertEquals(setOf("pptx", "ppt", "pdf"), (type as FileKitType.File).extensions)
+    }
+
+    @Test
+    fun `no filters means a picker that accepts anything`() {
+        // FileKitType.File() with no extensions means "all files"; an empty extension set would
+        // instead be a picker that can select nothing at all.
+        assertNull((toFileKitType(emptyList()) as FileKitType.File).extensions)
+    }
+
+    // ── FileKitFileChooser: which picker a request maps to ──────────────────────
+
+    @Test
+    fun `a plain request opens the single-file picker`() {
+        assertEquals(
+            FileKitFileChooser.PickerMode.SINGLE_FILE,
+            FileKitFileChooser.pickerMode(selectDirectory = false, multiple = false),
+        )
+    }
+
+    @Test
+    fun `a multiple request opens the multi-file picker`() {
+        assertEquals(
+            FileKitFileChooser.PickerMode.MULTIPLE_FILES,
+            FileKitFileChooser.pickerMode(selectDirectory = false, multiple = true),
+        )
+    }
+
+    @Test
+    fun `a directory request opens the directory picker whatever multiple says`() {
+        // No call site asks for several directories, and the directory picker has no multi mode —
+        // so selectDirectory has to win, or the request would open a file picker instead.
+        assertEquals(
+            FileKitFileChooser.PickerMode.DIRECTORY,
+            FileKitFileChooser.pickerMode(selectDirectory = true, multiple = false),
+        )
+        assertEquals(
+            FileKitFileChooser.PickerMode.DIRECTORY,
+            FileKitFileChooser.pickerMode(selectDirectory = true, multiple = true),
+        )
+    }
+
+    // ── FileKitFileChooser: the name the save dialog opens with ─────────────────
+
+    @Test
+    fun `a suggested name loses the extension the picker will add back`() {
+        // FileKit appends the default extension itself; leaving it on offers "schedule.cps.cps".
+        assertEquals("schedule" to "cps", FileKitFileChooser.saveNameParts("schedule.cps", listOf("cps")))
+    }
+
+    @Test
+    fun `stripping the extension ignores case`() {
+        assertEquals("SUNDAY" to "cps", FileKitFileChooser.saveNameParts("SUNDAY.CPS", listOf("cps")))
+    }
+
+    @Test
+    fun `a name carrying a different offered extension keeps that one as the default`() {
+        val parts = FileKitFileChooser.saveNameParts("deck.pdf", listOf("pptx", "pdf"))
+
+        assertEquals("deck" to "pdf", parts, "saving a PDF must not default the dialog back to pptx")
+    }
+
+    @Test
+    fun `a name with no offered extension is left whole and gains the first`() {
+        assertEquals("notes.txt" to "cps", FileKitFileChooser.saveNameParts("notes.txt", listOf("cps")))
+    }
+
+    @Test
+    fun `with no extensions on offer the name is passed through as typed`() {
+        assertEquals("whatever" to null, FileKitFileChooser.saveNameParts("whatever", emptyList()))
+    }
+
     // ── FileKitFileChooser: what comes back out of it ───────────────────────────
 
-    private fun toPathOrNull(file: File): Any? =
-        FileKitFileChooser::class.java
-            .getDeclaredMethod("toPathOrNull", File::class.java)
-            .apply { isAccessible = true }
-            .invoke(FileKitFileChooser, file)
+    private fun toPathOrNull(file: File): Path? = with(FileKitFileChooser) { file.toPathOrNull() }
 
     @Test
     fun `a real selection converts to a path`() {
@@ -184,5 +829,339 @@ class PlatformFileChooserTest {
         val notARealPath = File("bad\u0000name")
 
         assertNull(toPathOrNull(notARealPath))
+    }
+
+    /** The same unconvertible pick used above, reused by the selection tests below. */
+    private val virtualShellItem get() = File("bad\u0000name")
+
+    @Test
+    fun `one picked file comes back as a one-item selection`() {
+        assertEquals(
+            listOf(File(dir, "song.sps").toPath()),
+            FileKitFileChooser.singleSelection(File(dir, "song.sps")),
+        )
+    }
+
+    @Test
+    fun `picking nothing is not a selection`() {
+        assertNull(FileKitFileChooser.singleSelection(null))
+        assertNull(
+            FileKitFileChooser.singleSelection(virtualShellItem),
+            "an unconvertible pick must read as cancelled, not crash",
+        )
+    }
+
+    @Test
+    fun `several picked files come back in order`() {
+        assertEquals(
+            listOf(File(dir, "a.sps").toPath(), File(dir, "b.sps").toPath()),
+            FileKitFileChooser.multipleSelection(listOf(File(dir, "a.sps"), File(dir, "b.sps"))),
+        )
+    }
+
+    @Test
+    fun `unconvertible files are dropped from a multiple selection`() {
+        assertEquals(
+            listOf(File(dir, "a.sps").toPath()),
+            FileKitFileChooser.multipleSelection(listOf(File(dir, "a.sps"), virtualShellItem)),
+            "one virtual shell item must not lose the real files picked alongside it",
+        )
+    }
+
+    @Test
+    fun `a multiple selection left with nothing reads as cancelled`() {
+        // The base class reads null as "cancelled"; an empty list would instead be unwrapped as a
+        // selection, so both of these have to collapse to null.
+        assertNull(FileKitFileChooser.multipleSelection(emptyList()))
+        assertNull(FileKitFileChooser.multipleSelection(listOf(virtualShellItem)))
+        assertNull(FileKitFileChooser.multipleSelection(null))
+    }
+
+    // ── FileKitFileChooser: running the native dialog end to end ────────────────
+    //
+    // openWith/saveWith are the real sequence with only the native picker passed in, so the real
+    // pickerMode, toFileKitType, saveNameParts and selection shaping all run.
+
+    @Test
+    fun `the picker is told the mode the type and the folder`() = runBlocking {
+        var seenMode: FileKitFileChooser.PickerMode? = null
+        var seenType: FileKitType? = null
+        var seenDirectory: File? = null
+
+        FileKitFileChooser.openWith(
+            path = dir.toPath(),
+            filters = listOf(filter("Songs", "sps")),
+            selectDirectory = false,
+            multiple = true,
+        ) { mode, type, directory ->
+            seenMode = mode
+            seenType = type
+            seenDirectory = directory.file
+            null
+        }
+
+        assertEquals(FileKitFileChooser.PickerMode.MULTIPLE_FILES, seenMode)
+        assertEquals(setOf("sps"), (seenType as FileKitType.File).extensions)
+        assertEquals(dir, seenDirectory)
+    }
+
+    @Test
+    fun `a single open takes the one file the picker returned`() = runBlocking {
+        val picked = FileKitFileChooser.openWith(
+            path = dir.toPath(),
+            filters = emptyList(),
+            selectDirectory = false,
+            multiple = false,
+        ) { _, _, _ -> listOf(File(dir, "song.sps")) }
+
+        assertEquals(listOf(File(dir, "song.sps").toPath()), picked)
+    }
+
+    @Test
+    fun `a multiple open keeps every file the picker returned`() = runBlocking {
+        val picked = FileKitFileChooser.openWith(
+            path = dir.toPath(),
+            filters = emptyList(),
+            selectDirectory = false,
+            multiple = true,
+        ) { _, _, _ -> listOf(File(dir, "a.sps"), File(dir, "b.sps")) }
+
+        assertEquals(listOf(File(dir, "a.sps").toPath(), File(dir, "b.sps").toPath()), picked)
+    }
+
+    @Test
+    fun `a directory open takes one folder even though the picker could hand back more`() = runBlocking {
+        // The directory picker has no multi mode, so a stray extra result must not widen the answer.
+        val picked = FileKitFileChooser.openWith(
+            path = dir.toPath(),
+            filters = emptyList(),
+            selectDirectory = true,
+            multiple = true,
+        ) { _, _, _ -> listOf(File(dir, "Songs"), File(dir, "Media")) }
+
+        assertEquals(listOf(File(dir, "Songs").toPath()), picked)
+    }
+
+    @Test
+    fun `a cancelled native picker reads as cancelled`() = runBlocking {
+        assertNull(
+            FileKitFileChooser.openWith(dir.toPath(), emptyList(), false, false) { _, _, _ -> null }
+        )
+        assertNull(
+            FileKitFileChooser.openWith(dir.toPath(), emptyList(), false, true) { _, _, _ -> emptyList() },
+            "an approved picker with nothing in it is still nothing picked",
+        )
+    }
+
+    @Test
+    fun `the saver is told the split name and the extensions it may use`() = runBlocking {
+        var seenName: String? = null
+        var seenExtension: String? = null
+        var seenAllowed: Set<String>? = null
+        var seenDirectory: File? = null
+
+        FileKitFileChooser.saveWith(
+            location = dir.toPath(),
+            suggestedName = "schedule.cps",
+            filters = listOf(filter("Schedule", "cps"), filter("PDF", "pdf")),
+        ) { baseName, extension, allowed, directory ->
+            seenName = baseName
+            seenExtension = extension
+            seenAllowed = allowed
+            seenDirectory = directory.file
+            null
+        }
+
+        assertEquals("schedule", seenName, "FileKit appends the extension itself")
+        assertEquals("cps", seenExtension)
+        assertEquals(setOf("cps", "pdf"), seenAllowed)
+        assertEquals(dir, seenDirectory)
+    }
+
+    @Test
+    fun `with no filters the saver is given no restriction at all`() = runBlocking {
+        var seenAllowed: Set<String>? = emptySet()
+
+        FileKitFileChooser.saveWith(dir.toPath(), "notes", emptyList()) { _, _, allowed, _ ->
+            seenAllowed = allowed
+            null
+        }
+
+        assertNull(seenAllowed, "an empty set would be a saver that permits nothing")
+    }
+
+    @Test
+    fun `a saved file comes back as a path`() = runBlocking {
+        val saved = FileKitFileChooser.saveWith(dir.toPath(), "schedule.cps", emptyList()) { _, _, _, _ ->
+            File(dir, "sunday.cps")
+        }
+
+        assertEquals(File(dir, "sunday.cps").toPath(), saved)
+    }
+
+    @Test
+    fun `a cancelled saver returns nothing`() = runBlocking {
+        assertNull(FileKitFileChooser.saveWith(dir.toPath(), "schedule.cps", emptyList()) { _, _, _, _ -> null })
+    }
+
+    // ── FileKitFileChooser: which window owns the dialog ────────────────────────
+
+    @Test
+    fun `every native dialog is given its title and an owner`() {
+        val settings = FileKitFileChooser.dialogSettings("Open Schedule")
+
+        assertEquals("Open Schedule", settings.title)
+        assertNull(settings.parentWindow, "headless there is no window to own it")
+    }
+
+    @Test
+    fun `with no windows open there is no parent to own the dialog`() {
+        // Headless there is nothing to find — the same answer as a dialog opened before any window
+        // is showing. FileKit must get null rather than a hidden helper window (JCEF, JavaFX).
+        assertNull(FileKitFileChooser.resolveParentWindow())
+    }
+
+    @Test
+    fun `the parent window is resolved from a background thread too`() {
+        // Callers are suspending functions on the IO dispatcher, so this has to marshal to the EDT
+        // itself rather than returning whatever an off-EDT query happens to see.
+        assertFalse(SwingUtilities.isEventDispatchThread(), "the test must not already be on the EDT")
+
+        assertNull(FileKitFileChooser.parentWindow())
+    }
+
+    @Test
+    fun `the parent window is resolved directly when already on the dispatch thread`() {
+        // invokeAndWait from the EDT is an error, so this path must not marshal.
+        assertNull(SwingFileChooser.onEventDispatchThread { FileKitFileChooser.parentWindow() })
+    }
+
+    /** A stand-in AWT window with the properties the owner-selection reads. */
+    private fun window(showing: Boolean, focused: Boolean, width: Int, height: Int): Window {
+        val win = mockk<Window>(relaxed = true)
+        every { win.isShowing } returns showing
+        every { win.isFocused } returns focused
+        every { win.width } returns width
+        every { win.height } returns height
+        return win
+    }
+
+    @Test
+    fun `the toolkit's active window owns the dialog outright`() {
+        val active = window(showing = true, focused = true, width = 800, height = 600)
+        val bigger = window(showing = true, focused = false, width = 1920, height = 1080)
+
+        assertEquals(
+            active,
+            FileKitFileChooser.chooseParentWindow(active, arrayOf(bigger, active)),
+            "the window the toolkit reports as active is the one the operator is looking at",
+        )
+    }
+
+    @Test
+    fun `with no active window a showing focused window is chosen`() {
+        val focused = window(showing = true, focused = true, width = 400, height = 300)
+        val unfocused = window(showing = true, focused = false, width = 1920, height = 1080)
+
+        assertEquals(focused, FileKitFileChooser.chooseParentWindow(null, arrayOf(unfocused, focused)))
+    }
+
+    @Test
+    fun `failing that the largest still-visible window is chosen`() {
+        // Nothing is focused, so the biggest real window wins — this is what keeps a small hidden
+        // helper window (JCEF, JavaFX) from stealing the dialog and hiding it behind itself.
+        val small = window(showing = true, focused = false, width = 200, height = 100)
+        val big = window(showing = true, focused = false, width = 1920, height = 1080)
+        val hiddenButHuge = window(showing = false, focused = false, width = 3000, height = 2000)
+
+        assertEquals(big, FileKitFileChooser.chooseParentWindow(null, arrayOf(small, big, hiddenButHuge)))
+    }
+
+    @Test
+    fun `a zero-sized window is never chosen as owner`() {
+        // The Swing owner frame is a 0x0 helper; it must not end up owning a native dialog.
+        val zeroSized = window(showing = true, focused = false, width = 0, height = 0)
+
+        assertNull(FileKitFileChooser.chooseParentWindow(null, arrayOf(zeroSized)))
+    }
+
+    @Test
+    fun `no windows at all means no owner`() {
+        assertNull(
+            FileKitFileChooser.chooseParentWindow(null, emptyArray()),
+            "a dialog with no owner centres on screen — better than crashing",
+        )
+    }
+
+    // ── FileKitFileChooser: falling back when native dialogs fail ────────────────
+    //
+    // withNativeDialog is why a machine whose native picker is broken (a missing library, a
+    // locked-down OS) still gets a working file dialog: the first failure latches and every dialog
+    // after it goes straight to Swing. nativeDialogsBroken is reset in setup/teardown so this
+    // per-JVM latch cannot leak into another test.
+
+    @Test
+    fun `a working native dialog is used and the fallback never runs`() = runBlocking {
+        var fellBack = false
+
+        val result = FileKitFileChooser.withNativeDialog(
+            context = "test",
+            attempt = { "native" },
+            fallback = { fellBack = true; "swing" },
+        )
+
+        assertEquals("native", result)
+        assertFalse(fellBack, "the Swing fallback must not run when the native dialog works")
+        assertFalse(FileKitFileChooser.nativeDialogsBroken, "a success must not latch the native path off")
+    }
+
+    @Test
+    fun `a failing native dialog falls back to Swing and latches`() = runBlocking {
+        var fellBack = false
+
+        val result = FileKitFileChooser.withNativeDialog(
+            context = "test",
+            attempt = { throw RuntimeException("no native dialog library") },
+            fallback = { fellBack = true; "swing" },
+        )
+
+        assertEquals("swing", result, "the operator still gets a dialog, just the Swing one")
+        assertTrue(fellBack)
+        assertTrue(FileKitFileChooser.nativeDialogsBroken, "a broken machine must not be asked to try again")
+    }
+
+    @Test
+    fun `once latched the native dialog is not attempted again`() = runBlocking {
+        FileKitFileChooser.nativeDialogsBroken = true
+        var attempted = false
+
+        val result = FileKitFileChooser.withNativeDialog(
+            context = "test",
+            attempt = { attempted = true; "native" },
+            fallback = { "swing" },
+        )
+
+        assertEquals("swing", result)
+        assertFalse(attempted, "re-attempting would fail and re-report the same fault on every single dialog")
+    }
+
+    @Test
+    fun `a cancelled dialog propagates and does not latch the native path off`() {
+        // Dismissing the dialog throws CancellationException — the operator's choice, not a fault.
+        // It must propagate unchanged, and it must NOT trip the broken latch.
+        var fellBack = false
+
+        assertFailsWith<CancellationException> {
+            runBlocking {
+                FileKitFileChooser.withNativeDialog(
+                    context = "test",
+                    attempt = { throw CancellationException("operator dismissed the dialog") },
+                    fallback = { fellBack = true; "swing" },
+                )
+            }
+        }
+
+        assertFalse(fellBack, "cancelling must not silently reopen as a Swing dialog")
+        assertFalse(FileKitFileChooser.nativeDialogsBroken, "cancelling is not a fault; the native path stays on")
     }
 }


### PR DESCRIPTION
Extract and test the remaining decision/orchestration logic in the three platform choosers, leaving only the irreducible OS-toolkit calls uncovered:

- FileKitFileChooser: withNativeDialog (native-failure fallback + latch + cancellation passthrough) and chooseParentWindow (owner-window selection) pulled out of the AWT/native calls and tested directly. 3% -> 91%.
- SwingFileChooser: runOpen/runSave run the full EDT orchestration with the owner frame and the one showDialog call injected, tested with a recording JFrame. Dead else-branch in applyFilters removed. 28% -> 84%.
- FileChooser.platformFor tested. 84% -> 99%.

Every remaining uncovered line is a native FileKit picker, a D-Bus session call, a JFrame construction, or a Swing dialog show - none runnable in a headless unit test. Package 33% -> 75% instruction, 32% -> 75% branch; the per-class business logic is 84-99%.