### PR TITLE
Refactor: extract SongsTab column-config and display-mode logic into tested helpers

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
@@ -185,6 +185,10 @@ import org.churchpresenter.app.churchpresenter.utils.isSongLineMode
 import org.churchpresenter.app.churchpresenter.utils.mergeColumnOrder
 import org.churchpresenter.app.churchpresenter.utils.moveColumn
 import org.churchpresenter.app.churchpresenter.utils.songColumnSortKey
+import org.churchpresenter.app.churchpresenter.viewmodel.resolveEditedSongPush
+import org.churchpresenter.app.churchpresenter.viewmodel.songCreditLine
+import org.churchpresenter.app.churchpresenter.viewmodel.songTitleLine
+import org.churchpresenter.app.churchpresenter.viewmodel.titleSlideSection
 import org.churchpresenter.app.churchpresenter.viewmodel.SongsViewModel
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -328,23 +332,14 @@ fun SongsTab(
     // updateSong() is async, so the viewModel's own selection state isn't guaranteed fresh yet.
     fun sendEditedSongToPresenter(editedSong: SongItem) {
         val sections = viewModel.getLyricSections(editedSong)
-        val sectionIndex = liveSectionIndex.coerceIn(-1, sections.size - 1)
-        val section = sections.getOrNull(sectionIndex) ?: LyricSection(
-            title = editedSong.title,
-            secondaryTitle = editedSong.secondaryTitle,
-            songNumber = editedSong.number.toIntOrNull() ?: 0,
-            lines = editedSong.lyrics,
-            secondaryLines = editedSong.secondaryLyrics,
-            type = Constants.SECTION_TYPE_SONG
-        )
-        val lineIndex = liveLineIndex.coerceIn(0, (section.lines.size - 1).coerceAtLeast(0))
         val bpm = appSettings.songBpm[editedSong.songId] ?: 0
+        val push = resolveEditedSongPush(sections, liveSectionIndex, liveLineIndex, editedSong, bpm)
         onAllSectionsChanged(sections)
-        onSectionIndexChanged(sectionIndex)
-        onLineIndexChanged(lineIndex)
-        onSongItemSelected(section.copy(bpm = bpm))
-        liveSectionIndex = sectionIndex
-        liveLineIndex = lineIndex
+        onSectionIndexChanged(push.sectionIndex)
+        onLineIndexChanged(push.lineIndex)
+        onSongItemSelected(push.section)
+        liveSectionIndex = push.sectionIndex
+        liveLineIndex = push.lineIndex
     }
 
     val tabFocusRequester = remember { FocusRequester() }
@@ -1634,22 +1629,11 @@ fun SongsTab(
                     // ── Title slide entry ────────────────────────────────────
                     if (titleSlideEnabled && currentSong != null && sections.isNotEmpty()) {
                         item {
-                            val titleLine = listOf(currentSong.number, currentSong.title)
-                                .filter { it.isNotBlank() }.joinToString(" – ")
-                            val creditLine = listOf(currentSong.author, currentSong.composer)
-                                .filter { it.isNotBlank() }.joinToString(" / ")
+                            val titleLine = songTitleLine(currentSong)
+                            val creditLine = songCreditLine(currentSong)
 
-                            fun buildTitleSection() = LyricSection(
-                                type = "title_slide",
-                                title = currentSong.title,
-                                secondaryTitle = currentSong.secondaryTitle,
-                                songNumber = currentSong.number.toIntOrNull() ?: 0,
-                                lines = buildList {
-                                    add(titleLine)
-                                    if (creditLine.isNotBlank()) add(creditLine)
-                                },
-                                bpm = appSettings.songBpm[currentSong.songId] ?: 0
-                            )
+                            fun buildTitleSection() =
+                                titleSlideSection(currentSong, appSettings.songBpm[currentSong.songId] ?: 0)
 
                             fun sendTitleSlide() {
                                 val ts = buildTitleSection()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
@@ -179,6 +179,12 @@ import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
 import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.utils.availableSongColumns
+import org.churchpresenter.app.churchpresenter.utils.draggedColumnIndex
+import org.churchpresenter.app.churchpresenter.utils.isSongLineMode
+import org.churchpresenter.app.churchpresenter.utils.mergeColumnOrder
+import org.churchpresenter.app.churchpresenter.utils.moveColumn
+import org.churchpresenter.app.churchpresenter.utils.songColumnSortKey
 import org.churchpresenter.app.churchpresenter.viewmodel.SongsViewModel
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -436,25 +442,9 @@ fun SongsTab(
     // Column order — "songbook" excluded when only one songbook loaded;
     // "add_to_schedule" excluded when the callback is absent
     val actionCols = setOf("favorites", "add_to_schedule")
-    val availableCols = buildList {
-        add("number"); add("title")
-        if (songbooks.size > 1) add("songbook")
-        add("tune")
-        add("play_count")
-        add("author")
-        add("composer")
-        if (onAddToSchedule != null) add("add_to_schedule")
-        add("favorites")
-    }
+    val availableCols = availableSongColumns(songbooks.size, hasAddToSchedule = onAddToSchedule != null)
     var colOrder by remember(appSettings.songColOrder, songbooks.size) {
-        val saved = appSettings.songColOrder
-        val order = if (saved.isEmpty()) availableCols
-        else {
-            val filtered = saved.filter { it in availableCols }
-            val missing = availableCols.filter { it !in filtered }
-            filtered + missing
-        }
-        mutableStateOf(order)
+        mutableStateOf(mergeColumnOrder(appSettings.songColOrder, availableCols))
     }
     // Drag-to-reorder state
     var draggingColId by remember { mutableStateOf<String?>(null) }
@@ -532,42 +522,15 @@ fun SongsTab(
         }
     }
 
-    fun sortKey(id: String) = when (id) {
-        "number"     -> Constants.SORT_NUMBER
-        "title"      -> Constants.SORT_TITLE
-        "songbook"   -> Constants.SORT_SONGBOOK
-        "tune"       -> Constants.SORT_TUNE
-        "play_count" -> Constants.SORT_PLAY_COUNT
-        "favorites"  -> Constants.SORT_FAVORITES
-        "author"     -> Constants.SORT_AUTHOR
-        "composer"   -> Constants.SORT_COMPOSER
-        else         -> ""
-    }
+    fun sortKey(id: String) = songColumnSortKey(id)
 
     // NOTE: operates on visibleCols (set after state vars), returns index within visibleCols
-    fun computeNewIdx(draggedId: String, accumX: Float, visibleCols: List<String>): Int {
-        val currentIdx = visibleCols.indexOf(draggedId)
-        if (currentIdx < 0) return 0
-        val handleW = with(density) { 6.dp.toPx() }
-        var remaining = accumX
-        var newIdx = currentIdx
-        if (remaining > 0f) {
-            var i = currentIdx + 1
-            while (i < visibleCols.size) {
-                val w = colWidth(visibleCols[i]) + handleW
-                if (remaining >= w / 2f) { newIdx = i; remaining -= w } else break
-                i++
-            }
-        } else {
-            var i = currentIdx - 1
-            while (i >= 0) {
-                val w = colWidth(visibleCols[i]) + handleW
-                if (-remaining >= w / 2f) { newIdx = i; remaining += w } else break
-                i--
-            }
-        }
-        return newIdx
-    }
+    fun computeNewIdx(draggedId: String, accumX: Float, visibleCols: List<String>): Int =
+        draggedColumnIndex(
+            draggedId, accumX, visibleCols,
+            columnWidthPx = ::colWidth,
+            handleWidthPx = with(density) { 6.dp.toPx() },
+        )
 
     @Composable
     fun DragHandle(colId: String, onDrag: (Float) -> Unit, onDragEnd: () -> Unit) {
@@ -602,10 +565,7 @@ fun SongsTab(
             .focusable()
             .onPreviewKeyEvent { keyEvent ->
                 if (keyEvent.type == KeyEventType.KeyDown) {
-                    val isLineMode = appSettings.songSettings.fullscreenDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                        appSettings.songSettings.lowerThirdDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                        appSettings.songSettings.lookAheadDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                        appSettings.songSettings.lowerThirdLookAheadDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE
+                    val isLineMode = isSongLineMode(appSettings.songSettings)
                     when (keyEvent.key) {
                         Key.DirectionLeft -> {
                             if (isLineMode) {
@@ -819,13 +779,9 @@ fun SongsTab(
                                 val newVisIdx = computeNewIdx(colId, dragAccumX, vc)
                                 val targetId = vc.getOrNull(newVisIdx)
                                 if (targetId != null) {
-                                    val fromIdx = colOrder.indexOf(colId)
-                                    val toIdx = colOrder.indexOf(targetId)
-                                    if (toIdx != fromIdx) {
-                                        val mutable = colOrder.toMutableList()
-                                        mutable.removeAt(fromIdx)
-                                        mutable.add(toIdx.coerceIn(0, mutable.size), colId)
-                                        colOrder = mutable
+                                    val reordered = moveColumn(colOrder, colId, targetId)
+                                    if (reordered !== colOrder) {
+                                        colOrder = reordered
                                         onSettingsChangeState.value { s -> s.copy(songColOrder = colOrder) }
                                     }
                                 }
@@ -1590,10 +1546,7 @@ fun SongsTab(
             }
 
             // Arrow key navigation hint — only in line mode
-            val isLineModeHint = appSettings.songSettings.fullscreenDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                    appSettings.songSettings.lowerThirdDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                    appSettings.songSettings.lookAheadDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                    appSettings.songSettings.lowerThirdLookAheadDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE
+            val isLineModeHint = isSongLineMode(appSettings.songSettings)
             if (isLineModeHint) {
                 Text(
                     text = lineNavHintStr,
@@ -1786,10 +1739,7 @@ fun SongsTab(
                                 else
                                     MaterialTheme.colorScheme.onSurface
 
-                                val isPerLineMode = appSettings.songSettings.fullscreenDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                                    appSettings.songSettings.lowerThirdDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                                    appSettings.songSettings.lookAheadDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
-                                    appSettings.songSettings.lowerThirdLookAheadDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE
+                                val isPerLineMode = isSongLineMode(appSettings.songSettings)
                                 val activeLineIndex = if (isPerLineMode && sectionIndex == selectedSectionIndex)
                                     viewModel.selectedLineIndex.value else -1
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SongColumns.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SongColumns.kt
@@ -1,0 +1,98 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+/**
+ * Table-column configuration for the song list — which columns exist, in what order, how a drag
+ * reorders them, and which sort key each drives. Pure list/string logic extracted from SongsTab so
+ * the table-config decisions can be tested without the Compose table around them.
+ */
+
+/**
+ * The columns available given how many songbooks are loaded and whether the add-to-schedule action is
+ * wired: `"songbook"` only appears with more than one book, `"add_to_schedule"` only when the callback
+ * is present.
+ */
+internal fun availableSongColumns(songbookCount: Int, hasAddToSchedule: Boolean): List<String> = buildList {
+    add("number"); add("title")
+    if (songbookCount > 1) add("songbook")
+    add("tune")
+    add("play_count")
+    add("author")
+    add("composer")
+    if (hasAddToSchedule) add("add_to_schedule")
+    add("favorites")
+}
+
+/**
+ * Reconciles a [saved] column order against the currently [available] columns: keeps the saved order
+ * for columns that still exist, drops ones that no longer do, and appends any newly-available columns
+ * at the end. Falls back to [available] as-is when nothing was saved.
+ */
+internal fun mergeColumnOrder(saved: List<String>, available: List<String>): List<String> {
+    if (saved.isEmpty()) return available
+    val filtered = saved.filter { it in available }
+    val missing = available.filter { it !in filtered }
+    return filtered + missing
+}
+
+/**
+ * Moves [colId] to sit at [targetId]'s position within [order]. Returns [order] unchanged (same
+ * reference) when either id is absent or they already share a position, so callers can detect a no-op
+ * with `!==`.
+ */
+internal fun moveColumn(order: List<String>, colId: String, targetId: String): List<String> {
+    val fromIdx = order.indexOf(colId)
+    val toIdx = order.indexOf(targetId)
+    if (fromIdx < 0 || toIdx < 0 || fromIdx == toIdx) return order
+    val mutable = order.toMutableList()
+    mutable.removeAt(fromIdx)
+    mutable.add(toIdx.coerceIn(0, mutable.size), colId)
+    return mutable
+}
+
+/** The sort key a column header drives, or `""` for a column that isn't sortable. */
+internal fun songColumnSortKey(colId: String): String = when (colId) {
+    "number" -> Constants.SORT_NUMBER
+    "title" -> Constants.SORT_TITLE
+    "songbook" -> Constants.SORT_SONGBOOK
+    "tune" -> Constants.SORT_TUNE
+    "play_count" -> Constants.SORT_PLAY_COUNT
+    "favorites" -> Constants.SORT_FAVORITES
+    "author" -> Constants.SORT_AUTHOR
+    "composer" -> Constants.SORT_COMPOSER
+    else -> ""
+}
+
+/**
+ * The new index for a column being drag-reordered. Starting from [draggedId]'s slot in [visibleCols],
+ * walks outward in the drag direction ([accumulatedDragPx] > 0 is rightward), advancing past each
+ * neighbour once the drag has covered half of that column's width plus a handle. [columnWidthPx] gives
+ * a column's pixel width and [handleWidthPx] the drag-handle width. Returns 0 if [draggedId] is absent.
+ */
+internal fun draggedColumnIndex(
+    draggedId: String,
+    accumulatedDragPx: Float,
+    visibleCols: List<String>,
+    columnWidthPx: (String) -> Float,
+    handleWidthPx: Float,
+): Int {
+    val currentIdx = visibleCols.indexOf(draggedId)
+    if (currentIdx < 0) return 0
+    var remaining = accumulatedDragPx
+    var newIdx = currentIdx
+    if (remaining > 0f) {
+        var i = currentIdx + 1
+        while (i < visibleCols.size) {
+            val w = columnWidthPx(visibleCols[i]) + handleWidthPx
+            if (remaining >= w / 2f) { newIdx = i; remaining -= w } else break
+            i++
+        }
+    } else {
+        var i = currentIdx - 1
+        while (i >= 0) {
+            val w = columnWidthPx(visibleCols[i]) + handleWidthPx
+            if (-remaining >= w / 2f) { newIdx = i; remaining += w } else break
+            i--
+        }
+    }
+    return newIdx
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SongDisplayMode.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SongDisplayMode.kt
@@ -1,0 +1,15 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
+
+/**
+ * True when any of the four song output surfaces — fullscreen, lower third, and their look-ahead
+ * variants — is in per-line mode rather than whole-verse mode. This is what turns on arrow-key line
+ * navigation, the on-screen nav hint and per-line highlighting. Extracted from three identical inline
+ * OR-chains in SongsTab so the "is any surface in line mode" question lives in one tested place.
+ */
+internal fun isSongLineMode(settings: SongSettings): Boolean =
+    settings.fullscreenDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
+        settings.lowerThirdDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
+        settings.lookAheadDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE ||
+        settings.lowerThirdLookAheadDisplayMode != Constants.SONG_DISPLAY_MODE_VERSE

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongPresenterPush.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongPresenterPush.kt
@@ -1,0 +1,65 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import org.churchpresenter.app.churchpresenter.data.SongItem
+import org.churchpresenter.app.churchpresenter.models.LyricSection
+import org.churchpresenter.app.churchpresenter.utils.Constants
+
+/**
+ * How a song reaches the presenter — the title-slide it builds and the section/line a live edit
+ * lands on. These were inline in SongsTab; pulled out here so the formatting and the coerce/fallback
+ * math are tested apart from the composable and the presenter callbacks around them.
+ */
+
+/** The heading line of a title slide: `"<number> – <title>"`, dropping either part when it's blank. */
+internal fun songTitleLine(song: SongItem): String =
+    listOf(song.number, song.title).filter { it.isNotBlank() }.joinToString(" – ")
+
+/** The credit line of a title slide: `"<author> / <composer>"`, dropping either part when it's blank. */
+internal fun songCreditLine(song: SongItem): String =
+    listOf(song.author, song.composer).filter { it.isNotBlank() }.joinToString(" / ")
+
+/**
+ * The title-slide [LyricSection] for [song] at [bpm]: a heading line plus a credit line when there is
+ * one. Its `songNumber` is the numeric part of the song number, or 0 when the number isn't numeric.
+ */
+internal fun titleSlideSection(song: SongItem, bpm: Int): LyricSection = LyricSection(
+    type = "title_slide",
+    title = song.title,
+    secondaryTitle = song.secondaryTitle,
+    songNumber = song.number.toIntOrNull() ?: 0,
+    lines = buildList {
+        add(songTitleLine(song))
+        val credit = songCreditLine(song)
+        if (credit.isNotBlank()) add(credit)
+    },
+    bpm = bpm,
+)
+
+/** Where a live-edited song lands: the section/line to select and the section to send. */
+internal data class EditedSongPush(val sectionIndex: Int, val lineIndex: Int, val section: LyricSection)
+
+/**
+ * Resolves where a live edit of [editedSong] should land. The previously-live [liveSectionIndex] is
+ * clamped into `[-1, sections.lastIndex]`; when it points at no section (empty list, or the -1
+ * "whole song" slot) a fallback section is built straight from the edited song. The line index is
+ * then clamped into that section's line range, and [bpm] is stamped onto the section that goes out.
+ */
+internal fun resolveEditedSongPush(
+    sections: List<LyricSection>,
+    liveSectionIndex: Int,
+    liveLineIndex: Int,
+    editedSong: SongItem,
+    bpm: Int,
+): EditedSongPush {
+    val sectionIndex = liveSectionIndex.coerceIn(-1, sections.size - 1)
+    val section = sections.getOrNull(sectionIndex) ?: LyricSection(
+        title = editedSong.title,
+        secondaryTitle = editedSong.secondaryTitle,
+        songNumber = editedSong.number.toIntOrNull() ?: 0,
+        lines = editedSong.lyrics,
+        secondaryLines = editedSong.secondaryLyrics,
+        type = Constants.SECTION_TYPE_SONG,
+    )
+    val lineIndex = liveLineIndex.coerceIn(0, (section.lines.size - 1).coerceAtLeast(0))
+    return EditedSongPush(sectionIndex, lineIndex, section.copy(bpm = bpm))
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/SongColumnsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/SongColumnsTest.kt
@@ -1,0 +1,126 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The song-list table's column configuration — availability, saved-order reconciliation, drag
+ * reorder, sort keys and drag-target math — extracted from SongsTab. A wrong result here drops a
+ * column an operator configured, forgets their saved order, or reorders the wrong column.
+ */
+class SongColumnsTest {
+
+    // ── availableSongColumns ──────────────────────────────────────────────────
+
+    @Test
+    fun `a single songbook and no add-action omits both optional columns`() {
+        val cols = availableSongColumns(songbookCount = 1, hasAddToSchedule = false)
+        assertFalse("songbook" in cols, "one songbook needs no songbook column")
+        assertFalse("add_to_schedule" in cols, "no callback means no add column")
+        assertEquals(listOf("number", "title", "tune", "play_count", "author", "composer", "favorites"), cols)
+    }
+
+    @Test
+    fun `multiple songbooks and an add-action include both optional columns in place`() {
+        val cols = availableSongColumns(songbookCount = 3, hasAddToSchedule = true)
+        assertEquals(
+            listOf("number", "title", "songbook", "tune", "play_count", "author", "composer", "add_to_schedule", "favorites"),
+            cols,
+        )
+    }
+
+    // ── mergeColumnOrder ──────────────────────────────────────────────────────
+
+    private val available = listOf("number", "title", "tune", "favorites")
+
+    @Test
+    fun `an empty saved order falls back to the available columns`() =
+        assertSame(available, mergeColumnOrder(emptyList(), available))
+
+    @Test
+    fun `a saved order is honoured and newly-available columns are appended`() =
+        assertEquals(
+            listOf("title", "number", "tune", "favorites"),
+            mergeColumnOrder(listOf("title", "number"), available),
+        )
+
+    @Test
+    fun `columns that no longer exist are dropped from the saved order`() =
+        assertEquals(
+            listOf("title", "number", "tune", "favorites"),
+            mergeColumnOrder(listOf("title", "gone", "number"), available),
+        )
+
+    // ── moveColumn ────────────────────────────────────────────────────────────
+
+    private val order = listOf("a", "b", "c", "d")
+
+    @Test
+    fun `a column moves to the target's position`() =
+        assertEquals(listOf("b", "c", "a", "d"), moveColumn(order, "a", "c"))
+
+    @Test
+    fun `moving to an earlier target shifts the rest right`() =
+        assertEquals(listOf("a", "d", "b", "c"), moveColumn(order, "d", "b"))
+
+    @Test
+    fun `moving a column onto itself is an unchanged same-reference no-op`() =
+        assertSame(order, moveColumn(order, "b", "b"))
+
+    @Test
+    fun `an absent id is an unchanged same-reference no-op`() =
+        assertSame(order, moveColumn(order, "z", "b"))
+
+    // ── songColumnSortKey ─────────────────────────────────────────────────────
+
+    @Test
+    fun `each sortable column maps to its sort key`() {
+        assertEquals(Constants.SORT_NUMBER, songColumnSortKey("number"))
+        assertEquals(Constants.SORT_TITLE, songColumnSortKey("title"))
+        assertEquals(Constants.SORT_SONGBOOK, songColumnSortKey("songbook"))
+        assertEquals(Constants.SORT_TUNE, songColumnSortKey("tune"))
+        assertEquals(Constants.SORT_PLAY_COUNT, songColumnSortKey("play_count"))
+        assertEquals(Constants.SORT_FAVORITES, songColumnSortKey("favorites"))
+        assertEquals(Constants.SORT_AUTHOR, songColumnSortKey("author"))
+        assertEquals(Constants.SORT_COMPOSER, songColumnSortKey("composer"))
+    }
+
+    @Test
+    fun `a non-sortable column has no sort key`() {
+        assertEquals("", songColumnSortKey("add_to_schedule"))
+        assertEquals("", songColumnSortKey("anything"))
+    }
+
+    // ── draggedColumnIndex ────────────────────────────────────────────────────
+
+    private val visible = listOf("a", "b", "c", "d")
+    // Uniform 100px columns + 6px handle → 106px per step, half-step threshold 53px.
+    private val width: (String) -> Float = { 100f }
+
+    @Test
+    fun `no drag keeps the column where it is`() =
+        assertEquals(1, draggedColumnIndex("b", accumulatedDragPx = 0f, visible, width, handleWidthPx = 6f))
+
+    @Test
+    fun `dragging past one half-step moves one slot right`() =
+        assertEquals(2, draggedColumnIndex("b", accumulatedDragPx = 60f, visible, width, handleWidthPx = 6f))
+
+    @Test
+    fun `a large rightward drag clamps at the last column`() =
+        assertEquals(3, draggedColumnIndex("b", accumulatedDragPx = 500f, visible, width, handleWidthPx = 6f))
+
+    @Test
+    fun `dragging left past one half-step moves one slot left`() =
+        assertEquals(0, draggedColumnIndex("b", accumulatedDragPx = -60f, visible, width, handleWidthPx = 6f))
+
+    @Test
+    fun `a drag under the half-step threshold does not move`() =
+        assertEquals(1, draggedColumnIndex("b", accumulatedDragPx = 40f, visible, width, handleWidthPx = 6f))
+
+    @Test
+    fun `an absent dragged id yields index zero`() =
+        assertEquals(0, draggedColumnIndex("z", accumulatedDragPx = 60f, visible, width, handleWidthPx = 6f))
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/SongDisplayModeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/SongDisplayModeTest.kt
@@ -1,0 +1,49 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `isSongLineMode` decides whether arrow-key line navigation, the nav hint and per-line highlighting
+ * are active. It was three identical inline OR-chains in SongsTab; the rule is "line mode if ANY of
+ * the four output surfaces is in line mode", so each surface is checked independently here.
+ */
+class SongDisplayModeTest {
+
+    private val verse = Constants.SONG_DISPLAY_MODE_VERSE
+    private val line = Constants.SONG_DISPLAY_MODE_LINE
+
+    private fun settings(
+        fullscreen: String = verse,
+        lowerThird: String = verse,
+        lookAhead: String = verse,
+        lowerThirdLookAhead: String = verse,
+    ) = SongSettings(
+        fullscreenDisplayMode = fullscreen,
+        lowerThirdDisplayMode = lowerThird,
+        lookAheadDisplayMode = lookAhead,
+        lowerThirdLookAheadDisplayMode = lowerThirdLookAhead,
+    )
+
+    @Test
+    fun `all surfaces in verse mode is not line mode`() =
+        assertFalse(isSongLineMode(settings()))
+
+    @Test
+    fun `the fullscreen surface alone in line mode is line mode`() =
+        assertTrue(isSongLineMode(settings(fullscreen = line)))
+
+    @Test
+    fun `the lower-third surface alone in line mode is line mode`() =
+        assertTrue(isSongLineMode(settings(lowerThird = line)))
+
+    @Test
+    fun `the look-ahead surface alone in line mode is line mode`() =
+        assertTrue(isSongLineMode(settings(lookAhead = line)))
+
+    @Test
+    fun `the lower-third look-ahead surface alone in line mode is line mode`() =
+        assertTrue(isSongLineMode(settings(lowerThirdLookAhead = line)))
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongPresenterPushTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongPresenterPushTest.kt
@@ -1,0 +1,96 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import org.churchpresenter.app.churchpresenter.data.SongItem
+import org.churchpresenter.app.churchpresenter.models.LyricSection
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * How a song is prepared for the presenter — the title slide it builds and where a live edit lands.
+ * These were inline in SongsTab; a wrong title/credit line mislabels the slide, and a wrong
+ * section/line index sends the operator to the wrong part of the song after an edit.
+ */
+class SongPresenterPushTest {
+
+    private fun song(
+        number: String = "123",
+        title: String = "Amazing Grace",
+        author: String = "",
+        composer: String = "",
+        secondaryTitle: String = "",
+        lyrics: List<String> = emptyList(),
+        secondaryLyrics: List<String> = emptyList(),
+    ) = SongItem(
+        number = number, title = title, author = author, composer = composer,
+        secondaryTitle = secondaryTitle, lyrics = lyrics, secondaryLyrics = secondaryLyrics,
+    )
+
+    // ── title / credit lines ──────────────────────────────────────────────────
+
+    @Test fun `title line joins number and title`() =
+        assertEquals("123 – Amazing Grace", songTitleLine(song()))
+
+    @Test fun `title line drops a blank number`() =
+        assertEquals("Amazing Grace", songTitleLine(song(number = "")))
+
+    @Test fun `title line drops a blank title`() =
+        assertEquals("123", songTitleLine(song(title = "")))
+
+    @Test fun `credit line joins author and composer`() =
+        assertEquals("Newton / Excell", songCreditLine(song(author = "Newton", composer = "Excell")))
+
+    @Test fun `credit line drops a blank part`() =
+        assertEquals("Newton", songCreditLine(song(author = "Newton")))
+
+    @Test fun `credit line is empty when neither is present`() =
+        assertEquals("", songCreditLine(song()))
+
+    // ── titleSlideSection ─────────────────────────────────────────────────────
+
+    @Test fun `a title slide carries heading and credit lines and the given bpm`() {
+        val section = titleSlideSection(song(author = "Newton", composer = "Excell"), bpm = 90)
+        assertEquals("title_slide", section.type)
+        assertEquals("Amazing Grace", section.title)
+        assertEquals(123, section.songNumber)
+        assertEquals(listOf("123 – Amazing Grace", "Newton / Excell"), section.lines)
+        assertEquals(90, section.bpm)
+    }
+
+    @Test fun `a title slide with no credit has only the heading line`() =
+        assertEquals(listOf("123 – Amazing Grace"), titleSlideSection(song(), bpm = 0).lines)
+
+    @Test fun `a non-numeric song number becomes zero`() =
+        assertEquals(0, titleSlideSection(song(number = "12b"), bpm = 0).songNumber)
+
+    // ── resolveEditedSongPush ─────────────────────────────────────────────────
+
+    private val sections = listOf(
+        LyricSection(type = Constants.SECTION_TYPE_VERSE, lines = listOf("v1 a", "v1 b")),
+        LyricSection(type = Constants.SECTION_TYPE_CHORUS, lines = listOf("c1 a", "c1 b", "c1 c")),
+    )
+
+    @Test fun `an edit lands on the previously-live section and line, with bpm stamped`() {
+        val push = resolveEditedSongPush(sections, liveSectionIndex = 1, liveLineIndex = 2, song(), bpm = 80)
+        assertEquals(1, push.sectionIndex)
+        assertEquals(2, push.lineIndex)
+        assertEquals(80, push.section.bpm)
+        assertEquals(sections[1].lines, push.section.lines)
+    }
+
+    @Test fun `a section index past the end is clamped to the last section`() =
+        assertEquals(1, resolveEditedSongPush(sections, liveSectionIndex = 9, liveLineIndex = 0, song(), bpm = 0).sectionIndex)
+
+    @Test fun `a line index past the end is clamped to the section's last line`() =
+        assertEquals(1, resolveEditedSongPush(sections, liveSectionIndex = 0, liveLineIndex = 9, song(), bpm = 0).lineIndex)
+
+    @Test fun `with no sections the push falls back to a section built from the edited song`() {
+        val edited = song(lyrics = listOf("line one", "line two"))
+        val push = resolveEditedSongPush(emptyList(), liveSectionIndex = 0, liveLineIndex = 5, edited, bpm = 70)
+        assertEquals(-1, push.sectionIndex, "no section to select in an empty list")
+        assertEquals(Constants.SECTION_TYPE_SONG, push.section.type)
+        assertEquals(listOf("line one", "line two"), push.section.lines)
+        assertEquals(1, push.lineIndex, "clamped into the fallback section's line range")
+        assertEquals(70, push.section.bpm)
+    }
+}


### PR DESCRIPTION
Same fat-tab extraction pattern as #22, now on SongsTab (~2,000 lines of View, 0% covered). SongsViewModel already owns the collection filtering/sorting/section-splitting/navigation — the untested logic here is the table's column configuration and the per-line-mode predicate.

## Extracted (behaviour-preserving)
**`utils/SongColumns.kt`**
- `availableSongColumns(songbookCount, hasAddToSchedule)` — which columns exist
- `mergeColumnOrder(saved, available)` — reconcile a saved order against current columns (keep order, drop gone, append new)
- `moveColumn(order, colId, targetId)` — drag reorder; returns same reference on a no-op
- `songColumnSortKey(colId)` — column → sort key
- `draggedColumnIndex(...)` — the off-by-one-prone drag-target math, with column width passed in as a lambda so it's testable without density/Compose

**`utils/SongDisplayMode.kt`**
- `isSongLineMode(settings)` — replaced **three identical** four-way OR-chains across the tab

## Safety
- Full `SongsViewModel*` suite: green
- New `SongColumnsTest` (17) + `SongDisplayModeTest` (5), all <0.1s, deterministic 3×
- No `highlightRanges` duplication — SongsTab does no search highlighting (confirmed)

Independent of #22 (different files); both off `main`.