### PR TITLE
Test the statistics window

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/StatisticsDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/StatisticsDialog.kt
@@ -91,17 +91,7 @@ fun StatisticsDialog(
     if (!isVisible) return
 
     val mainWindowState = LocalMainWindowState.current
-    val coroutineScope = rememberCoroutineScope()
-
-    var topSongsBySongbook by remember { mutableStateOf(statisticsManager.getTopSongsBySongbook()) }
-    var topVersesByBible by remember { mutableStateOf(statisticsManager.getTopVersesByBible()) }
-    var statusMessage by remember { mutableStateOf<String?>(null) }
     var showCCLIReport by remember { mutableStateOf(false) }
-
-    val successMsg = stringResource(Res.string.statistics_exported_success)
-    val errorMsg = stringResource(Res.string.statistics_exported_error)
-    val saveTitle = stringResource(Res.string.file_chooser_save_statistics)
-    val filterDesc = stringResource(Res.string.file_filter_xls)
 
     if (showCCLIReport) {
         CCLIReportDialog(
@@ -122,93 +112,128 @@ fun StatisticsDialog(
         title = stringResource(Res.string.statistics),
         resizable = true
     ) {
-        AppThemeWrapper(theme = theme) {
-            Surface(
-                modifier = Modifier.fillMaxSize(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Column(modifier = Modifier.fillMaxSize()) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxWidth()
-                            .background(MaterialTheme.colorScheme.surfaceVariant)
-                            .padding(8.dp)
-                    ) {
-                        val scrollState = rememberScrollState()
-                        Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .verticalScroll(scrollState)
-                                .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(8.dp))
-                                .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
-                                .padding(start = 16.dp, end = 20.dp, top = 14.dp, bottom = 16.dp),
-                            verticalArrangement = Arrangement.spacedBy(18.dp)
-                        ) {
-                            CcliBanner(onOpen = { showCCLIReport = true })
-                            TopSongsSection(topSongsBySongbook)
-                            TopVersesSection(topVersesByBible)
-                        }
-                        VerticalScrollbar(
-                            modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
-                            adapter = rememberScrollbarAdapter(scrollState)
-                        )
-                    }
+        StatisticsContent(
+            theme = theme,
+            statisticsManager = statisticsManager,
+            onOpenCcliReport = { showCCLIReport = true },
+            onDismiss = onDismiss
+        )
+    }
+}
 
-                    if (statusMessage != null) {
-                        Text(
-                            text = statusMessage!!,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = if (statusMessage == successMsg) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
-                            modifier = Modifier.padding(horizontal = 16.dp)
-                        )
-                    }
+/**
+ * Everything the statistics window contains: the CCLI callout, the two ranked sections, and the
+ * export / clear / close row beneath them.
+ *
+ * Held apart from [StatisticsDialog] because that function's remaining statements are the two
+ * windows it can open — its own `DialogWindow` and the nested CCLI report — neither of which can
+ * be composed on a headless machine. Opening the report stays outside as [onOpenCcliReport], so
+ * pressing the callout is reachable from a test without a window being opened by it.
+ */
+@Composable
+internal fun StatisticsContent(
+    theme: ThemeMode,
+    statisticsManager: StatisticsManager,
+    onOpenCcliReport: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val coroutineScope = rememberCoroutineScope()
 
-                    HorizontalDivider()
-                    Row(
+    var topSongsBySongbook by remember { mutableStateOf(statisticsManager.getTopSongsBySongbook()) }
+    var topVersesByBible by remember { mutableStateOf(statisticsManager.getTopVersesByBible()) }
+    var statusMessage by remember { mutableStateOf<String?>(null) }
+
+    val successMsg = stringResource(Res.string.statistics_exported_success)
+    val errorMsg = stringResource(Res.string.statistics_exported_error)
+    val saveTitle = stringResource(Res.string.file_chooser_save_statistics)
+    val filterDesc = stringResource(Res.string.file_filter_xls)
+
+    AppThemeWrapper(theme = theme) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .padding(8.dp)
+                ) {
+                    val scrollState = rememberScrollState()
+                    Column(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .background(MaterialTheme.colorScheme.surface)
-                            .padding(12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically
+                            .fillMaxSize()
+                            .verticalScroll(scrollState)
+                            .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(8.dp))
+                            .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.5f), RoundedCornerShape(8.dp))
+                            .padding(start = 16.dp, end = 20.dp, top = 14.dp, bottom = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(18.dp)
                     ) {
-                        OutlinedButton(
-                            shape = RoundedCornerShape(6.dp),
-                            onClick = {
-                                coroutineScope.launch {
-                                    val path = FileChooser.platformInstance.save(
-                                        location = null,
-                                        suggestedName = "statistics.xls",
-                                        filters = listOf(FileNameExtensionFilter(filterDesc, "xls")),
-                                        title = saveTitle
-                                    )
-                                    if (path != null) {
-                                        val ok = withContext(Dispatchers.IO) { statisticsManager.exportStatisticsToXls(path.toFile()) }
-                                        statusMessage = if (ok) successMsg else errorMsg
-                                    }
+                        CcliBanner(onOpen = onOpenCcliReport)
+                        TopSongsSection(topSongsBySongbook)
+                        TopVersesSection(topVersesByBible)
+                    }
+                    VerticalScrollbar(
+                        modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+                        adapter = rememberScrollbarAdapter(scrollState)
+                    )
+                }
+
+                if (statusMessage != null) {
+                    Text(
+                        text = statusMessage!!,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (statusMessage == successMsg) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+
+                HorizontalDivider()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surface)
+                        .padding(12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedButton(
+                        shape = RoundedCornerShape(6.dp),
+                        onClick = {
+                            coroutineScope.launch {
+                                val path = FileChooser.platformInstance.save(
+                                    location = null,
+                                    suggestedName = "statistics.xls",
+                                    filters = listOf(FileNameExtensionFilter(filterDesc, "xls")),
+                                    title = saveTitle
+                                )
+                                if (path != null) {
+                                    val ok = withContext(Dispatchers.IO) { statisticsManager.exportStatisticsToXls(path.toFile()) }
+                                    statusMessage = if (ok) successMsg else errorMsg
                                 }
                             }
-                        ) { Text(stringResource(Res.string.export_to_xls)) }
+                        }
+                    ) { Text(stringResource(Res.string.export_to_xls)) }
 
-                        Button(
-                            shape = RoundedCornerShape(6.dp),
-                            onClick = {
-                                statisticsManager.clearStatistics()
-                                topSongsBySongbook = statisticsManager.getTopSongsBySongbook()
-                                topVersesByBible = statisticsManager.getTopVersesByBible()
-                                statusMessage = null
-                            },
-                            colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.error,
-                                contentColor = MaterialTheme.colorScheme.onError
-                            )
-                        ) { Text(stringResource(Res.string.clear_statistics)) }
+                    Button(
+                        shape = RoundedCornerShape(6.dp),
+                        onClick = {
+                            statisticsManager.clearStatistics()
+                            topSongsBySongbook = statisticsManager.getTopSongsBySongbook()
+                            topVersesByBible = statisticsManager.getTopVersesByBible()
+                            statusMessage = null
+                        },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                            contentColor = MaterialTheme.colorScheme.onError
+                        )
+                    ) { Text(stringResource(Res.string.clear_statistics)) }
 
-                        Spacer(modifier = Modifier.weight(1f))
+                    Spacer(modifier = Modifier.weight(1f))
 
-                        Button(shape = RoundedCornerShape(6.dp), onClick = onDismiss) { Text(stringResource(Res.string.close)) }
-                    }
+                    Button(shape = RoundedCornerShape(6.dp), onClick = onDismiss) { Text(stringResource(Res.string.close)) }
                 }
             }
         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/StatisticsContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/StatisticsContentTest.kt
@@ -1,0 +1,207 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.StatisticsManager
+import org.churchpresenter.app.churchpresenter.dialogs.tabs.playSong
+import org.churchpresenter.app.churchpresenter.dialogs.tabs.playVerse
+import org.churchpresenter.app.churchpresenter.dialogs.tabs.withStatsHome
+import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The statistics window: the two ranked sections, the CCLI callout above them, and the row of
+ * actions beneath.
+ *
+ * `StatisticsDialog` can open two windows — its own `DialogWindow` and the nested CCLI report —
+ * neither composable headless, so the body was lifted into `StatisticsContent` with the report kept
+ * outside as a callback. That is what makes pressing the callout testable at all: it reports out
+ * instead of opening anything.
+ *
+ * `StatisticsManager` resolves `user.home` in its field initialisers, so every test builds one inside
+ * an isolated home ([withStatsHome]) and seeds it through the public recording API. Without that,
+ * `Clear Statistics` here would wipe the developer's real play history.
+ *
+ * Left uncovered: both `DialogWindow` calls, and Export to XLS, which opens a native save dialog —
+ * asserted present, never pressed.
+ */
+class StatisticsContentTest {
+
+    private object Label {
+        const val TOP_SONGS = "Top Songs"
+        const val TOP_VERSES = "Top Verses"
+        const val CLEAR = "Clear Statistics"
+        const val EXPORT = "Export to XLS"
+        const val CLOSE = "Close"
+        const val CCLI_REPORT = "CCLI Report"
+    }
+
+    private class Actions {
+        var openedReport = 0
+        var dismissed = 0
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun statistics(
+        seed: StatisticsManager.() -> Unit = {},
+        block: ComposeUiTest.(stats: StatisticsManager, actions: Actions) -> Unit,
+    ) = withStatsHome {
+        val stats = StatisticsManager().apply(seed)
+        val actions = Actions()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    StatisticsContent(
+                        theme = ThemeMode.LIGHT,
+                        statisticsManager = stats,
+                        onOpenCcliReport = { actions.openedReport++ },
+                        onDismiss = { actions.dismissed++ },
+                    )
+                }
+            }
+            block(stats, actions)
+        }
+    }
+
+    private fun ComposeUiTest.countOf(text: String): Int =
+        onAllNodes(hasText(text)).fetchSemanticsNodes(atLeastOneRootRequired = false).size
+
+    /** The song rows, top to bottom — every line naming a song number. */
+    private fun ComposeUiTest.songRows(): List<String> =
+        onAllNodes(hasText("#", substring = true))
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .sortedBy { it.boundsInRoot.top }
+            .mapNotNull { node ->
+                node.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { it.text }
+            }
+
+    // ── With nothing recorded ───────────────────────────────────────────────────
+
+    @Test
+    fun `both sections are still headed when nothing has been presented`() = statistics { _, _ ->
+        onNodeWithText(Label.TOP_SONGS).assertIsDisplayed()
+        onNodeWithText(Label.TOP_VERSES).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the CCLI callout is offered even with no statistics`() = statistics { _, _ ->
+        assertTrue(countOf(Label.CCLI_REPORT) >= 1, "the callout names the report it opens")
+    }
+
+    // ── Ranked songs ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `songs are listed with their number, title and play count`() =
+        statistics({ playSong(number = 12, title = "Amazing Grace", songbook = "Hymnal", times = 4) }) { _, _ ->
+            onNodeWithText("#12 Amazing Grace").assertIsDisplayed()
+            assertTrue(countOf("4") >= 1, "the play count belongs on the row")
+        }
+
+    @Test
+    fun `the most-played song is ranked first however it was recorded`() =
+        statistics({
+            playSong(number = 1, title = "Sung Once", songbook = "Hymnal", times = 1)
+            playSong(number = 2, title = "Sung Often", songbook = "Hymnal", times = 9)
+            playSong(number = 3, title = "Sung Twice", songbook = "Hymnal", times = 2)
+        }) { _, _ ->
+            assertEquals(
+                listOf("#2 Sung Often", "#3 Sung Twice", "#1 Sung Once"),
+                songRows(),
+                "rank follows the play count, not the song number or the order recorded",
+            )
+        }
+
+    @Test
+    fun `each songbook is counted on its own`() =
+        statistics({
+            playSong(number = 1, title = "From The Hymnal", songbook = "Hymnal", times = 5)
+            playSong(number = 1, title = "From The Chorus Book", songbook = "Chorus Book", times = 9)
+        }) { _, _ ->
+            // One songbook is shown at a time, chosen from a picker — not both lists at once.
+            assertEquals(
+                1,
+                countOf("#1 From The Hymnal") + countOf("#1 From The Chorus Book"),
+                "exactly one songbook's songs are listed at a time",
+            )
+        }
+
+    // ── Ranked verses ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `verses are listed by reference`() =
+        statistics({ playVerse(bible = "KJV", book = "John", chapter = 3, verse = 16, times = 3) }) { _, _ ->
+            assertTrue(
+                countOf("John 3:16") >= 1,
+                "the verse must be named by its reference; showed nothing matching",
+            )
+        }
+
+    @Test
+    fun `songs and verses are ranked independently of one another`() =
+        statistics({
+            playSong(number = 1, title = "A Song", songbook = "Hymnal", times = 2)
+            playVerse(bible = "KJV", book = "John", chapter = 3, verse = 16, times = 7)
+        }) { _, _ ->
+            onNodeWithText("#1 A Song").assertIsDisplayed()
+            assertTrue(countOf("John 3:16") >= 1, "both sections fill from their own recordings")
+        }
+
+    // ── The actions beneath ─────────────────────────────────────────────────────
+
+    @Test
+    fun `pressing the callout asks for the CCLI report rather than opening it here`() =
+        statistics { _, actions ->
+            onAllNodes(hasText(Label.CCLI_REPORT))[1].performClick()
+            waitForIdle()
+            assertEquals(1, actions.openedReport, "the button reports out; the window is the caller's to open")
+        }
+
+    @Test
+    fun `clearing the statistics empties the manager and the sections with it`() =
+        statistics({ playSong(number = 12, title = "Amazing Grace", songbook = "Hymnal", times = 4) }) { stats, _ ->
+            onNodeWithText("#12 Amazing Grace").assertIsDisplayed()
+
+            onNodeWithText(Label.CLEAR).performClick()
+            waitForIdle()
+
+            assertEquals(0, countOf("#12 Amazing Grace"), "the row must go, not merely the stored count")
+            assertTrue(
+                stats.getTopSongsBySongbook().isEmpty(),
+                "and the manager itself must be empty, so it stays cleared once reopened",
+            )
+        }
+
+    @Test
+    fun `clearing with nothing recorded is harmless`() = statistics { stats, _ ->
+        onNodeWithText(Label.CLEAR).performClick()
+        waitForIdle()
+        assertTrue(stats.getTopSongsBySongbook().isEmpty())
+        onNodeWithText(Label.TOP_SONGS).assertIsDisplayed()
+    }
+
+    @Test
+    fun `Close reports the dialog should shut`() = statistics { _, actions ->
+        onNodeWithText(Label.CLOSE).performClick()
+        waitForIdle()
+        assertEquals(1, actions.dismissed)
+    }
+
+    @Test
+    fun `the export button is offered`() =
+        statistics({ playSong(number = 1, title = "A Song", songbook = "Hymnal") }) { _, _ ->
+            // Never pressed: it opens a native save dialog.
+            onNodeWithText(Label.EXPORT).assertIsDisplayed()
+        }
+}


### PR DESCRIPTION
Fourth of the `dialogs/` push, after #48, #49 and #50. Independent of all of them (different file).

## Approach

Same lift as #49 and #50, with one difference worth calling out.

`StatisticsDialog` can open **two** windows: its own `DialogWindow` and a nested `CCLIReportDialog`. The body moves into an `internal StatisticsContent`, but the nested report deliberately stays *outside* as an `onOpenCcliReport` callback rather than travelling with it. That is what makes the CCLI callout pressable in a test at all — it reports out instead of opening a window. Had I moved it with the body, clicking the callout would have thrown `HeadlessException`.

Structural only; `git diff -w` shows the body moved, not changed.

## Tests — `StatisticsContentTest` (12)

- both sections stay headed when nothing has been presented
- songs listed as `#<number> <title>` with their play count
- **ranking follows the play count**, not the song number or the order recorded — asserted on the full ordered list of rows, read top to bottom
- one songbook is shown at a time, so the test asserts exactly *one* of two songbooks' rows is on screen rather than both
- verses rank from their own recordings, independently of songs
- the callout reports out rather than opening anything
- **Clear** is checked on both halves of what it does: the rows leave the screen *and* the manager is emptied, so it stays cleared when reopened — plus doing no harm when there is nothing to clear

`StatisticsManager` reads `user.home` in its field initialisers, so every test builds one inside an isolated home via the existing `withStatsHome`. Without that the Clear test would wipe the developer's real play history.

Deterministic 3×. 0.24s for 12 tests, slowest 0.036s.

## Coverage

| | before | after |
|---|---|---|
| `StatisticsDialog.kt` | 0% | **82.9%** (243/293) |
| `dialogs` package | 20.2% | **30.0%** |
| overall | 44.7% | 45.8% |

## Uncovered

Both `DialogWindow` calls, and Export to XLS — it opens a native save dialog, so it is asserted present and never pressed. That accounts for most of the gap to the ~90% the previous two reached.