### PR TITLE
Test the Q&A remote window's derived addresses

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/QARemoteDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/QARemoteDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -127,7 +128,6 @@ fun QARemoteDialog(
     val availableFonts = remember {
         GraphicsEnvironment.getLocalGraphicsEnvironment().availableFontFamilyNames.toList()
     }
-    val strQrMessageDefault = stringResource(Res.string.qa_qr_message_default)
     val mainWindowState = LocalMainWindowState.current
     val dialogWidth = 760.dp
     val dialogHeight = 700.dp
@@ -139,10 +139,6 @@ fun QARemoteDialog(
         width = dialogWidth,
         height = dialogHeight
     )
-    val copyText: (String) -> Unit = { text ->
-        java.awt.Toolkit.getDefaultToolkit().systemClipboard
-            .setContents(java.awt.datatransfer.StringSelection(text), null)
-    }
 
     // Grow the window (never shrink) when content overflows the current viewport, instead of
     // relying on a single guessed-at fixed height — the scroll stays as a fallback beyond the cap.
@@ -156,6 +152,68 @@ fun QARemoteDialog(
         }
     }
 
+    DialogWindow(
+        onCloseRequest = onDismiss,
+        state = dialogState,
+        title = stringResource(Res.string.qa_remote_dialog_title),
+        resizable = false
+    ) {
+        QARemoteContent(
+            serverUrl = serverUrl,
+            qaDisplayUrl = qaDisplayUrl,
+            onQaDisplayUrlChanged = onQaDisplayUrlChanged,
+            apiKeyEnabled = apiKeyEnabled,
+            apiKey = apiKey,
+            tunnelStatus = tunnelStatus,
+            tunnelUrl = tunnelUrl,
+            onStartTunnel = onStartTunnel,
+            onStopTunnel = onStopTunnel,
+            qaSettings = qaSettings,
+            onSettingsChange = onSettingsChange,
+            availableFonts = availableFonts,
+            scrollState = scrollState,
+            copyText = { text ->
+                java.awt.Toolkit.getDefaultToolkit().systemClipboard
+                    .setContents(java.awt.datatransfer.StringSelection(text), null)
+            },
+            onDismiss = onDismiss
+        )
+    }
+}
+
+/**
+ * Everything the Q&A remote window contains: the two share panels with their QR codes, the tunnel
+ * controls, the display settings, and the addresses it derives for each.
+ *
+ * Held apart from [QARemoteDialog] because that function's remaining work is the `DialogWindow` it
+ * opens and the grow-to-fit effect sizing it, neither of which can run on a headless machine.
+ *
+ * Three things are taken as parameters rather than reached for here, because each is a piece of the
+ * machine rather than of the dialog: [availableFonts] comes from `GraphicsEnvironment`,
+ * [copyText] writes the system clipboard, and [scrollState] is shared with the sizing effect above.
+ * Passing them in is what lets a test press Copy and see *which* address was handed over — the
+ * point of the URL-building rules below.
+ */
+@Composable
+internal fun QARemoteContent(
+    serverUrl: String,
+    qaDisplayUrl: String,
+    onQaDisplayUrlChanged: (String) -> Unit,
+    apiKeyEnabled: Boolean,
+    apiKey: String,
+    tunnelStatus: TunnelStatus,
+    tunnelUrl: String,
+    onStartTunnel: () -> Unit,
+    onStopTunnel: () -> Unit,
+    qaSettings: QASettings,
+    onSettingsChange: ((AppSettings) -> AppSettings) -> Unit,
+    availableFonts: List<String>,
+    scrollState: ScrollState = rememberScrollState(),
+    copyText: (String) -> Unit = {},
+    onDismiss: () -> Unit
+) {
+    val strQrMessageDefault = stringResource(Res.string.qa_qr_message_default)
+
     val effectiveBaseUrl = qaDisplayUrl.ifEmpty { serverUrl }
     val submissionUrl = if (effectiveBaseUrl.isNotEmpty()) "$effectiveBaseUrl/qa" else ""
     val adminBaseUrl = if (tunnelUrl.isNotEmpty() && qaDisplayUrl == tunnelUrl) tunnelUrl else serverUrl
@@ -165,419 +223,412 @@ fun QARemoteDialog(
         else "$adminBaseUrl/qa/admin"
     } else ""
 
-    DialogWindow(
-        onCloseRequest = onDismiss,
-        state = dialogState,
-        title = stringResource(Res.string.qa_remote_dialog_title),
-        resizable = false
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
     ) {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(scrollState)
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = stringResource(Res.string.qa_remote_dialog_description),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center
-                )
+            Text(
+                text = stringResource(Res.string.qa_remote_dialog_description),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center
+            )
 
-                if (submissionUrl.isNotEmpty()) {
-                    Spacer(Modifier.height(12.dp))
+            if (submissionUrl.isNotEmpty()) {
+                Spacer(Modifier.height(12.dp))
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        // ── Left: Submission QR ──────────────────────────
-                        Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                stringResource(Res.string.qa_submit_questions),
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Spacer(Modifier.height(8.dp))
-                            val submissionQR = remember(submissionUrl) { generateQRCodeBitmap(submissionUrl, 150) }
-                            if (submissionQR != null) {
-                                Image(bitmap = submissionQR, contentDescription = stringResource(Res.string.qa_submit_questions), modifier = Modifier.size(150.dp))
-                            }
-                            Spacer(Modifier.height(8.dp))
-                            SelectionContainer {
-                                Text(
-                                    submissionUrl,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    textAlign = TextAlign.Center
-                                )
-                            }
-                            Spacer(Modifier.height(8.dp))
-                            Button(
-                                shape = RoundedCornerShape(6.dp),
-                                onClick = { copyText(submissionUrl) },
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-                                )
-                            ) {
-                                Text(stringResource(Res.string.qa_copy_url), style = MaterialTheme.typography.labelSmall)
-                            }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    // ── Left: Submission QR ──────────────────────────
+                    Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            stringResource(Res.string.qa_submit_questions),
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        val submissionQR = remember(submissionUrl) { generateQRCodeBitmap(submissionUrl, 150) }
+                        if (submissionQR != null) {
+                            Image(bitmap = submissionQR, contentDescription = stringResource(Res.string.qa_submit_questions), modifier = Modifier.size(150.dp))
                         }
-
-                        // ── Center: Public Access ─────────────────────────
-                        Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                        Spacer(Modifier.height(8.dp))
+                        SelectionContainer {
                             Text(
-                                stringResource(Res.string.qa_public_access),
-                                style = MaterialTheme.typography.titleSmall,
-                                fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSurface
-                            )
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                stringResource(Res.string.qa_public_access_description),
+                                submissionUrl,
                                 style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                color = MaterialTheme.colorScheme.primary,
                                 textAlign = TextAlign.Center
                             )
-                            Spacer(Modifier.height(8.dp))
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        Button(
+                            shape = RoundedCornerShape(6.dp),
+                            onClick = { copyText(submissionUrl) },
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                        ) {
+                            Text(stringResource(Res.string.qa_copy_url), style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
 
-                            when (tunnelStatus) {
-                                TunnelStatus.Idle -> {
+                    // ── Center: Public Access ─────────────────────────
+                    Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(
+                            stringResource(Res.string.qa_public_access),
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            stringResource(Res.string.qa_public_access_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(Modifier.height(8.dp))
+
+                        when (tunnelStatus) {
+                            TunnelStatus.Idle -> {
+                                Button(
+                                    onClick = onStartTunnel,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(6.dp)
+                                ) {
+                                    Text(stringResource(Res.string.qa_enable_public_access), style = MaterialTheme.typography.labelSmall)
+                                }
+                            }
+                            TunnelStatus.Downloading -> {
+                                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                                    Text(stringResource(Res.string.qa_downloading_tunnel), style = MaterialTheme.typography.bodySmall)
+                                }
+                            }
+                            TunnelStatus.Starting -> {
+                                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                                    Text(stringResource(Res.string.qa_starting_tunnel), style = MaterialTheme.typography.bodySmall)
+                                }
+                            }
+                            is TunnelStatus.Connected -> {
+                                Text(stringResource(Res.string.qa_qr_code_shows), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                Spacer(Modifier.height(4.dp))
+
+                                Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.fillMaxWidth()) {
+                                    val isLocal = qaDisplayUrl.isEmpty() || qaDisplayUrl == serverUrl
                                     Button(
-                                        onClick = onStartTunnel,
-                                        modifier = Modifier.fillMaxWidth(),
-                                        shape = RoundedCornerShape(6.dp)
-                                    ) {
-                                        Text(stringResource(Res.string.qa_enable_public_access), style = MaterialTheme.typography.labelSmall)
-                                    }
-                                }
-                                TunnelStatus.Downloading -> {
-                                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                                        Text(stringResource(Res.string.qa_downloading_tunnel), style = MaterialTheme.typography.bodySmall)
-                                    }
-                                }
-                                TunnelStatus.Starting -> {
-                                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
-                                        Text(stringResource(Res.string.qa_starting_tunnel), style = MaterialTheme.typography.bodySmall)
-                                    }
-                                }
-                                is TunnelStatus.Connected -> {
-                                    Text(stringResource(Res.string.qa_qr_code_shows), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                                    Spacer(Modifier.height(4.dp))
-
-                                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), modifier = Modifier.fillMaxWidth()) {
-                                        val isLocal = qaDisplayUrl.isEmpty() || qaDisplayUrl == serverUrl
-                                        Button(
-                                            onClick = { onQaDisplayUrlChanged(serverUrl) },
-                                            modifier = Modifier.weight(1f),
-                                            colors = if (isLocal) ButtonDefaults.buttonColors(
-                                                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                                            ) else ButtonDefaults.buttonColors(
-                                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-                                            ),
-                                            shape = RoundedCornerShape(6.dp)
-                                        ) {
-                                            Text(stringResource(Res.string.qa_local), style = MaterialTheme.typography.labelSmall)
-                                        }
-                                        Button(
-                                            onClick = { onQaDisplayUrlChanged(tunnelUrl) },
-                                            modifier = Modifier.weight(1f),
-                                            colors = if (!isLocal) ButtonDefaults.buttonColors(
-                                                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                                            ) else ButtonDefaults.buttonColors(
-                                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-                                            ),
-                                            shape = RoundedCornerShape(6.dp)
-                                        ) {
-                                            Text(stringResource(Res.string.qa_public), style = MaterialTheme.typography.labelSmall)
-                                        }
-                                    }
-
-                                    Spacer(Modifier.height(8.dp))
-                                    Button(
-                                        onClick = {
-                                            onStopTunnel()
-                                            onQaDisplayUrlChanged(serverUrl)
-                                        },
-                                        colors = ButtonDefaults.buttonColors(
-                                            containerColor = MaterialTheme.colorScheme.error,
-                                            contentColor = MaterialTheme.colorScheme.onError
+                                        onClick = { onQaDisplayUrlChanged(serverUrl) },
+                                        modifier = Modifier.weight(1f),
+                                        colors = if (isLocal) ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                                        ) else ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
                                         ),
-                                        modifier = Modifier.fillMaxWidth(),
                                         shape = RoundedCornerShape(6.dp)
                                     ) {
-                                        Text(stringResource(Res.string.qa_disable_public_access), style = MaterialTheme.typography.labelSmall)
+                                        Text(stringResource(Res.string.qa_local), style = MaterialTheme.typography.labelSmall)
+                                    }
+                                    Button(
+                                        onClick = { onQaDisplayUrlChanged(tunnelUrl) },
+                                        modifier = Modifier.weight(1f),
+                                        colors = if (!isLocal) ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                            contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                                        ) else ButtonDefaults.buttonColors(
+                                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                                        ),
+                                        shape = RoundedCornerShape(6.dp)
+                                    ) {
+                                        Text(stringResource(Res.string.qa_public), style = MaterialTheme.typography.labelSmall)
                                     }
                                 }
-                                is TunnelStatus.Error -> {
-                                    Text(
-                                        tunnelStatus.message,
-                                        color = MaterialTheme.colorScheme.error,
-                                        style = MaterialTheme.typography.bodySmall,
-                                        textAlign = TextAlign.Center,
-                                        modifier = Modifier.padding(bottom = 4.dp)
-                                    )
-                                    Button(
-                                        onClick = onStartTunnel,
-                                        modifier = Modifier.fillMaxWidth(),
-                                        shape = RoundedCornerShape(6.dp)
-                                    ) {
-                                        Text(stringResource(Res.string.qa_retry), style = MaterialTheme.typography.labelSmall)
-                                    }
+
+                                Spacer(Modifier.height(8.dp))
+                                Button(
+                                    onClick = {
+                                        onStopTunnel()
+                                        onQaDisplayUrlChanged(serverUrl)
+                                    },
+                                    colors = ButtonDefaults.buttonColors(
+                                        containerColor = MaterialTheme.colorScheme.error,
+                                        contentColor = MaterialTheme.colorScheme.onError
+                                    ),
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(6.dp)
+                                ) {
+                                    Text(stringResource(Res.string.qa_disable_public_access), style = MaterialTheme.typography.labelSmall)
                                 }
                             }
-
-                            Spacer(Modifier.height(16.dp))
-                            NumberSettingsTextField(
-                                label = stringResource(Res.string.qa_cooldown_label),
-                                initialText = qaSettings.rateLimitCooldownSeconds,
-                                range = 0..600,
-                                onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(rateLimitCooldownSeconds = it)) } },
-                                modifier = Modifier.fillMaxWidth()
-                            )
+                            is TunnelStatus.Error -> {
+                                Text(
+                                    tunnelStatus.message,
+                                    color = MaterialTheme.colorScheme.error,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.padding(bottom = 4.dp)
+                                )
+                                Button(
+                                    onClick = onStartTunnel,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    shape = RoundedCornerShape(6.dp)
+                                ) {
+                                    Text(stringResource(Res.string.qa_retry), style = MaterialTheme.typography.labelSmall)
+                                }
+                            }
                         }
 
-                        // ── Right: Admin QR ──────────────────────────────
-                        Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(stringResource(Res.string.qa_admin_panel), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
-                            Spacer(Modifier.height(4.dp))
+                        Spacer(Modifier.height(16.dp))
+                        NumberSettingsTextField(
+                            label = stringResource(Res.string.qa_cooldown_label),
+                            initialText = qaSettings.rateLimitCooldownSeconds,
+                            range = 0..600,
+                            onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(rateLimitCooldownSeconds = it)) } },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
+                    // ── Right: Admin QR ──────────────────────────────
+                    Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text(stringResource(Res.string.qa_admin_panel), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            stringResource(Res.string.qa_admin_uses_api_key),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center
+                        )
+                        Spacer(Modifier.height(8.dp))
+
+                        val adminQR = remember(adminQrUrl) { generateQRCodeBitmap(adminQrUrl, 150) }
+                        if (adminQR != null) {
+                            Image(bitmap = adminQR, contentDescription = stringResource(Res.string.qa_admin_panel), modifier = Modifier.size(150.dp))
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        SelectionContainer {
                             Text(
-                                stringResource(Res.string.qa_admin_uses_api_key),
+                                adminQrUrl.ifEmpty { adminDisplayUrl },
                                 style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                color = MaterialTheme.colorScheme.primary,
                                 textAlign = TextAlign.Center
                             )
-                            Spacer(Modifier.height(8.dp))
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        Button(
+                            shape = RoundedCornerShape(6.dp),
+                            onClick = { copyText(adminQrUrl.ifEmpty { adminDisplayUrl }) },
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                            )
+                        ) {
+                            Text(stringResource(Res.string.qa_copy_url), style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
 
-                            val adminQR = remember(adminQrUrl) { generateQRCodeBitmap(adminQrUrl, 150) }
-                            if (adminQR != null) {
-                                Image(bitmap = adminQR, contentDescription = stringResource(Res.string.qa_admin_panel), modifier = Modifier.size(150.dp))
-                            }
-                            Spacer(Modifier.height(8.dp))
-                            SelectionContainer {
-                                Text(
-                                    adminQrUrl.ifEmpty { adminDisplayUrl },
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.primary,
-                                    textAlign = TextAlign.Center
+                Spacer(Modifier.height(16.dp))
+                HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                Spacer(Modifier.height(12.dp))
+
+                Text(stringResource(Res.string.qa_display_styling), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
+                Spacer(Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    // ── Left: QR Code styling ────────────────────────
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(stringResource(Res.string.qa_styling_qr_group), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
+                        Spacer(Modifier.height(8.dp))
+
+                        Text(stringResource(Res.string.qa_qr_message_label), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurface)
+                        Spacer(Modifier.height(4.dp))
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(42.dp)
+                                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
+                                .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp)),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Box(modifier = Modifier.weight(1f).padding(horizontal = 12.dp)) {
+                                BasicTextField(
+                                    value = qaSettings.qrCodeMessage,
+                                    onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrCodeMessage = it)) } },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    singleLine = true,
+                                    textStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
+                                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                                    decorationBox = { innerTextField ->
+                                        if (qaSettings.qrCodeMessage.isEmpty()) {
+                                            Text(strQrMessageDefault, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f), maxLines = 1)
+                                        }
+                                        innerTextField()
+                                    }
                                 )
                             }
-                            Spacer(Modifier.height(8.dp))
-                            Button(
-                                shape = RoundedCornerShape(6.dp),
-                                onClick = { copyText(adminQrUrl.ifEmpty { adminDisplayUrl }) },
-                                colors = ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-                                )
+                            FilledIconButton(
+                                onClick = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrCodeMessage = "")) } },
+                                modifier = Modifier.size(30.dp),
+                                shape = RoundedCornerShape(5.dp),
+                                colors = IconButtonDefaults.filledIconButtonColors(containerColor = Color.Transparent, contentColor = MaterialTheme.colorScheme.onSurfaceVariant)
                             ) {
-                                Text(stringResource(Res.string.qa_copy_url), style = MaterialTheme.typography.labelSmall)
+                                Icon(Icons.Default.Refresh, contentDescription = stringResource(Res.string.qa_qr_message_reset), modifier = Modifier.size(16.dp))
+                            }
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            ColorPickerField(label = stringResource(Res.string.qa_qr_fg_color), color = qaSettings.qrForegroundColor, onColorChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrForegroundColor = it)) } }, modifier = Modifier.weight(1f))
+                            ColorPickerField(label = stringResource(Res.string.qa_qr_bg_color), color = qaSettings.qrBackgroundColor, onColorChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrBackgroundColor = it)) } }, modifier = Modifier.weight(1f))
+                        }
+                        Spacer(Modifier.height(4.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+                            Text(stringResource(Res.string.qa_opacity), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurface)
+                            Spacer(Modifier.width(4.dp))
+                            SlimSlider(
+                                value = qaSettings.qrBackgroundOpacity / 100f,
+                                onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrBackgroundOpacity = (it * 100).toInt())) } },
+                                valueRange = 0f..1f,
+                                modifier = Modifier.weight(1f),
+                                trailingLabel = "${qaSettings.qrBackgroundOpacity}%"
+                            )
+                        }
+                    }
+
+                    // ── Center: Position ──────────────────────────────
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(stringResource(Res.string.qa_position), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
+                        Spacer(Modifier.height(8.dp))
+                        val positions = listOf(
+                            Constants.TOP_LEFT to stringResource(Res.string.qa_pos_tl),
+                            Constants.TOP_CENTER to stringResource(Res.string.qa_pos_tc),
+                            Constants.TOP_RIGHT to stringResource(Res.string.qa_pos_tr),
+                            Constants.CENTER_LEFT to stringResource(Res.string.qa_pos_cl),
+                            Constants.CENTER to stringResource(Res.string.qa_pos_c),
+                            Constants.CENTER_RIGHT to stringResource(Res.string.qa_pos_cr),
+                            Constants.BOTTOM_LEFT to stringResource(Res.string.qa_pos_bl),
+                            Constants.BOTTOM_CENTER to stringResource(Res.string.qa_pos_bc),
+                            Constants.BOTTOM_RIGHT to stringResource(Res.string.qa_pos_br),
+                        )
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp), modifier = Modifier.fillMaxWidth()) {
+                            positions.chunked(3).forEach { rowItems ->
+                                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                                    rowItems.forEach { (posConst, posLabel) ->
+                                        val isSelected = qaSettings.position == posConst
+                                        Box(
+                                            modifier = Modifier.weight(1f).height(28.dp).clip(RoundedCornerShape(3.dp))
+                                                .background(if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant)
+                                                .clickable { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(position = posConst)) } },
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Text(posLabel, style = MaterialTheme.typography.labelSmall, color = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant)
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
 
-                    Spacer(Modifier.height(16.dp))
-                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-                    Spacer(Modifier.height(12.dp))
+                    // ── Right: Text & Background ─────────────────────
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(stringResource(Res.string.qa_styling_text_group), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
+                        Spacer(Modifier.height(8.dp))
 
-                    Text(stringResource(Res.string.qa_display_styling), style = MaterialTheme.typography.titleSmall, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.onSurface)
-                    Spacer(Modifier.height(8.dp))
+                        ColorPickerField(label = stringResource(Res.string.qa_text_color), color = qaSettings.textColor, onColorChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(textColor = it)) } }, modifier = Modifier.fillMaxWidth())
+                        Spacer(Modifier.height(8.dp))
+                        TextStyleButtons(
+                                bold = qaSettings.bold, italic = qaSettings.italic, underline = qaSettings.underline, shadow = qaSettings.shadow,
+                                onBoldChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(bold = it)) } },
+                                onItalicChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(italic = it)) } },
+                                onUnderlineChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(underline = it)) } },
+                                onShadowChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(shadow = it)) } }
+                        )
 
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        // ── Left: QR Code styling ────────────────────────
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(stringResource(Res.string.qa_styling_qr_group), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
-                            Spacer(Modifier.height(8.dp))
+                        AnimatedVisibility(visible = qaSettings.shadow) {
+                            ShadowDetailRow(
+                                shadowColor = qaSettings.shadowColor, shadowSize = qaSettings.shadowSize, shadowOpacity = qaSettings.shadowOpacity,
+                                onColorChange = { c -> onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(shadowColor = c)) } },
+                                onSizeChange = { v -> onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(shadowSize = v)) } },
+                                onOpacityChange = { v -> onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(shadowOpacity = v)) } },
+                            )
+                        }
 
-                            Text(stringResource(Res.string.qa_qr_message_label), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurface)
-                            Spacer(Modifier.height(4.dp))
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(42.dp)
-                                    .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(8.dp))
-                                    .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp)),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Box(modifier = Modifier.weight(1f).padding(horizontal = 12.dp)) {
-                                    BasicTextField(
-                                        value = qaSettings.qrCodeMessage,
-                                        onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrCodeMessage = it)) } },
+                        Spacer(Modifier.height(8.dp))
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                            FontSettingsDropdown(label = stringResource(Res.string.qa_font), value = qaSettings.fontType, fonts = availableFonts, onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(fontType = it)) } }, modifier = Modifier.weight(1f))
+                            NumberSettingsTextField(label = stringResource(Res.string.qa_size), initialText = qaSettings.fontSize, range = 8..200, onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(fontSize = it)) } })
+                        }
+
+                        Spacer(Modifier.height(8.dp))
+                        Column(horizontalAlignment = Alignment.Start) {
+                            val bgIsTransparent = qaSettings.backgroundColor.equals("transparent", ignoreCase = true)
+                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.Bottom) {
+                                if (bgIsTransparent) {
+                                    OutlinedButton(
+                                        onClick = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(backgroundColor = "#1E1E2E")) } },
                                         modifier = Modifier.fillMaxWidth(),
-                                        singleLine = true,
-                                        textStyle = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
-                                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                                        decorationBox = { innerTextField ->
-                                            if (qaSettings.qrCodeMessage.isEmpty()) {
-                                                Text(strQrMessageDefault, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f), maxLines = 1)
-                                            }
-                                            innerTextField()
-                                        }
-                                    )
+                                        shape = RoundedCornerShape(6.dp),
+                                        colors = ButtonDefaults.outlinedButtonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer, contentColor = MaterialTheme.colorScheme.onSecondaryContainer)
+                                    ) { Text(stringResource(Res.string.qa_background_color) + " · " + stringResource(Res.string.qa_transparent), style = MaterialTheme.typography.labelSmall) }
+                                } else {
+                                    ColorPickerField(label = stringResource(Res.string.qa_background_color), color = qaSettings.backgroundColor, onColorChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(backgroundColor = it)) } }, modifier = Modifier.weight(1f))
+                                    OutlinedButton(
+                                        onClick = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(backgroundColor = "transparent")) } },
+                                        shape = RoundedCornerShape(6.dp)
+                                    ) { Text(stringResource(Res.string.qa_transparent), style = MaterialTheme.typography.labelSmall) }
                                 }
-                                FilledIconButton(
-                                    onClick = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrCodeMessage = "")) } },
-                                    modifier = Modifier.size(30.dp),
-                                    shape = RoundedCornerShape(5.dp),
-                                    colors = IconButtonDefaults.filledIconButtonColors(containerColor = Color.Transparent, contentColor = MaterialTheme.colorScheme.onSurfaceVariant)
-                                ) {
-                                    Icon(Icons.Default.Refresh, contentDescription = stringResource(Res.string.qa_qr_message_reset), modifier = Modifier.size(16.dp))
-                                }
-                            }
-                            Spacer(Modifier.height(8.dp))
-                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                ColorPickerField(label = stringResource(Res.string.qa_qr_fg_color), color = qaSettings.qrForegroundColor, onColorChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrForegroundColor = it)) } }, modifier = Modifier.weight(1f))
-                                ColorPickerField(label = stringResource(Res.string.qa_qr_bg_color), color = qaSettings.qrBackgroundColor, onColorChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrBackgroundColor = it)) } }, modifier = Modifier.weight(1f))
                             }
                             Spacer(Modifier.height(4.dp))
                             Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
                                 Text(stringResource(Res.string.qa_opacity), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurface)
                                 Spacer(Modifier.width(4.dp))
                                 SlimSlider(
-                                    value = qaSettings.qrBackgroundOpacity / 100f,
-                                    onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(qrBackgroundOpacity = (it * 100).toInt())) } },
+                                    value = qaSettings.backgroundOpacity / 100f,
+                                    onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(backgroundOpacity = (it * 100).toInt())) } },
                                     valueRange = 0f..1f,
                                     modifier = Modifier.weight(1f),
-                                    trailingLabel = "${qaSettings.qrBackgroundOpacity}%"
+                                    trailingLabel = "${qaSettings.backgroundOpacity}%"
                                 )
-                            }
-                        }
-
-                        // ── Center: Position ──────────────────────────────
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(stringResource(Res.string.qa_position), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
-                            Spacer(Modifier.height(8.dp))
-                            val positions = listOf(
-                                Constants.TOP_LEFT to stringResource(Res.string.qa_pos_tl),
-                                Constants.TOP_CENTER to stringResource(Res.string.qa_pos_tc),
-                                Constants.TOP_RIGHT to stringResource(Res.string.qa_pos_tr),
-                                Constants.CENTER_LEFT to stringResource(Res.string.qa_pos_cl),
-                                Constants.CENTER to stringResource(Res.string.qa_pos_c),
-                                Constants.CENTER_RIGHT to stringResource(Res.string.qa_pos_cr),
-                                Constants.BOTTOM_LEFT to stringResource(Res.string.qa_pos_bl),
-                                Constants.BOTTOM_CENTER to stringResource(Res.string.qa_pos_bc),
-                                Constants.BOTTOM_RIGHT to stringResource(Res.string.qa_pos_br),
-                            )
-                            Column(verticalArrangement = Arrangement.spacedBy(2.dp), modifier = Modifier.fillMaxWidth()) {
-                                positions.chunked(3).forEach { rowItems ->
-                                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-                                        rowItems.forEach { (posConst, posLabel) ->
-                                            val isSelected = qaSettings.position == posConst
-                                            Box(
-                                                modifier = Modifier.weight(1f).height(28.dp).clip(RoundedCornerShape(3.dp))
-                                                    .background(if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surfaceVariant)
-                                                    .clickable { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(position = posConst)) } },
-                                                contentAlignment = Alignment.Center
-                                            ) {
-                                                Text(posLabel, style = MaterialTheme.typography.labelSmall, color = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        // ── Right: Text & Background ─────────────────────
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(stringResource(Res.string.qa_styling_text_group), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurface)
-                            Spacer(Modifier.height(8.dp))
-
-                            ColorPickerField(label = stringResource(Res.string.qa_text_color), color = qaSettings.textColor, onColorChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(textColor = it)) } }, modifier = Modifier.fillMaxWidth())
-                            Spacer(Modifier.height(8.dp))
-                            TextStyleButtons(
-                                    bold = qaSettings.bold, italic = qaSettings.italic, underline = qaSettings.underline, shadow = qaSettings.shadow,
-                                    onBoldChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(bold = it)) } },
-                                    onItalicChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(italic = it)) } },
-                                    onUnderlineChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(underline = it)) } },
-                                    onShadowChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(shadow = it)) } }
-                            )
-
-                            AnimatedVisibility(visible = qaSettings.shadow) {
-                                ShadowDetailRow(
-                                    shadowColor = qaSettings.shadowColor, shadowSize = qaSettings.shadowSize, shadowOpacity = qaSettings.shadowOpacity,
-                                    onColorChange = { c -> onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(shadowColor = c)) } },
-                                    onSizeChange = { v -> onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(shadowSize = v)) } },
-                                    onOpacityChange = { v -> onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(shadowOpacity = v)) } },
-                                )
-                            }
-
-                            Spacer(Modifier.height(8.dp))
-                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                                FontSettingsDropdown(label = stringResource(Res.string.qa_font), value = qaSettings.fontType, fonts = availableFonts, onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(fontType = it)) } }, modifier = Modifier.weight(1f))
-                                NumberSettingsTextField(label = stringResource(Res.string.qa_size), initialText = qaSettings.fontSize, range = 8..200, onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(fontSize = it)) } })
-                            }
-
-                            Spacer(Modifier.height(8.dp))
-                            Column(horizontalAlignment = Alignment.Start) {
-                                val bgIsTransparent = qaSettings.backgroundColor.equals("transparent", ignoreCase = true)
-                                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.Bottom) {
-                                    if (bgIsTransparent) {
-                                        OutlinedButton(
-                                            onClick = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(backgroundColor = "#1E1E2E")) } },
-                                            modifier = Modifier.fillMaxWidth(),
-                                            shape = RoundedCornerShape(6.dp),
-                                            colors = ButtonDefaults.outlinedButtonColors(containerColor = MaterialTheme.colorScheme.secondaryContainer, contentColor = MaterialTheme.colorScheme.onSecondaryContainer)
-                                        ) { Text(stringResource(Res.string.qa_background_color) + " · " + stringResource(Res.string.qa_transparent), style = MaterialTheme.typography.labelSmall) }
-                                    } else {
-                                        ColorPickerField(label = stringResource(Res.string.qa_background_color), color = qaSettings.backgroundColor, onColorChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(backgroundColor = it)) } }, modifier = Modifier.weight(1f))
-                                        OutlinedButton(
-                                            onClick = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(backgroundColor = "transparent")) } },
-                                            shape = RoundedCornerShape(6.dp)
-                                        ) { Text(stringResource(Res.string.qa_transparent), style = MaterialTheme.typography.labelSmall) }
-                                    }
-                                }
-                                Spacer(Modifier.height(4.dp))
-                                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-                                    Text(stringResource(Res.string.qa_opacity), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurface)
-                                    Spacer(Modifier.width(4.dp))
-                                    SlimSlider(
-                                        value = qaSettings.backgroundOpacity / 100f,
-                                        onValueChange = { onSettingsChange { s -> s.copy(qaSettings = s.qaSettings.copy(backgroundOpacity = (it * 100).toInt())) } },
-                                        valueRange = 0f..1f,
-                                        modifier = Modifier.weight(1f),
-                                        trailingLabel = "${qaSettings.backgroundOpacity}%"
-                                    )
-                                }
                             }
                         }
                     }
-                } else {
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        stringResource(Res.string.qa_server_hint),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center
-                    )
                 }
+            } else {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    stringResource(Res.string.qa_server_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+            }
 
-                Spacer(Modifier.height(16.dp))
-                Button(
-                    shape = RoundedCornerShape(6.dp),
-                    onClick = onDismiss,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
-                    )
-                ) {
-                    Text(stringResource(Res.string.close))
-                }
+            Spacer(Modifier.height(16.dp))
+            Button(
+                shape = RoundedCornerShape(6.dp),
+                onClick = onDismiss,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            ) {
+                Text(stringResource(Res.string.close))
             }
         }
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/QARemoteContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/QARemoteContentTest.kt
@@ -1,0 +1,206 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.QASettings
+import org.churchpresenter.app.churchpresenter.server.TunnelStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The Q&A remote window, and the two addresses it works out for the room.
+ *
+ * One of these goes on a screen for a congregation to scan and the other is the moderator's own way
+ * in, so getting them mixed up either hides the queue or hands the room the controls. They are
+ * *derived* — from the server address, an optional public tunnel, and whether an API key is set —
+ * which is what this covers.
+ *
+ * `QARemoteDialog` opens a `DialogWindow` and sizes it with a grow-to-fit effect, neither of which
+ * runs headless, so the body was lifted into `QARemoteContent`. Three things that content now takes
+ * as parameters were previously reached for inside it: the font list (`GraphicsEnvironment`), the
+ * clipboard writer, and the scroll state shared with the sizing effect. Injecting the clipboard is
+ * what lets these tests press Copy and assert *which* address was handed over, rather than only
+ * that a button exists.
+ *
+ * Left uncovered: the `DialogWindow` call and the grow-to-fit effect.
+ */
+class QARemoteContentTest {
+
+    private companion object {
+        const val SERVER = "http://192.168.1.50:8080"
+        const val TUNNEL = "https://abc-def.trycloudflare.com"
+    }
+
+    private object Label {
+        const val COPY = "Copy URL"
+    }
+
+
+    private class Clipboard {
+        val written = mutableListOf<String>()
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun qaRemote(
+        serverUrl: String = SERVER,
+        qaDisplayUrl: String = "",
+        apiKeyEnabled: Boolean = false,
+        apiKey: String = "",
+        tunnelStatus: TunnelStatus = TunnelStatus.Idle,
+        tunnelUrl: String = "",
+        block: ComposeUiTest.(Clipboard) -> Unit,
+    ) {
+        val clipboard = Clipboard()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    QARemoteContent(
+                        serverUrl = serverUrl,
+                        qaDisplayUrl = qaDisplayUrl,
+                        onQaDisplayUrlChanged = {},
+                        apiKeyEnabled = apiKeyEnabled,
+                        apiKey = apiKey,
+                        tunnelStatus = tunnelStatus,
+                        tunnelUrl = tunnelUrl,
+                        onStartTunnel = {},
+                        onStopTunnel = {},
+                        qaSettings = QASettings(),
+                        onSettingsChange = {},
+                        availableFonts = listOf("Arial", "Helvetica"),
+                        copyText = { clipboard.written += it },
+                        onDismiss = {},
+                    )
+                }
+            }
+            block(clipboard)
+        }
+    }
+
+    /** Exact match: the URL panels each render their address as one whole node. */
+    private fun ComposeUiTest.shows(text: String): Boolean =
+        onAllNodes(hasText(text)).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
+
+    /** Substring match, for asserting no address was built at all. */
+    private fun ComposeUiTest.showsAnyContaining(fragment: String): Boolean =
+        onAllNodes(hasText(fragment, substring = true))
+            .fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
+
+    /** Presses the nth Copy button: the submission panel's is first, the moderator's second. */
+    private fun ComposeUiTest.copy(index: Int) {
+        onAllNodes(hasText(Label.COPY))[index].performClick()
+        waitForIdle()
+    }
+
+    // ── The address the congregation scans ──────────────────────────────────────
+
+    @Test
+    fun `the submission address is the server with the Q and A path on it`() = qaRemote { _ ->
+        assertTrue(shows("$SERVER/qa"), "the room's address is the server plus /qa")
+    }
+
+    @Test
+    fun `a configured display address is preferred over the server's own`() =
+        qaRemote(qaDisplayUrl = TUNNEL, tunnelUrl = TUNNEL) { _ ->
+            assertTrue(shows("$TUNNEL/qa"), "the address chosen for display is the one to publish")
+            assertTrue(!shows("$SERVER/qa"), "the local address must not be the one shown to the room")
+        }
+
+    @Test
+    fun `with no server address at all nothing is offered to scan`() =
+        qaRemote(serverUrl = "") { _ ->
+            assertTrue(
+                !showsAnyContaining("/qa"),
+                "an address cannot be built from nothing, so neither panel may show a path",
+            )
+        }
+
+    // ── The moderator's own way in ──────────────────────────────────────────────
+
+    @Test
+    fun `the moderator address stays on the local server while the tunnel is unused`() = qaRemote { _ ->
+        assertTrue(shows("$SERVER/qa/admin"), "moderation stays on the LAN unless deliberately published")
+    }
+
+    @Test
+    fun `the moderator address follows the tunnel only when the tunnel is what is being displayed`() =
+        qaRemote(qaDisplayUrl = TUNNEL, tunnelUrl = TUNNEL) { _ ->
+            assertTrue(shows("$TUNNEL/qa/admin"), "publishing over the tunnel moves moderation there too")
+        }
+
+    @Test
+    fun `a running tunnel that is not being displayed leaves moderation local`() =
+        qaRemote(qaDisplayUrl = "", tunnelUrl = TUNNEL, tunnelStatus = TunnelStatus.Connected(TUNNEL)) { _ ->
+            // The tunnel exists but the room is being given the LAN address, so the moderator keeps it too.
+            assertTrue(shows("$SERVER/qa/admin"), "a tunnel merely running must not move the moderator link")
+        }
+
+    // ── The API key in the moderator link ───────────────────────────────────────
+
+    @Test
+    fun `an enabled API key is carried in the moderator link so the QR opens straight in`() =
+        qaRemote(apiKeyEnabled = true, apiKey = "secret123") { _ ->
+            assertTrue(
+                shows("$SERVER/qa/admin?password=secret123"),
+                "the moderator's QR has to get past the key without it being typed on a phone",
+            )
+        }
+
+    @Test
+    fun `a key with characters that would break a URL is encoded`() =
+        qaRemote(apiKeyEnabled = true, apiKey = "p@ss word&more") { _ ->
+            assertTrue(
+                shows("$SERVER/qa/admin?password=p%40ss+word%26more"),
+                "an unencoded & would cut the key short and an unencoded space would break the link",
+            )
+        }
+
+    @Test
+    fun `a key that is set but not enabled is left out`() =
+        qaRemote(apiKeyEnabled = false, apiKey = "secret123") { _ ->
+            assertTrue(shows("$SERVER/qa/admin"), "the plain link is the one to show")
+            assertTrue(!shows("$SERVER/qa/admin?password=secret123"), "a disabled key must not be published")
+        }
+
+    @Test
+    fun `an enabled but empty key adds nothing`() =
+        qaRemote(apiKeyEnabled = true, apiKey = "") { _ ->
+            assertTrue(shows("$SERVER/qa/admin"), "there is no key to carry, so the link stays plain")
+        }
+
+    // ── Copying ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `copying the first panel copies the address the congregation scans`() = qaRemote { clipboard ->
+        copy(0)
+        assertEquals(listOf("$SERVER/qa"), clipboard.written)
+    }
+
+    @Test
+    fun `copying the moderator panel copies the link including its key`() =
+        qaRemote(apiKeyEnabled = true, apiKey = "secret123") { clipboard ->
+            copy(1)
+            assertEquals(
+                listOf("$SERVER/qa/admin?password=secret123"),
+                clipboard.written,
+                "the copied moderator link must be the one that actually gets in",
+            )
+        }
+
+    // ── Tunnel state ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a tunnel error is reported rather than swallowed`() =
+        qaRemote(tunnelStatus = TunnelStatus.Error("cloudflared exited")) { _ ->
+            onNodeWithText("cloudflared exited").assertIsDisplayed()
+        }
+}


### PR DESCRIPTION
Fifth of the `dialogs/` push. Independent of #51 (different file).

## Approach

Same lift as #49–#51, with the most parameter-passing yet.

`QARemoteDialog` opens a `DialogWindow` *and* sizes it with a grow-to-fit `LaunchedEffect`, neither of which runs headless. The body moves into `QARemoteContent`, and three things it used to reach for become parameters, because each is a piece of the machine rather than of the dialog:

| now a parameter | why |
|---|---|
| `availableFonts` | came from `GraphicsEnvironment` — which AGENT.md notes throws under the headless suite |
| `scrollState` | shared with the sizing effect, which stays outside |
| `copyText` | writes the system clipboard, which also throws headless |

Injecting the last one is the point: it makes the Copy buttons pressable, so a test can assert **which** address was handed over rather than merely that a button exists. That is AGENT.md's "take the sequence around it as a function with that step as a parameter", and it is what turns this from a render test into a behaviour test.

## Tests — `QARemoteContentTest` (13)

The dialog works out **two** addresses. One goes on a screen for the congregation to scan; the other is the moderator's own way in. Mixing them up either hides the queue or hands the room the controls — so:

**The submission address**
- server + `/qa`, with a configured display URL preferred over the server's own
- nothing shown at all when there is no server address to build from

**The moderator address**
- stays on the LAN server by default
- follows the tunnel *only* when the tunnel is what is being displayed — **a tunnel merely running must not move it**, which is the subtle one
- carries an enabled API key so the QR opens straight in without it being typed on a phone
- **URL-encodes that key** — an unencoded `&` would cut it short and a space would break the link (`p@ss word&more` → `p%40ss+word%26more`)
- leaves the key out when it is disabled, or enabled but empty

**Copying** — pressing each panel's Copy hands over exactly that panel's address, key included.

Deterministic 3×. 0.4s for 13 tests.

## Coverage

| | before | after |
|---|---|---|
| `QARemoteDialog.kt` | 0% | **79.3%** (302/381) |
| `dialogs` package | 30.0% | **35.7%** |
| overall | 45.8% | 46.4% |

## Uncovered

The `DialogWindow` call and the grow-to-fit effect — both need a real window.

## One note on the tests themselves

`shows()` matches text exactly, which is right for the URL panels since each renders its address as one whole node. The "no server address" case needed a substring matcher instead — with an exact matcher that assertion would have passed against an empty string without proving anything. It passes with the stricter check too, but it was worth not leaving in.