### PR TITLE
Make the STT drip feed honour its speed setting

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenter.kt
@@ -15,13 +15,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.Layout
@@ -246,14 +247,11 @@ private fun buildDisplayText(
     showWordHighlighting: Boolean,
     baseColor: Color
 ): AnnotatedString {
+    // Same shaping the drip-feed cursor counts against — see captionText in SttDripFeed.kt.
     val lines = mutableListOf<String>()
-    for (seg in segments) {
-        if (seg.text.isNotBlank()) {
-            lines.add(seg.text.trim().replace(Regex("\\s+"), " "))
-        }
-    }
+    captionText(segments).takeIf { it.isNotEmpty() }?.let { lines.add(it) }
     if (showInProgress && inProgressText.isNotBlank()) {
-        lines.add(inProgressText.trim().replace(Regex("\\s+"), " "))
+        lines.add(normalizeSegmentText(inProgressText))
     }
 
     if (lines.isEmpty()) return AnnotatedString("")
@@ -310,37 +308,43 @@ private fun buildDisplayText(
 }
 
 /**
- * Drip feed: reveals the newest segment letter-by-letter (ChatGPT-style).
- * Returns the segment list with the last segment's text partially revealed.
+ * Drip feed: reveals the caption letter-by-letter (ChatGPT-style) at [delayMs] per character.
+ *
+ * ONE cursor runs over the whole caption rather than over the newest segment, so a segment arriving
+ * mid-reveal extends the text to type out instead of snapping its predecessor to full. The cursor
+ * starts at the end of whatever is already on screen — an output opened mid-service shows the
+ * backlog it inherits, it does not re-type it. Speed changes apply to the reveal in flight, since
+ * the effect is keyed on [delayMs].
+ *
+ * The character arithmetic lives in `SttDripFeed.kt`.
  */
 @Composable
-private fun useDripFeed(segments: List<STTSegment>, enabled: Boolean, delayMs: Long = 40L): List<STTSegment> {
-    if (!enabled || segments.isEmpty()) return segments
+private fun useDripFeed(segments: List<STTSegment>, enabled: Boolean, delayMs: Long): List<STTSegment> {
+    if (!enabled) return segments
 
-    val lastSegment = segments.last()
-    val fullNewText = remember(lastSegment.id, lastSegment.text) {
-        lastSegment.text.trim()
-    }
+    val fullText = captionText(segments)
+    val latestFullText = rememberUpdatedState(fullText)
+    val revealed = remember { mutableIntStateOf(fullText.length) }
 
-    var revealedForSegmentId by remember { mutableIntStateOf(lastSegment.id) }
-    var revealedCharCount by remember { mutableIntStateOf(Int.MAX_VALUE) }
-
-    // If segment changed but LaunchedEffect hasn't fired, show 0 characters
-    val effectiveRevealed = if (revealedForSegmentId != lastSegment.id) 0 else revealedCharCount
-
-    LaunchedEffect(lastSegment.id, lastSegment.text) {
-        revealedForSegmentId = lastSegment.id
-        revealedCharCount = 0
-        for (i in 1..fullNewText.length) {
-            delay(delayMs)
-            revealedCharCount = i
+    LaunchedEffect(delayMs) {
+        var previous = latestFullText.value
+        snapshotFlow { latestFullText.value }.collectLatest { current ->
+            if (current != previous) {
+                revealed.intValue = reanchorCursor(previous, revealed.intValue, current)
+                previous = current
+            }
+            while (revealed.intValue < current.length) {
+                delay(delayMs)
+                revealed.intValue = minOf(
+                    current.length,
+                    revealed.intValue + revealStep(revealed.intValue, current.length)
+                )
+            }
         }
     }
 
-    if (effectiveRevealed >= fullNewText.length) return segments
-
-    val revealedText = fullNewText.take(effectiveRevealed)
-    return segments.dropLast(1) + lastSegment.copy(text = revealedText)
+    if (revealed.intValue >= fullText.length) return segments
+    return applyRevealBudget(segments, revealed.intValue)
 }
 
 private fun sttPositionToAlignment(position: String): Alignment = when (position) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/SttDripFeed.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/SttDripFeed.kt
@@ -1,0 +1,100 @@
+package org.churchpresenter.app.churchpresenter.presenter
+
+import org.churchpresenter.app.churchpresenter.viewmodel.STTSegment
+
+/**
+ * The character arithmetic behind the STT drip feed (the letter-by-letter caption reveal).
+ *
+ * The reveal is a single cursor over the WHOLE caption, not a per-segment one. The STT server
+ * delivers completed segments a few seconds apart; a per-segment cursor has to reset every time one
+ * arrives, which snaps the previous segment to its full text and makes the configured speed
+ * irrelevant whenever a segment cannot finish revealing before the next lands. One cursor over the
+ * joined caption keeps the reveal continuous across segment boundaries.
+ *
+ * Kept separate from the composable so the arithmetic is testable without a composition.
+ */
+
+private val WHITESPACE_RUN = Regex("\\s+")
+
+/**
+ * How much backlog the reveal tolerates before it starts drawing more than one character per tick.
+ * At a slow speed the reveal is easily outrun by live speech; without this the caption would drift
+ * further behind the room for the rest of the service. Sized so a lag of one full caption line
+ * roughly doubles the rate, and a large backlog is consumed briskly without ever jumping.
+ */
+private const val CATCH_UP_CHARS = 120
+
+/** One segment as it appears in the caption: trimmed, with internal whitespace collapsed. */
+internal fun normalizeSegmentText(text: String): String = text.trim().replace(WHITESPACE_RUN, " ")
+
+/** The full caption these segments produce — the exact string the presenter would draw. */
+internal fun captionText(segments: List<STTSegment>): String =
+    segments.mapNotNull { normalizeSegmentText(it.text).takeIf(String::isNotEmpty) }
+        .joinToString(" ")
+
+/**
+ * The segments trimmed to the first [revealed] characters of the caption, so the caller can render
+ * them through the ordinary display path. Segments past the cursor are dropped and the one it lands
+ * inside is truncated; the list is returned untouched once the cursor covers the whole caption.
+ */
+internal fun applyRevealBudget(segments: List<STTSegment>, revealed: Int): List<STTSegment> {
+    if (revealed <= 0) return emptyList()
+    if (revealed >= captionText(segments).length) return segments
+    val revealedSegments = ArrayList<STTSegment>(segments.size)
+    var used = 0
+    var first = true
+    for (segment in segments) {
+        val text = normalizeSegmentText(segment.text)
+        if (text.isEmpty()) continue
+        val separator = if (first) 0 else 1
+        val budget = revealed - used - separator
+        if (budget <= 0) break
+        if (budget >= text.length) {
+            revealedSegments.add(segment)
+            used += separator + text.length
+            first = false
+        } else {
+            revealedSegments.add(segment.copy(text = text.take(budget)))
+            break
+        }
+    }
+    return revealedSegments
+}
+
+/**
+ * Where the cursor belongs after the caption changed from [prevFull] to [newFull].
+ *
+ * A pure append — the ordinary case, a new segment landing — keeps the cursor exactly where it was
+ * so the reveal simply carries on. When the server's rolling window has also dropped text off the
+ * front, however much of the already-shown text survived stays shown and the cursor moves back with
+ * it. When the window has scrolled past everything that was shown, the reveal starts over on text
+ * nobody has read yet. Only a caption rewritten past recognition sends the cursor to the end:
+ * showing it all at once is a far smaller fault than re-typing words the room has already read.
+ */
+internal fun reanchorCursor(prevFull: String, prevRevealed: Int, newFull: String): Int {
+    val revealed = prevRevealed.coerceIn(0, prevFull.length)
+    val shown = prevFull.take(revealed)
+    if (newFull.startsWith(shown)) return revealed
+
+    val carriedOver = overlapLength(shown, newFull)
+    if (carriedOver > 0) return carriedOver
+    if (revealed == 0) return 0
+    // Nothing shown survived. If the new caption still picks up where the old one left off, the
+    // window merely scrolled past it and the rest has never been read — reveal it properly.
+    if (overlapLength(prevFull, newFull) > 0) return 0
+    return newFull.length
+}
+
+/** The largest number of characters by which the tail of [a] and the head of [b] coincide. */
+private fun overlapLength(a: String, b: String): Int {
+    var length = minOf(a.length, b.length)
+    while (length > 0 && !a.endsWith(b.take(length))) length--
+    return length
+}
+
+/**
+ * Characters to reveal on this tick: one at the configured speed when the reveal is keeping up,
+ * more as the backlog grows. See [CATCH_UP_CHARS].
+ */
+internal fun revealStep(revealed: Int, target: Int): Int =
+    1 + (target - revealed).coerceAtLeast(0) / CATCH_UP_CHARS

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenterDripFeedRenderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenterDripFeedRenderTest.kt
@@ -1,0 +1,139 @@
+package org.churchpresenter.app.churchpresenter.presenter
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.churchpresenter.app.churchpresenter.data.settings.STTSettings
+import org.churchpresenter.app.churchpresenter.viewmodel.STTSegment
+import kotlin.test.Test
+
+/**
+ * The drip feed as the room sees it — the letter-by-letter caption reveal, driven by the
+ * "Speed (ms/letter)" setting on the STT tab.
+ *
+ * These cover the reported failure: at any speed slower than roughly the default the reveal used to
+ * restart on every arriving segment, so the pace on screen was set by the STT server's segment
+ * cadence and 100, 120 and 140 ms/letter were indistinguishable. The knob has to be the thing that
+ * decides the pace, and a segment landing mid-reveal must not snap the sentence before it to full.
+ *
+ * Every wait here is on the test's VIRTUAL clock (`autoAdvance = false` + `advanceTimeBy`), so the
+ * timing is exact and the tests cost no wall-clock time. The reveal only runs on text that arrives
+ * after the first composition — an output opened mid-service deliberately inherits its backlog
+ * whole rather than re-typing it — so each case starts from an empty caption and then speaks.
+ */
+@OptIn(ExperimentalTestApi::class)
+class STTPresenterDripFeedRenderTest {
+
+    private val screen = Modifier.size(1920.dp, 1080.dp)
+
+    private val spoken = "Blessed are the peacemakers"   // 27 characters
+    private val alsoSpoken = "Rejoice and be glad"
+
+    private fun segment(text: String, id: Int) =
+        STTSegment(id = id, timestamp = "", text = text, start = 0.0, end = 1.0, completed = true)
+
+    private fun dripping(speedMs: Int) =
+        STTSettings(displayMode = "transcribe", dripFeedEnabled = true, dripFeedSpeed = speedMs)
+
+    /**
+     * Renders the presenter over a caption that starts empty, and hands the body a setter for the
+     * segments and for the settings so a test can speak, and can change the speed mid-reveal.
+     */
+    private fun runDrip(
+        initialSettings: STTSettings,
+        body: ComposeUiTest.(speak: (List<STTSegment>) -> Unit, retune: (STTSettings) -> Unit) -> Unit,
+    ) = runComposeUiTest {
+        var segments by mutableStateOf(emptyList<STTSegment>())
+        var settings by mutableStateOf(initialSettings)
+        mainClock.autoAdvance = false
+        setContent {
+            Box(screen) {
+                STTPresenter(
+                    segments = segments,
+                    inProgressText = "",
+                    translationSegments = emptyList(),
+                    inProgressTranslation = "",
+                    highlightedWords = emptyList(),
+                    sttSettings = settings,
+                )
+            }
+        }
+        body({ segments = it }, { settings = it })
+    }
+
+    @Test
+    fun `a fast speed has more of the sentence on screen than a slow one`() {
+        runDrip(dripping(speedMs = 25)) { speak, _ ->
+            speak(listOf(segment(spoken, id = 1)))
+            mainClock.advanceTimeBy(300)   // 12 letters at 25ms
+            onNodeWithText("Blessed are", substring = true)
+                .assertExists("at 25 ms/letter 300 ms must have typed well past the first word")
+        }
+        runDrip(dripping(speedMs = 200)) { speak, _ ->
+            speak(listOf(segment(spoken, id = 1)))
+            mainClock.advanceTimeBy(300)   // 1 letter at 200ms
+            onNodeWithText("Blessed", substring = true)
+                .assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun `a segment arriving mid-reveal does not snap the sentence before it to full`() {
+        runDrip(dripping(speedMs = 100)) { speak, _ ->
+            speak(listOf(segment(spoken, id = 1)))
+            mainClock.advanceTimeBy(350)   // 3 letters in — nowhere near the whole sentence
+            onNodeWithText(spoken, substring = true).assertDoesNotExist()
+
+            // The bug: a new segment reset the cursor, which dumped the sentence before it on
+            // screen whole — so the pace came from the server's cadence, not from the speed setting.
+            speak(listOf(segment(spoken, id = 1), segment(alsoSpoken, id = 2)))
+            mainClock.advanceTimeByFrame()
+            onNodeWithText(spoken, substring = true).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun `the reveal keeps going until the whole caption has been read out`() {
+        runDrip(dripping(speedMs = 100)) { speak, _ ->
+            speak(listOf(segment(spoken, id = 1)))
+            mainClock.advanceTimeBy(350)
+            speak(listOf(segment(spoken, id = 1), segment(alsoSpoken, id = 2)))
+            mainClock.advanceTimeBy(10_000)
+
+            onNodeWithText(spoken, substring = true).assertExists()
+            onNodeWithText(alsoSpoken, substring = true)
+                .assertExists("the cursor must carry on across the boundary, not stall at the first segment")
+        }
+    }
+
+    @Test
+    fun `changing the speed applies to the reveal already in flight`() {
+        runDrip(dripping(speedMs = 1_000)) { speak, retune ->
+            speak(listOf(segment(spoken, id = 1)))
+            mainClock.advanceTimeBy(1_100)   // 1 letter at 1000ms
+            onNodeWithText("Blessed", substring = true).assertDoesNotExist()
+
+            retune(dripping(speedMs = 1))
+            mainClock.advanceTimeBy(100)
+            onNodeWithText(spoken, substring = true)
+                .assertExists("a speed change must not wait for the next segment to take effect")
+        }
+    }
+
+    @Test
+    fun `drip feed switched off puts the caption up immediately`() {
+        runDrip(STTSettings(displayMode = "transcribe", dripFeedEnabled = false)) { speak, _ ->
+            speak(listOf(segment(spoken, id = 1)))
+            mainClock.advanceTimeByFrame()
+            onNodeWithText(spoken, substring = true).assertExists()
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/SttDripFeedTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/SttDripFeedTest.kt
@@ -1,0 +1,165 @@
+package org.churchpresenter.app.churchpresenter.presenter
+
+import org.churchpresenter.app.churchpresenter.viewmodel.STTSegment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The character arithmetic behind the letter-by-letter caption reveal.
+ *
+ * What matters to the room: the reveal advances at the configured pace, never re-types words that
+ * have already been read, and never falls so far behind live speech that the caption stops being
+ * the sentence being spoken. Every rule here is one of those three, and every one is exercised
+ * against the caption string the presenter actually draws — [captionText] is the same joining
+ * `buildDisplayText` renders, so a cursor position always means the same thing on both sides.
+ */
+class SttDripFeedTest {
+
+    private fun segment(text: String, id: Int = 1) =
+        STTSegment(id = id, timestamp = "", text = text, start = 0.0, end = 1.0, completed = true)
+
+    private val blessed = listOf(segment("Blessed are", id = 1), segment("the peacemakers", id = 2))
+
+    // ── captionText ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `segments are joined into the caption the presenter draws`() {
+        assertEquals("Blessed are the peacemakers", captionText(blessed))
+    }
+
+    @Test
+    fun `ragged whitespace from the transcriber is collapsed`() {
+        val ragged = listOf(segment("  Blessed   are \n"), segment(" the  peacemakers ", id = 2))
+        assertEquals(
+            "Blessed are the peacemakers",
+            captionText(ragged),
+            "the cursor counts characters of the drawn caption, so both sides must normalise alike",
+        )
+    }
+
+    @Test
+    fun `blank segments take up no room in the caption`() {
+        val withBlank = listOf(segment("Blessed are"), segment("   ", id = 2), segment("the peacemakers", id = 3))
+        assertEquals("Blessed are the peacemakers", captionText(withBlank))
+    }
+
+    // ── applyRevealBudget ───────────────────────────────────────────────────────
+
+    @Test
+    fun `a cursor mid-word truncates that segment and drops the rest`() {
+        val shown = applyRevealBudget(blessed, revealed = 5)
+        assertEquals("Bless", captionText(shown))
+    }
+
+    @Test
+    fun `a cursor exactly on a segment boundary stops before the joining space`() {
+        val shown = applyRevealBudget(blessed, revealed = 11)
+        assertEquals("Blessed are", captionText(shown))
+        assertEquals(1, shown.size, "the next segment has not been reached yet")
+    }
+
+    @Test
+    fun `a cursor past the boundary spends one character on the joining space`() {
+        val shown = applyRevealBudget(blessed, revealed = 13)
+        assertEquals(
+            "Blessed are t",
+            captionText(shown),
+            "13 revealed characters must be 13 characters of caption, space included",
+        )
+    }
+
+    @Test
+    fun `a cursor at the end returns the segments untouched`() {
+        assertSame(
+            blessed,
+            applyRevealBudget(blessed, revealed = captionText(blessed).length + 50),
+            "once caught up the reveal must not allocate a new list every frame",
+        )
+    }
+
+    @Test
+    fun `a cursor at zero shows nothing`() {
+        assertEquals("", captionText(applyRevealBudget(blessed, revealed = 0)))
+    }
+
+    @Test
+    fun `every cursor position renders exactly that many characters`() {
+        val full = captionText(blessed)
+        for (cursor in 0..full.length) {
+            assertEquals(
+                // trimEnd: a cursor landing exactly on a joining space draws the words either side
+                // of it identically whether or not the space itself is emitted.
+                full.take(cursor).trimEnd(),
+                captionText(applyRevealBudget(blessed, cursor)),
+                "cursor $cursor must draw the first $cursor characters of the caption",
+            )
+        }
+    }
+
+    // ── reanchorCursor ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `a newly arrived segment lets the reveal carry straight on`() {
+        assertEquals(
+            5,
+            reanchorCursor("Blessed are", prevRevealed = 5, newFull = "Blessed are the peacemakers"),
+            "an append must not restart the reveal — that is the bug that made the speed setting inert",
+        )
+    }
+
+    @Test
+    fun `text dropped off the front of the window shifts the cursor with it`() {
+        // Shown was "Blessed are the peac"; the window has since dropped "Blessed are ", so
+        // "the peac" — 8 characters — is what stays on screen.
+        assertEquals(
+            8,
+            reanchorCursor("Blessed are the peacemakers", prevRevealed = 20, newFull = "the peacemakers"),
+            "the same words stay revealed after the rolling window trims older segments",
+        )
+    }
+
+    @Test
+    fun `a window that scrolled past everything shown reveals the rest properly`() {
+        assertEquals(
+            0,
+            reanchorCursor("Blessed are the peacemakers", prevRevealed = 5, newFull = "peacemakers and more"),
+            "none of this has been read yet, so it must be typed out rather than dumped on screen",
+        )
+    }
+
+    @Test
+    fun `a caption rewritten past recognition jumps to the end rather than re-typing`() {
+        assertEquals(
+            "Rejoice and be glad".length,
+            reanchorCursor("Blessed are the peacemakers", prevRevealed = 20, newFull = "Rejoice and be glad"),
+            "showing everything at once beats making the room read the same words twice",
+        )
+    }
+
+    @Test
+    fun `an empty caption starts the next reveal from the beginning`() {
+        assertEquals(0, reanchorCursor("", prevRevealed = 0, newFull = "Blessed are"))
+    }
+
+    // ── revealStep ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a reveal that is keeping up draws one character per tick`() {
+        assertEquals(1, revealStep(revealed = 20, target = 27), "the configured speed is the speed")
+    }
+
+    @Test
+    fun `a reveal left far behind live speech draws faster to catch up`() {
+        assertTrue(
+            revealStep(revealed = 0, target = 2_000) > 1,
+            "a caption that keeps drifting behind the speaker stops being the caption for what is said",
+        )
+    }
+
+    @Test
+    fun `a caught-up reveal never steps backwards`() {
+        assertEquals(1, revealStep(revealed = 40, target = 10), "a shrinking caption must not produce a negative step")
+    }
+}


### PR DESCRIPTION
## The bug

On the STT tab, **Drip Feed → Speed (ms/letter)** appeared to do nothing — 100, 120 and 140 ms all produced an identical reveal pace on the presenter output and the live preview.

The setting was saving and reaching the presenter fine. `useDripFeed` was the problem: it revealed **only the newest segment**, and reset the cursor to zero every time another segment arrived — which also dropped the previous segment out of the truncated slot and rendered it in full instantly.

`STTManager` rebuilds its segment list from the server's *completed* segments, which land a few seconds apart. So once the speed was slow enough that a segment couldn't finish revealing before the next one arrived (~50 chars × 100 ms ≈ 5 s, against a cadence of a few seconds), the reveal never completed and the visible pace was set entirely by the server's cadence. The knob only had a visible effect below roughly its 25 ms default.

## The fix

One cursor over the whole caption instead of one per segment:

- a segment landing mid-reveal **extends** the text still to be typed rather than resetting it, so nothing snaps to full;
- the cursor follows the caption when the server's rolling window trims text off the front, and starts over only on text nobody has read yet;
- it accelerates when it falls far behind live speech, so a slow speed can't leave the caption drifting behind the room for the rest of the service;
- the effect is keyed on the speed, so a change applies to the reveal already in flight instead of waiting for the next segment;
- the cursor starts at the end of whatever is already on screen, so an output opened mid-service inherits its backlog rather than re-typing it. That also removes the one-frame full-text flash the old `Int.MAX_VALUE` sentinel caused at the start of every segment.

The character arithmetic moves into `SttDripFeed.kt`, testable without a composition, and `buildDisplayText` now joins the caption through the same `captionText` the cursor counts against so the two can't drift apart.

## Tests

- `SttDripFeedTest` — caption joining/normalisation, truncation at every cursor position, and re-anchoring across append / front-trim / scrolled-past / rewritten captions.
- `STTPresenterDripFeedRenderTest` — the presenter in a real composition on the test's **virtual clock**: a fast speed has more on screen than a slow one at the same instant, a segment arriving mid-reveal does not snap its predecessor to full (the reported bug), the reveal carries on across the boundary to the end, a speed change applies mid-flight, and drip-off still shows the caption immediately. No sleeps; slowest case 0.89 s including Compose warm-up.

`./gradlew :composeApp:check` passes; the new tests were run three times with `--rerun-tasks`.