### PR TITLE
Test the song editor's rules

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/EditSongDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/EditSongDialog.kt
@@ -98,6 +98,54 @@ fun EditSongDialog(
 ) {
     if (!isVisible || song == null) return
 
+    val mainWindowState = LocalMainWindowState.current
+    DialogWindow(
+        onCloseRequest = onDismiss,
+        state = rememberDialogState(
+            position = centeredOnMainWindow(mainWindowState, 800.dp, 700.dp),
+            width = 800.dp,
+            height = 700.dp
+        ),
+        title = if (isNewSong) stringResource(Res.string.new_song) else stringResource(Res.string.edit_song),
+        resizable = true
+    ) {
+        EditSongContent(
+            song = song,
+            songbooks = songbooks,
+            existingSongs = existingSongs,
+            isNewSong = isNewSong,
+            theme = theme,
+            isVisible = isVisible,
+            onDismiss = onDismiss,
+            onSave = onSave
+        )
+    }
+}
+
+/**
+ * The song editor itself: the identifying fields, the two lyric panes, and the Save that rebuilds
+ * the song from them.
+ *
+ * Held apart from [EditSongDialog] because that function's only other statement is the
+ * `DialogWindow` it opens, which cannot be composed on a headless machine. Keeping the window down
+ * to that one call leaves the editing rules — the digits-only song number, the duplicate check, the
+ * conditions under which Save is offered at all — reachable from a test.
+ *
+ * [isVisible] is taken only because the edit buffers are keyed on it, so that reopening the dialog
+ * over the same song discards an abandoned edit rather than resuming it.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun EditSongContent(
+    song: SongItem,
+    songbooks: List<String>,
+    existingSongs: List<SongItem>,
+    isNewSong: Boolean,
+    theme: ThemeMode,
+    isVisible: Boolean = true,
+    onDismiss: () -> Unit,
+    onSave: (SongItem) -> Unit
+) {
     // Filter out non-digits from song number (handles cases like "3.1" -> "3" or "31")
     var editedNumber by remember(isVisible, song) { mutableStateOf(song.number.filter { it.isDigit() }) }
     var editedTitle by remember(isVisible, song) { mutableStateOf(song.title) }
@@ -122,323 +170,312 @@ fun EditSongDialog(
         }
     }
 
-    val mainWindowState = LocalMainWindowState.current
-    DialogWindow(
-        onCloseRequest = onDismiss,
-        state = rememberDialogState(
-            position = centeredOnMainWindow(mainWindowState, 800.dp, 700.dp),
-            width = 800.dp,
-            height = 700.dp
-        ),
-        title = if (isNewSong) stringResource(Res.string.new_song) else stringResource(Res.string.edit_song),
-        resizable = true
-    ) {
-        AppThemeWrapper(theme = theme) {
-            Surface(
-                modifier = Modifier.fillMaxSize(),
-                color = MaterialTheme.colorScheme.background
+
+    AppThemeWrapper(theme = theme) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(16.dp)
             ) {
+                // Content area: fixed-height fields scroll if needed, lyrics fill the rest
                 Column(
-                    modifier = Modifier.fillMaxSize().padding(16.dp)
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(bottom = 16.dp)
                 ) {
-                    // Content area: fixed-height fields scroll if needed, lyrics fill the rest
-                    Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(bottom = 16.dp)
-                    ) {
-                    val separatorColor = MaterialTheme.colorScheme.primary
-                    val separatorBg = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)
-                    val lyricsHighlightTransformation = remember(separatorColor, separatorBg) {
-                        VisualTransformation { text ->
-                            val annotated = buildAnnotatedString {
-                                val lines = text.text.split("\n")
-                                lines.forEachIndexed { i, line ->
-                                    val trimmed = line.trim()
-                                    if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
-                                        pushStyle(
-                                            SpanStyle(
-                                                color = separatorColor,
-                                                background = separatorBg,
-                                                fontWeight = FontWeight.Bold
-                                            )
+                val separatorColor = MaterialTheme.colorScheme.primary
+                val separatorBg = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)
+                val lyricsHighlightTransformation = remember(separatorColor, separatorBg) {
+                    VisualTransformation { text ->
+                        val annotated = buildAnnotatedString {
+                            val lines = text.text.split("\n")
+                            lines.forEachIndexed { i, line ->
+                                val trimmed = line.trim()
+                                if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+                                    pushStyle(
+                                        SpanStyle(
+                                            color = separatorColor,
+                                            background = separatorBg,
+                                            fontWeight = FontWeight.Bold
                                         )
-                                        append(line)
-                                        pop()
-                                    } else {
-                                        append(line)
-                                    }
-                                    if (i < lines.size - 1) append("\n")
+                                    )
+                                    append(line)
+                                    pop()
+                                } else {
+                                    append(line)
                                 }
+                                if (i < lines.size - 1) append("\n")
                             }
-                            TransformedText(annotated, OffsetMapping.Identity)
                         }
+                        TransformedText(annotated, OffsetMapping.Identity)
                     }
-                    Column(
-                        modifier = Modifier.verticalScroll(rememberScrollState())
+                }
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState())
+                ) {
+                    // First row: Song Number, Songbook, Tune
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        // First row: Song Number, Songbook, Tune
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
+                        SettingsTextField(
+                            value = editedNumber,
+                            onValueChange = { newValue ->
+                                // Only allow digits
+                                if (newValue.all { it.isDigit() }) {
+                                    editedNumber = newValue
+                                }
+                            },
+                            modifier = Modifier.weight(0.2f),
+                            label = stringResource(Res.string.song_number),
+                            fillWidth = true,
+                            singleLine = true,
+                        )
+
+                        var songbookExpanded by remember { mutableStateOf(false) }
+                        var isAddingNew by remember(isVisible) { mutableStateOf(false) }
+
+                        if (isAddingNew) {
                             SettingsTextField(
-                                value = editedNumber,
-                                onValueChange = { newValue ->
-                                    // Only allow digits
-                                    if (newValue.all { it.isDigit() }) {
-                                        editedNumber = newValue
-                                    }
-                                },
-                                modifier = Modifier.weight(0.2f),
-                                label = stringResource(Res.string.song_number),
+                                value = editedSongbook,
+                                onValueChange = { editedSongbook = it },
+                                modifier = Modifier.weight(0.5f),
+                                label = stringResource(Res.string.song_book),
                                 fillWidth = true,
                                 singleLine = true,
+                                trailingIcon = {
+                                    IconButton(
+                                        onClick = {
+                                            editedSongbook = song.songbook
+                                            isAddingNew = false
+                                        },
+                                        modifier = Modifier.size(20.dp)
+                                    ) {
+                                        Icon(Icons.Default.Close, contentDescription = null, modifier = Modifier.size(14.dp))
+                                    }
+                                }
                             )
-
-                            var songbookExpanded by remember { mutableStateOf(false) }
-                            var isAddingNew by remember(isVisible) { mutableStateOf(false) }
-
-                            if (isAddingNew) {
+                        } else {
+                            ExposedDropdownMenuBox(
+                                expanded = songbookExpanded,
+                                onExpandedChange = { songbookExpanded = it },
+                                modifier = Modifier.weight(0.5f)
+                            ) {
                                 SettingsTextField(
                                     value = editedSongbook,
-                                    onValueChange = { editedSongbook = it },
-                                    modifier = Modifier.weight(0.5f),
+                                    onValueChange = {},
+                                    readOnly = true,
+                                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = songbookExpanded) },
+                                    modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
                                     label = stringResource(Res.string.song_book),
                                     fillWidth = true,
                                     singleLine = true,
-                                    trailingIcon = {
-                                        IconButton(
-                                            onClick = {
-                                                editedSongbook = song.songbook
-                                                isAddingNew = false
-                                            },
-                                            modifier = Modifier.size(20.dp)
-                                        ) {
-                                            Icon(Icons.Default.Close, contentDescription = null, modifier = Modifier.size(14.dp))
-                                        }
-                                    }
                                 )
-                            } else {
-                                ExposedDropdownMenuBox(
+                                ExposedDropdownMenu(
                                     expanded = songbookExpanded,
-                                    onExpandedChange = { songbookExpanded = it },
-                                    modifier = Modifier.weight(0.5f)
+                                    onDismissRequest = { songbookExpanded = false }
                                 ) {
-                                    SettingsTextField(
-                                        value = editedSongbook,
-                                        onValueChange = {},
-                                        readOnly = true,
-                                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = songbookExpanded) },
-                                        modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
-                                        label = stringResource(Res.string.song_book),
-                                        fillWidth = true,
-                                        singleLine = true,
-                                    )
-                                    ExposedDropdownMenu(
-                                        expanded = songbookExpanded,
-                                        onDismissRequest = { songbookExpanded = false }
-                                    ) {
-                                        songbooks.forEach { songbook ->
-                                            DropdownMenuItem(
-                                                text = { Text(songbook) },
-                                                onClick = {
-                                                    editedSongbook = songbook
-                                                    songbookExpanded = false
-                                                }
-                                            )
-                                        }
-                                        HorizontalDivider()
+                                    songbooks.forEach { songbook ->
                                         DropdownMenuItem(
-                                            text = { Text(stringResource(Res.string.add_new)) },
+                                            text = { Text(songbook) },
                                             onClick = {
+                                                editedSongbook = songbook
                                                 songbookExpanded = false
-                                                editedSongbook = ""
-                                                isAddingNew = true
                                             }
                                         )
                                     }
+                                    HorizontalDivider()
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(Res.string.add_new)) },
+                                        onClick = {
+                                            songbookExpanded = false
+                                            editedSongbook = ""
+                                            isAddingNew = true
+                                        }
+                                    )
                                 }
                             }
-
-                            SettingsTextField(
-                                value = editedTune,
-                                onValueChange = { editedTune = it },
-                                modifier = Modifier.weight(0.3f),
-                                label = stringResource(Res.string.tune),
-                                fillWidth = true,
-                                singleLine = true,
-                            )
                         }
 
-                        // Second row: Primary Title and Secondary Title
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            SettingsTextField(
-                                value = editedTitle,
-                                onValueChange = {
-                                    editedTitle = it
-                                    titleManuallyEdited = it.isNotBlank()
-                                },
-                                modifier = Modifier.weight(0.5f),
-                                label = stringResource(Res.string.song_title),
-                                fillWidth = true,
-                                singleLine = true,
-                            )
+                        SettingsTextField(
+                            value = editedTune,
+                            onValueChange = { editedTune = it },
+                            modifier = Modifier.weight(0.3f),
+                            label = stringResource(Res.string.tune),
+                            fillWidth = true,
+                            singleLine = true,
+                        )
+                    }
 
-                            SettingsTextField(
-                                value = editedSecondaryTitle,
-                                onValueChange = { editedSecondaryTitle = it },
-                                modifier = Modifier.weight(0.5f),
-                                label = stringResource(Res.string.secondary_title),
-                                fillWidth = true,
-                                singleLine = true,
-                            )
-                        }
-
-                        if (isDuplicate) {
-                            Text(
-                                text = stringResource(Res.string.duplicate_song_error),
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.bodySmall,
-                                modifier = Modifier.padding(bottom = 4.dp)
-                            )
-                        }
-
-                        // Third row: Author and Composer
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            SettingsTextField(
-                                value = editedAuthor,
-                                onValueChange = { editedAuthor = it },
-                                modifier = Modifier.weight(0.4f),
-                                label = stringResource(Res.string.author),
-                                fillWidth = true,
-                                singleLine = true,
-                            )
-
-                            SettingsTextField(
-                                value = editedComposer,
-                                onValueChange = { editedComposer = it },
-                                modifier = Modifier.weight(0.4f),
-                                label = stringResource(Res.string.composer),
-                                fillWidth = true,
-                                singleLine = true,
-                            )
-
-                            SettingsTextField(
-                                value = editedCcli,
-                                onValueChange = { editedCcli = it },
-                                modifier = Modifier.weight(0.2f),
-                                label = stringResource(Res.string.ccli_number),
-                                fillWidth = true,
-                                singleLine = true,
-                            )
-                        }
-
-                        // Lyrics section - side by side
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
-                        ) {
-                            Text(
-                                text = stringResource(Res.string.lyrics),
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier = Modifier.weight(1f).padding(bottom = 4.dp)
-                            )
-                            Text(
-                                text = stringResource(Res.string.secondary_lyrics),
-                                style = MaterialTheme.typography.titleMedium,
-                                modifier = Modifier.weight(1f).padding(bottom = 4.dp)
-                            )
-                        }
-                    } // end top fields (scrollable if window is shrunk)
-
-                    // Lyrics fields fill the rest of the available height
+                    // Second row: Primary Title and Secondary Title
                     Row(
-                        modifier = Modifier.fillMaxWidth().weight(1f),
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        LyricsTextField(
-                            value = editedLyrics,
-                            onValueChange = { newLyrics ->
-                                editedLyrics = newLyrics
-                                // Auto-fill title from first non-header, non-blank lyric line
-                                if (isNewSong && !titleManuallyEdited) {
-                                    val firstContentLine = newLyrics.lines().firstOrNull { line ->
-                                        val trimmed = line.trim()
-                                        trimmed.isNotBlank() && !trimmed.startsWith("[")
-                                    }?.trim() ?: ""
-                                    editedTitle = firstContentLine
-                                }
+                        SettingsTextField(
+                            value = editedTitle,
+                            onValueChange = {
+                                editedTitle = it
+                                titleManuallyEdited = it.isNotBlank()
                             },
-                            modifier = Modifier.weight(1f).fillMaxHeight(),
-                            placeholder = { Text(stringResource(Res.string.enter_lyrics_here)) },
-                            visualTransformation = lyricsHighlightTransformation
+                            modifier = Modifier.weight(0.5f),
+                            label = stringResource(Res.string.song_title),
+                            fillWidth = true,
+                            singleLine = true,
                         )
-                        LyricsTextField(
-                            value = editedSecondaryLyrics,
-                            onValueChange = { editedSecondaryLyrics = it },
-                            modifier = Modifier.weight(1f).fillMaxHeight(),
-                            placeholder = { Text(stringResource(Res.string.enter_secondary_lyrics_here)) },
-                            visualTransformation = lyricsHighlightTransformation
+
+                        SettingsTextField(
+                            value = editedSecondaryTitle,
+                            onValueChange = { editedSecondaryTitle = it },
+                            modifier = Modifier.weight(0.5f),
+                            label = stringResource(Res.string.secondary_title),
+                            fillWidth = true,
+                            singleLine = true,
                         )
                     }
 
-                    // Help text
-                    Text(
-                        text = stringResource(Res.string.lyrics_format_help),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 4.dp)
-                    )
+                    if (isDuplicate) {
+                        Text(
+                            text = stringResource(Res.string.duplicate_song_error),
+                            color = MaterialTheme.colorScheme.error,
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.padding(bottom = 4.dp)
+                        )
                     }
 
-                    // Action buttons
+                    // Third row: Author and Composer
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        SettingsTextField(
+                            value = editedAuthor,
+                            onValueChange = { editedAuthor = it },
+                            modifier = Modifier.weight(0.4f),
+                            label = stringResource(Res.string.author),
+                            fillWidth = true,
+                            singleLine = true,
+                        )
+
+                        SettingsTextField(
+                            value = editedComposer,
+                            onValueChange = { editedComposer = it },
+                            modifier = Modifier.weight(0.4f),
+                            label = stringResource(Res.string.composer),
+                            fillWidth = true,
+                            singleLine = true,
+                        )
+
+                        SettingsTextField(
+                            value = editedCcli,
+                            onValueChange = { editedCcli = it },
+                            modifier = Modifier.weight(0.2f),
+                            label = stringResource(Res.string.ccli_number),
+                            fillWidth = true,
+                            singleLine = true,
+                        )
+                    }
+
+                    // Lyrics section - side by side
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.End,
-                        verticalAlignment = Alignment.CenterVertically
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        TextButton(
-                            shape = RoundedCornerShape(6.dp),
-                            onClick = onDismiss,
-                            modifier = Modifier.padding(end = 8.dp)
-                        ) {
-                            Text(stringResource(Res.string.cancel))
-                        }
+                        Text(
+                            text = stringResource(Res.string.lyrics),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.weight(1f).padding(bottom = 4.dp)
+                        )
+                        Text(
+                            text = stringResource(Res.string.secondary_lyrics),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.weight(1f).padding(bottom = 4.dp)
+                        )
+                    }
+                } // end top fields (scrollable if window is shrunk)
 
-                        Button(
-                            shape = RoundedCornerShape(6.dp),
-                            enabled = !isDuplicate && (!isNewSong || (editedSongbook.isNotBlank() && editedTitle.isNotBlank())),
-                            onClick = {
-                                val updatedSong = SongItem(
-                                    number = editedNumber,
-                                    title = editedTitle,
-                                    songbook = editedSongbook,
-                                    tune = editedTune,
-                                    author = editedAuthor,
-                                    composer = editedComposer,
-                                    lyrics = editedLyrics.split("\n"),
-                                    secondaryTitle = editedSecondaryTitle,
-                                    secondaryLyrics = editedSecondaryLyrics.split("\n").let {
-                                        if (it.all { line -> line.isBlank() || line.trim().startsWith("[") }) emptyList() else it
-                                    },
-                                    sourceFile = song.sourceFile,
-                                    ccliNumber = editedCcli
-                                )
-                                onSave(updatedSong)
-                            },
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.primary
+                // Lyrics fields fill the rest of the available height
+                Row(
+                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    LyricsTextField(
+                        value = editedLyrics,
+                        onValueChange = { newLyrics ->
+                            editedLyrics = newLyrics
+                            // Auto-fill title from first non-header, non-blank lyric line
+                            if (isNewSong && !titleManuallyEdited) {
+                                val firstContentLine = newLyrics.lines().firstOrNull { line ->
+                                    val trimmed = line.trim()
+                                    trimmed.isNotBlank() && !trimmed.startsWith("[")
+                                }?.trim() ?: ""
+                                editedTitle = firstContentLine
+                            }
+                        },
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        placeholder = { Text(stringResource(Res.string.enter_lyrics_here)) },
+                        visualTransformation = lyricsHighlightTransformation
+                    )
+                    LyricsTextField(
+                        value = editedSecondaryLyrics,
+                        onValueChange = { editedSecondaryLyrics = it },
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
+                        placeholder = { Text(stringResource(Res.string.enter_secondary_lyrics_here)) },
+                        visualTransformation = lyricsHighlightTransformation
+                    )
+                }
+
+                // Help text
+                Text(
+                    text = stringResource(Res.string.lyrics_format_help),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+                }
+
+                // Action buttons
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TextButton(
+                        shape = RoundedCornerShape(6.dp),
+                        onClick = onDismiss,
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Text(stringResource(Res.string.cancel))
+                    }
+
+                    Button(
+                        shape = RoundedCornerShape(6.dp),
+                        enabled = !isDuplicate && (!isNewSong || (editedSongbook.isNotBlank() && editedTitle.isNotBlank())),
+                        onClick = {
+                            val updatedSong = SongItem(
+                                number = editedNumber,
+                                title = editedTitle,
+                                songbook = editedSongbook,
+                                tune = editedTune,
+                                author = editedAuthor,
+                                composer = editedComposer,
+                                lyrics = editedLyrics.split("\n"),
+                                secondaryTitle = editedSecondaryTitle,
+                                secondaryLyrics = editedSecondaryLyrics.split("\n").let {
+                                    if (it.all { line -> line.isBlank() || line.trim().startsWith("[") }) emptyList() else it
+                                },
+                                sourceFile = song.sourceFile,
+                                ccliNumber = editedCcli
                             )
-                        ) {
-                            Text(stringResource(Res.string.save))
-                        }
+                            onSave(updatedSong)
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.primary
+                        )
+                    ) {
+                        Text(stringResource(Res.string.save))
                     }
                 }
             }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/EditSongContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/EditSongContentTest.kt
@@ -1,0 +1,370 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.SongItem
+import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The song editor's rules: what it puts in the fields when it opens, when it will let a song be
+ * saved, and what it hands back when it is.
+ *
+ * A song saved wrong is wrong in the library from then on, so the assertions here are mostly about
+ * the `SongItem` that comes out of Save rather than about the fields looking right. Three things the
+ * editor *derives* rather than passes through get a test each: the digits-only song number, the
+ * title auto-filled from the lyrics of a brand-new song, and the secondary lyrics discarded when
+ * they are nothing but section headers.
+ *
+ * `EditSongDialog` opens a `DialogWindow`, which cannot be composed headless, so the window's body
+ * was lifted into `EditSongContent` — an extraction, no logic moved or changed — and that is what
+ * these drive. The `Window` call and its sizing are what remain uncovered.
+ *
+ * Fields carry their captions as separate nodes rather than in their own semantics, so they are
+ * addressed by ordinal. `the editor lays its fields out in a known order` pins those ordinals, so a
+ * reordering fails loudly there instead of quietly changing what every other test types into.
+ */
+class EditSongContentTest {
+
+    /**
+     * Ordinals among the editor's text inputs, in composition order.
+     *
+     * The songbook is absent on purpose: it is a read-only dropdown anchor rather than a typed field,
+     * so it publishes no set-text action and is reached through [songbook] instead.
+     */
+    private object Field {
+        const val NUMBER = 0
+        const val TUNE = 1
+        const val TITLE = 2
+        const val SECONDARY_TITLE = 3
+        const val AUTHOR = 4
+        const val COMPOSER = 5
+        const val CCLI = 6
+        const val LYRICS = 7
+        const val SECONDARY_LYRICS = 8
+        const val COUNT = 9
+    }
+
+    private object Label {
+        const val SAVE = "Save"
+        const val CANCEL = "Cancel"
+        const val ADD_NEW = "Add New..."
+    }
+
+    /**
+     * The songbook control: the one field carrying a value that refuses typed text, because it is a
+     * dropdown anchor. Matching on that pair reaches it without depending on where it sits.
+     */
+    private val readOnlyField = SemanticsMatcher("a field with a value but no set-text action") {
+        it.config.getOrNull(SemanticsProperties.EditableText) != null &&
+            it.config.getOrNull(SemanticsActions.SetText) == null
+    }
+
+    private class Saved {
+        var song: SongItem? = null
+        var dismissed = 0
+    }
+
+    private fun aSong(
+        number: String = "42",
+        title: String = "Amazing Grace",
+        songbook: String = "Hymnal",
+        lyrics: List<String> = listOf("[Verse 1]", "Amazing grace how sweet the sound"),
+        secondaryLyrics: List<String> = emptyList(),
+        sourceFile: String = "/songs/hymnal/42.sps",
+    ) = SongItem(
+        number = number,
+        title = title,
+        songbook = songbook,
+        lyrics = lyrics,
+        secondaryLyrics = secondaryLyrics,
+        sourceFile = sourceFile,
+    )
+
+    /** A song with nothing filled in, as the New Song command hands one over. */
+    private fun blankSong() = aSong(number = "", title = "", songbook = "", lyrics = emptyList(), sourceFile = "")
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun editor(
+        song: SongItem = aSong(),
+        existingSongs: List<SongItem> = emptyList(),
+        isNewSong: Boolean = false,
+        songbooks: List<String> = emptyList(),
+        block: ComposeUiTest.(Saved) -> Unit,
+    ) {
+        val saved = Saved()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    EditSongContent(
+                        song = song,
+                        songbooks = songbooks,
+                        existingSongs = existingSongs,
+                        isNewSong = isNewSong,
+                        theme = ThemeMode.LIGHT,
+                        onDismiss = { saved.dismissed++ },
+                        onSave = { saved.song = it },
+                    )
+                }
+            }
+            block(saved)
+        }
+    }
+
+    private fun ComposeUiTest.field(ordinal: Int): SemanticsNodeInteraction =
+        onAllNodes(hasSetTextAction())[ordinal]
+
+    private fun ComposeUiTest.fieldCount(): Int =
+        onAllNodes(hasSetTextAction()).fetchSemanticsNodes(atLeastOneRootRequired = false).size
+
+    private fun ComposeUiTest.songbook(): SemanticsNodeInteraction = onNode(readOnlyField)
+
+    private fun ComposeUiTest.type(ordinal: Int, text: String) {
+        field(ordinal).performTextReplacement(text)
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.tap(text: String) {
+        onNodeWithText(text).performClick()
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.save() = tap(Label.SAVE)
+
+    // ── Structure ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the editor lays its fields out in a known order`() = editor { _ ->
+        assertEquals(
+            Field.COUNT,
+            fieldCount(),
+            "the editor offers nine typed fields; the other tests address them by position",
+        )
+        field(Field.NUMBER).assertTextContains("42")
+        field(Field.TITLE).assertTextContains("Amazing Grace")
+        songbook().assertTextContains("Hymnal")
+    }
+
+    // ── What it opens with ──────────────────────────────────────────────────────
+
+    @Test
+    fun `a song number carrying punctuation is reduced to its digits`() =
+        editor(aSong(number = "3.1")) { saved ->
+            // The library keys on the number, so "3.1" has to become a number, not stay a label.
+            field(Field.NUMBER).assertTextContains("31")
+            save()
+            assertEquals("31", saved.song?.number, "every non-digit is dropped, the digits kept in order")
+        }
+
+    // ── Saving ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `saving hands back every edited field`() = editor { saved ->
+        type(Field.TITLE, "Be Thou My Vision")
+        type(Field.AUTHOR, "Dallan Forgaill")
+        type(Field.COMPOSER, "Traditional Irish")
+        type(Field.CCLI, "30639")
+        type(Field.TUNE, "SLANE")
+        type(Field.SECONDARY_TITLE, "Sei Du mein Ziel")
+        save()
+
+        val song = saved.song
+        assertEquals("Be Thou My Vision", song?.title)
+        assertEquals("Dallan Forgaill", song?.author)
+        assertEquals("Traditional Irish", song?.composer)
+        assertEquals("30639", song?.ccliNumber)
+        assertEquals("SLANE", song?.tune)
+        assertEquals("Sei Du mein Ziel", song?.secondaryTitle)
+    }
+
+    @Test
+    fun `lyrics are saved as one entry per line`() = editor { saved ->
+        type(Field.LYRICS, "[Verse 1]\nAmazing grace\nhow sweet the sound")
+        save()
+        assertEquals(
+            listOf("[Verse 1]", "Amazing grace", "how sweet the sound"),
+            saved.song?.lyrics,
+            "each line becomes its own entry, section headers included",
+        )
+    }
+
+    @Test
+    fun `the song's file on disk is carried through untouched`() =
+        editor(aSong(sourceFile = "/songs/hymnal/42.sps")) { saved ->
+            type(Field.TITLE, "Renamed Entirely")
+            save()
+            assertEquals(
+                "/songs/hymnal/42.sps",
+                saved.song?.sourceFile,
+                "an edit rewrites the song in place, so it must not lose track of which file that is",
+            )
+        }
+
+    @Test
+    fun `secondary lyrics that are only section headers are discarded`() = editor { saved ->
+        // A second language left with nothing but the structure copied over is not a translation.
+        type(Field.SECONDARY_LYRICS, "[Verse 1]\n\n[Chorus]\n  ")
+        save()
+        assertEquals(
+            emptyList(),
+            saved.song?.secondaryLyrics,
+            "headers and blank lines alone must not be stored as a second language",
+        )
+    }
+
+    @Test
+    fun `secondary lyrics with real content are kept`() = editor { saved ->
+        type(Field.SECONDARY_LYRICS, "[Verse 1]\nO Gnade Gottes")
+        save()
+        assertEquals(
+            listOf("[Verse 1]", "O Gnade Gottes"),
+            saved.song?.secondaryLyrics,
+            "one line of actual text makes the whole thing a translation worth keeping",
+        )
+    }
+
+    // ── Refusing to save ────────────────────────────────────────────────────────
+
+    @Test
+    fun `a song duplicating another's number, title and songbook cannot be saved`() {
+        val existing = aSong(sourceFile = "/a.sps")
+        editor(song = aSong(sourceFile = "/b.sps"), existingSongs = listOf(existing)) { _ ->
+            onNodeWithText(Label.SAVE).assertIsNotEnabled()
+        }
+    }
+
+    @Test
+    fun `a song does not count as a duplicate of itself`() {
+        val self = aSong(sourceFile = "/a.sps")
+        editor(song = self, existingSongs = listOf(self)) { _ ->
+            // Editing a song already in the library must not lock its own Save button.
+            onNodeWithText(Label.SAVE).assertIsEnabled()
+        }
+    }
+
+    @Test
+    fun `the duplicate check ignores case in the title and songbook`() {
+        val existing = aSong(title = "amazing grace", songbook = "hymnal", sourceFile = "/a.sps")
+        editor(song = aSong(sourceFile = "/b.sps"), existingSongs = listOf(existing)) { _ ->
+            onNodeWithText(Label.SAVE).assertIsNotEnabled()
+        }
+    }
+
+    @Test
+    fun `a different number is not a duplicate`() {
+        val existing = aSong(number = "42", sourceFile = "/a.sps")
+        editor(song = aSong(number = "43", sourceFile = "/b.sps"), existingSongs = listOf(existing)) { _ ->
+            onNodeWithText(Label.SAVE).assertIsEnabled()
+        }
+    }
+
+    @Test
+    fun `a new song cannot be saved until it has both a title and a songbook`() =
+        editor(song = blankSong(), isNewSong = true) { _ ->
+            onNodeWithText(Label.SAVE).assertIsNotEnabled()
+        }
+
+    @Test
+    fun `a new song with a title but no songbook still cannot be saved`() =
+        editor(song = blankSong(), isNewSong = true) { _ ->
+            type(Field.TITLE, "Something New")
+            onNodeWithText(Label.SAVE).assertIsNotEnabled()
+        }
+
+    @Test
+    fun `an existing song is saveable as it stands`() = editor { _ ->
+        onNodeWithText(Label.SAVE).assertIsEnabled()
+    }
+
+    // ── The title a new song gets for free ──────────────────────────────────────
+
+    @Test
+    fun `a new song takes its title from the first real line of the lyrics`() =
+        editor(song = blankSong(), isNewSong = true) { _ ->
+            type(Field.LYRICS, "[Verse 1]\nAmazing grace how sweet the sound")
+            field(Field.TITLE).assertTextContains("Amazing grace how sweet the sound")
+        }
+
+    @Test
+    fun `section headers and blank lines are skipped when guessing the title`() =
+        editor(song = blankSong(), isNewSong = true) { _ ->
+            type(Field.LYRICS, "\n[Chorus]\n\n  Be thou my vision  \nO Lord of my heart")
+            field(Field.TITLE).assertTextContains("Be thou my vision")
+        }
+
+    @Test
+    fun `a title typed by hand is not overwritten by later lyric edits`() =
+        editor(song = blankSong(), isNewSong = true) { _ ->
+            type(Field.TITLE, "My Own Title")
+            type(Field.LYRICS, "[Verse 1]\nSome first line entirely unlike it")
+            field(Field.TITLE).assertTextContains("My Own Title")
+        }
+
+    @Test
+    fun `an existing song's title is never guessed over`() = editor(aSong(title = "Amazing Grace")) { _ ->
+        type(Field.LYRICS, "[Verse 1]\nA completely different first line")
+        field(Field.TITLE).assertTextContains("Amazing Grace")
+    }
+
+    // ── Choosing a songbook ─────────────────────────────────────────────────────
+
+    @Test
+    fun `the songbook is picked from those already in the library`() =
+        editor(song = blankSong(), isNewSong = true, songbooks = listOf("Hymnal", "Chorus Book")) { saved ->
+            type(Field.TITLE, "Something New")
+            onNodeWithText(Label.SAVE).assertIsNotEnabled()
+
+            songbook().performClick()
+            waitForIdle()
+            tap("Chorus Book")
+
+            songbook().assertTextContains("Chorus Book")
+            onNodeWithText(Label.SAVE).assertIsEnabled()
+            save()
+            assertEquals("Chorus Book", saved.song?.songbook, "the songbook chosen must be the one saved")
+        }
+
+    @Test
+    fun `a songbook the library does not have yet can be typed in instead`() =
+        editor(song = blankSong(), isNewSong = true, songbooks = listOf("Hymnal")) { saved ->
+            type(Field.TITLE, "Something New")
+
+            songbook().performClick()
+            waitForIdle()
+            tap(Label.ADD_NEW)
+
+            // Add New turns the picker into a tenth, typeable field.
+            assertEquals(Field.COUNT + 1, fieldCount(), "the songbook becomes a typed field")
+            type(Field.NUMBER + 1, "Youth Songbook")
+            save()
+            assertEquals("Youth Songbook", saved.song?.songbook)
+        }
+
+    // ── Leaving ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Cancel closes without saving`() = editor { saved ->
+        type(Field.TITLE, "Edited But Abandoned")
+        tap(Label.CANCEL)
+        assertEquals(1, saved.dismissed)
+        assertNull(saved.song, "an abandoned edit must not reach the library")
+    }
+}


### PR DESCRIPTION
Third of the `dialogs/` push, after #48 and #49. Independent of both (different file).

## Approach

Same as #49, which proved out best: `EditSongDialog` opens a `DialogWindow` that cannot be composed headless, so its body is lifted into an `internal EditSongContent` and the window is left holding a single call. Structural only — `git diff -w` shows the body moved, not changed; the body's `@OptIn(ExperimentalMaterial3Api::class)` travels with it.

## Tests — `EditSongContentTest` (21)

Aimed at the `SongItem` that comes out of Save, since a song saved wrong stays wrong in the library. The three things the editor **derives** rather than passes through get a test each:

- **the song number reduced to its digits** — `"3.1"` becomes `"31"`, because the library keys on it
- **a new song's title guessed from the lyrics** — first line that is neither blank nor a section header; never guessed over a title typed by hand, and never over an existing song's title
- **secondary lyrics discarded when they are only headers and blank lines**, kept as soon as one real line appears — a second language with nothing but the structure copied over is not a translation

Plus the duplicate rule from all four sides: number + title + songbook blocks Save, case-insensitively; a song is **not** a duplicate of itself (matched on `sourceFile`); a different number is not a duplicate. And the new-song gate: no Save until both title and songbook are set.

## One thing worth knowing

The songbook turned out **not to be a typed field at all** — it is always a read-only `ExposedDropdownMenuBox` anchor, and `songbooks` only fills its menu. I had assumed otherwise and my first pass mis-numbered every field after it. It is now reached by matching the one field that carries a value yet publishes no set-text action, and both of its paths are driven: picking an existing songbook, and **Add New** turning it into a genuinely typed field.

That is also why `the editor lays its fields out in a known order` exists — it pins the nine ordinals so a reordering fails loudly in one place rather than quietly changing what every other test types into.

## Coverage

| | before | after |
|---|---|---|
| `EditSongDialog.kt` | 0% | **90.3%** (297/329) |
| `dialogs` package | 15.4% | 20.2% |

Deterministic 3×. 0.74s for 21 tests, slowest 0.11s.

## Uncovered

The `DialogWindow` call and its sizing.

## Note on what I skipped

`PlanningCenterImportDialog` (524 lines) was next by size, but I passed on it: its two windows wrap an OAuth flow (`Desktop.browse`, a local callback server, token exchange) and a network-backed ViewModel. Most of it is genuinely unreachable rather than merely window-wrapped, so the return is poor. `QARemoteDialog`, `StatisticsDialog` and `UpdateAvailableDialog` are the better next targets — all plain data and callbacks.