### PR TITLE
Refactor: extract ScheduleTab display, zoom and dropped-file logic into tested helpers

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
@@ -120,7 +120,6 @@ import churchpresenter.composeapp.generated.resources.tooltip_open_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_remove
 import churchpresenter.composeapp.generated.resources.tooltip_remove_from_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_save_schedule
-import kotlin.math.abs
 import kotlinx.coroutines.launch
 import org.churchpresenter.app.churchpresenter.composables.TooltipIconButton
 import org.churchpresenter.app.churchpresenter.data.settings.PlanningCenterSettings
@@ -130,7 +129,20 @@ import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
 import org.churchpresenter.app.churchpresenter.utils.Utils
+import org.churchpresenter.app.churchpresenter.utils.DroppedFileAction
+import org.churchpresenter.app.churchpresenter.utils.IMAGE_EXTENSIONS
+import org.churchpresenter.app.churchpresenter.utils.classifyDroppedFile
+import org.churchpresenter.app.churchpresenter.utils.scheduleCanZoomIn
+import org.churchpresenter.app.churchpresenter.utils.scheduleCanZoomOut
+import org.churchpresenter.app.churchpresenter.utils.scheduleShowCardActions
+import org.churchpresenter.app.churchpresenter.utils.scheduleSingleLineCards
+import org.churchpresenter.app.churchpresenter.utils.scheduleZoomIn
+import org.churchpresenter.app.churchpresenter.utils.scheduleZoomOut
 import org.churchpresenter.app.churchpresenter.viewmodel.ScheduleViewModel
+import org.churchpresenter.app.churchpresenter.viewmodel.announcementTimerSubtext
+import org.churchpresenter.app.churchpresenter.viewmodel.scheduleItemDetailText
+import org.churchpresenter.app.churchpresenter.viewmodel.scheduleItemGlyph
+import kotlin.math.abs
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import java.awt.datatransfer.DataFlavor
@@ -176,15 +188,8 @@ data class ScheduleTabActions(
     val addDictionary: (number: String, word: String, transliteration: String, definition: String) -> Unit = { _, _, _, _ -> }
 )
 
-/**
- * Card zoom rungs, as a percentage of the normal card size. The two rungs just below 100 exist
- * to strip the card down before it starts shrinking: 99 drops the action buttons, 98 collapses
- * the card to a single line (see [ZOOM_HIDE_ACTIONS_BELOW] / [ZOOM_SINGLE_LINE_AT_OR_BELOW]).
- */
-private val ZOOM_LEVELS = listOf(70, 80, 90, 98, 99, 100, 110, 120, 130, 140, 150)
+/** The card zoom percentage a schedule opens at; the rung ladder itself lives in ScheduleZoom.kt. */
 private const val ZOOM_DEFAULT = 100
-private const val ZOOM_HIDE_ACTIONS_BELOW = 100
-private const val ZOOM_SINGLE_LINE_AT_OR_BELOW = 98
 
 /** How far the pointer must travel on a card's icon before it becomes a reorder drag. */
 private val DRAG_HANDLE_THRESHOLD = 4.dp
@@ -192,9 +197,6 @@ private val DRAG_HANDLE_THRESHOLD = 4.dp
 /** Height of the drop-here-to-remove zone at the bottom of the list, shown while dragging. */
 private val DELETE_ZONE_HEIGHT = 56.dp
 
-/** The rung nearest [percent], so a value persisted before the ladder existed still resolves. */
-private fun nearestZoomIndex(percent: Int): Int =
-    ZOOM_LEVELS.indices.minBy { abs(ZOOM_LEVELS[it] - percent) }
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -420,21 +422,20 @@ fun ScheduleTab(
                 modifier = Modifier.padding(end = 6.dp)
             )
             // Card zoom controls (own Row so FlowRow wraps them as one group)
-            val zoomIndex = nearestZoomIndex(itemZoomPercent)
             Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
                 TooltipIconButton(
                     painter = painterResource(Res.drawable.ic_zoom_out),
                     text = stringResource(Res.string.tooltip_schedule_zoom_out),
-                    onClick = { onItemZoomChange(ZOOM_LEVELS[zoomIndex - 1]) },
-                    enabled = zoomIndex > 0,
+                    onClick = { onItemZoomChange(scheduleZoomOut(itemZoomPercent)) },
+                    enabled = scheduleCanZoomOut(itemZoomPercent),
                     buttonSize = 32.dp,
                     iconTint = MaterialTheme.colorScheme.onSurface
                 )
                 TooltipIconButton(
                     painter = painterResource(Res.drawable.ic_zoom_in),
                     text = stringResource(Res.string.tooltip_schedule_zoom_in),
-                    onClick = { onItemZoomChange(ZOOM_LEVELS[zoomIndex + 1]) },
-                    enabled = zoomIndex < ZOOM_LEVELS.lastIndex,
+                    onClick = { onItemZoomChange(scheduleZoomIn(itemZoomPercent)) },
+                    enabled = scheduleCanZoomIn(itemZoomPercent),
                     buttonSize = 32.dp,
                     iconTint = MaterialTheme.colorScheme.onSurface
                 )
@@ -464,8 +465,8 @@ fun ScheduleTab(
             val zoomedDensity = remember(baseDensity, itemZoomPercent) {
                 Density(baseDensity.density * itemZoomPercent / 100f, baseDensity.fontScale)
             }
-            val showCardActions = itemZoomPercent >= ZOOM_HIDE_ACTIONS_BELOW
-            val singleLineCards = itemZoomPercent <= ZOOM_SINGLE_LINE_AT_OR_BELOW
+            val showCardActions = scheduleShowCardActions(itemZoomPercent)
+            val singleLineCards = scheduleSingleLineCards(itemZoomPercent)
 
             // Reorder gesture, shared by the whole-card shift+drag and the per-card icon handle.
             // The handle path arms only after real movement so a plain click still selects the card.
@@ -724,19 +725,7 @@ fun ScheduleTab(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = when (item) {
-                                is ScheduleItem.SongItem -> "♪"
-                                is ScheduleItem.BibleVerseItem -> "✝"
-                                is ScheduleItem.LabelItem -> "🏷"
-                                is ScheduleItem.PictureItem -> "📷"
-                                is ScheduleItem.PresentationItem -> "📊"
-                                is ScheduleItem.MediaItem -> "🎬"
-                                is ScheduleItem.LowerThirdItem -> "▼"
-                                is ScheduleItem.AnnouncementItem -> "📢"
-                                is ScheduleItem.WebsiteItem -> "🌐"
-                                is ScheduleItem.SceneItem -> "🎬"
-                                is ScheduleItem.DictionaryItem -> "📖"
-                            },
+                            text = scheduleItemGlyph(item),
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.primary,
                             modifier = Modifier.width(24.dp)
@@ -815,11 +804,6 @@ fun ScheduleTab(
     }
 }
 
-private val IMAGE_EXTENSIONS = setOf("jpg", "jpeg", "png", "gif", "bmp", "webp")
-private val VIDEO_EXTENSIONS = setOf("mp4", "avi", "mov", "mkv", "webm")
-private val AUDIO_EXTENSIONS = setOf("mp3", "wav", "flac")
-private val PRESENTATION_EXTENSIONS = setOf("ppt", "pptx", "key", "pdf")
-
 private fun handleDroppedFiles(files: List<File>, viewModel: ScheduleViewModel) {
     for (file in files) {
         if (file.isDirectory) {
@@ -834,14 +818,12 @@ private fun handleDroppedFiles(files: List<File>, viewModel: ScheduleViewModel) 
         }
 
         val ext = file.extension.lowercase()
-        when {
-            ext in PRESENTATION_EXTENSIONS -> {
+        when (classifyDroppedFile(ext)) {
+            DroppedFileAction.PRESENTATION ->
                 viewModel.addPresentation(file.absolutePath, file.nameWithoutExtension, 0, ext)
-            }
-            ext in VIDEO_EXTENSIONS || ext in AUDIO_EXTENSIONS -> {
+            DroppedFileAction.MEDIA ->
                 viewModel.addMedia(file.absolutePath, file.nameWithoutExtension, "local")
-            }
-            ext in IMAGE_EXTENSIONS -> {
+            DroppedFileAction.PICTURE -> {
                 // Single image dropped — add parent folder as picture source
                 val parentFolder = file.parentFile
                 val imageCount = parentFolder?.listFiles()?.count { child ->
@@ -853,9 +835,9 @@ private fun handleDroppedFiles(files: List<File>, viewModel: ScheduleViewModel) 
                     imageCount
                 )
             }
-            ext == "json" -> {
+            DroppedFileAction.LOWER_THIRD ->
                 viewModel.addLowerThird(file.nameWithoutExtension, file.nameWithoutExtension, false, 0L)
-            }
+            DroppedFileAction.NONE -> {}
         }
     }
 }
@@ -946,19 +928,7 @@ private fun ScheduleItemRow(
                     modifier = Modifier.width(4.dp).height(16.dp)
                 )
                 Text(
-                    text = when (item) {
-                        is ScheduleItem.SongItem -> "♪"
-                        is ScheduleItem.BibleVerseItem -> "✝"
-                        is ScheduleItem.LabelItem -> "🏷"
-                        is ScheduleItem.PictureItem -> "📷"
-                        is ScheduleItem.PresentationItem -> "📊"
-                        is ScheduleItem.MediaItem -> "🎬"
-                        is ScheduleItem.LowerThirdItem -> "▼"
-                        is ScheduleItem.AnnouncementItem -> "📢"
-                        is ScheduleItem.WebsiteItem -> "🌐"
-                        is ScheduleItem.SceneItem -> "🎬"
-                        is ScheduleItem.DictionaryItem -> "📖"
-                    },
+                    text = scheduleItemGlyph(item),
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.width(24.dp)
@@ -1029,28 +999,28 @@ private fun ScheduleItemRow(
                     is ScheduleItem.SongItem -> {} // already handled above
                     is ScheduleItem.BibleVerseItem -> Text(
                         maxLines = 1,
-                        text = item.verseText.take(100) + if (item.verseText.length > 100) "..." else "",
+                        text = scheduleItemDetailText(item).orEmpty(),
                         style = MaterialTheme.typography.bodySmall,
                         color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                                 else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
                     )
                     is ScheduleItem.PictureItem -> Text(
                         maxLines = 1,
-                        text = item.folderPath,
+                        text = scheduleItemDetailText(item).orEmpty(),
                         style = MaterialTheme.typography.bodySmall,
                         color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                                 else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
                     )
                     is ScheduleItem.PresentationItem -> Text(
                         maxLines = 1,
-                        text = "${item.fileType.uppercase()} - ${item.filePath}",
+                        text = scheduleItemDetailText(item).orEmpty(),
                         style = MaterialTheme.typography.bodySmall,
                         color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                                 else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
                     )
                     is ScheduleItem.MediaItem -> Text(
                         maxLines = 1,
-                        text = "${item.mediaType.uppercase()} - ${item.mediaUrl}",
+                        text = scheduleItemDetailText(item).orEmpty(),
                         style = MaterialTheme.typography.bodySmall,
                         color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
                                 else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
@@ -1066,11 +1036,7 @@ private fun ScheduleItemRow(
                     is ScheduleItem.AnnouncementItem -> {
                         // Duration (count-up) and the live Clock have no fixed h:m:s to preview here —
                         // their live value only exists once the item is triggered, so show nothing.
-                        val timerSubtext = when (item.timerMode) {
-                            "clock" -> "%02d:%02d:%02d".format(item.targetHour, item.targetMinute, item.targetSecond)
-                            "count_up", "clock_display" -> null
-                            else -> "%02d:%02d".format(item.timerMinutes, item.timerSeconds)
-                        }
+                        val timerSubtext = announcementTimerSubtext(item)
                         if (item.isTimer && timerSubtext != null) {
                             Text(
                                 maxLines = 1,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
@@ -120,6 +120,7 @@ import churchpresenter.composeapp.generated.resources.tooltip_open_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_remove
 import churchpresenter.composeapp.generated.resources.tooltip_remove_from_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_save_schedule
+import kotlin.math.abs
 import kotlinx.coroutines.launch
 import org.churchpresenter.app.churchpresenter.composables.TooltipIconButton
 import org.churchpresenter.app.churchpresenter.data.settings.PlanningCenterSettings
@@ -142,7 +143,6 @@ import org.churchpresenter.app.churchpresenter.viewmodel.ScheduleViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.announcementTimerSubtext
 import org.churchpresenter.app.churchpresenter.viewmodel.scheduleItemDetailText
 import org.churchpresenter.app.churchpresenter.viewmodel.scheduleItemGlyph
-import kotlin.math.abs
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import java.awt.datatransfer.DataFlavor
@@ -196,7 +196,6 @@ private val DRAG_HANDLE_THRESHOLD = 4.dp
 
 /** Height of the drop-here-to-remove zone at the bottom of the list, shown while dragging. */
 private val DELETE_ZONE_HEIGHT = 56.dp
-
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/DroppedFileClassifier.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/DroppedFileClassifier.kt
@@ -1,0 +1,25 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+/**
+ * Which schedule action a dropped file maps to, decided by its extension. Extracted from
+ * ScheduleTab's `handleDroppedFiles` so the extension → action rule is tested without touching the
+ * filesystem or the view model. The folder-vs-file and image-count handling stays in the tab (it is
+ * genuine File I/O); only this pure classification moves here.
+ */
+
+/** Image extensions — also used by the tab to count pictures inside a dropped folder. */
+internal val IMAGE_EXTENSIONS = setOf("jpg", "jpeg", "png", "gif", "bmp", "webp")
+private val VIDEO_EXTENSIONS = setOf("mp4", "avi", "mov", "mkv", "webm")
+private val AUDIO_EXTENSIONS = setOf("mp3", "wav", "flac")
+private val PRESENTATION_EXTENSIONS = setOf("ppt", "pptx", "key", "pdf")
+
+internal enum class DroppedFileAction { PRESENTATION, MEDIA, PICTURE, LOWER_THIRD, NONE }
+
+/** The action a single dropped file (already lower-cased [extension]) should be added as. */
+internal fun classifyDroppedFile(extension: String): DroppedFileAction = when {
+    extension in PRESENTATION_EXTENSIONS -> DroppedFileAction.PRESENTATION
+    extension in VIDEO_EXTENSIONS || extension in AUDIO_EXTENSIONS -> DroppedFileAction.MEDIA
+    extension in IMAGE_EXTENSIONS -> DroppedFileAction.PICTURE
+    extension == "json" -> DroppedFileAction.LOWER_THIRD
+    else -> DroppedFileAction.NONE
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoom.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoom.kt
@@ -1,0 +1,38 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.math.abs
+
+/**
+ * The schedule card zoom ladder. Zoom snaps to fixed rungs (so a value persisted before the ladder
+ * existed still resolves to the nearest one), and below full size the card sheds its action buttons
+ * and then collapses to a single line before it starts shrinking. Extracted from ScheduleTab so the
+ * rung math and the two shed/collapse thresholds are tested without the Compose controls.
+ */
+
+internal val ZOOM_LEVELS = listOf(70, 80, 90, 98, 99, 100, 110, 120, 130, 140, 150)
+private const val ZOOM_HIDE_ACTIONS_BELOW = 100
+private const val ZOOM_SINGLE_LINE_AT_OR_BELOW = 98
+
+/** The rung nearest [percent], so a value persisted before the ladder existed still resolves. */
+internal fun nearestZoomIndex(percent: Int): Int =
+    ZOOM_LEVELS.indices.minBy { abs(ZOOM_LEVELS[it] - percent) }
+
+/** The next rung up from [percent] (clamped at the top rung). */
+internal fun scheduleZoomIn(percent: Int): Int =
+    ZOOM_LEVELS[(nearestZoomIndex(percent) + 1).coerceAtMost(ZOOM_LEVELS.lastIndex)]
+
+/** The next rung down from [percent] (clamped at the bottom rung). */
+internal fun scheduleZoomOut(percent: Int): Int =
+    ZOOM_LEVELS[(nearestZoomIndex(percent) - 1).coerceAtLeast(0)]
+
+/** Whether there is a higher rung to zoom into. */
+internal fun scheduleCanZoomIn(percent: Int): Boolean = nearestZoomIndex(percent) < ZOOM_LEVELS.lastIndex
+
+/** Whether there is a lower rung to zoom out to. */
+internal fun scheduleCanZoomOut(percent: Int): Boolean = nearestZoomIndex(percent) > 0
+
+/** At or above full size the cards keep their action buttons; below it they shed them. */
+internal fun scheduleShowCardActions(percent: Int): Boolean = percent >= ZOOM_HIDE_ACTIONS_BELOW
+
+/** At or below the collapse threshold the cards render a single line only. */
+internal fun scheduleSingleLineCards(percent: Int): Boolean = percent <= ZOOM_SINGLE_LINE_AT_OR_BELOW

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplay.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplay.kt
@@ -1,0 +1,51 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.utils.Constants
+
+/**
+ * How a schedule item is labelled in the list — its type glyph, its grey detail line, and an
+ * announcement timer's preview. Extracted from ScheduleTab (the glyph `when` was duplicated at two
+ * sites) so the per-type mapping is exhaustive over the sealed [ScheduleItem] and tested in one place.
+ */
+
+/** The single-glyph type indicator shown on a schedule row and its drag preview. */
+internal fun scheduleItemGlyph(item: ScheduleItem): String = when (item) {
+    is ScheduleItem.SongItem -> "♪"
+    is ScheduleItem.BibleVerseItem -> "✝"
+    is ScheduleItem.LabelItem -> "🏷"
+    is ScheduleItem.PictureItem -> "📷"
+    is ScheduleItem.PresentationItem -> "📊"
+    is ScheduleItem.MediaItem -> "🎬"
+    is ScheduleItem.LowerThirdItem -> "▼"
+    is ScheduleItem.AnnouncementItem -> "📢"
+    is ScheduleItem.WebsiteItem -> "🌐"
+    is ScheduleItem.SceneItem -> "🎬"
+    is ScheduleItem.DictionaryItem -> "📖"
+}
+
+/**
+ * The grey secondary line under a schedule row, or null for types that show none (or whose detail is
+ * rendered with a string resource in the View, e.g. lower-third pause duration). A long Bible verse
+ * is truncated to 100 chars with an ellipsis.
+ */
+internal fun scheduleItemDetailText(item: ScheduleItem): String? = when (item) {
+    is ScheduleItem.BibleVerseItem ->
+        item.verseText.take(100) + if (item.verseText.length > 100) "..." else ""
+    is ScheduleItem.PictureItem -> item.folderPath
+    is ScheduleItem.PresentationItem -> "${item.fileType.uppercase()} - ${item.filePath}"
+    is ScheduleItem.MediaItem -> "${item.mediaType.uppercase()} - ${item.mediaUrl}"
+    else -> null
+}
+
+/**
+ * The h:m:s preview for an announcement timer, or null when there is nothing fixed to preview: a
+ * count-up timer and the live clock display only have a value once triggered. A clock-target timer
+ * previews the target time-of-day; a plain duration timer previews its minutes:seconds.
+ */
+internal fun announcementTimerSubtext(item: ScheduleItem.AnnouncementItem): String? = when (item.timerMode) {
+    Constants.TIMER_MODE_CLOCK ->
+        "%02d:%02d:%02d".format(item.targetHour, item.targetMinute, item.targetSecond)
+    Constants.TIMER_MODE_COUNT_UP, Constants.TIMER_MODE_CLOCK_DISPLAY -> null
+    else -> "%02d:%02d".format(item.timerMinutes, item.timerSeconds)
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplay.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplay.kt
@@ -25,9 +25,11 @@ internal fun scheduleItemGlyph(item: ScheduleItem): String = when (item) {
 }
 
 /**
- * The grey secondary line under a schedule row, or null for types that show none (or whose detail is
- * rendered with a string resource in the View, e.g. lower-third pause duration). A long Bible verse
- * is truncated to 100 chars with an ellipsis.
+ * The grey secondary line for the four schedule item types whose detail is a plain formatted string —
+ * Bible verse (truncated to 100 chars with an ellipsis), picture folder, and the `TYPE - path` line
+ * for presentations and media. Returns null for every other type: some show no detail, and others
+ * (e.g. the lower-third pause duration) render theirs with a string resource in the View, so those
+ * branches stay in `ScheduleItemRow` rather than routing through here.
  */
 internal fun scheduleItemDetailText(item: ScheduleItem): String? = when (item) {
     is ScheduleItem.BibleVerseItem ->

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/DroppedFileClassifierTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/DroppedFileClassifierTest.kt
@@ -1,0 +1,43 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * How a dropped file's extension maps to a schedule action. A wrong category adds the file as the
+ * wrong item type (a video as a picture, a deck as media), so every branch of the classifier is
+ * pinned here — plus the unknown-extension fallthrough that must add nothing.
+ */
+class DroppedFileClassifierTest {
+
+    @Test fun `presentation decks classify as presentation`() {
+        for (ext in listOf("ppt", "pptx", "key", "pdf")) {
+            assertEquals(DroppedFileAction.PRESENTATION, classifyDroppedFile(ext), ext)
+        }
+    }
+
+    @Test fun `video and audio classify as media`() {
+        for (ext in listOf("mp4", "avi", "mov", "mkv", "webm", "mp3", "wav", "flac")) {
+            assertEquals(DroppedFileAction.MEDIA, classifyDroppedFile(ext), ext)
+        }
+    }
+
+    @Test fun `images classify as picture`() {
+        for (ext in IMAGE_EXTENSIONS) {
+            assertEquals(DroppedFileAction.PICTURE, classifyDroppedFile(ext), ext)
+        }
+    }
+
+    @Test fun `a json file classifies as a lower third`() =
+        assertEquals(DroppedFileAction.LOWER_THIRD, classifyDroppedFile("json"))
+
+    @Test fun `an unknown extension classifies as none`() {
+        assertEquals(DroppedFileAction.NONE, classifyDroppedFile("txt"))
+        assertEquals(DroppedFileAction.NONE, classifyDroppedFile(""))
+        assertEquals(DroppedFileAction.NONE, classifyDroppedFile("docx"))
+    }
+
+    @Test fun `the image extension set is exposed for the folder-count path`() =
+        assertTrue("jpg" in IMAGE_EXTENSIONS && "png" in IMAGE_EXTENSIONS)
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoomTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoomTest.kt
@@ -1,0 +1,57 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The schedule card zoom ladder. Zoom snaps to fixed rungs and the two rungs just below 100 strip
+ * the card (drop actions, then collapse to one line) before it shrinks. These pin the rung math,
+ * the clamped step, and the two shed/collapse thresholds.
+ */
+class ScheduleZoomTest {
+
+    @Test fun `an exact percent resolves to its own rung`() =
+        assertEquals(5, nearestZoomIndex(100)) // ZOOM_LEVELS[5] == 100
+
+    @Test fun `a between-rungs percent resolves to the nearest rung`() =
+        assertEquals(1, nearestZoomIndex(84)) // closer to 80 than 90
+
+    @Test fun `a percent below the ladder resolves to the lowest rung`() =
+        assertEquals(0, nearestZoomIndex(40))
+
+    @Test fun `a percent above the ladder resolves to the highest rung`() =
+        assertEquals(ZOOM_LEVELS.lastIndex, nearestZoomIndex(500))
+
+    @Test fun `zooming in steps to the next rung up`() =
+        assertEquals(110, scheduleZoomIn(100))
+
+    @Test fun `zooming out steps to the next rung down`() =
+        assertEquals(99, scheduleZoomOut(100))
+
+    @Test fun `zooming in at the top rung stays put`() =
+        assertEquals(150, scheduleZoomIn(150))
+
+    @Test fun `zooming out at the bottom rung stays put`() =
+        assertEquals(70, scheduleZoomOut(70))
+
+    @Test fun `can-zoom flags respect the ladder ends`() {
+        assertFalse(scheduleCanZoomOut(70), "already at the smallest rung")
+        assertTrue(scheduleCanZoomIn(70))
+        assertFalse(scheduleCanZoomIn(150), "already at the largest rung")
+        assertTrue(scheduleCanZoomOut(150))
+    }
+
+    @Test fun `card actions show at full size and hide just below it`() {
+        assertTrue(scheduleShowCardActions(100))
+        assertTrue(scheduleShowCardActions(110))
+        assertFalse(scheduleShowCardActions(99))
+    }
+
+    @Test fun `cards collapse to a single line at or below the collapse rung`() {
+        assertTrue(scheduleSingleLineCards(98))
+        assertTrue(scheduleSingleLineCards(70))
+        assertFalse(scheduleSingleLineCards(99))
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplayTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplayTest.kt
@@ -1,0 +1,83 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * How schedule rows are labelled — the type glyph, the grey detail line, and the timer preview.
+ * The glyph `when` was duplicated at two sites in ScheduleTab; the detail line and timer preview
+ * carried real formatting (verse truncation, uppercase type tags, the count-up/clock "no preview"
+ * rule) that was never tested.
+ */
+class ScheduleItemDisplayTest {
+
+    // ── glyph (exhaustive over the sealed type) ────────────────────────────────
+
+    @Test
+    fun `every schedule item type has its own glyph`() {
+        val cases = listOf(
+            ScheduleItem.SongItem(id = "1", songNumber = 1, title = "t", songbook = "b") to "♪",
+            ScheduleItem.BibleVerseItem(id = "2", bookName = "John", chapter = 3, verseNumber = 16, verseText = "x") to "✝",
+            ScheduleItem.LabelItem(id = "3", text = "l", textColor = "#fff", backgroundColor = "#000") to "🏷",
+            ScheduleItem.PictureItem(id = "4", folderPath = "/p", folderName = "p", imageCount = 1) to "📷",
+            ScheduleItem.PresentationItem(id = "5", filePath = "/d.pptx", fileName = "d", slideCount = 1, fileType = "pptx") to "📊",
+            ScheduleItem.MediaItem(id = "6", mediaUrl = "/m.mp4", mediaTitle = "m", mediaType = "local") to "🎬",
+            ScheduleItem.LowerThirdItem(id = "7", presetId = "p", presetLabel = "p", pauseAtFrame = false, pauseDurationMs = 0L) to "▼",
+            ScheduleItem.AnnouncementItem(id = "8", text = "a") to "📢",
+            ScheduleItem.WebsiteItem(id = "9", url = "https://x") to "🌐",
+            ScheduleItem.SceneItem(id = "10", sceneId = "s", sceneName = "s") to "🎬",
+            ScheduleItem.DictionaryItem(id = "11", number = "1", word = "w", transliteration = "t", definition = "d") to "📖",
+        )
+        for ((item, glyph) in cases) {
+            assertEquals(glyph, scheduleItemGlyph(item), item::class.simpleName)
+        }
+    }
+
+    // ── detail line ────────────────────────────────────────────────────────────
+
+    @Test fun `a short bible verse shows in full`() =
+        assertEquals("For God so loved", scheduleItemDetailText(
+            ScheduleItem.BibleVerseItem(id = "1", bookName = "John", chapter = 3, verseNumber = 16, verseText = "For God so loved")))
+
+    @Test fun `a long bible verse is truncated to 100 chars with an ellipsis`() {
+        val verse = "a".repeat(150)
+        val detail = scheduleItemDetailText(
+            ScheduleItem.BibleVerseItem(id = "1", bookName = "John", chapter = 3, verseNumber = 16, verseText = verse))
+        assertEquals(103, detail!!.length, "100 chars + ellipsis")
+        assertTrue(detail.endsWith("..."))
+    }
+
+    @Test fun `a presentation detail is its uppercased type and path`() =
+        assertEquals("PPTX - /decks/a.pptx", scheduleItemDetailText(
+            ScheduleItem.PresentationItem(id = "1", filePath = "/decks/a.pptx", fileName = "a", slideCount = 3, fileType = "pptx")))
+
+    @Test fun `a media detail is its uppercased type and url`() =
+        assertEquals("LOCAL - /clips/a.mp4", scheduleItemDetailText(
+            ScheduleItem.MediaItem(id = "1", mediaUrl = "/clips/a.mp4", mediaTitle = "a", mediaType = "local")))
+
+    @Test fun `a type with no simple detail line returns null`() =
+        assertNull(scheduleItemDetailText(ScheduleItem.SongItem(id = "1", songNumber = 1, title = "t", songbook = "b")))
+
+    // ── announcement timer preview ─────────────────────────────────────────────
+
+    private fun timer(mode: String) = ScheduleItem.AnnouncementItem(
+        id = "1", text = "a", isTimer = true, timerMode = mode,
+        timerMinutes = 5, timerSeconds = 9, targetHour = 9, targetMinute = 30, targetSecond = 5,
+    )
+
+    @Test fun `a clock-target timer previews the target time of day`() =
+        assertEquals("09:30:05", announcementTimerSubtext(timer(Constants.TIMER_MODE_CLOCK)))
+
+    @Test fun `a duration timer previews minutes and seconds`() =
+        assertEquals("05:09", announcementTimerSubtext(timer(Constants.TIMER_MODE_DURATION)))
+
+    @Test fun `a count-up timer has no fixed preview`() =
+        assertNull(announcementTimerSubtext(timer(Constants.TIMER_MODE_COUNT_UP)))
+
+    @Test fun `a live clock display has no fixed preview`() =
+        assertNull(announcementTimerSubtext(timer(Constants.TIMER_MODE_CLOCK_DISPLAY)))
+}


### PR DESCRIPTION
Same fat-tab extraction pattern as #22/#23, now on ScheduleTab (~1,300 lines of View, 0% covered). ScheduleViewModel already owns list mutation/undo; the untested logic here is row labelling, the zoom ladder, and dropped-file classification.

## Extracted (behaviour-preserving)
**viewmodel/ScheduleItemDisplay.kt**
- `scheduleItemGlyph(item)` — the type→glyph `when` (was **duplicated** at two sites: the row and the drag preview)
- `scheduleItemDetailText(item)` — the grey subtitle, including the 100-char Bible-verse truncation and the `TYPE - path` tags
- `announcementTimerSubtext(item)` — the timer preview, incl. the count-up / live-clock "no fixed preview" rule

**utils/ScheduleZoom.kt** — the card zoom rung ladder: `nearestZoomIndex`, clamped `scheduleZoomIn/Out`, `scheduleCanZoomIn/Out`, and the `scheduleShowCardActions` / `scheduleSingleLineCards` thresholds

**utils/DroppedFileClassifier.kt** — `classifyDroppedFile(ext)` → `DroppedFileAction` (the folder/image-count File I/O stays in the tab; only the pure extension→action decision moves)

## Safety
- Full `ScheduleViewModel*` suite: green
- New: `ScheduleItemDisplayTest` (10), `ScheduleZoomTest` (11), `DroppedFileClassifierTest` (6) — 27 pure cases, all <0.1s, deterministic 3×

## Scope note
ScheduleTab is **not** in PR #9's changed-file set, so this doesn't conflict with the dev's per-output-go-live work. The remaining ScheduleTab target (the drag drop-target/delete-zone hit-test math) is left for a follow-up — it needs the gesture geometry threaded out of `awaitPointerEventScope`, so it's higher-risk than this batch.