### PR TITLE
Refactor: extract the schedule reorder-drag hit-test math into a tested helper

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
@@ -132,7 +132,9 @@ import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
 import org.churchpresenter.app.churchpresenter.utils.Utils
 import org.churchpresenter.app.churchpresenter.utils.DroppedFileAction
 import org.churchpresenter.app.churchpresenter.utils.IMAGE_EXTENSIONS
+import org.churchpresenter.app.churchpresenter.utils.DragItemGeometry
 import org.churchpresenter.app.churchpresenter.utils.classifyDroppedFile
+import org.churchpresenter.app.churchpresenter.utils.dragDropTarget
 import org.churchpresenter.app.churchpresenter.utils.scheduleCanZoomIn
 import org.churchpresenter.app.churchpresenter.utils.scheduleCanZoomOut
 import org.churchpresenter.app.churchpresenter.utils.scheduleShowCardActions
@@ -540,15 +542,17 @@ fun ScheduleTab(
                                     }
                                     dragCursorY += deltaY
                                     // Over the delete zone the card is being removed, not reordered
-                                    isOverDeleteZone = listHeightPx > 0 &&
-                                        dragCursorY >= listHeightPx - deleteZonePx
-                                    if (!isOverDeleteZone) {
-                                        val target = listState.layoutInfo.visibleItemsInfo
-                                            .firstOrNull { info ->
-                                                dragCursorY >= info.offset &&
-                                                dragCursorY <= info.offset + info.size
-                                            }
-                                        if (target != null) dropTargetIndex = target.index
+                                    val hit = dragDropTarget(
+                                        cursorY = dragCursorY,
+                                        listHeightPx = listHeightPx,
+                                        deleteZonePx = deleteZonePx,
+                                        visibleItems = listState.layoutInfo.visibleItemsInfo.map {
+                                            DragItemGeometry(it.index, it.offset, it.size)
+                                        },
+                                    )
+                                    isOverDeleteZone = hit.overDeleteZone
+                                    if (!hit.overDeleteZone) {
+                                        hit.targetIndex?.let { dropTargetIndex = it }
                                     }
                                 }
                             }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleDragMath.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleDragMath.kt
@@ -1,0 +1,30 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+/** A visible schedule row's geometry for drag hit-testing: its list [index], top [offset] and [size] in px. */
+internal data class DragItemGeometry(val index: Int, val offset: Int, val size: Int)
+
+/** The result of a drag move: whether the cursor is over the delete zone, and the row index it points at. */
+internal data class DragDropTarget(val overDeleteZone: Boolean, val targetIndex: Int?)
+
+/**
+ * Where a reorder drag currently points, from the cursor's vertical position. Extracted from
+ * ScheduleTab's pointer loop so this off-by-one-prone hit-testing is tested apart from the gesture.
+ *
+ * If [cursorY] has entered the delete zone — the [deleteZonePx]-tall strip at the bottom of a
+ * [listHeightPx]-tall list — the drop removes the card, so [DragDropTarget.overDeleteZone] is true and
+ * no target index is computed (a zero list height disables the zone). Otherwise the target is the
+ * first visible row whose vertical span `[offset, offset + size]` contains the cursor, or null when
+ * the cursor is in a gap or past the ends — in which case the caller keeps the previous target.
+ */
+internal fun dragDropTarget(
+    cursorY: Float,
+    listHeightPx: Int,
+    deleteZonePx: Float,
+    visibleItems: List<DragItemGeometry>,
+): DragDropTarget {
+    if (listHeightPx > 0 && cursorY >= listHeightPx - deleteZonePx) {
+        return DragDropTarget(overDeleteZone = true, targetIndex = null)
+    }
+    val target = visibleItems.firstOrNull { cursorY >= it.offset && cursorY <= it.offset + it.size }
+    return DragDropTarget(overDeleteZone = false, targetIndex = target?.index)
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleDragMathTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleDragMathTest.kt
@@ -1,0 +1,66 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The reorder-drag hit-testing extracted from ScheduleTab's pointer loop. A wrong result drops a
+ * card on the wrong row or fails to notice the delete zone, so the delete-zone boundary, the
+ * row-span containment (including the shared-edge tie-break), the gaps, and the ends are all pinned.
+ */
+class ScheduleDragMathTest {
+
+    // Three contiguous 50px rows: [0,50) [50,100) [100,150).
+    private val rows = listOf(
+        DragItemGeometry(index = 0, offset = 0, size = 50),
+        DragItemGeometry(index = 1, offset = 50, size = 50),
+        DragItemGeometry(index = 2, offset = 100, size = 50),
+    )
+
+    // ── delete zone ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `reaching the bottom strip is over the delete zone and computes no target`() {
+        val hit = dragDropTarget(cursorY = 950f, listHeightPx = 1000, deleteZonePx = 56f, visibleItems = rows)
+        assertTrue(hit.overDeleteZone)
+        assertNull(hit.targetIndex, "a delete drop needs no reorder target")
+    }
+
+    @Test
+    fun `just above the delete zone is not over it`() =
+        assertFalse(dragDropTarget(943f, listHeightPx = 1000, deleteZonePx = 56f, visibleItems = rows).overDeleteZone)
+
+    @Test
+    fun `a zero-height list disables the delete zone`() =
+        assertFalse(dragDropTarget(950f, listHeightPx = 0, deleteZonePx = 56f, visibleItems = rows).overDeleteZone)
+
+    // ── row targeting ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `a cursor inside a row targets that row`() =
+        assertEquals(1, dragDropTarget(70f, 1000, 56f, rows).targetIndex, "70px lands in row 1's [50,100) span")
+
+    @Test
+    fun `at a shared row boundary the earlier row wins`() =
+        // 50px is the bottom edge of row 0 and the top edge of row 1; firstOrNull picks row 0.
+        assertEquals(0, dragDropTarget(50f, 1000, 56f, rows).targetIndex)
+
+    @Test
+    fun `a cursor in a gap between rows targets nothing`() {
+        val gapped = listOf(DragItemGeometry(0, 0, 40), DragItemGeometry(1, 60, 40))
+        assertNull(dragDropTarget(50f, 1000, 56f, gapped).targetIndex, "50px is in the 40..60 gap")
+    }
+
+    @Test
+    fun `a cursor above every row targets nothing`() {
+        val below = listOf(DragItemGeometry(0, 100, 50), DragItemGeometry(1, 150, 50))
+        assertNull(dragDropTarget(10f, 1000, 56f, below).targetIndex)
+    }
+
+    @Test
+    fun `an empty visible list targets nothing`() =
+        assertNull(dragDropTarget(70f, 1000, 56f, emptyList()).targetIndex)
+}


### PR DESCRIPTION
The last ScheduleTab target from the #27 scout — deferred there as higher-risk because the drag hit-testing was woven into `awaitPointerEventScope`. `#9` doesn't touch `ScheduleTab`, so this is conflict-free.

## Extracted (behaviour-preserving)
`utils/ScheduleDragMath.kt` — `dragDropTarget(cursorY, listHeightPx, deleteZonePx, visibleItems)` → `DragDropTarget(overDeleteZone, targetIndex)`. The gesture loop now maps `listState.layoutInfo.visibleItemsInfo` into plain `DragItemGeometry(index, offset, size)` and reads back the result, instead of inlining:
- delete-zone check (`cursorY >= listHeightPx - deleteZonePx`, disabled when height is 0),
- first visible row whose `[offset, offset+size]` span contains the cursor (else keep the previous target).

## Tests
`ScheduleDragMathTest` (8): the delete-zone boundary and its zero-height guard, row-span containment, the shared-edge tie-break (earlier row wins), gaps between rows, cursor past the ends, and the empty-list case. Deterministic 3×.

No behaviour change — just the off-by-one-prone math lifted out where it can be tested directly.