### PR TITLE
Fix: deflake disk-loading SongsViewModel tests (closes #24)

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
@@ -2,6 +2,7 @@ package org.churchpresenter.app.churchpresenter.viewmodel
 
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -26,7 +27,15 @@ import java.io.File
 
 class SongsViewModel(
     private var appSettings: AppSettings,
-    private val onSongsLoaded: ((List<SongItem>) -> Unit)? = null
+    private val onSongsLoaded: ((List<SongItem>) -> Unit)? = null,
+    // Test seams (production defaults reproduce the shipping behaviour):
+    //  - [dispatcher] backs the view-model scope. It is Dispatchers.Main in the app so state updates
+    //    land on the UI thread; tests pass Dispatchers.Default so many view models loading at once
+    //    don't all queue behind each other on the single Swing event thread and time out.
+    //  - [enableFolderWatcher] starts the directory watcher that reloads on file changes. Tests turn
+    //    it off so a blocking watch loop and its self-triggered reloads don't race the assertions.
+    dispatcher: CoroutineDispatcher = Dispatchers.Main,
+    private val enableFolderWatcher: Boolean = true,
 ) {
     private val _songsData = mutableStateOf(Songs())
     val songsData: State<Songs> = _songsData
@@ -34,7 +43,7 @@ class SongsViewModel(
     private val _isLoading = mutableStateOf(false)
     val isLoading: State<Boolean> = _isLoading
 
-    private val viewModelScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    private val viewModelScope = CoroutineScope(dispatcher + SupervisorJob())
     private var loadSongsJob: kotlinx.coroutines.Job? = null
     private val songFolderWatcher = SongFolderWatcher(viewModelScope) { loadSongs() }
     private val _allSongItems = mutableStateOf<List<SongItem>>(emptyList())
@@ -260,7 +269,7 @@ class SongsViewModel(
                 }
 
                 // Start watching the song directory for changes
-                if (storageDir.isNotEmpty()) {
+                if (enableFolderWatcher && storageDir.isNotEmpty()) {
                     songFolderWatcher.watchDirectory(File(storageDir))
                 }
             } finally {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsFilteringTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsFilteringTest.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
+import kotlinx.coroutines.Dispatchers
+
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.server.SongCatalogResponse
 import org.churchpresenter.app.churchpresenter.server.SongDto
@@ -43,7 +45,7 @@ class SongsFilteringTest {
             songBooks = entries.size,
             total = entries.sumOf { it.songs.size },
         )
-        return SongsViewModel(AppSettings()).also {
+        return SongsViewModel(AppSettings(), dispatcher = Dispatchers.Default, enableFolderWatcher = false).also {
             created.add(it)
             it.setInstanceLinkSource(active = true, catalog = catalog, fetchDetail = null)
         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelEditDeleteTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelEditDeleteTest.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
+import kotlinx.coroutines.Dispatchers
+
 import org.churchpresenter.app.churchpresenter.data.SongFileParser
 import org.churchpresenter.app.churchpresenter.data.SongItem
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
@@ -51,7 +53,7 @@ class SongsViewModelEditDeleteTest {
     }
 
     private fun viewModel(): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)))
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
         created.add(vm)
         awaitUntil("songs") { vm.filteredSongItems.value.size >= 3 }
         return vm

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelLibraryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelLibraryTest.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
+import kotlinx.coroutines.Dispatchers
+
 import org.churchpresenter.app.churchpresenter.data.SongFileParser
 import org.churchpresenter.app.churchpresenter.data.SongItem
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
@@ -64,7 +66,7 @@ class SongsViewModelLibraryTest {
     }
 
     private fun viewModel(): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)))
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
         created.add(vm)
         awaitUntil("songs to load") { vm.filteredSongItems.value.isNotEmpty() }
         return vm
@@ -105,7 +107,7 @@ class SongsViewModelLibraryTest {
 
     @Test
     fun `an empty storage directory yields no songs`() {
-        val vm = SongsViewModel(AppSettings()).also { created.add(it) }
+        val vm = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Default, enableFolderWatcher = false).also { created.add(it) }
         awaitUntil("the load to finish") { !vm.isLoading.value }
         assertTrue(vm.filteredSongItems.value.isEmpty())
     }
@@ -259,7 +261,7 @@ class SongsViewModelLibraryTest {
         val vm = viewModel()
         assertFalse(vm.createSong(SongItem(number = "1", title = "No Book", songbook = "", lyrics = listOf("l"))))
 
-        val unconfigured = SongsViewModel(AppSettings()).also { created.add(it) }
+        val unconfigured = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Default, enableFolderWatcher = false).also { created.add(it) }
         assertFalse(unconfigured.createSong(SongItem(number = "1", title = "T", songbook = "Hymnal", lyrics = listOf("l"))))
     }
 
@@ -360,7 +362,7 @@ class SongsViewModelLibraryTest {
 
     @Test
     fun `adding to the schedule with nothing selected reports failure`() {
-        val vm = SongsViewModel(AppSettings()).also { created.add(it) }
+        val vm = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Default, enableFolderWatcher = false).also { created.add(it) }
         var called = false
         assertFalse(vm.addCurrentSongToSchedule { _, _, _, _ -> called = true })
         assertFalse(called)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelNavigationEdgeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelNavigationEdgeTest.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
+import kotlinx.coroutines.Dispatchers
+
 import org.churchpresenter.app.churchpresenter.data.SongFileParser
 import org.churchpresenter.app.churchpresenter.data.SongItem
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
@@ -56,7 +58,7 @@ class SongsViewModelNavigationEdgeTest {
     }
 
     private fun viewModel(): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)))
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
         created.add(vm)
         val deadline = System.currentTimeMillis() + 5_000
         while (vm.filteredSongItems.value.isEmpty() && System.currentTimeMillis() < deadline) Thread.sleep(20)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelRemoteFollowerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelRemoteFollowerTest.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
+import kotlinx.coroutines.Dispatchers
+
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
 import org.churchpresenter.app.churchpresenter.server.SongCatalogResponse
@@ -66,7 +68,7 @@ class SongsViewModelRemoteFollowerTest {
 
     /** A follower whose fetch is [detailFor], counting every call. */
     private fun follower(detailFor: (String, String) -> SongDetailDto?): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)))
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
         created.add(vm)
         vm.setInstanceLinkSource(
             active = true,
@@ -133,7 +135,7 @@ class SongsViewModelRemoteFollowerTest {
 
     @Test
     fun `with no fetch function configured a selection fetches nothing`() {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)))
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
         created.add(vm)
         vm.setInstanceLinkSource(active = true, catalog = catalog(), fetchDetail = null)
         awaitUntil("the mirrored catalog") { vm.filteredSongItems.value.isNotEmpty() }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelSortingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelSortingTest.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
+import kotlinx.coroutines.Dispatchers
+
 import org.churchpresenter.app.churchpresenter.data.SongFileParser
 import org.churchpresenter.app.churchpresenter.data.SongItem
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
@@ -58,7 +60,7 @@ class SongsViewModelSortingTest {
     }
 
     private fun viewModel(): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)))
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
         created.add(vm)
         awaitUntil("songs") { vm.filteredSongItems.value.size == 3 }
         return vm
@@ -213,7 +215,7 @@ class SongsViewModelSortingTest {
                 SongItem(number = "0042", title = "Padded", songbook = "Hymnal", lyrics = listOf("l")),
                 File(File(padded, "Hymnal"), "0042 - Padded.song").absolutePath,
             )
-            val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = padded.absolutePath)))
+            val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = padded.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
                 .also { created.add(it) }
             awaitUntil("padded song") { vm.filteredSongItems.value.isNotEmpty() }
 


### PR DESCRIPTION
Closes #24 — the flaky disk-loading `SongsViewModel` tests that have been failing real PR CI (#27 and #30 both hit it) with `timed out after 5000ms`.

## Root cause
Every `SongsViewModel` runs its async `loadSongs()` on a scope backed by **`Dispatchers.Main`** — the single Swing event thread. When many view models load at once (the test suite in one JVM, or a loaded CI runner), their loads serialize behind each other on that one thread and don't finish within the test's 5s `awaitUntil`. The real `SongFolderWatcher` compounds it: a blocking watch loop holds an IO thread and re-triggers `loadSongs` on its own cache writes.

## Fix — two constructor seams, production behaviour unchanged
```kotlin
dispatcher: CoroutineDispatcher = Dispatchers.Main,   // app: UI thread
enableFolderWatcher: Boolean = true,                  // app: watches for changes
```
The disk-loading Songs tests now construct with `Dispatchers.Default` (loads run in parallel, off the single event thread) and `enableFolderWatcher = false` (no blocking watch loop / self-triggered reloads racing the assertions). The app constructs with the defaults, so nothing changes at runtime.

## Verified
- The **full Songs suite runs green 5× consecutively** with `--rerun-tasks` (it was failing ~50% before).
- Full `:composeApp:jvmTest` green.

No production behaviour change — only a test seam with shipping defaults.