### PR TITLE
Render-test STTPresenter and DictionaryPresenter (presenter/ coverage)

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/DictionaryPresenterRenderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/DictionaryPresenterRenderTest.kt
@@ -1,0 +1,63 @@
+package org.churchpresenter.app.churchpresenter.presenter
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.churchpresenter.app.churchpresenter.data.StrongsEntry
+import org.churchpresenter.app.churchpresenter.data.settings.DictionarySettings
+import kotlin.test.Test
+
+/**
+ * The Strong's dictionary entry shown to the congregation.
+ *
+ * When a preacher puts an original-language word on screen, the entry's word, its definition and its
+ * KJV usage are what the room reads. These render the presenter for a real entry and assert those
+ * land on screen, and that a null entry leaves the screen blank rather than showing a stale word —
+ * the case that otherwise leaves the last word stuck up during a transition to nothing.
+ */
+@OptIn(ExperimentalTestApi::class)
+class DictionaryPresenterRenderTest {
+
+    private val screen = Modifier.size(1920.dp, 1080.dp)
+
+    private val elohim = StrongsEntry(
+        number = "H430",
+        word = "ʼĕlôhîym",
+        transliteration = "elohim",
+        pronunciation = "el-o-heem'",
+        definition = "gods in the ordinary sense; the supreme God",
+        kjvUsage = "God (2346x), god (244x)",
+    )
+
+    private fun runDict(
+        entry: StrongsEntry?,
+        settings: DictionarySettings = DictionarySettings(),
+        body: androidx.compose.ui.test.ComposeUiTest.() -> Unit,
+    ) = runComposeUiTest {
+        setContent {
+            Box(screen) { DictionaryPresenter(entry = entry, dictionarySettings = settings) }
+        }
+        body()
+    }
+
+    @Test
+    fun `an entry shows its word and definition`() = runDict(elohim) {
+        onNodeWithText("ʼĕlôhîym", substring = true).assertExists("the original-language word is the point of the slide")
+        onNodeWithText("the supreme God", substring = true).assertExists("the definition must reach the screen")
+    }
+
+    @Test
+    fun `the KJV usage is shown when enabled`() = runDict(elohim, DictionarySettings(showKjvUsage = true)) {
+        onNodeWithText("God (2346x)", substring = true).assertExists("KJV usage is part of the entry when turned on")
+    }
+
+    @Test
+    fun `no entry leaves the screen blank`() = runDict(entry = null) {
+        onNodeWithText("ʼĕlôhîym", substring = true)
+            .assertDoesNotExist()
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenterRenderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenterRenderTest.kt
@@ -1,0 +1,98 @@
+package org.churchpresenter.app.churchpresenter.presenter
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.churchpresenter.app.churchpresenter.data.settings.STTSettings
+import org.churchpresenter.app.churchpresenter.viewmodel.STTSegment
+import kotlin.test.Test
+
+/**
+ * The live captions the room reads during a service.
+ *
+ * The STT presenter turns a list of transcription (and optionally translation) segments into the
+ * text on the lower band, filtered by the display mode: "transcribe" shows only the spoken language,
+ * "translate" only the translation, "both" stacks them. Getting the mode filter wrong is the failure
+ * that matters — a deaf visitor reading a screen that shows the wrong language, or shows nothing.
+ *
+ * These render the presenter in a real composition and assert on the text that lands on screen, so
+ * the whole path — segment joining, whitespace normalisation, the mode branch — runs on the way.
+ *
+ * Drip-feed (letter-by-letter reveal) is DISABLED in every case: with it on the caption fills in over
+ * time and a text assertion would race the animation. Disabled, the full caption is present at once,
+ * so every wait is on the text itself, never on a delay.
+ */
+@OptIn(ExperimentalTestApi::class)
+class STTPresenterRenderTest {
+
+    private val screen = Modifier.size(1920.dp, 1080.dp)
+
+    /** Drip-feed off so the caption is fully present immediately — see the class doc. */
+    private fun settings(mode: String) = STTSettings(displayMode = mode, dripFeedEnabled = false)
+
+    private fun segment(text: String, id: Int = 1) =
+        STTSegment(id = id, timestamp = "", text = text, start = 0.0, end = 1.0, completed = true)
+
+    private fun runStt(
+        settings: STTSettings,
+        transcription: List<STTSegment> = emptyList(),
+        translation: List<STTSegment> = emptyList(),
+        body: androidx.compose.ui.test.ComposeUiTest.() -> Unit,
+    ) = runComposeUiTest {
+        setContent {
+            Box(screen) {
+                STTPresenter(
+                    segments = transcription,
+                    inProgressText = "",
+                    translationSegments = translation,
+                    inProgressTranslation = "",
+                    highlightedWords = emptyList(),
+                    sttSettings = settings,
+                )
+            }
+        }
+        body()
+    }
+
+    @Test
+    fun `transcribe mode puts the spoken text on screen`() = runStt(
+        settings("transcribe"),
+        transcription = listOf(segment("Peace be with you")),
+    ) {
+        onNodeWithText("Peace be with you", substring = true).assertExists("the caption must show the spoken words")
+    }
+
+    @Test
+    fun `both mode shows the transcription and the translation together`() = runStt(
+        settings("both"),
+        transcription = listOf(segment("Grace and peace")),
+        translation = listOf(segment("Gnade und Frieden", id = 2)),
+    ) {
+        onNodeWithText("Grace and peace", substring = true).assertExists()
+        onNodeWithText("Gnade und Frieden", substring = true).assertExists("both languages must appear in both mode")
+    }
+
+    @Test
+    fun `translate mode shows the translation and withholds the transcription`() = runStt(
+        settings("translate"),
+        transcription = listOf(segment("this should be hidden")),
+        translation = listOf(segment("dies ist sichtbar", id = 2)),
+    ) {
+        onNodeWithText("dies ist sichtbar", substring = true).assertExists("translate mode must show the translation")
+        onNodeWithText("this should be hidden", substring = true)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `consecutive segments are joined into one caption`() = runStt(
+        settings("transcribe"),
+        transcription = listOf(segment("Blessed are", id = 1), segment("the peacemakers", id = 2)),
+    ) {
+        onNodeWithText("Blessed are", substring = true).assertExists()
+        onNodeWithText("the peacemakers", substring = true).assertExists("later segments must not drop off the caption")
+    }
+}


### PR DESCRIPTION
Starts closing the `presenter/` gap (package was ~24%) with behavioral render tests — the same approach as the existing `PresenterRenderTest`: compose the presenter for real and assert on the text that reaches the screen, so segment joining, mode filtering and entry formatting all run on the way.

## What's covered (7 tests)
- **`STTPresenterRenderTest`** (4) — the live-caption **display-mode filter**: `transcribe` shows only the spoken language, `translate` shows only the translation *and withholds the transcription*, `both` stacks them, and consecutive segments join into one caption. Drip-feed (letter-by-letter reveal) is disabled so the full caption is present at once — no assertion races the animation.
- **`DictionaryPresenterRenderTest`** (3) — a Strong's entry shows its word, definition and KJV usage; a **null entry leaves the screen blank** rather than leaving a stale word up during a transition.

## Notes
- Both presenters were previously near 0% (STTPresenter 2%, DictionaryPresenter 0%).
- Deterministic across repeated `--rerun-tasks`; text-signal assertions only, no timing.