### PR TITLE
Test: colour-picker maths and scene-canvas snap geometry

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneCanvas.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneCanvas.kt
@@ -381,9 +381,10 @@ fun SceneCanvas(
 
 // --- Snap computation ---
 
-private data class SnapResult(val x: Float, val y: Float, val snapLines: List<SnapLine>)
+internal data class SnapResult(val x: Float, val y: Float, val snapLines: List<SnapLine>)
 
-private fun computeSnap(
+// internal (not private) so the snap geometry can be unit-tested directly; no behaviour change.
+internal fun computeSnap(
     x: Float, y: Float, w: Float, h: Float,
     sources: List<SceneSource>, excludeId: String,
     canvasWidth: Float, canvasHeight: Float

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/ColorMathTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/ColorMathTest.kt
@@ -1,0 +1,99 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.ui.graphics.Color
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The colour conversions behind ColorPickerDialog — hex parse/format and the HSV round-trip that the
+ * hue/saturation wheel relies on. Colour maths is quietly easy to get wrong (channel order, the wrap
+ * at hue 360, an off-by-one in the 0–255 scaling), and a wrong result silently sends the wrong colour
+ * to a background or lower third, so the branches and the round-trips are pinned here.
+ */
+class ColorMathTest {
+
+    // ── cpColorToHex ───────────────────────────────────────────────────────────
+
+    @Test fun `primaries and extremes format to their hex`() {
+        assertEquals("#FF0000", cpColorToHex(Color(255, 0, 0)))
+        assertEquals("#00FF00", cpColorToHex(Color(0, 255, 0)))
+        assertEquals("#0000FF", cpColorToHex(Color(0, 0, 255)))
+        assertEquals("#FFFFFF", cpColorToHex(Color(255, 255, 255)))
+        assertEquals("#000000", cpColorToHex(Color(0, 0, 0)))
+        assertEquals("#123456", cpColorToHex(Color(0x12, 0x34, 0x56)))
+    }
+
+    // ── cpTryParseHex ──────────────────────────────────────────────────────────
+
+    @Test fun `a six-digit hex parses, with or without the hash and in any case`() {
+        assertEquals("#FF0000", cpColorToHex(assertNotNull(cpTryParseHex("#FF0000"))))
+        assertEquals("#112233", cpColorToHex(assertNotNull(cpTryParseHex("112233"))), "the leading # is optional")
+        assertEquals("#FF0000", cpColorToHex(assertNotNull(cpTryParseHex("#ff0000"))), "lower case is accepted")
+    }
+
+    @Test fun `an eight-digit hex parses as AARRGGBB and the alpha is dropped from the hex form`() =
+        assertEquals("#112233", cpColorToHex(assertNotNull(cpTryParseHex("#FF112233"))))
+
+    @Test fun `malformed hex yields null rather than throwing`() {
+        assertNull(cpTryParseHex("xyz"))
+        assertNull(cpTryParseHex("#12345"), "five digits is neither RGB nor ARGB")
+        assertNull(cpTryParseHex(""))
+        assertNull(cpTryParseHex("#GG0000"), "non-hex digits")
+    }
+
+    @Test fun `format then parse is a round trip for opaque colours`() {
+        for (hex in listOf("#FF0000", "#00FF00", "#0000FF", "#123456", "#ABCDEF", "#000000", "#FFFFFF")) {
+            assertEquals(hex, cpColorToHex(assertNotNull(cpTryParseHex(hex))), "round trip of $hex")
+        }
+    }
+
+    // ── HSV ────────────────────────────────────────────────────────────────────
+
+    private fun assertApprox(expected: Float, actual: Float, tol: Float, what: String) =
+        assertTrue(abs(expected - actual) <= tol, "$what: expected ~$expected, was $actual")
+
+    @Test fun `converting a colour to HSV reads the expected hue, saturation and value`() {
+        val (hr, sr, vr) = cpColorToHsv(Color(255, 0, 0))
+        assertApprox(0f, hr, 0.5f, "red hue"); assertApprox(1f, sr, 0.01f, "red sat"); assertApprox(1f, vr, 0.01f, "red val")
+
+        val (hg, _, _) = cpColorToHsv(Color(0, 255, 0))
+        assertApprox(120f, hg, 0.5f, "green hue")
+
+        val (hb, _, _) = cpColorToHsv(Color(0, 0, 255))
+        assertApprox(240f, hb, 0.5f, "blue hue")
+    }
+
+    @Test fun `a grey has zero saturation and a value equal to its brightness`() {
+        val (h, s, v) = cpColorToHsv(Color(128, 128, 128))
+        assertApprox(0f, h, 0.5f, "grey hue is undefined, reported 0")
+        assertApprox(0f, s, 0.01f, "grey saturation")
+        assertApprox(128f / 255f, v, 0.01f, "grey value")
+    }
+
+    @Test fun `black is value zero and white is full value with no saturation`() {
+        assertApprox(0f, cpColorToHsv(Color(0, 0, 0)).third, 0.01f, "black value")
+        val white = cpColorToHsv(Color(255, 255, 255))
+        assertApprox(1f, white.third, 0.01f, "white value")
+        assertApprox(0f, white.second, 0.01f, "white saturation")
+    }
+
+    @Test fun `HSV to colour produces the pure primaries at full saturation and value`() {
+        assertEquals("#FF0000", cpColorToHex(cpHsvToColor(0f, 1f, 1f)))
+        assertEquals("#00FF00", cpColorToHex(cpHsvToColor(120f, 1f, 1f)))
+        assertEquals("#0000FF", cpColorToHex(cpHsvToColor(240f, 1f, 1f)))
+    }
+
+    @Test fun `colour to HSV and back reproduces the colour`() {
+        for (c in listOf(Color(200, 50, 90), Color(30, 180, 240), Color(255, 200, 0))) {
+            val (h, s, v) = cpColorToHsv(c)
+            val back = cpHsvToColor(h, s, v)
+            assertApprox(c.red, back.red, 0.01f, "red channel")
+            assertApprox(c.green, back.green, 0.01f, "green channel")
+            assertApprox(c.blue, back.blue, 0.01f, "blue channel")
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneSnapTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneSnapTest.kt
@@ -1,0 +1,83 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import org.churchpresenter.app.churchpresenter.models.SceneSource
+import org.churchpresenter.app.churchpresenter.models.SourceTransform
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The scene-canvas drag snapping — how a dragged source clicks onto the canvas guides (left/centre/
+ * right, top/centre/bottom) and onto other sources' edges within the snap threshold. Coordinates are
+ * normalised 0..1 and the threshold is 6px / canvas size, so at 1000px the window to snap is 0.006.
+ * A wrong result snaps to the wrong guide or fails to snap; the guides, the threshold edge, the
+ * source targets, and the exclude/invisible rules are pinned here.
+ */
+class SceneSnapTest {
+
+    private val w = 1000f
+    private val h = 1000f            // threshold = 6/1000 = 0.006 on each axis
+    private val size = 0.2f          // the dragged source is 0.2 x 0.2
+
+    private fun snap(x: Float, y: Float, sources: List<SceneSource> = emptyList(), excludeId: String = "self") =
+        computeSnap(x, y, size, size, sources, excludeId, canvasWidth = w, canvasHeight = h)
+
+    private fun approx(a: Float, b: Float) = abs(a - b) <= 0.0005f
+
+    private fun source(id: String, x: Float, visible: Boolean = true) = SceneSource.ImageSource(
+        id = id, name = id, filePath = "",
+        transform = SourceTransform(x = x, y = 0f, width = 0.1f, height = 0.1f),
+        visible = visible,
+    )
+
+    @Test
+    fun `a left edge just inside the threshold snaps to the canvas left`() {
+        val r = snap(x = 0.003f, y = 0.4f) // left edge 0.003 is within 0.006 of guide 0
+        assertTrue(approx(0f, r.x), "x snaps so the left edge sits on 0, was ${r.x}")
+        assertTrue(r.snapLines.any { it.orientation == SnapOrientation.VERTICAL && approx(it.position, 0f) })
+    }
+
+    @Test
+    fun `a centre near the canvas centre snaps the centre to 0-5`() {
+        // centre = x + 0.1; put it at 0.502 so it's 0.002 from the 0.5 guide.
+        val r = snap(x = 0.402f, y = 0.4f)
+        assertTrue(approx(0.4f, r.x), "x moves 0.002 so the centre lands on 0.5, was ${r.x}")
+    }
+
+    @Test
+    fun `a top edge near the canvas top snaps on the vertical axis`() {
+        // x=0.31 keeps every x-edge (0.31/0.41/0.51) clear of the guides; top edge 0.004 is within 0.006 of 0.
+        val r = snap(x = 0.31f, y = 0.004f)
+        assertTrue(approx(0f, r.y), "y snaps to 0, was ${r.y}")
+        assertTrue(r.snapLines.any { it.orientation == SnapOrientation.HORIZONTAL })
+    }
+
+    @Test
+    fun `an edge outside the threshold does not snap`() {
+        // edges 0.2 / 0.275 / 0.35 are all more than 0.006 from any guide (0, 0.5, 1).
+        val r = snap(x = 0.2f, y = 0.2f)
+        assertTrue(approx(0.2f, r.x) && approx(0.2f, r.y), "unchanged, was (${r.x}, ${r.y})")
+        assertEquals(emptyList(), r.snapLines, "no guides shown when nothing snaps")
+    }
+
+    // These use a source edge at 0.2 and drag to 0.203 — deliberately away from every canvas guide
+    // (0/0.5/1), so the only thing that could snap x is the other source's edge.
+    @Test
+    fun `a dragged source snaps to another source's edge`() {
+        val r = snap(x = 0.203f, y = 0.4f, sources = listOf(source("other", x = 0.2f)))
+        assertTrue(approx(0.2f, r.x), "x snaps onto the other source's edge at 0.2, was ${r.x}")
+    }
+
+    @Test
+    fun `the dragged source's own geometry is excluded`() {
+        val r = snap(x = 0.203f, y = 0.4f, sources = listOf(source("self", x = 0.2f)), excludeId = "self")
+        assertTrue(approx(0.203f, r.x), "no self-snap, x unchanged, was ${r.x}")
+    }
+
+    @Test
+    fun `an invisible source is not a snap target`() {
+        val r = snap(x = 0.203f, y = 0.4f, sources = listOf(source("other", x = 0.2f, visible = false)))
+        assertTrue(approx(0.203f, r.x), "a hidden source offers no edge to snap to, was ${r.x}")
+    }
+}


### PR DESCRIPTION
More coverage in `composables/` — two pure, error-prone pieces that had no tests. Independent of every open PR.

## ColorPickerDialog colour maths — `ColorMathTest` (10)
`cpColorToHex` / `cpTryParseHex` / `cpColorToHsv` / `cpHsvToColor` were already `internal`, so tested directly — no production change. Covers channel order, the 6- and 8-digit (AARRGGBB) forms with optional `#` and any case, malformed→null, and the HSV round-trips (colour→HSV→colour reproduces the colour; the pure primaries map to full-sat/value hues).

## Scene-canvas snap — `SceneSnapTest` (7)
`computeSnap` widened `private → internal` (no behaviour change) so the drag-snap geometry is testable. Covers the canvas guides (left/centre/right, top/centre/bottom), the threshold boundary (6px / canvas size = 0.006 at 1000px), snapping to another source's edge, and the exclude-self / invisible-source rules.

> Writing these surfaced a real subtlety the tests now account for: with a 0.2-wide source dragged near 0.3, its **own right edge** snaps to the canvas centre (0.5) — so the source-snap tests deliberately use edges away from the guides to isolate the behaviour.

All 17 cases deterministic 3×.