### PR TITLE
Test the setup wizard's navigation

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardDialog.kt
@@ -182,9 +182,6 @@ fun SetupWizardDialog(
     onOpenSettings: () -> Unit = {},
     onDismiss: () -> Unit
 ) {
-    var step by remember { mutableStateOf(0) }
-    var goingForward by remember { mutableStateOf(true) }
-
     val windowState = rememberWindowState(
         width = 700.dp,
         height = 620.dp,
@@ -199,130 +196,161 @@ fun SetupWizardDialog(
         resizable = false,
         alwaysOnTop = alwaysOnTop
     ) {
-        LanguageProvider(language = selectedLanguage) {
-            AppThemeWrapper(theme = theme) {
-                Surface(
-                    modifier = Modifier.fillMaxSize(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    Column(modifier = Modifier.fillMaxSize()) {
+        SetupWizardContent(
+            theme = theme,
+            selectedLanguage = selectedLanguage,
+            onLanguageSelected = onLanguageSelected,
+            onThemeSelected = onThemeSelected,
+            onOpenSettings = onOpenSettings,
+            onDismiss = onDismiss
+        )
+    }
+}
 
-                        // Step indicator header — seamless dark with a faint accent glow
+/**
+ * Everything the wizard window contains: the step header, the animated step body and the
+ * Skip/Back/Next/Done row, together with the step counter those three read from.
+ *
+ * Held apart from [SetupWizardDialog] because that function's only other statement is the `Window`
+ * it opens, which cannot be composed on a headless machine. Keeping the window down to that one call
+ * leaves the wizard's actual behaviour — which step follows which, and which buttons a step offers —
+ * reachable from a test.
+ */
+@Composable
+internal fun SetupWizardContent(
+    theme: ThemeMode,
+    selectedLanguage: Language,
+    onLanguageSelected: (Language) -> Unit,
+    onThemeSelected: (ThemeMode) -> Unit,
+    onOpenSettings: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var step by remember { mutableStateOf(0) }
+    var goingForward by remember { mutableStateOf(true) }
+
+    LanguageProvider(language = selectedLanguage) {
+        AppThemeWrapper(theme = theme) {
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.background
+            ) {
+                Column(modifier = Modifier.fillMaxSize()) {
+
+                    // Step indicator header — seamless dark with a faint accent glow
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                Brush.verticalGradient(
+                                    listOf(
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
+                                        Color.Transparent
+                                    )
+                                )
+                            )
+                            .padding(horizontal = 24.dp, vertical = 16.dp)
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Text(
+                                text = stringResource(Res.string.setup_wizard_title),
+                                style = MaterialTheme.typography.titleMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(modifier = Modifier.height(10.dp))
+                            StepDots(currentStep = step, totalSteps = TOTAL_STEPS)
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = stringResource(Res.string.setup_wizard_step, step + 1, TOTAL_STEPS),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+
+                    // Step content — animated slide
+                    AnimatedContent(
+                        targetState = step,
+                        modifier = Modifier.weight(1f).fillMaxWidth(),
+                        transitionSpec = {
+                            if (goingForward) {
+                                slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
+                            } else {
+                                slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
+                            }
+                        },
+                        label = "wizard_step"
+                    ) { currentStep ->
                         Box(
                             modifier = Modifier
-                                .fillMaxWidth()
-                                .background(
-                                    Brush.verticalGradient(
-                                        listOf(
-                                            MaterialTheme.colorScheme.primary.copy(alpha = 0.10f),
-                                            Color.Transparent
-                                        )
-                                    )
-                                )
-                                .padding(horizontal = 24.dp, vertical = 16.dp)
+                                .fillMaxSize()
+                                .padding(horizontal = 32.dp, vertical = 24.dp),
+                            contentAlignment = Alignment.TopCenter
                         ) {
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Text(
-                                    text = stringResource(Res.string.setup_wizard_title),
-                                    style = MaterialTheme.typography.titleMedium,
-                                    fontWeight = FontWeight.Bold,
-                                    color = MaterialTheme.colorScheme.primary
+                            when (currentStep) {
+                                0 -> LanguageStep(
+                                    selectedLanguage = selectedLanguage,
+                                    onLanguageSelected = onLanguageSelected
                                 )
-                                Spacer(modifier = Modifier.height(10.dp))
-                                StepDots(currentStep = step, totalSteps = TOTAL_STEPS)
-                                Spacer(modifier = Modifier.height(4.dp))
-                                Text(
-                                    text = stringResource(Res.string.setup_wizard_step, step + 1, TOTAL_STEPS),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                1 -> ThemeStep(
+                                    selectedTheme = theme,
+                                    onThemeSelected = onThemeSelected
                                 )
+                                2 -> WelcomeStep()
+                                3 -> BibleStep(onOpenSettings = onOpenSettings)
+                                4 -> SongsStep(onOpenSettings = onOpenSettings)
+                                5 -> ProjectionStep(onOpenSettings = onOpenSettings)
+                                6 -> VlcStep()
+                                7 -> ReadyStep()
                             }
                         }
+                    }
 
-                        // Step content — animated slide
-                        AnimatedContent(
-                            targetState = step,
-                            modifier = Modifier.weight(1f).fillMaxWidth(),
-                            transitionSpec = {
-                                if (goingForward) {
-                                    slideInHorizontally { it } togetherWith slideOutHorizontally { -it }
-                                } else {
-                                    slideInHorizontally { -it } togetherWith slideOutHorizontally { it }
-                                }
-                            },
-                            label = "wizard_step"
-                        ) { currentStep ->
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(horizontal = 32.dp, vertical = 24.dp),
-                                contentAlignment = Alignment.TopCenter
-                            ) {
-                                when (currentStep) {
-                                    0 -> LanguageStep(
-                                        selectedLanguage = selectedLanguage,
-                                        onLanguageSelected = onLanguageSelected
-                                    )
-                                    1 -> ThemeStep(
-                                        selectedTheme = theme,
-                                        onThemeSelected = onThemeSelected
-                                    )
-                                    2 -> WelcomeStep()
-                                    3 -> BibleStep(onOpenSettings = onOpenSettings)
-                                    4 -> SongsStep(onOpenSettings = onOpenSettings)
-                                    5 -> ProjectionStep(onOpenSettings = onOpenSettings)
-                                    6 -> VlcStep()
-                                    7 -> ReadyStep()
-                                }
+                    HorizontalDivider()
+
+                    // Navigation buttons
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(MaterialTheme.colorScheme.surface)
+                            .padding(horizontal = 24.dp, vertical = 14.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (step < TOTAL_STEPS - 1) {
+                            TextButton(shape = RoundedCornerShape(6.dp), onClick = onDismiss) {
+                                Text(stringResource(Res.string.setup_wizard_skip))
                             }
+                        } else {
+                            Spacer(modifier = Modifier.width(80.dp))
                         }
 
-                        HorizontalDivider()
-
-                        // Navigation buttons
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .background(MaterialTheme.colorScheme.surface)
-                                .padding(horizontal = 24.dp, vertical = 14.dp),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            if (step > 0) {
+                                OutlinedButton(
+                                    shape = RoundedCornerShape(6.dp),
+                                    onClick = {
+                                    goingForward = false
+                                    step--
+                                }) {
+                                    Text(stringResource(Res.string.setup_wizard_back))
+                                }
+                            }
                             if (step < TOTAL_STEPS - 1) {
-                                TextButton(shape = RoundedCornerShape(6.dp), onClick = onDismiss) {
-                                    Text(stringResource(Res.string.setup_wizard_skip))
+                                Button(
+                                    shape = RoundedCornerShape(6.dp),
+                                    onClick = {
+                                    goingForward = true
+                                    step++
+                                }) {
+                                    Text(stringResource(Res.string.setup_wizard_next))
                                 }
                             } else {
-                                Spacer(modifier = Modifier.width(80.dp))
-                            }
-
-                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                if (step > 0) {
-                                    OutlinedButton(
-                                        shape = RoundedCornerShape(6.dp),
-                                        onClick = {
-                                        goingForward = false
-                                        step--
-                                    }) {
-                                        Text(stringResource(Res.string.setup_wizard_back))
-                                    }
-                                }
-                                if (step < TOTAL_STEPS - 1) {
-                                    Button(
-                                        shape = RoundedCornerShape(6.dp),
-                                        onClick = {
-                                        goingForward = true
-                                        step++
-                                    }) {
-                                        Text(stringResource(Res.string.setup_wizard_next))
-                                    }
-                                } else {
-                                    Button(shape = RoundedCornerShape(6.dp), onClick = onDismiss) {
-                                        Text(stringResource(Res.string.setup_wizard_done))
-                                    }
+                                Button(shape = RoundedCornerShape(6.dp), onClick = onDismiss) {
+                                    Text(stringResource(Res.string.setup_wizard_done))
                                 }
                             }
                         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardContentTest.kt
@@ -1,0 +1,219 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.Language
+import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The first-run wizard's navigation: which step follows which, and what each one offers to press.
+ *
+ * This is the very first thing a new user sees, and it is the only place the app asks for a language
+ * and a theme before anything else exists — so a wizard that cannot be advanced, cannot be skipped,
+ * or drops its final button strands someone on their first launch.
+ *
+ * `SetupWizardDialog` opens a `Window`, which cannot be composed headless, so the window's body was
+ * lifted into `SetupWizardContent` — an extraction, no logic moved or changed — and that is what
+ * these drive. The `Window` call itself, the eight-step *content* copy, and the wizard's placement
+ * on screen are what remain uncovered.
+ *
+ * The step body is an `AnimatedContent`, so during a transition both the outgoing and the incoming
+ * step are briefly on screen. Every assertion here is therefore made after the transition has
+ * settled, and reads the step counter — which is outside the animation and always singular — rather
+ * than counting step content.
+ */
+class SetupWizardContentTest {
+
+    private object Label {
+        const val TITLE = "Getting Started"
+        const val SKIP = "Skip"
+        const val BACK = "Back"
+        const val NEXT = "Next"
+        const val DONE = "Get Started"
+        const val LAST_STEP = 8
+
+        fun step(n: Int) = "Step $n of $LAST_STEP"
+    }
+
+    /** What the wizard reported back, so a test can assert on the choice rather than on a stub. */
+    private class Choices {
+        var language: Language? = null
+        var theme: ThemeMode? = null
+        var dismissed = 0
+        var openedSettings = 0
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun wizard(
+        theme: ThemeMode = ThemeMode.SYSTEM,
+        language: Language = Language.ENGLISH,
+        block: ComposeUiTest.(Choices) -> Unit,
+    ) {
+        val choices = Choices()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    SetupWizardContent(
+                        theme = theme,
+                        selectedLanguage = language,
+                        onLanguageSelected = { choices.language = it },
+                        onThemeSelected = { choices.theme = it },
+                        onOpenSettings = { choices.openedSettings++ },
+                        onDismiss = { choices.dismissed++ },
+                    )
+                }
+            }
+            block(choices)
+        }
+    }
+
+    /** Presses Next and lets the slide transition finish, so only one step is on screen after. */
+    private fun ComposeUiTest.next() {
+        onNodeWithText(Label.NEXT).performClick()
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.back() {
+        onNodeWithText(Label.BACK).performClick()
+        waitForIdle()
+    }
+
+    // ── Where the wizard opens ──────────────────────────────────────────────────
+
+    @Test
+    fun `the wizard opens on the first of eight steps`() = wizard { _ ->
+        onNodeWithText(Label.TITLE).assertIsDisplayed()
+        onNodeWithText(Label.step(1)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the first step offers no way back`() = wizard { _ ->
+        onAllNodesWithTextCount(Label.BACK).let {
+            assertEquals(0, it, "there is nothing behind the first step to go back to")
+        }
+    }
+
+    // ── Moving through ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `Next advances one step at a time`() = wizard { _ ->
+        next()
+        onNodeWithText(Label.step(2)).assertIsDisplayed()
+        next()
+        onNodeWithText(Label.step(3)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `Back returns to the step before`() = wizard { _ ->
+        next()
+        next()
+        onNodeWithText(Label.step(3)).assertIsDisplayed()
+        back()
+        onNodeWithText(Label.step(2)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `every step from the second on offers Back`() = wizard { _ ->
+        repeat(Label.LAST_STEP - 1) { i ->
+            next()
+            assertEquals(
+                1,
+                onAllNodesWithTextCount(Label.BACK),
+                "step ${i + 2} must offer a way back",
+            )
+        }
+    }
+
+    // ── The last step ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `the wizard runs to an eighth and final step`() = wizard { _ ->
+        repeat(Label.LAST_STEP - 1) { next() }
+        onNodeWithText(Label.step(Label.LAST_STEP)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the final step swaps Next for the finish button and drops Skip`() = wizard { _ ->
+        repeat(Label.LAST_STEP - 1) { next() }
+        assertEquals(0, onAllNodesWithTextCount(Label.NEXT), "there is nowhere left to advance to")
+        assertEquals(0, onAllNodesWithTextCount(Label.SKIP), "nothing left to skip on the last step")
+        onNodeWithText(Label.DONE).assertIsDisplayed()
+    }
+
+    @Test
+    fun `finishing on the last step closes the wizard`() = wizard { choices ->
+        repeat(Label.LAST_STEP - 1) { next() }
+        onNodeWithText(Label.DONE).performClick()
+        waitForIdle()
+        assertEquals(1, choices.dismissed, "pressing the finish button must close the wizard")
+    }
+
+    // ── Skipping ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Skip closes the wizard from the very first step`() = wizard { choices ->
+        onNodeWithText(Label.SKIP).performClick()
+        waitForIdle()
+        assertEquals(1, choices.dismissed, "Skip must let someone out without walking the wizard")
+    }
+
+    @Test
+    fun `Skip is still offered partway through`() = wizard { choices ->
+        next()
+        next()
+        onNodeWithText(Label.SKIP).performClick()
+        waitForIdle()
+        assertEquals(1, choices.dismissed)
+    }
+
+    // ── The two steps that ask for something ────────────────────────────────────
+
+    @Test
+    fun `choosing a language on the first step reports that language`() = wizard { choices ->
+        assertNull(choices.language, "nothing is chosen until it is pressed")
+        onNodeWithText(Language.GERMAN.nativeName).performClick()
+        waitForIdle()
+        assertEquals(Language.GERMAN, choices.language, "the pill pressed must be the language reported")
+    }
+
+    @Test
+    fun `every language the app supports is offered on the first step`() = wizard { _ ->
+        Language.entries.forEach { language ->
+            assertTrue(
+                onAllNodesWithTextCount(language.nativeName) >= 1,
+                "${language.nativeName} must be offered in its own script",
+            )
+        }
+    }
+
+    @Test
+    fun `choosing a theme on the second step reports that theme`() = wizard { choices ->
+        next()
+        assertNull(choices.theme)
+        onNodeWithText("Dark Theme").performClick()
+        waitForIdle()
+        assertEquals(ThemeMode.DARK, choices.theme, "the theme pressed must be the theme reported")
+    }
+
+    @Test
+    fun `walking the whole wizard never reports a language or theme by itself`() = wizard { choices ->
+        repeat(Label.LAST_STEP - 1) { next() }
+        assertNull(choices.language, "merely passing the language step must not choose one")
+        assertNull(choices.theme, "merely passing the theme step must not choose one")
+        assertEquals(0, choices.dismissed, "walking to the end must not close the wizard on its own")
+    }
+
+    private fun ComposeUiTest.onAllNodesWithTextCount(text: String): Int =
+        onAllNodes(androidx.compose.ui.test.hasText(text)).fetchSemanticsNodes(atLeastOneRootRequired = false).size
+}


### PR DESCRIPTION
Second of the `dialogs/` coverage push. Independent of #48 (different file) and of every other open PR.

## The approach, and why it beat #48's

`SetupWizardDialog` opens a `Window`, which throws `HeadlessException` under the suite's `java.awt.headless=true`. #48 worked around the same problem in `CCLIReportDialog` by widening the *content* composables and driving them individually — that reached **58.7%**.

Here I lifted the whole window body into an `internal SetupWizardContent`, leaving `Window` holding a single call. That is AGENT.md's prescribed shape for an unreachable step ("shrink the unreachable call itself to one step of its own, and take the sequence around it as a function"), and it reached **91.5%** — because the tests can now walk all eight steps and cover every step composable on the way, instead of poking each one in isolation.

**No logic moved or changed.** `step`/`goingForward` move with the body that was their only reader. Review with `git diff -w`: the real change is 32 added lines, everything else is re-indentation.

## Tests — `SetupWizardContentTest` (14)

This is the first thing a new user sees, and the only place the app asks for a language and a theme before anything else exists — a wizard that can't be advanced, can't be skipped, or drops its final button strands someone on first launch. So:

- opens on step 1 of 8; Next and Back each move exactly one step
- the first step offers no Back; every later one does (checked at all seven)
- the eighth swaps Next for **Get Started** and drops Skip entirely
- Skip closes from the first step and from partway through
- the language step reports the language actually pressed, and offers all of them in their own scripts
- the theme step reports the theme actually pressed
- walking the whole wizard reports **nothing** on its own — passing the language step must not pick a language, and reaching the end must not close the wizard

Assertions read the step counter, which sits outside the `AnimatedContent` and is always singular; step content is briefly doubled mid-transition. Every interaction waits for idle — no fixed pauses anywhere.

Deterministic 3×. 2.9s for the class, slowest test 0.84s.

## Coverage

| | before | after |
|---|---|---|
| `SetupWizardDialog.kt` | 0% | **91.5%** (720/787) |
| `dialogs` package | 10.5% | 15.4% |
| overall | 43.7% | 44.2% |

## Uncovered

The `Window` call itself and the wizard's placement on screen — a display is the only way to reach those.

## Follow-up this suggests

The extraction pattern here is worth retrofitting to #48: `CCLIReportDialog` at 58.7% leaves its whole `DialogWindow` body — the date pickers, preset buttons and tab switching — unreachable, and the same lift would likely take it past 85%. Happy to do that as a third PR rather than churn #48, unless you'd rather I fold it in.