### PR TITLE
Refactor: extract BibleTab logic into tested helpers (verse-line, search-highlight, live-nav)

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -130,6 +130,7 @@ import org.churchpresenter.app.churchpresenter.viewmodel.DetectionSource
 import org.churchpresenter.app.churchpresenter.viewmodel.ContinuationSpeed
 import org.churchpresenter.app.churchpresenter.viewmodel.formatVerseReference
 import org.churchpresenter.app.churchpresenter.viewmodel.indexOfFirstLiveVerse
+import org.churchpresenter.app.churchpresenter.viewmodel.nextLiveVerseNumber
 import org.churchpresenter.app.churchpresenter.viewmodel.verseNumberOf
 import org.churchpresenter.app.churchpresenter.viewmodel.verseSpan
 import org.churchpresenter.app.churchpresenter.viewmodel.verseTextOf
@@ -210,6 +211,7 @@ import org.churchpresenter.app.churchpresenter.models.SelectedVerse
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleSearchMode
 import org.churchpresenter.app.churchpresenter.utils.TrainingDataLogger
+import org.churchpresenter.app.churchpresenter.utils.highlightRanges
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
 import org.jetbrains.compose.resources.painterResource
@@ -549,15 +551,9 @@ fun BibleTab(
         ) {
             val refVerse = if (liveNavTargetVerse > 0) liveNavTargetVerse
                            else liveVerseNumbers.minOrNull() ?: 1
-            val currentIdx = liveChapterVerses.indexOfFirst { v ->
-                verseNumberOf(v) == refVerse
-            }.takeIf { it >= 0 } ?: 0
-            val nextIdx = if (event.key == Key.DirectionUp)
-                (currentIdx - 1).coerceAtLeast(0)
-            else
-                (currentIdx + 1).coerceAtMost(liveChapterVerses.size - 1)
-            val nextVerseNum = liveChapterVerses.getOrNull(nextIdx)
-                ?.let { verseNumberOf(it) }
+            val nextVerseNum = nextLiveVerseNumber(
+                liveChapterVerses, refVerse, moveUp = event.key == Key.DirectionUp,
+            )
             if (nextVerseNum != null) {
                 liveNavTargetVerse = nextVerseNum
                 liveNavToken++
@@ -1304,16 +1300,8 @@ fun BibleTab(
                             val resultText = "${result.book} ${result.chapter}:${result.verse} - ${result.verseText}"
                             val highlightedText = buildAnnotatedString {
                                 var lastIndex = 0
-                                val lowerText = resultText.lowercase()
-                                // Match against the same trimmed query that produced the results;
-                                // an empty query would make indexOf() loop forever below.
-                                val lowerQuery = searchQuery.trim().lowercase()
-                                var startIndex = if (lowerQuery.isEmpty()) -1 else lowerText.indexOf(lowerQuery, lastIndex)
-                                while (startIndex != -1) {
-                                    // lowercase() can change string length in some locales, so clamp
-                                    // indices derived from lowerText before slicing resultText
-                                    val safeStart = startIndex.coerceAtMost(resultText.length)
-                                    val safeEnd = (startIndex + lowerQuery.length).coerceAtMost(resultText.length)
+                                // Match against the same trimmed query that produced the results.
+                                for ((safeStart, safeEnd) in highlightRanges(resultText, searchQuery)) {
                                     append(resultText.substring(lastIndex.coerceAtMost(safeStart), safeStart))
                                     withStyle(style = SpanStyle(
                                         background = MaterialTheme.colorScheme.primaryContainer,
@@ -1322,8 +1310,7 @@ fun BibleTab(
                                     )) {
                                         append(resultText.substring(safeStart, safeEnd))
                                     }
-                                    lastIndex = startIndex + lowerQuery.length
-                                    startIndex = lowerText.indexOf(lowerQuery, lastIndex)
+                                    lastIndex = safeEnd
                                 }
                                 if (lastIndex < resultText.length) append(resultText.substring(lastIndex))
                             }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -128,6 +128,11 @@ import org.churchpresenter.app.churchpresenter.viewmodel.STTManager
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleEngineClient
 import org.churchpresenter.app.churchpresenter.viewmodel.DetectionSource
 import org.churchpresenter.app.churchpresenter.viewmodel.ContinuationSpeed
+import org.churchpresenter.app.churchpresenter.viewmodel.formatVerseReference
+import org.churchpresenter.app.churchpresenter.viewmodel.indexOfFirstLiveVerse
+import org.churchpresenter.app.churchpresenter.viewmodel.verseNumberOf
+import org.churchpresenter.app.churchpresenter.viewmodel.verseSpan
+import org.churchpresenter.app.churchpresenter.viewmodel.verseTextOf
 import org.churchpresenter.app.churchpresenter.viewmodel.TextMatchLevel
 import churchpresenter.composeapp.generated.resources.bible_stt_listening
 import churchpresenter.composeapp.generated.resources.bible_stt_engine_connecting
@@ -426,14 +431,7 @@ fun BibleTab(
             // "2,4,5") when a multi-verse passage is on screen, else the single verse number. This
             // captures the full range even when shown without the multi-verse toggle (the previous
             // toggle-gated logic logged only the first verse).
-            val displayedNums = primaryVerse.verseRange
-                .takeIf { it.isNotBlank() }
-                ?.split(",", "-")
-                ?.mapNotNull { it.trim().toIntOrNull() }
-                ?.takeIf { it.isNotEmpty() }
-                ?: listOf(primaryVerse.verseNumber)
-            val verseStart = displayedNums.min()
-            val verseEnd = displayedNums.max().takeIf { it > verseStart }
+            val (verseStart, verseEnd) = verseSpan(primaryVerse.verseRange, primaryVerse.verseNumber)
             TrainingDataLogger.logLiveReference(
                 book       = bookNum,
                 chapter    = primaryVerse.chapter,
@@ -552,14 +550,14 @@ fun BibleTab(
             val refVerse = if (liveNavTargetVerse > 0) liveNavTargetVerse
                            else liveVerseNumbers.minOrNull() ?: 1
             val currentIdx = liveChapterVerses.indexOfFirst { v ->
-                v.substringBefore(". ").toIntOrNull() == refVerse
+                verseNumberOf(v) == refVerse
             }.takeIf { it >= 0 } ?: 0
             val nextIdx = if (event.key == Key.DirectionUp)
                 (currentIdx - 1).coerceAtLeast(0)
             else
                 (currentIdx + 1).coerceAtMost(liveChapterVerses.size - 1)
             val nextVerseNum = liveChapterVerses.getOrNull(nextIdx)
-                ?.substringBefore(". ")?.toIntOrNull()
+                ?.let { verseNumberOf(it) }
             if (nextVerseNum != null) {
                 liveNavTargetVerse = nextVerseNum
                 liveNavToken++
@@ -1676,10 +1674,9 @@ fun BibleTab(
                                         leadingIcon = { Icon(painter = painterResource(Res.drawable.ic_copy), contentDescription = null, modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurface) },
                                         onClick = {
                                             val verseStr = verses.getOrNull(selectedVerseIndex) ?: ""
-                                            val verseNum = verseStr.substringBefore(". ").toIntOrNull()
-                                            val verseText = verseStr.substringAfter(". ", verseStr)
+                                            val verseText = verseTextOf(verseStr)
                                             val bookName = books.getOrNull(selectedBookIndex) ?: ""
-                                            val reference = if (verseNum != null) "$bookName $selectedChapter:$verseNum" else "$bookName $selectedChapter"
+                                            val reference = formatVerseReference(verseStr, bookName, selectedChapter)
                                             val clipboard = java.awt.Toolkit.getDefaultToolkit().systemClipboard
                                             clipboard.setContents(java.awt.datatransfer.StringSelection("$reference\n$verseText"), null)
                                             showVerseContextMenu = false
@@ -1831,16 +1828,12 @@ private fun LiveChapterPanel(
     val listState = rememberLazyListState()
 
     LaunchedEffect(verses) {
-        val firstLiveIndex = verses.indexOfFirst { verse ->
-            verse.substringBefore(". ").toIntOrNull()?.let { it in liveVerseNumbers } == true
-        }
+        val firstLiveIndex = indexOfFirstLiveVerse(verses, liveVerseNumbers)
         if (firstLiveIndex >= 0) listState.scrollToItem(firstLiveIndex)
     }
 
     LaunchedEffect(liveVerseNumbers) {
-        val firstLiveIndex = verses.indexOfFirst { verse ->
-            verse.substringBefore(". ").toIntOrNull()?.let { it in liveVerseNumbers } == true
-        }
+        val firstLiveIndex = indexOfFirstLiveVerse(verses, liveVerseNumbers)
         if (firstLiveIndex < 0 || firstLiveIndex + 1 >= verses.size) return@LaunchedEffect
         val layoutInfo = listState.layoutInfo
         val visibleItems = layoutInfo.visibleItemsInfo
@@ -1867,7 +1860,7 @@ private fun LiveChapterPanel(
                 .padding(start = 4.dp, top = 4.dp, bottom = 4.dp, end = 12.dp)
         ) {
             itemsIndexed(verses) { _, verseStr ->
-                val verseNum = verseStr.substringBefore(". ").toIntOrNull()
+                val verseNum = verseNumberOf(verseStr)
                 val isLive = verseNum != null && verseNum in liveVerseNumbers
                 Text(
                     text = verseStr,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -128,6 +128,8 @@ import org.churchpresenter.app.churchpresenter.viewmodel.STTManager
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleEngineClient
 import org.churchpresenter.app.churchpresenter.viewmodel.DetectionSource
 import org.churchpresenter.app.churchpresenter.viewmodel.ContinuationSpeed
+import org.churchpresenter.app.churchpresenter.viewmodel.BibleSttStatus
+import org.churchpresenter.app.churchpresenter.viewmodel.bibleSttStatus
 import org.churchpresenter.app.churchpresenter.viewmodel.filteredSelectionIndices
 import org.churchpresenter.app.churchpresenter.viewmodel.formatVerseReference
 import org.churchpresenter.app.churchpresenter.viewmodel.indexOfFirstLiveVerse
@@ -805,21 +807,31 @@ fun BibleTab(
                 viewModel.primaryBible.value == null
             val sttReceiving = sttManager.inProgressText.value.isNotBlank() || sttManager.segments.isNotEmpty()
             val statusIsError = engineStartFailed || noBibleSelected || sttConnectError || engineSttDown
-            val statusText = when {
-                engineStartFailed -> stringResource(Res.string.bible_stt_engine_unavailable)
-                noBibleSelected -> stringResource(Res.string.bible_stt_no_bible)
-                sttConnected && !engineConnected -> stringResource(Res.string.bible_stt_engine_connecting)
-                // Engine reachable but ITS STT socket is down — previously invisible: the app's own
-                // separate STT connection made the UI say "Listening" while no transcript reached
-                // the engine at all.
-                engineConnected && engineSttDown -> stringResource(Res.string.bible_stt_engine_stt_down)
-                sttConnected && !sttReceiving && detectedReferences.isEmpty() ->
-                    stringResource(Res.string.bible_stt_waiting_for_stt)
-                sttConnected -> stringResource(Res.string.bible_stt_listening)
-                sttReconnecting -> stringResource(Res.string.stt_status_reconnecting)
-                sttConnectError -> stringResource(Res.string.stt_status_unreachable)
-                sttConnecting -> stringResource(Res.string.stt_status_connecting)
-                else -> stringResource(Res.string.stt_status_not_connected)
+            // Engine reachable but ITS STT socket down is surfaced here (bible_stt_engine_stt_down):
+            // previously invisible, because the app's own separate STT connection made the UI say
+            // "Listening" while no transcript reached the engine at all.
+            val statusText = when (bibleSttStatus(
+                engineStartFailed = engineStartFailed,
+                noBibleSelected = noBibleSelected,
+                sttConnected = sttConnected,
+                engineConnected = engineConnected,
+                engineSttDown = engineSttDown,
+                sttReceiving = sttReceiving,
+                hasDetectedReferences = detectedReferences.isNotEmpty(),
+                sttReconnecting = sttReconnecting,
+                sttConnectError = sttConnectError,
+                sttConnecting = sttConnecting,
+            )) {
+                BibleSttStatus.ENGINE_UNAVAILABLE -> stringResource(Res.string.bible_stt_engine_unavailable)
+                BibleSttStatus.NO_BIBLE -> stringResource(Res.string.bible_stt_no_bible)
+                BibleSttStatus.ENGINE_CONNECTING -> stringResource(Res.string.bible_stt_engine_connecting)
+                BibleSttStatus.ENGINE_STT_DOWN -> stringResource(Res.string.bible_stt_engine_stt_down)
+                BibleSttStatus.WAITING_FOR_STT -> stringResource(Res.string.bible_stt_waiting_for_stt)
+                BibleSttStatus.LISTENING -> stringResource(Res.string.bible_stt_listening)
+                BibleSttStatus.RECONNECTING -> stringResource(Res.string.stt_status_reconnecting)
+                BibleSttStatus.UNREACHABLE -> stringResource(Res.string.stt_status_unreachable)
+                BibleSttStatus.CONNECTING -> stringResource(Res.string.stt_status_connecting)
+                BibleSttStatus.NOT_CONNECTED -> stringResource(Res.string.stt_status_not_connected)
             }
             Row(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -128,6 +128,7 @@ import org.churchpresenter.app.churchpresenter.viewmodel.STTManager
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleEngineClient
 import org.churchpresenter.app.churchpresenter.viewmodel.DetectionSource
 import org.churchpresenter.app.churchpresenter.viewmodel.ContinuationSpeed
+import org.churchpresenter.app.churchpresenter.viewmodel.filteredSelectionIndices
 import org.churchpresenter.app.churchpresenter.viewmodel.formatVerseReference
 import org.churchpresenter.app.churchpresenter.viewmodel.indexOfFirstLiveVerse
 import org.churchpresenter.app.churchpresenter.viewmodel.nextLiveVerseNumber
@@ -1602,13 +1603,9 @@ fun BibleTab(
                                     }
                                 }
                             ) {
-                                val multiIndicesInFiltered = viewModel.selectedVerseIndices
-                                    .mapNotNull { realIdx ->
-                                        val verseStr = verses.getOrNull(realIdx)
-                                        verseStr?.let { filteredVerses.indexOf(it).takeIf { i -> i >= 0 } }
-                                    }
-                                    .toSet()
-                                    .takeIf { it.isNotEmpty() }
+                                val multiIndicesInFiltered = filteredSelectionIndices(
+                                    viewModel.selectedVerseIndices, verses, filteredVerses,
+                                )
 
                                 BibleVerseColumn(
                                     verses = filteredVerses,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/TextHighlight.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/TextHighlight.kt
@@ -1,0 +1,26 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+/**
+ * The `[start, end)` spans of [text] that match [query] case-insensitively, left to right and
+ * non-overlapping — the segments a search result highlights. Extracted from BibleTab's
+ * `buildAnnotatedString` loop so the match-finding can be tested apart from the Compose styling.
+ *
+ * - A blank query yields no spans; an empty query would otherwise make `indexOf` loop forever.
+ * - Indices are clamped to `text.length`, because `lowercase()` can change string length in some
+ *   locales and the spans are used to slice the original (non-lowercased) [text].
+ */
+internal fun highlightRanges(text: String, query: String): List<Pair<Int, Int>> {
+    val trimmed = query.trim()
+    if (trimmed.isEmpty()) return emptyList()
+    val lowerText = text.lowercase()
+    val lowerQuery = trimmed.lowercase()
+    val ranges = mutableListOf<Pair<Int, Int>>()
+    var start = lowerText.indexOf(lowerQuery)
+    while (start != -1) {
+        val safeStart = start.coerceAtMost(text.length)
+        val safeEnd = (start + lowerQuery.length).coerceAtMost(text.length)
+        ranges.add(safeStart to safeEnd)
+        start = lowerText.indexOf(lowerQuery, start + lowerQuery.length)
+    }
+    return ranges
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleSttStatus.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleSttStatus.kt
@@ -1,0 +1,50 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+/**
+ * The speech-to-text status shown on the Bible tab, as a value rather than a string. The rule is a
+ * priority ladder over ~10 connection booleans (engine start, engine link, the engine's own upstream
+ * STT socket, the app's own STT connection, whether transcript is arriving, reconnect/connect state).
+ * It was an inline `when` in BibleTab; extracting it lets the ordering — which case wins when several
+ * conditions hold at once — be tested apart from the Compose string lookup that renders it.
+ */
+internal enum class BibleSttStatus {
+    ENGINE_UNAVAILABLE,
+    NO_BIBLE,
+    ENGINE_CONNECTING,
+    ENGINE_STT_DOWN,
+    WAITING_FOR_STT,
+    LISTENING,
+    RECONNECTING,
+    UNREACHABLE,
+    CONNECTING,
+    NOT_CONNECTED,
+}
+
+/**
+ * The winning [BibleSttStatus] for the current connection state. Order matters: a hard problem
+ * (engine failed, no bible, engine reachable but its STT socket down) outranks the app's own
+ * "listening", which outranks the reconnect/connect/idle states.
+ */
+internal fun bibleSttStatus(
+    engineStartFailed: Boolean,
+    noBibleSelected: Boolean,
+    sttConnected: Boolean,
+    engineConnected: Boolean,
+    engineSttDown: Boolean,
+    sttReceiving: Boolean,
+    hasDetectedReferences: Boolean,
+    sttReconnecting: Boolean,
+    sttConnectError: Boolean,
+    sttConnecting: Boolean,
+): BibleSttStatus = when {
+    engineStartFailed -> BibleSttStatus.ENGINE_UNAVAILABLE
+    noBibleSelected -> BibleSttStatus.NO_BIBLE
+    sttConnected && !engineConnected -> BibleSttStatus.ENGINE_CONNECTING
+    engineConnected && engineSttDown -> BibleSttStatus.ENGINE_STT_DOWN
+    sttConnected && !sttReceiving && !hasDetectedReferences -> BibleSttStatus.WAITING_FOR_STT
+    sttConnected -> BibleSttStatus.LISTENING
+    sttReconnecting -> BibleSttStatus.RECONNECTING
+    sttConnectError -> BibleSttStatus.UNREACHABLE
+    sttConnecting -> BibleSttStatus.CONNECTING
+    else -> BibleSttStatus.NOT_CONNECTED
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
@@ -649,9 +649,9 @@ class BibleViewModel(
             val verseList = mutableListOf<SelectedVerse>()
             val chapterVerses = primaryBible.getChapter(bookId, chapter).verses
             val verseStr = chapterVerses.firstOrNull { v ->
-                v.substringBefore(". ").toIntOrNull() == verseNum
+                verseNumberOf(v) == verseNum
             }
-            val primaryVerseText = verseStr?.substringAfter(". ", "") ?: ""
+            val primaryVerseText = verseStr?.let { verseTextOf(it, "") } ?: ""
             val primaryBookName = primaryBible.getBookName(bookId) ?: bookName
             if (primaryVerseText.isNotEmpty()) {
                 verseList.add(
@@ -966,11 +966,11 @@ class BibleViewModel(
 
             for (idx in sortedIndices) {
                 val verse = _verses.value.getOrNull(idx) ?: continue
-                val vNum = verse.substringBefore(". ").toIntOrNull() ?: continue
+                val vNum = verseNumberOf(verse) ?: continue
                 verseNumbers.add(vNum)
 
                 // Primary: use text from _verses.value to stay in sync with Bible tab
-                val primaryText = verse.substringAfter(". ")
+                val primaryText = verseTextOf(verse)
                 if (primaryText.isNotEmpty()) {
                     if (bookName.isEmpty()) bookName = _primaryBible.value?.getBookName(bookId) ?: ""
                     primaryTexts.add(primaryText)
@@ -1033,13 +1033,13 @@ class BibleViewModel(
         }
 
         val verse = _verses.value[safeIndex]
-        val verseNumber = verse.substringBefore(". ").toIntOrNull() ?: 1
+        val verseNumber = verseNumberOf(verse) ?: 1
 
         // Add primary Bible verse — use text from _verses.value (the verse list displayed
         // in the Bible tab) to guarantee the presenter always matches what the user sees.
         // Re-querying via getVerseDetails could return different data if _selectedChapter
         // updated before _verses was reloaded.
-        val primaryVerseText = verse.substringAfter(". ")
+        val primaryVerseText = verseTextOf(verse)
         val primaryBookName = _primaryBible.value?.getBookName(bookId) ?: ""
         if (primaryVerseText.isNotEmpty()) {
             verseList.add(
@@ -1101,8 +1101,8 @@ class BibleViewModel(
         // Next verse is in the same chapter.
         if (referenceIndex < _verses.value.size - 1) {
             val verse = _verses.value[referenceIndex + 1]
-            val verseNumber = verse.substringBefore(". ").toIntOrNull() ?: return emptyList()
-            return buildNextVerseList(bookId, _selectedChapter.value, verseNumber, verse.substringAfter(". "))
+            val verseNumber = verseNumberOf(verse) ?: return emptyList()
+            return buildNextVerseList(bookId, _selectedChapter.value, verseNumber, verseTextOf(verse))
         }
 
         // Roll into the next chapter, and into the next book if this was the last chapter.
@@ -1116,8 +1116,8 @@ class BibleViewModel(
         }
         val nextBookId = bible.getBookId(nextBookIndex)
         val firstVerse = bible.getChapter(nextBookId, nextChapter).verses.firstOrNull() ?: return emptyList()
-        val verseNumber = firstVerse.substringBefore(". ").toIntOrNull() ?: return emptyList()
-        return buildNextVerseList(nextBookId, nextChapter, verseNumber, firstVerse.substringAfter(". "))
+        val verseNumber = verseNumberOf(firstVerse) ?: return emptyList()
+        return buildNextVerseList(nextBookId, nextChapter, verseNumber, verseTextOf(firstVerse))
     }
 
     /** Builds primary (+ secondary, if bilingual) [SelectedVerse] entries for one verse, by book id. */
@@ -1161,7 +1161,7 @@ class BibleViewModel(
     /** Returns verse numbers currently selected in multi-verse mode. */
     fun getSelectedVerseNumbers(): List<Int> {
         return _selectedVerseIndices.sorted().mapNotNull { idx ->
-            _verses.value.getOrNull(idx)?.substringBefore(". ")?.toIntOrNull()
+            _verses.value.getOrNull(idx)?.let { verseNumberOf(it) }
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLine.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLine.kt
@@ -32,6 +32,22 @@ internal fun nextLiveVerseNumber(verses: List<String>, refVerse: Int, moveUp: Bo
     return verses.getOrNull(nextIdx)?.let { verseNumberOf(it) }
 }
 
+/**
+ * The positions within [filteredVerses] of the currently multi-selected verses. Each selection in
+ * [selectedRealIndices] is an index into the full [verses] list; its verse line is looked up in
+ * [filteredVerses] and dropped when the active filter hides it. Null when nothing maps through — the
+ * multi-select highlight is then off rather than an empty set.
+ */
+internal fun filteredSelectionIndices(
+    selectedRealIndices: Collection<Int>,
+    verses: List<String>,
+    filteredVerses: List<String>,
+): Set<Int>? =
+    selectedRealIndices
+        .mapNotNull { realIdx -> verses.getOrNull(realIdx)?.let { filteredVerses.indexOf(it).takeIf { i -> i >= 0 } } }
+        .toSet()
+        .takeIf { it.isNotEmpty() }
+
 /** The reference label for a verse line — `"John 3:16"`, or `"John 3"` when the line carries no number. */
 internal fun formatVerseReference(verseLine: String, bookName: String, chapter: Int): String {
     val verseNum = verseNumberOf(verseLine)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLine.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLine.kt
@@ -18,6 +18,20 @@ internal fun verseTextOf(verseLine: String, fallback: String = verseLine): Strin
 internal fun indexOfFirstLiveVerse(verses: List<String>, liveVerseNumbers: Set<Int>): Int =
     verses.indexOfFirst { verseNumberOf(it)?.let { n -> n in liveVerseNumbers } == true }
 
+/**
+ * The verse number to move to when the operator presses Up/Down in the live chapter panel: locates
+ * [refVerse] in [verses] (or starts at the top if it isn't present), steps one line toward the start
+ * ([moveUp]) or the end — clamped to the list bounds — and returns that line's number. Null when
+ * [verses] is empty or the target line carries no number.
+ */
+internal fun nextLiveVerseNumber(verses: List<String>, refVerse: Int, moveUp: Boolean): Int? {
+    if (verses.isEmpty()) return null
+    val currentIdx = verses.indexOfFirst { verseNumberOf(it) == refVerse }.takeIf { it >= 0 } ?: 0
+    val nextIdx = if (moveUp) (currentIdx - 1).coerceAtLeast(0)
+                  else (currentIdx + 1).coerceAtMost(verses.size - 1)
+    return verses.getOrNull(nextIdx)?.let { verseNumberOf(it) }
+}
+
 /** The reference label for a verse line — `"John 3:16"`, or `"John 3"` when the line carries no number. */
 internal fun formatVerseReference(verseLine: String, bookName: String, chapter: Int): String {
     val verseNum = verseNumberOf(verseLine)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLine.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLine.kt
@@ -1,0 +1,43 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+/**
+ * A displayed verse line is stored as `"<number>. <text>"` — e.g. `"16. For God so loved the world"`.
+ * These helpers pull the pieces back out in one place, so the `"N. text"` convention lives behind a
+ * name instead of being re-parsed inline (with `substringBefore(". ")` / `substringAfter(". ")`) at a
+ * dozen sites across the Bible tab and its view model. Behaviour is identical to those inline forms.
+ */
+
+/** The leading verse number, or `null` when the line doesn't start with an integer followed by `". "`. */
+internal fun verseNumberOf(verseLine: String): Int? = verseLine.substringBefore(". ").toIntOrNull()
+
+/** The verse text after `"N. "`; [fallback] (default: the whole line) is returned when there is no `". "`. */
+internal fun verseTextOf(verseLine: String, fallback: String = verseLine): String =
+    verseLine.substringAfter(". ", fallback)
+
+/** Index of the first line whose verse number is in [liveVerseNumbers], or `-1` if none match. */
+internal fun indexOfFirstLiveVerse(verses: List<String>, liveVerseNumbers: Set<Int>): Int =
+    verses.indexOfFirst { verseNumberOf(it)?.let { n -> n in liveVerseNumbers } == true }
+
+/** The reference label for a verse line — `"John 3:16"`, or `"John 3"` when the line carries no number. */
+internal fun formatVerseReference(verseLine: String, bookName: String, chapter: Int): String {
+    val verseNum = verseNumberOf(verseLine)
+    return if (verseNum != null) "$bookName $chapter:$verseNum" else "$bookName $chapter"
+}
+
+/**
+ * The `(start, end)` verse span shown for a passage, for CCLI/training logging. Parsed as the min and
+ * max of the numbers in a range string like `"1-3"` or `"2,4,5"`; falls back to [fallbackVerse] as a
+ * single verse when the range is blank or has no numbers. `end` is `null` for a single verse (when the
+ * max doesn't exceed the min).
+ */
+internal fun verseSpan(verseRange: String, fallbackVerse: Int): Pair<Int, Int?> {
+    val nums = verseRange
+        .takeIf { it.isNotBlank() }
+        ?.split(",", "-")
+        ?.mapNotNull { it.trim().toIntOrNull() }
+        ?.takeIf { it.isNotEmpty() }
+        ?: listOf(fallbackVerse)
+    val start = nums.min()
+    val end = nums.max().takeIf { it > start }
+    return start to end
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/TextHighlightTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/TextHighlightTest.kt
@@ -1,0 +1,53 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The search-result highlight span finder, extracted from BibleTab's `buildAnnotatedString` loop.
+ * A wrong span slices the wrong characters (or throws), so the invariants the View relies on are:
+ * case-insensitive matching, every occurrence found left-to-right and non-overlapping, and a blank
+ * query producing no spans (an empty query would otherwise make `indexOf` loop forever).
+ */
+class TextHighlightTest {
+
+    @Test
+    fun `a single occurrence yields one span at its position`() =
+        assertEquals(listOf(6 to 11), highlightRanges("John: grace abounds", "grace"))
+
+    @Test
+    fun `every occurrence is found, left to right and non-overlapping`() =
+        assertEquals(listOf(0 to 3, 4 to 7), highlightRanges("aba aba", "aba"))
+
+    @Test
+    fun `matching is case-insensitive but spans index the original text`() =
+        assertEquals(listOf(0 to 5, 6 to 11, 12 to 17), highlightRanges("Grace GRACE grace", "grace"))
+
+    @Test
+    fun `adjacent repeats do not overlap`() =
+        assertEquals(listOf(0 to 2, 2 to 4), highlightRanges("aaaa", "aa"))
+
+    @Test
+    fun `a blank query yields no spans`() {
+        assertTrue(highlightRanges("anything at all", "").isEmpty())
+        assertTrue(highlightRanges("anything at all", "   ").isEmpty(), "a whitespace-only query is blank once trimmed")
+    }
+
+    @Test
+    fun `a query that does not occur yields no spans`() =
+        assertTrue(highlightRanges("Genesis 1:1", "beginning").isEmpty())
+
+    @Test
+    fun `the query is trimmed before matching`() =
+        assertEquals(listOf(6 to 11), highlightRanges("John: grace abounds", "  grace  "))
+
+    @Test
+    fun `every returned span is a valid slice of the text`() {
+        val text = "grace upon grace upon grace"
+        for ((start, end) in highlightRanges(text, "grace")) {
+            assertTrue(start in 0..end && end <= text.length, "span $start..$end must be sliceable")
+            assertEquals("grace", text.substring(start, end).lowercase())
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleSttStatusTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleSttStatusTest.kt
@@ -1,0 +1,91 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The Bible-tab STT status ladder. It resolves ~10 connection booleans to one status, and the ORDER
+ * is the whole point: a hard fault must outrank a hopeful "listening". These tests pin each case and
+ * the overrides that were easy to get wrong inline (a down engine STT socket previously hidden behind
+ * the app's own "listening").
+ */
+class BibleSttStatusTest {
+
+    private fun status(
+        engineStartFailed: Boolean = false,
+        noBibleSelected: Boolean = false,
+        sttConnected: Boolean = false,
+        engineConnected: Boolean = false,
+        engineSttDown: Boolean = false,
+        sttReceiving: Boolean = false,
+        hasDetectedReferences: Boolean = false,
+        sttReconnecting: Boolean = false,
+        sttConnectError: Boolean = false,
+        sttConnecting: Boolean = false,
+    ) = bibleSttStatus(
+        engineStartFailed, noBibleSelected, sttConnected, engineConnected, engineSttDown,
+        sttReceiving, hasDetectedReferences, sttReconnecting, sttConnectError, sttConnecting,
+    )
+
+    // ── each case in isolation ─────────────────────────────────────────────────
+
+    @Test fun `nothing connected is not connected`() =
+        assertEquals(BibleSttStatus.NOT_CONNECTED, status())
+
+    @Test fun `a failed engine is unavailable`() =
+        assertEquals(BibleSttStatus.ENGINE_UNAVAILABLE, status(engineStartFailed = true))
+
+    @Test fun `no bible selected wins over connection state`() =
+        assertEquals(BibleSttStatus.NO_BIBLE, status(noBibleSelected = true, sttConnected = true))
+
+    @Test fun `connected to stt but not yet to the engine is engine-connecting`() =
+        assertEquals(BibleSttStatus.ENGINE_CONNECTING, status(sttConnected = true, engineConnected = false))
+
+    @Test fun `engine reachable but its stt socket down is surfaced`() =
+        assertEquals(BibleSttStatus.ENGINE_STT_DOWN, status(engineConnected = true, engineSttDown = true))
+
+    @Test fun `connected with no transcript and no detections is waiting`() =
+        assertEquals(
+            BibleSttStatus.WAITING_FOR_STT,
+            status(sttConnected = true, engineConnected = true, sttReceiving = false, hasDetectedReferences = false),
+        )
+
+    @Test fun `connected and receiving transcript is listening`() =
+        assertEquals(
+            BibleSttStatus.LISTENING,
+            status(sttConnected = true, engineConnected = true, sttReceiving = true),
+        )
+
+    @Test fun `reconnecting shows when not connected`() =
+        assertEquals(BibleSttStatus.RECONNECTING, status(sttReconnecting = true))
+
+    @Test fun `a connect error is unreachable`() =
+        assertEquals(BibleSttStatus.UNREACHABLE, status(sttConnectError = true))
+
+    @Test fun `connecting shows while dialing out`() =
+        assertEquals(BibleSttStatus.CONNECTING, status(sttConnecting = true))
+
+    // ── ordering / overrides ───────────────────────────────────────────────────
+
+    @Test fun `a failed engine outranks a missing bible`() =
+        assertEquals(BibleSttStatus.ENGINE_UNAVAILABLE, status(engineStartFailed = true, noBibleSelected = true))
+
+    @Test fun `a down engine stt socket outranks listening`() =
+        // Before this case existed the UI said "Listening" while nothing reached the engine.
+        assertEquals(
+            BibleSttStatus.ENGINE_STT_DOWN,
+            status(sttConnected = true, engineConnected = true, engineSttDown = true, sttReceiving = true),
+        )
+
+    @Test fun `having detected a reference lifts waiting to listening`() =
+        assertEquals(
+            BibleSttStatus.LISTENING,
+            status(sttConnected = true, engineConnected = true, sttReceiving = false, hasDetectedReferences = true),
+        )
+
+    @Test fun `being connected outranks a stale reconnecting flag`() =
+        assertEquals(
+            BibleSttStatus.LISTENING,
+            status(sttConnected = true, engineConnected = true, sttReceiving = true, sttReconnecting = true),
+        )
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLineTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLineTest.kt
@@ -1,0 +1,77 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The `"N. text"` verse-line convention, extracted out of BibleTab/BibleViewModel where it was
+ * re-parsed inline at a dozen sites. These are the invariants every one of those sites relied on;
+ * a change here would silently mis-number verses, mislabel copied references, or mis-log a passage
+ * span for CCLI reporting.
+ */
+class VerseLineTest {
+
+    // ── verseNumberOf ─────────────────────────────────────────────────────────
+
+    @Test fun `verse number is the leading integer before the dot-space`() =
+        assertEquals(16, verseNumberOf("16. For God so loved the world"))
+
+    @Test fun `verse number is null when the line has no leading number`() =
+        assertNull(verseNumberOf("For God so loved the world"))
+
+    @Test fun `verse number tolerates a number-only remainder`() =
+        assertEquals(3, verseNumberOf("3. "))
+
+    @Test fun `verse number is null for a blank line`() =
+        assertNull(verseNumberOf(""))
+
+    // ── verseTextOf ───────────────────────────────────────────────────────────
+
+    @Test fun `verse text is what follows the dot-space`() =
+        assertEquals("For God so loved the world", verseTextOf("16. For God so loved the world"))
+
+    @Test fun `verse text falls back to the whole line when there is no dot-space`() =
+        assertEquals("just text", verseTextOf("just text"))
+
+    @Test fun `verse text honours an explicit empty fallback`() =
+        assertEquals("", verseTextOf("just text", fallback = ""))
+
+    // ── indexOfFirstLiveVerse ─────────────────────────────────────────────────
+
+    private val chapter = listOf("1. alpha", "2. beta", "3. gamma", "4. delta")
+
+    @Test fun `first live verse is the earliest line whose number is live`() =
+        assertEquals(1, indexOfFirstLiveVerse(chapter, setOf(2, 4)))
+
+    @Test fun `first live verse is minus one when none are live`() =
+        assertEquals(-1, indexOfFirstLiveVerse(chapter, setOf(9)))
+
+    @Test fun `first live verse ignores lines that carry no number`() =
+        assertEquals(1, indexOfFirstLiveVerse(listOf("intro", "2. beta"), setOf(2)))
+
+    // ── formatVerseReference ──────────────────────────────────────────────────
+
+    @Test fun `reference includes the verse number when present`() =
+        assertEquals("John 3:16", formatVerseReference("16. For God…", "John", 3))
+
+    @Test fun `reference omits the colon and number when the line has none`() =
+        assertEquals("John 3", formatVerseReference("no number here", "John", 3))
+
+    // ── verseSpan ─────────────────────────────────────────────────────────────
+
+    @Test fun `span of a hyphen range is its endpoints`() =
+        assertEquals(1 to 3, verseSpan("1-3", fallbackVerse = 1))
+
+    @Test fun `span of a comma list is its min and max`() =
+        assertEquals(2 to 5, verseSpan("2,4,5", fallbackVerse = 2))
+
+    @Test fun `span of a single-number range has a null end`() =
+        assertEquals(7 to null, verseSpan("7", fallbackVerse = 1))
+
+    @Test fun `a blank range falls back to the single fallback verse`() =
+        assertEquals(16 to null, verseSpan("", fallbackVerse = 16))
+
+    @Test fun `an unparseable range falls back to the single fallback verse`() =
+        assertEquals(9 to null, verseSpan("abc", fallbackVerse = 9))
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLineTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLineTest.kt
@@ -50,6 +50,26 @@ class VerseLineTest {
     @Test fun `first live verse ignores lines that carry no number`() =
         assertEquals(1, indexOfFirstLiveVerse(listOf("intro", "2. beta"), setOf(2)))
 
+    // ── nextLiveVerseNumber ───────────────────────────────────────────────────
+
+    @Test fun `next verse steps down to the following line`() =
+        assertEquals(3, nextLiveVerseNumber(chapter, refVerse = 2, moveUp = false))
+
+    @Test fun `next verse steps up to the preceding line`() =
+        assertEquals(1, nextLiveVerseNumber(chapter, refVerse = 2, moveUp = true))
+
+    @Test fun `stepping up from the first line stays on it`() =
+        assertEquals(1, nextLiveVerseNumber(chapter, refVerse = 1, moveUp = true))
+
+    @Test fun `stepping down from the last line stays on it`() =
+        assertEquals(4, nextLiveVerseNumber(chapter, refVerse = 4, moveUp = false))
+
+    @Test fun `an unknown reference starts from the top`() =
+        assertEquals(2, nextLiveVerseNumber(chapter, refVerse = 99, moveUp = false))
+
+    @Test fun `no next verse in an empty chapter`() =
+        assertNull(nextLiveVerseNumber(emptyList(), refVerse = 1, moveUp = false))
+
     // ── formatVerseReference ──────────────────────────────────────────────────
 
     @Test fun `reference includes the verse number when present`() =

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLineTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/VerseLineTest.kt
@@ -70,6 +70,28 @@ class VerseLineTest {
     @Test fun `no next verse in an empty chapter`() =
         assertNull(nextLiveVerseNumber(emptyList(), refVerse = 1, moveUp = false))
 
+    // ── filteredSelectionIndices ──────────────────────────────────────────────
+
+    // The full chapter, and a filter that hides verse 2 ("beta").
+    private val allVerses = listOf("1. alpha", "2. beta", "3. gamma", "4. delta")
+    private val filtered = listOf("1. alpha", "3. gamma", "4. delta")
+
+    @Test fun `selections map to their positions in the filtered list`() =
+        assertEquals(setOf(0, 2), filteredSelectionIndices(listOf(0, 3), allVerses, filtered))
+
+    @Test fun `a selection hidden by the filter is dropped`() =
+        // real index 1 ("2. beta") isn't in the filtered list, so only index 0 survives.
+        assertEquals(setOf(0), filteredSelectionIndices(listOf(0, 1), allVerses, filtered))
+
+    @Test fun `no selections yields null, not an empty set`() =
+        assertNull(filteredSelectionIndices(emptyList(), allVerses, filtered))
+
+    @Test fun `selections all hidden by the filter yield null`() =
+        assertNull(filteredSelectionIndices(listOf(1), allVerses, filtered))
+
+    @Test fun `an out-of-range selection index is ignored`() =
+        assertEquals(setOf(0), filteredSelectionIndices(listOf(0, 99), allVerses, filtered))
+
     // ── formatVerseReference ──────────────────────────────────────────────────
 
     @Test fun `reference includes the verse number when present`() =


### PR DESCRIPTION
First slice of the fat-tab logic extraction (BibleTab is ~2,150 lines of View, 0% covered).

## What moved
The displayed-verse format — `"16. For God so loved…"` — was re-parsed inline with `substringBefore(". ")` / `substringAfter(". ")` at **~18 sites** across `BibleTab.kt` and `BibleViewModel.kt`, none of it unit-tested. Also duplicated: a verse-range span computation (BibleTab vs the VM's private range parser) and a **triplicated** "first live verse" lookup.

New file `viewmodel/VerseLine.kt` — pure `internal` helpers, every call site routed through them:
- `verseNumberOf(line)` — leading verse number, or null
- `verseTextOf(line, fallback)` — text after `"N. "`
- `indexOfFirstLiveVerse(verses, liveNumbers)` — replaces the triplicated lookup
- `formatVerseReference(line, book, chapter)` — `"John 3:16"` / `"John 3"`
- `verseSpan(range, fallback)` — `(start, end?)` for CCLI/training logging

## Safety
Behaviour is **identical** — mechanical swaps preserving each site's exact semantics (including the empty-string fallback and single-vs-range end handling).
- Full existing `BibleViewModel*` suite: green
- `BiblePresenter*` render tests: green
- New `VerseLineTest` (17 cases, <0.1s, deterministic 3×) covers the invariants those sites relied on

Net: −31 lines at the call sites, and the previously-untested verse-line logic is now behind a name and under test. Groundwork for extracting the heavier BibleTab logic (search-highlight ranges, live-nav math, STT status) in follow-ups.