### PR TITLE
Refactor: extract + test v4l2 camera-format parsing

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -1140,13 +1140,57 @@ private fun listCameraDevicesWithDeckLink(deckLinkDeviceFormat: String = "DeckLi
     return devices
 }
 
-private data class CameraFormat(
+internal data class CameraFormat(
     val width: Int,
     val height: Int,
     val fps: Int,
     val displayName: String = "${width}x${height} @ ${fps}fps",
     val encodedValue: String = "${width}x${height}@${fps}"
 )
+
+// The regex parsing below is pure and reused across two Linux tools; kept out of the process calls so
+// the (error-prone) line matching is unit-tested directly from captured sample output.
+private val CAMERA_SIZE_PATTERN = Regex("""(\d{3,5})x(\d{3,5})""")
+private val CAMERA_FPS_PATTERN = Regex("""(\d+(?:\.\d+)?)\s*fps""")
+
+/**
+ * Sizes and frame rates from `ffmpeg -f v4l2 -list_formats` output: every line carrying a `WxH` adds
+ * one format, taking a same-line `N fps` if present (else 30). Unmatched lines are skipped.
+ */
+internal fun parseFfmpegV4l2Formats(output: String): Set<Triple<Int, Int, Int>> = buildSet {
+    for (line in output.lines()) {
+        val size = CAMERA_SIZE_PATTERN.find(line) ?: continue
+        val w = size.groupValues[1].toIntOrNull() ?: continue
+        val h = size.groupValues[2].toIntOrNull() ?: continue
+        val fps = CAMERA_FPS_PATTERN.find(line)?.groupValues?.get(1)?.toDoubleOrNull()?.toInt() ?: 30
+        add(Triple(w, h, fps))
+    }
+}
+
+/**
+ * Sizes and frame rates from `v4l2-ctl --list-formats-ext` output, where a `WxH` appears on its own
+ * line and the frame rates for it follow on later `N fps` lines — so each fps line pairs with the
+ * most recent size seen.
+ */
+internal fun parseV4l2CtlFormats(output: String): Set<Triple<Int, Int, Int>> = buildSet {
+    var lastW = 0
+    var lastH = 0
+    for (line in output.lines()) {
+        CAMERA_SIZE_PATTERN.find(line)?.let {
+            lastW = it.groupValues[1].toIntOrNull() ?: 0
+            lastH = it.groupValues[2].toIntOrNull() ?: 0
+        }
+        val fps = CAMERA_FPS_PATTERN.find(line)
+        if (fps != null && lastW > 0 && lastH > 0) {
+            add(Triple(lastW, lastH, fps.groupValues[1].toDoubleOrNull()?.toInt() ?: 30))
+        }
+    }
+}
+
+/** Largest area first, then highest frame rate; mapped to the display model. */
+internal fun sortedCameraFormats(sizes: Set<Triple<Int, Int, Int>>): List<CameraFormat> =
+    sizes.sortedWith(compareByDescending<Triple<Int, Int, Int>> { it.first * it.second }.thenByDescending { it.third })
+        .map { (w, h, fps) -> CameraFormat(w, h, fps) }
 
 /** Cache format listings so we don't re-open the device every time the source recomposes. */
 private val cameraFormatCache = mutableMapOf<String, List<CameraFormat>>()
@@ -1208,17 +1252,7 @@ private fun listV4l2Formats(device: String): List<CameraFormat> {
             .redirectErrorStream(true).start()
         val output = process.inputStream.bufferedReader().readText()
         process.waitFor()
-        // Match lines like: 1920x1080 or similar, and fps values
-        val sizePattern = Regex("""(\d{3,5})x(\d{3,5})""")
-        for (line in output.lines()) {
-            val sizeMatch = sizePattern.find(line) ?: continue
-            val w = sizeMatch.groupValues[1].toIntOrNull() ?: continue
-            val h = sizeMatch.groupValues[2].toIntOrNull() ?: continue
-            // v4l2 format lines may include fps info
-            val fpsMatch = Regex("""(\d+(?:\.\d+)?)\s*fps""").find(line)
-            val fps = fpsMatch?.groupValues?.get(1)?.toDoubleOrNull()?.toInt() ?: 30
-            formats.add(Triple(w, h, fps))
-        }
+        formats.addAll(parseFfmpegV4l2Formats(output))
     } catch (e: Exception) {
         System.err.println("[Camera] Error listing v4l2 formats: ${e.message}")
     }
@@ -1229,27 +1263,10 @@ private fun listV4l2Formats(device: String): List<CameraFormat> {
                 .redirectErrorStream(true).start()
             val output = process.inputStream.bufferedReader().readText()
             process.waitFor()
-            val sizePattern = Regex("""(\d{3,5})x(\d{3,5})""")
-            val fpsPattern = Regex("""(\d+(?:\.\d+)?)\s*fps""")
-            var lastW = 0
-            var lastH = 0
-            for (line in output.lines()) {
-                val sizeMatch = sizePattern.find(line)
-                if (sizeMatch != null) {
-                    lastW = sizeMatch.groupValues[1].toIntOrNull() ?: 0
-                    lastH = sizeMatch.groupValues[2].toIntOrNull() ?: 0
-                }
-                val fpsMatch = fpsPattern.find(line)
-                if (fpsMatch != null && lastW > 0 && lastH > 0) {
-                    val fps = fpsMatch.groupValues[1].toDoubleOrNull()?.toInt() ?: 30
-                    formats.add(Triple(lastW, lastH, fps))
-                }
-            }
+            formats.addAll(parseV4l2CtlFormats(output))
         } catch (_: Exception) {}
     }
-    return formats
-        .sortedWith(compareByDescending<Triple<Int, Int, Int>> { it.first * it.second }.thenByDescending { it.third })
-        .map { (w, h, fps) -> CameraFormat(w, h, fps) }
+    return sortedCameraFormats(formats)
 }
 
 private fun listAvfoundationFormats(deviceIndex: String): List<CameraFormat> {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraFormatParsingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraFormatParsingTest.kt
@@ -1,0 +1,70 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Parsing camera resolutions/frame-rates out of the two Linux tools the app shells to, and the
+ * ordering it presents them in. The line matching is fiddly — a size can appear with or without an
+ * fps, `v4l2-ctl` puts the fps on lines after the size, and a wrong parse offers the operator a
+ * resolution the camera can't do — so it's captured here from representative tool output.
+ */
+class CameraFormatParsingTest {
+
+    // ── ffmpeg -list_formats ────────────────────────────────────────────────────
+
+    @Test
+    fun `ffmpeg lines yield their size, defaulting fps to 30 when absent`() {
+        val out = """
+            [video4linux2] Raw: yuyv422: 1920x1080 30 fps
+            [video4linux2] Compressed: mjpeg: 1280x720 60 fps
+            [video4linux2] Raw: yuyv422: 640x480
+        """.trimIndent()
+        assertEquals(
+            setOf(Triple(1920, 1080, 30), Triple(1280, 720, 60), Triple(640, 480, 30)),
+            parseFfmpegV4l2Formats(out),
+        )
+    }
+
+    @Test
+    fun `ffmpeg lines without a resolution are skipped`() =
+        assertTrue(parseFfmpegV4l2Formats("Input #0, video4linux2\n  Stream mapping:\n").isEmpty())
+
+    @Test
+    fun `an empty ffmpeg output yields no formats`() =
+        assertTrue(parseFfmpegV4l2Formats("").isEmpty())
+
+    // ── v4l2-ctl --list-formats-ext ─────────────────────────────────────────────
+
+    @Test
+    fun `v4l2-ctl pairs each fps line with the most recent size`() {
+        val out = """
+            	Size: Discrete 1920x1080
+            		Interval: Discrete 0.033s (30.000 fps)
+            		Interval: Discrete 0.067s (15.000 fps)
+            	Size: Discrete 1280x720
+            		Interval: Discrete 0.033s (30.000 fps)
+        """.trimIndent()
+        assertEquals(
+            setOf(Triple(1920, 1080, 30), Triple(1920, 1080, 15), Triple(1280, 720, 30)),
+            parseV4l2CtlFormats(out),
+        )
+    }
+
+    @Test
+    fun `a v4l2-ctl fps line before any size is ignored`() =
+        assertTrue(parseV4l2CtlFormats("Interval: Discrete 0.033s (30.000 fps)\n").isEmpty())
+
+    // ── ordering ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `formats sort by area then by frame rate, both descending`() {
+        val sorted = sortedCameraFormats(setOf(Triple(1280, 720, 30), Triple(1920, 1080, 30), Triple(1920, 1080, 60)))
+        assertEquals(
+            listOf(Triple(1920, 1080, 60), Triple(1920, 1080, 30), Triple(1280, 720, 30)),
+            sorted.map { Triple(it.width, it.height, it.fps) },
+            "largest area first, and within an area the higher fps first",
+        )
+    }
+}


### PR DESCRIPTION
`listV4l2Formats` (in SourcePropertiesPanel) shells out to `ffmpeg -list_formats` and `v4l2-ctl --list-formats-ext` and parsed their text output inline with regexes — pure, error-prone logic that had no tests. Independent of every open PR (#9 doesn't touch this file).

## Extracted (behaviour-preserving)
The process calls stay in `listV4l2Formats`; only the parsing moves out:
- `parseFfmpegV4l2Formats(output)` — each `WxH` line, with a same-line `N fps` or a 30 default.
- `parseV4l2CtlFormats(output)` — `WxH` on its own line, fps on the following lines (each fps pairs with the most recent size).
- `sortedCameraFormats(sizes)` — largest area first, then highest fps; mapped to the display model.

`CameraFormat` widened `private → internal` (no behaviour change).

## Tests — `CameraFormatParsingTest` (6)
Representative tool output for each parser (size-with/without-fps, non-resolution lines skipped, empty output; the size-then-fps pairing and the ignore-fps-before-any-size rule), plus the area-then-fps ordering. Deterministic 3×.