### PR TITLE
Test the CCLI report's three content bodies

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportDialog.kt
@@ -392,7 +392,7 @@ fun CCLIReportDialog(
 // ── Songs tab ─────────────────────────────────────────────────────────────────
 
 @Composable
-private fun SongsReportContent(songs: List<SongSummary>) {
+internal fun SongsReportContent(songs: List<SongSummary>) {
     val primary = MaterialTheme.colorScheme.primary
     val totalPlays = songs.sumOf { it.count }
 
@@ -430,7 +430,7 @@ private fun SongsReportContent(songs: List<SongSummary>) {
 // ── Bible tab ─────────────────────────────────────────────────────────────────
 
 @Composable
-private fun BibleReportContent(verses: List<VerseSummary>) {
+internal fun BibleReportContent(verses: List<VerseSummary>) {
     val secondary = MaterialTheme.colorScheme.tertiary
     val totalPlays = verses.sumOf { it.count }
 
@@ -472,7 +472,7 @@ private fun BibleReportContent(verses: List<VerseSummary>) {
 // ── Activity tab ──────────────────────────────────────────────────────────────
 
 @Composable
-private fun ActivityContent(activity: List<ActivityPoint>) {
+internal fun ActivityContent(activity: List<ActivityPoint>) {
     val primary = MaterialTheme.colorScheme.primary
     val verseColor = VERSE_BAR_COLOR
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportDialog.kt
@@ -164,6 +164,39 @@ fun CCLIReportDialog(
     if (!isVisible) return
 
     val mainWindowState = LocalMainWindowState.current
+
+    DialogWindow(
+        onCloseRequest = onDismiss,
+        state = rememberDialogState(
+            position = centeredOnMainWindow(mainWindowState, 940.dp, 700.dp),
+            width = 940.dp, height = 700.dp
+        ),
+        title = stringResource(Res.string.ccli_report_title),
+        resizable = true
+    ) {
+        CCLIReportContent(
+            theme = theme,
+            statisticsManager = statisticsManager,
+            onDismiss = onDismiss
+        )
+    }
+}
+
+/**
+ * Everything the report window contains: the quick-range presets and date pickers, the tab row
+ * over the three report bodies, the export buttons and the status line they write to.
+ *
+ * Held apart from [CCLIReportDialog] because that function's only other statement is the
+ * `DialogWindow` it opens, which cannot be composed on a headless machine. Keeping the window down
+ * to that one call leaves the report's own behaviour — which range each preset selects, what the
+ * tab counts say, and what is shown when there is no event log at all — reachable from a test.
+ */
+@Composable
+internal fun CCLIReportContent(
+    theme: ThemeMode,
+    statisticsManager: StatisticsManager,
+    onDismiss: () -> Unit
+) {
     val coroutineScope = rememberCoroutineScope()
     val today = remember { LocalDate.now() }
     val zone = remember { ZoneId.systemDefault() }
@@ -228,161 +261,151 @@ fun CCLIReportDialog(
     val xlsChooserTitle = stringResource(Res.string.ccli_file_chooser_xls)
     val xlsFilterDesc = stringResource(Res.string.ccli_file_filter_xls)
 
-    DialogWindow(
-        onCloseRequest = onDismiss,
-        state = rememberDialogState(
-            position = centeredOnMainWindow(mainWindowState, 940.dp, 700.dp),
-            width = 940.dp, height = 700.dp
-        ),
-        title = stringResource(Res.string.ccli_report_title),
-        resizable = true
-    ) {
-        AppThemeWrapper(theme = theme) {
-            Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                Column(modifier = Modifier.fillMaxSize()) {
+    AppThemeWrapper(theme = theme) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            Column(modifier = Modifier.fillMaxSize()) {
 
-                    // ── Date range header ────────────────────────────────────
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
-                            .padding(horizontal = 16.dp, vertical = 10.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                // ── Date range header ────────────────────────────────────
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        .padding(horizontal = 16.dp, vertical = 10.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    // Preset buttons
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        PresetButton(stringResource(Res.string.ccli_preset_30d), active = activePreset == 0) {
+                            activePreset = 0; applyPreset(30)
+                        }
+                        PresetButton(stringResource(Res.string.ccli_preset_90d), active = activePreset == 1) {
+                            activePreset = 1; applyPreset(90)
+                        }
+                        PresetButton(stringResource(Res.string.ccli_preset_this_year), active = activePreset == 2) {
+                            activePreset = 2
+                            fromYear = today.year; fromMonth = 1; fromDay = 1
+                            toYear = today.year; toMonth = today.monthValue; toDay = today.dayOfMonth
+                        }
+                        PresetButton(stringResource(Res.string.ccli_preset_last_year), active = activePreset == 3) {
+                            activePreset = 3
+                            fromYear = today.year - 1; fromMonth = 1; fromDay = 1
+                            toYear = today.year - 1; toMonth = 12; toDay = 31
+                        }
+                        PresetButton(stringResource(Res.string.ccli_preset_all_time), active = activePreset == 4) {
+                            activePreset = 4; applyPreset(null)
+                        }
+                    }
+                    // Date pickers
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        // Preset buttons
-                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                            PresetButton(stringResource(Res.string.ccli_preset_30d), active = activePreset == 0) {
-                                activePreset = 0; applyPreset(30)
-                            }
-                            PresetButton(stringResource(Res.string.ccli_preset_90d), active = activePreset == 1) {
-                                activePreset = 1; applyPreset(90)
-                            }
-                            PresetButton(stringResource(Res.string.ccli_preset_this_year), active = activePreset == 2) {
-                                activePreset = 2
-                                fromYear = today.year; fromMonth = 1; fromDay = 1
-                                toYear = today.year; toMonth = today.monthValue; toDay = today.dayOfMonth
-                            }
-                            PresetButton(stringResource(Res.string.ccli_preset_last_year), active = activePreset == 3) {
-                                activePreset = 3
-                                fromYear = today.year - 1; fromMonth = 1; fromDay = 1
-                                toYear = today.year - 1; toMonth = 12; toDay = 31
-                            }
-                            PresetButton(stringResource(Res.string.ccli_preset_all_time), active = activePreset == 4) {
-                                activePreset = 4; applyPreset(null)
-                            }
-                        }
-                        // Date pickers
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            Text(stringResource(Res.string.ccli_from), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            DatePicker(
-                                year = fromYear, month = fromMonth, day = fromDay,
-                                yearRange = yearRange,
-                                onChanged = { y, m, d -> activePreset = null; fromYear = y; fromMonth = m; fromDay = d }
-                            )
-                            Spacer(Modifier.width(16.dp))
-                            Text(stringResource(Res.string.ccli_to), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            DatePicker(
-                                year = toYear, month = toMonth, day = toDay,
-                                yearRange = yearRange,
-                                onChanged = { y, m, d -> activePreset = null; toYear = y; toMonth = m; toDay = d }
-                            )
-                        }
-                    }
-
-                    HorizontalDivider()
-
-                    if (!hasLog) {
-                        Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
-                            Text(
-                                stringResource(Res.string.ccli_no_events),
-                                style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.padding(32.dp)
-                            )
-                        }
-                    } else {
-                        // ── Tabs ─────────────────────────────────────────────
-                        PrimaryTabRow(selectedTabIndex = selectedTab) {
-                            Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 },
-                                text = { Text(stringResource(Res.string.ccli_tab_songs) + " (${songs.size})") })
-                            Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 },
-                                text = { Text(stringResource(Res.string.ccli_tab_bible) + " (${verses.size})") })
-                            Tab(selected = selectedTab == 2, onClick = { selectedTab = 2 },
-                                text = { Text(stringResource(Res.string.ccli_tab_activity)) })
-                        }
-
-                        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                            when (selectedTab) {
-                                0 -> SongsReportContent(songs)
-                                1 -> BibleReportContent(verses)
-                                2 -> ActivityContent(activity)
-                            }
-                        }
-                    }
-
-                    // ── Status message ───────────────────────────────────────
-                    if (statusMessage != null) {
-                        Text(
-                            text = statusMessage!!,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = if (statusIsSuccess) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp)
+                        Text(stringResource(Res.string.ccli_from), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        DatePicker(
+                            year = fromYear, month = fromMonth, day = fromDay,
+                            yearRange = yearRange,
+                            onChanged = { y, m, d -> activePreset = null; fromYear = y; fromMonth = m; fromDay = d }
+                        )
+                        Spacer(Modifier.width(16.dp))
+                        Text(stringResource(Res.string.ccli_to), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        DatePicker(
+                            year = toYear, month = toMonth, day = toDay,
+                            yearRange = yearRange,
+                            onChanged = { y, m, d -> activePreset = null; toYear = y; toMonth = m; toDay = d }
                         )
                     }
+                }
 
-                    // ── Bottom buttons ───────────────────────────────────────
-                    HorizontalDivider()
-                    Row(
-                        modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface).padding(12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        OutlinedButton(
-                            shape = RoundedCornerShape(6.dp),
-                            onClick = {
-                                coroutineScope.launch {
-                                    val f = fromMs(); val t = toMs()
-                                    val path = FileChooser.platformInstance.save(
-                                        location = null,
-                                        suggestedName = "ccli_report.csv",
-                                        filters = listOf(FileNameExtensionFilter(csvFilterDesc, "csv")),
-                                        title = csvChooserTitle
-                                    )
-                                    if (path != null) {
-                                        val ok = withContext(Dispatchers.IO) { statisticsManager.exportCcliCsv(path.toFile(), f, t) }
-                                        statusIsSuccess = ok; statusMessage = if (ok) successMsg else errorMsg
-                                    }
-                                }
-                            }
-                        ) { Text(stringResource(Res.string.ccli_export_csv)) }
+                HorizontalDivider()
 
-                        OutlinedButton(
-                            shape = RoundedCornerShape(6.dp),
-                            onClick = {
-                                coroutineScope.launch {
-                                    val f = fromMs(); val t = toMs()
-                                    val path = FileChooser.platformInstance.save(
-                                        location = null,
-                                        suggestedName = "ccli_report.xls",
-                                        filters = listOf(FileNameExtensionFilter(xlsFilterDesc, "xls")),
-                                        title = xlsChooserTitle
-                                    )
-                                    if (path != null) {
-                                        val ok = withContext(Dispatchers.IO) { statisticsManager.exportFilteredXls(path.toFile(), f, t) }
-                                        statusIsSuccess = ok; statusMessage = if (ok) successMsg else errorMsg
-                                    }
-                                }
-                            }
-                        ) { Text(stringResource(Res.string.ccli_export_xls)) }
-
-                        Spacer(Modifier.weight(1f))
-
-                        Button(shape = RoundedCornerShape(6.dp), onClick = onDismiss) { Text(stringResource(Res.string.close)) }
+                if (!hasLog) {
+                    Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        Text(
+                            stringResource(Res.string.ccli_no_events),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(32.dp)
+                        )
                     }
+                } else {
+                    // ── Tabs ─────────────────────────────────────────────
+                    PrimaryTabRow(selectedTabIndex = selectedTab) {
+                        Tab(selected = selectedTab == 0, onClick = { selectedTab = 0 },
+                            text = { Text(stringResource(Res.string.ccli_tab_songs) + " (${songs.size})") })
+                        Tab(selected = selectedTab == 1, onClick = { selectedTab = 1 },
+                            text = { Text(stringResource(Res.string.ccli_tab_bible) + " (${verses.size})") })
+                        Tab(selected = selectedTab == 2, onClick = { selectedTab = 2 },
+                            text = { Text(stringResource(Res.string.ccli_tab_activity)) })
+                    }
+
+                    Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                        when (selectedTab) {
+                            0 -> SongsReportContent(songs)
+                            1 -> BibleReportContent(verses)
+                            2 -> ActivityContent(activity)
+                        }
+                    }
+                }
+
+                // ── Status message ───────────────────────────────────────
+                if (statusMessage != null) {
+                    Text(
+                        text = statusMessage!!,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (statusIsSuccess) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 2.dp)
+                    )
+                }
+
+                // ── Bottom buttons ───────────────────────────────────────
+                HorizontalDivider()
+                Row(
+                    modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface).padding(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedButton(
+                        shape = RoundedCornerShape(6.dp),
+                        onClick = {
+                            coroutineScope.launch {
+                                val f = fromMs(); val t = toMs()
+                                val path = FileChooser.platformInstance.save(
+                                    location = null,
+                                    suggestedName = "ccli_report.csv",
+                                    filters = listOf(FileNameExtensionFilter(csvFilterDesc, "csv")),
+                                    title = csvChooserTitle
+                                )
+                                if (path != null) {
+                                    val ok = withContext(Dispatchers.IO) { statisticsManager.exportCcliCsv(path.toFile(), f, t) }
+                                    statusIsSuccess = ok; statusMessage = if (ok) successMsg else errorMsg
+                                }
+                            }
+                        }
+                    ) { Text(stringResource(Res.string.ccli_export_csv)) }
+
+                    OutlinedButton(
+                        shape = RoundedCornerShape(6.dp),
+                        onClick = {
+                            coroutineScope.launch {
+                                val f = fromMs(); val t = toMs()
+                                val path = FileChooser.platformInstance.save(
+                                    location = null,
+                                    suggestedName = "ccli_report.xls",
+                                    filters = listOf(FileNameExtensionFilter(xlsFilterDesc, "xls")),
+                                    title = xlsChooserTitle
+                                )
+                                if (path != null) {
+                                    val ok = withContext(Dispatchers.IO) { statisticsManager.exportFilteredXls(path.toFile(), f, t) }
+                                    statusIsSuccess = ok; statusMessage = if (ok) successMsg else errorMsg
+                                }
+                            }
+                        }
+                    ) { Text(stringResource(Res.string.ccli_export_xls)) }
+
+                    Spacer(Modifier.weight(1f))
+
+                    Button(shape = RoundedCornerShape(6.dp), onClick = onDismiss) { Text(stringResource(Res.string.close)) }
                 }
             }
         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportContentShellTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportContentShellTest.kt
@@ -1,0 +1,208 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.StatisticsManager
+import org.churchpresenter.app.churchpresenter.dialogs.tabs.playSong
+import org.churchpresenter.app.churchpresenter.dialogs.tabs.playVerse
+import org.churchpresenter.app.churchpresenter.dialogs.tabs.withStatsHome
+import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The report window's shell: the tab row over the three bodies, the quick-range presets, and what is
+ * shown before anything has ever been recorded.
+ *
+ * `CCLIReportDialog` opens a `DialogWindow`, which cannot be composed headless, so the window's body
+ * was lifted into `CCLIReportContent` — an extraction, no logic moved or changed — and that is what
+ * these drive. `CCLIReportContentTest` covers the three report bodies underneath; this covers the
+ * frame around them.
+ *
+ * `StatisticsManager` resolves `user.home` in its field initialisers and writes its two JSON files
+ * there, so every test builds one inside an isolated home ([withStatsHome]) and seeds it through the
+ * public recording API — the same path the app uses.
+ *
+ * The report loads its three result sets on a background dispatcher, so tests wait for the tab
+ * counts to arrive rather than pausing: the count in the tab label is the positive signal that the
+ * load finished.
+ *
+ * Left uncovered: the `DialogWindow` call, and the two export buttons, which open a native save
+ * dialog through `FileChooser.platformInstance` — they are asserted to be present, never pressed.
+ */
+class CCLIReportContentShellTest {
+
+    private object Tab {
+        const val ACTIVITY = "Activity"
+        const val NO_EVENTS =
+            "No event log yet. Song and verse presentations are tracked automatically starting now."
+        const val CLOSE = "Close"
+        const val EXPORT_CSV = "Export CCLI CSV"
+        const val EXPORT_XLS = "Export XLS"
+        const val FROM = "From:"
+        const val TO = "To:"
+
+        fun songs(n: Int) = "Songs ($n)"
+        fun bible(n: Int) = "Bible ($n)"
+    }
+
+    private object Preset {
+        const val LAST_30 = "Last 30 Days"
+        const val LAST_90 = "Last 90 Days"
+        const val THIS_YEAR = "This Year"
+        const val LAST_YEAR = "Last Year"
+        const val ALL_TIME = "All Time"
+    }
+
+    private class Closed { var count = 0 }
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun report(
+        seed: StatisticsManager.() -> Unit = {},
+        block: ComposeUiTest.(Closed) -> Unit,
+    ) = withStatsHome {
+        val stats = StatisticsManager().apply(seed)
+        val closed = Closed()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    CCLIReportContent(
+                        theme = ThemeMode.LIGHT,
+                        statisticsManager = stats,
+                        onDismiss = { closed.count++ },
+                    )
+                }
+            }
+            block(closed)
+        }
+    }
+
+    private fun ComposeUiTest.countOf(text: String): Int =
+        onAllNodes(hasText(text)).fetchSemanticsNodes(atLeastOneRootRequired = false).size
+
+    /** The tab counts only appear once the background load has returned. */
+    private fun ComposeUiTest.awaitLoaded(songs: Int, verses: Int) =
+        waitUntil("the report must finish loading and label its tabs", timeoutMillis = 5_000) {
+            countOf(Tab.songs(songs)) == 1 && countOf(Tab.bible(verses)) == 1
+        }
+
+    // ── Before anything has been recorded ───────────────────────────────────────
+
+    @Test
+    fun `with no event log the report explains itself instead of showing empty tabs`() =
+        report { _ ->
+            onNodeWithText(Tab.NO_EVENTS).assertIsDisplayed()
+            assertEquals(0, countOf(Tab.ACTIVITY), "there are no tabs to offer over an empty log")
+        }
+
+    @Test
+    fun `the date range controls are offered even with no event log`() = report { _ ->
+        onNodeWithText(Tab.FROM).assertIsDisplayed()
+        onNodeWithText(Tab.TO).assertIsDisplayed()
+        listOf(Preset.LAST_30, Preset.LAST_90, Preset.THIS_YEAR, Preset.LAST_YEAR, Preset.ALL_TIME)
+            .forEach { onNodeWithText(it).assertIsDisplayed() }
+    }
+
+    // ── With recorded activity ──────────────────────────────────────────────────
+
+    @Test
+    fun `each tab counts what it holds`() =
+        report({
+            playSong(number = 1, title = "Amazing Grace", songbook = "Hymnal", times = 3)
+            playSong(number = 2, title = "Be Thou My Vision", songbook = "Hymnal")
+            playVerse(bible = "KJV", book = "John", chapter = 3, verse = 16, times = 2)
+        }) { _ ->
+            // Two distinct songs and one distinct verse, however many times each was shown.
+            awaitLoaded(songs = 2, verses = 1)
+            onNodeWithText(Tab.ACTIVITY).assertIsDisplayed()
+        }
+
+    @Test
+    fun `the songs tab opens first and its table lists what was recorded`() =
+        report({ playSong(number = 1, title = "Amazing Grace", songbook = "Hymnal", times = 3) }) { _ ->
+            awaitLoaded(songs = 1, verses = 0)
+            assertTrue(
+                countOf("Amazing Grace") >= 1,
+                "the songs report is the one the dialog opens on, so its rows must already be there",
+            )
+        }
+
+    @Test
+    fun `choosing the Bible tab swaps the songs report for the verse report`() =
+        report({
+            playSong(number = 1, title = "Amazing Grace", songbook = "Hymnal")
+            playVerse(bible = "KJV", book = "John", chapter = 3, verse = 16)
+        }) { _ ->
+            awaitLoaded(songs = 1, verses = 1)
+            onNodeWithText(Tab.bible(1)).performClick()
+            waitForIdle()
+            assertTrue(countOf("John 3:16") >= 1, "the verse report must be showing")
+            assertEquals(0, countOf("Amazing Grace"), "the songs report must be gone, not merely behind it")
+        }
+
+    @Test
+    fun `choosing the Activity tab shows the over-time report`() =
+        report({ playSong(number = 1, title = "Amazing Grace", songbook = "Hymnal") }) { _ ->
+            awaitLoaded(songs = 1, verses = 0)
+            onNodeWithText(Tab.ACTIVITY).performClick()
+            waitForIdle()
+            onNodeWithText(CcliLabel.ACTIVITY_TITLE).assertIsDisplayed()
+            assertEquals(0, countOf("Amazing Grace"), "the songs table belongs to the tab that was left")
+        }
+
+    // ── Quick ranges ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the last-year preset moves the range off the current year entirely`() =
+        report({ playSong(number = 1, title = "Amazing Grace", songbook = "Hymnal") }) { _ ->
+            awaitLoaded(songs = 1, verses = 0)
+            onNodeWithText(Preset.LAST_YEAR).performClick()
+            // The song was recorded just now, so a range ending last December must exclude it.
+            waitUntil("the range change must reload the report", timeoutMillis = 5_000) {
+                countOf(Tab.songs(0)) == 1
+            }
+            assertEquals(
+                0,
+                countOf("Amazing Grace"),
+                "a song presented today cannot appear in last year's report",
+            )
+        }
+
+    @Test
+    fun `the all-time preset brings everything back into range`() =
+        report({ playSong(number = 1, title = "Amazing Grace", songbook = "Hymnal") }) { _ ->
+            awaitLoaded(songs = 1, verses = 0)
+            onNodeWithText(Preset.LAST_YEAR).performClick()
+            waitUntil("last year must exclude it first", timeoutMillis = 5_000) { countOf(Tab.songs(0)) == 1 }
+
+            onNodeWithText(Preset.ALL_TIME).performClick()
+            waitUntil("all time must take it back", timeoutMillis = 5_000) { countOf(Tab.songs(1)) == 1 }
+            assertTrue(countOf("Amazing Grace") >= 1, "the row must be back in the table too")
+        }
+
+    // ── Leaving ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Close reports the dialog should shut`() = report { closed ->
+        onNodeWithText(Tab.CLOSE).performClick()
+        waitForIdle()
+        assertEquals(1, closed.count)
+    }
+
+    @Test
+    fun `both export buttons are offered`() =
+        report({ playSong(number = 1, title = "Amazing Grace", songbook = "Hymnal") }) { _ ->
+            // Never pressed: each opens a native save dialog.
+            onNodeWithText(Tab.EXPORT_CSV).assertIsDisplayed()
+            onNodeWithText(Tab.EXPORT_XLS).assertIsDisplayed()
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportContentTest.kt
@@ -1,0 +1,213 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The three report bodies behind the CCLI dialog's tabs: songs, Bible and activity.
+ *
+ * This is the report a church files against its copyright licence, so what it counts matters more
+ * than how it looks — the totals in each subtitle, the per-book aggregation on the Bible tab, the
+ * busiest-period pick on the activity tab, and the rank the table assigns each row. Each of those is
+ * derived, not passed through, so each is asserted against a fixture whose answer is known.
+ *
+ * See `CCLIReportDialogTestSupport` for why these drive the content composables rather than
+ * `CCLIReportDialog` itself, and for what is consequently left uncovered.
+ */
+class CCLIReportContentTest {
+
+    // ── Songs tab ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `with no songs the tab says there is no data rather than an empty table`() =
+        reportContent({ SongsReportContent(emptyList()) }) {
+            onNodeWithText(CcliLabel.NO_DATA).assertIsDisplayed()
+            assertFalse(
+                renderedText().contains("Title"),
+                "the table header must not be drawn over an empty report",
+            )
+        }
+
+    @Test
+    fun `the songs subtitle counts unique titles and total plays separately`() =
+        reportContent({
+            SongsReportContent(listOf(song("Amazing Grace", count = 3), song("Be Thou My Vision", count = 4)))
+        }) {
+            onNodeWithText(CcliLabel.SONGS_CHART).assertIsDisplayed()
+            // Two songs, but seven presentations between them.
+            onNodeWithText(CcliLabel.songsSummary(unique = 2, plays = 7)).assertIsDisplayed()
+        }
+
+    @Test
+    fun `each song row carries its rank, title, author, songbook, CCLI number and both dates`() {
+        val first = JAN_2026
+        val last = JAN_2026 + 5 * DAY_MS
+        reportContent({
+            SongsReportContent(
+                listOf(
+                    song(
+                        "Amazing Grace",
+                        count = 9,
+                        author = "John Newton",
+                        songbook = "Hymnal",
+                        ccli = "22025",
+                        firstUsed = first,
+                        lastUsed = last,
+                    ),
+                ),
+            )
+        }) {
+            val table = tableText()
+            listOf("1", "Amazing Grace", "John Newton", "Hymnal", "22025", "9", formatDate(first), formatDate(last))
+                .forEach { assertTrue(table.contains(it), "the song row must show \"$it\"; showed $table") }
+        }
+    }
+
+    @Test
+    fun `rows are ranked from one in the order they were given`() =
+        reportContent({
+            SongsReportContent(
+                listOf(song("Amazing Grace", count = 9), song("Be Thou My Vision", count = 4), song("Hoy", count = 1)),
+            )
+        }) {
+            val table = tableText()
+            val ranks = listOf("1", "2", "3").map { table.indexOf(it) }
+            assertTrue(ranks.none { it < 0 }, "every row must be numbered; showed $table")
+            assertEquals(ranks.sorted(), ranks, "ranks must run 1, 2, 3 down the table")
+        }
+
+    @Test
+    fun `a song with no author, songbook or CCLI number shows a dash in each`() =
+        reportContent({
+            SongsReportContent(listOf(song("Untitled Chorus", author = "", songbook = "", ccli = "")))
+        }) {
+            assertEquals(
+                3,
+                tableText().count { it == CcliLabel.BLANK },
+                "each of the three blank fields must render its own dash",
+            )
+        }
+
+    @Test
+    fun `the songs chart is capped at twelve entries however many were presented`() {
+        val songs = (1..15).map { song("Song $it", count = 100 - it) }
+        reportContent({ SongsReportContent(songs) }) {
+            val charted = chartLabels()
+            assertTrue(charted.contains("Song 12"), "the twelfth song belongs on the chart; charted $charted")
+            assertFalse(charted.contains("Song 13"), "the thirteenth must be left off; charted $charted")
+        }
+    }
+
+    // ── Bible tab ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `with no verses the tab says there is no data`() =
+        reportContent({ BibleReportContent(emptyList()) }) {
+            onNodeWithText(CcliLabel.NO_DATA).assertIsDisplayed()
+        }
+
+    @Test
+    fun `the Bible subtitle counts unique verses and total plays separately`() =
+        reportContent({
+            BibleReportContent(listOf(verse("John", count = 2), verse("John", number = 17, count = 3)))
+        }) {
+            onNodeWithText(CcliLabel.BIBLE_CHART).assertIsDisplayed()
+            onNodeWithText(CcliLabel.bibleSummary(unique = 2, plays = 5)).assertIsDisplayed()
+        }
+
+    @Test
+    fun `the chart totals verses by book and ranks the books by that total`() =
+        reportContent({
+            BibleReportContent(
+                listOf(
+                    verse("John", number = 16, count = 2),
+                    verse("Psalms", number = 1, count = 4),
+                    verse("John", number = 17, count = 5),   // John now totals 7
+                    verse("Acts", number = 2, count = 1),
+                ),
+            )
+        }) {
+            assertEquals(
+                listOf("John" to "7", "Psalms" to "4", "Acts" to "1"),
+                chartRows(),
+                "each book totals its own verses — John's 2 and 5 make 7 — and the books rank by that total, " +
+                    "not by how many distinct verses each contributed",
+            )
+        }
+
+    @Test
+    fun `a verse row shows its reference as book chapter and verse`() =
+        reportContent({ BibleReportContent(listOf(verse("John", chapter = 3, number = 16, count = 4))) }) {
+            assertTrue(
+                tableText().contains("John 3:16"),
+                "the reference must read \"John 3:16\"; showed ${tableText()}",
+            )
+        }
+
+    @Test
+    fun `a verse recorded against no Bible shows a dash for it`() =
+        reportContent({ BibleReportContent(listOf(verse("John", bible = ""))) }) {
+            assertTrue(tableText().contains(CcliLabel.BLANK), "the missing Bible name must render as a dash")
+        }
+
+    // ── Activity tab ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `with no activity points the tab says there is no data`() =
+        reportContent({ ActivityContent(emptyList()) }) {
+            onNodeWithText(CcliLabel.NO_DATA).assertIsDisplayed()
+        }
+
+    @Test
+    fun `periods that exist but recorded nothing count as no data`() =
+        reportContent({ ActivityContent(listOf(activity("Jan", 0, 0), activity("Feb", 0, 0))) }) {
+            onNodeWithText(CcliLabel.NO_DATA)
+                .assertIsDisplayed()
+            assertFalse(
+                renderedText().contains(CcliLabel.STAT_SONGS),
+                "empty periods must not be dressed up as a report with zeroed stat cards",
+            )
+        }
+
+    @Test
+    fun `the stat cards total songs and verses across every period`() =
+        reportContent({
+            ActivityContent(listOf(activity("Jan", 3, 1), activity("Feb", 4, 6), activity("Mar", 0, 2)))
+        }) {
+            val shown = renderedText()
+            assertTrue(shown.contains(CcliLabel.STAT_SONGS) && shown.contains("7"), "songs total 3 + 4 + 0 = 7")
+            assertTrue(shown.contains(CcliLabel.STAT_VERSES) && shown.contains("9"), "verses total 1 + 6 + 2 = 9")
+        }
+
+    @Test
+    fun `the busiest period is the one with the most songs and verses combined`() =
+        reportContent({
+            // February has fewer songs than January but the larger combined total.
+            ActivityContent(listOf(activity("Jan", 6, 1), activity("Feb", 4, 6), activity("Mar", 1, 1)))
+        }) {
+            assertTrue(
+                renderedText().contains("Feb (10)"),
+                "February's 4 + 6 beats January's 6 + 1; showed ${renderedText()}",
+            )
+        }
+
+    @Test
+    fun `the chart is labelled with the span it covers and a legend for both bars`() =
+        reportContent({
+            ActivityContent(listOf(activity("Jan", 1, 1), activity("Feb", 2, 2), activity("Mar", 3, 3)))
+        }) {
+            onNodeWithText(CcliLabel.ACTIVITY_TITLE).assertIsDisplayed()
+            assertTrue(
+                renderedText().contains("Jan – Mar"),
+                "the span runs from the first period to the last; showed ${renderedText()}",
+            )
+            onNodeWithText(CcliLabel.LEGEND_SONGS).assertIsDisplayed()
+            onNodeWithText(CcliLabel.LEGEND_BIBLE).assertIsDisplayed()
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportDialogTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportDialogTestSupport.kt
@@ -1,0 +1,172 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.ActivityPoint
+import org.churchpresenter.app.churchpresenter.data.SongSummary
+import org.churchpresenter.app.churchpresenter.data.VerseSummary
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Harness, fixtures and labels shared by the `CCLIReportDialog` test classes.
+ *
+ * **What these tests can and cannot reach.** `CCLIReportDialog` itself wraps its whole body in a
+ * `DialogWindow` — a real AWT window — and the suite runs with `java.awt.headless=true`, so composing
+ * the public entry point throws `HeadlessException`. What the dialog *shows*, though, is three
+ * content composables over plain data ([SongsReportContent], [BibleReportContent], [ActivityContent]),
+ * and those are ordinary Compose with no window in them. They were widened `private` → `internal`
+ * (no behaviour change) and are driven directly here, which reaches the tables, the two chart kinds,
+ * the stat cards and every empty state through their real callers.
+ *
+ * Left uncovered, and deliberately: the `DialogWindow` block itself, and the date pickers, preset
+ * buttons and CSV/XLS export handlers that live inside it. Those need either a display or a native
+ * file dialog. The date arithmetic behind the presets (`fromMs`/`toMs`/`applyPreset`) is local to the
+ * dialog composable and would have to be lifted to a top-level function before it could be tested;
+ * that is a worthwhile follow-up, not something these tests reach.
+ *
+ * **Dates.** The tables format with `SimpleDateFormat("MMM d, yyyy")` in the default locale and zone,
+ * so expected strings are built with [formatDate] — the same formatter over the same fixture instant —
+ * rather than hardcoded. A hardcoded "Jan 5, 2026" would pass in one timezone and fail in another;
+ * this still proves the cell shows *that* song's `firstUsed` in *that* column.
+ */
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** Renders [content] on its own, the way the dialog's tab body would. */
+@OptIn(ExperimentalTestApi::class)
+internal fun reportContent(
+    content: @Composable () -> Unit,
+    block: ComposeUiTest.() -> Unit,
+) = runComposeUiTest {
+    setContent { MaterialTheme { content() } }
+    block()
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────────────────────────────
+
+/** A fixed instant, so nothing here depends on the wall clock. */
+internal const val JAN_2026 = 1_767_225_600_000L
+internal const val DAY_MS = 86_400_000L
+
+internal fun song(
+    title: String,
+    count: Int = 1,
+    author: String = "Charles Wesley",
+    songbook: String = "Hymnal",
+    ccli: String = "12345",
+    number: Int = 1,
+    firstUsed: Long = JAN_2026,
+    lastUsed: Long = JAN_2026 + DAY_MS,
+) = SongSummary(
+    songNumber = number,
+    title = title,
+    songbook = songbook,
+    author = author,
+    ccliNumber = ccli,
+    count = count,
+    firstUsed = firstUsed,
+    lastUsed = lastUsed,
+)
+
+internal fun verse(
+    book: String,
+    chapter: Int = 3,
+    number: Int = 16,
+    count: Int = 1,
+    bible: String = "KJV",
+    firstUsed: Long = JAN_2026,
+    lastUsed: Long = JAN_2026 + DAY_MS,
+) = VerseSummary(
+    bibleName = bible,
+    bookName = book,
+    chapter = chapter,
+    verseNumber = number,
+    count = count,
+    firstUsed = firstUsed,
+    lastUsed = lastUsed,
+)
+
+internal fun activity(label: String, songs: Int, verses: Int) =
+    ActivityPoint(label = label, songCount = songs, verseCount = verses)
+
+/** The tables' own format, applied to the same instant a fixture carries. */
+internal fun formatDate(ms: Long): String =
+    SimpleDateFormat("MMM d, yyyy", Locale.getDefault()).format(Date(ms))
+
+// ── Labels, as the dialog renders them ──────────────────────────────────────────────────────────
+
+internal object CcliLabel {
+    const val NO_DATA = "No data for this period."
+    const val SONGS_CHART = "Top Songs"
+    const val BIBLE_CHART = "Top Bible Books"
+    const val ACTIVITY_TITLE = "Presentations Over Time"
+    const val LEGEND_SONGS = "Songs"
+    const val LEGEND_BIBLE = "Bible Verses"
+    const val STAT_SONGS = "Songs presented"
+    const val STAT_VERSES = "Bible verses"
+    const val STAT_BUSIEST = "Busiest period"
+    const val BLANK = "—"
+
+    /** The subtitle under a chart heading, which reports both totals. */
+    fun songsSummary(unique: Int, plays: Int) = "$unique unique songs · $plays total plays"
+    fun bibleSummary(unique: Int, plays: Int) = "$unique unique verses · $plays total plays"
+}
+
+/** The left-hand chart column is 300.dp wide; everything right of it is the table. */
+private const val CHART_PANEL_WIDTH = 300f
+
+// ── Reading what was rendered ───────────────────────────────────────────────────────────────────
+
+private fun ComposeUiTest.textNodes() =
+    onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .map { it.boundsInRoot to (it.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { t -> t.text } ?: "") }
+
+/** Every string on screen, in traversal order. */
+internal fun ComposeUiTest.renderedText(): List<String> = textNodes().map { it.second }
+
+/**
+ * The ranked labels in the left-hand chart, top to bottom.
+ *
+ * The chart and the table both render the same titles, so they are told apart by position: the chart
+ * occupies a fixed-width column on the left. Each chart row publishes its label and its value as two
+ * nodes side by side; only the label — the leftmost of the pair — is returned.
+ */
+internal fun ComposeUiTest.chartLabels(): List<String> =
+    textNodes()
+        .filter { it.first.left < CHART_PANEL_WIDTH }
+        .groupBy { it.first.top }
+        .toSortedMap()
+        .values
+        .mapNotNull { band -> band.minByOrNull { it.first.left }?.second }
+
+/**
+ * The chart's ranked rows as `label to value`, top to bottom.
+ *
+ * A row publishes its label and its total as two nodes on the same horizontal band, so a band
+ * carrying exactly two is a row; the heading and its subtitle sit alone on theirs and drop out.
+ */
+internal fun ComposeUiTest.chartRows(): List<Pair<String, String>> =
+    textNodes()
+        .filter { it.first.left < CHART_PANEL_WIDTH }
+        .groupBy { it.first.top }
+        .toSortedMap()
+        .values
+        .mapNotNull { band ->
+            val cells = band.sortedBy { it.first.left }
+            if (cells.size == 2) cells[0].second to cells[1].second else null
+        }
+
+/** The strings rendered in the table, right of the chart column. */
+internal fun ComposeUiTest.tableText(): List<String> =
+    textNodes().filter { it.first.left >= CHART_PANEL_WIDTH }.map { it.second }


### PR DESCRIPTION
First of the `dialogs/` coverage push. Independent of #49 (different file) and of every other open PR.

## Why `dialogs/` was stuck at 3.5%

`CCLIReportDialog` — like `SetupWizardDialog`, `EditSongDialog`, `StatisticsDialog`, `PlanningCenterImportDialog` and `QARemoteDialog` — wraps its whole body in a **`DialogWindow`**, a real AWT window. The suite runs `java.awt.headless=true`, so composing the public entry point throws `HeadlessException`. I confirmed that with a throwaway probe before writing anything. That is the whole reason this package sat at 3.5% while `dialogs/tabs` is at 94.6%: the two dialogs that *are* covered (`ColorPickerDialog` 84%, `CrashFeedbackDialog`) use the in-composition `Dialog`, or no wrapper at all.

## What this does

Two commits, in the order I learned it.

**1. Widen the three report bodies** — `SongsReportContent`, `BibleReportContent`, `ActivityContent` from `private` to `internal`, and drive them directly. That reached 58.7%.

**2. Lift the window body out** — after #49 showed the better shape, `CCLIReportContent` now holds everything the `DialogWindow` contained, leaving the window with a single call. That is AGENT.md's prescribed form for an unreachable step, and it took the file to **88.0%**.

Both moves are structural. `git diff -w` shows the bodies unchanged, only moved; the window keeps `mainWindowState`, which only ever fed its position.

## Tests (26)

**`CCLIReportContentTest` (16)** — what the report *derives*, since this is what a church files against its copyright licence:
- the unique-vs-total split in each subtitle (2 songs / 7 plays)
- per-book aggregation and ranking — John's 2 + 5 make 7, and books rank by that sum, not by distinct verse count
- the busiest period picked on songs **+** verses, not songs alone
- 1-based row ranks; the reference formatted `John 3:16`; the twelve-entry chart cap
- a dash for a blank author / songbook / CCLI number / Bible name
- periods that exist but recorded nothing must read as *no data*, not a report with zeroed stat cards

**`CCLIReportContentShellTest` (10)** — the frame around them, against a real seeded `StatisticsManager`:
- the no-event-log notice standing in for tabs that would all be empty
- per-tab counts distinguishing distinct songs from repeat presentations
- each tab *swapping* the body rather than stacking on it
- two presets end to end — **Last Year** must exclude a song presented today, **All Time** must take it back — which exercises the date arithmetic I had flagged as needing a separate extraction; lifting the body made it reachable as-is
- Close reporting out

Chart rows are read by geometry, the convention `StatisticsTabTestSupport` already uses, because chart and table render the same titles. Dates go through the tables' own `SimpleDateFormat` over a fixed fixture instant, so nothing depends on the wall clock or a timezone. Background loads are awaited on the tab counts — a positive signal, no fixed pauses.

Deterministic 3×. In full-suite context both classes cost **0.82s for 26 tests**, slowest single test 0.137s. (Run in isolation the first test in a class reads ~1.5s; that is one-time JVM and first-composition warmup, not the test's own cost.)

## Coverage

| | before | after |
|---|---|---|
| `CCLIReportDialog.kt` | 0% | **88.0%** (646/734) |
| `dialogs` package | 3.5% | 14.1% |

## Uncovered

The `DialogWindow` call itself, and the two export buttons — each opens a native save dialog through `FileChooser.platformInstance`, so they are asserted present and never pressed.