### PR TITLE
Test the update dialog's download state machine

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/UpdateAvailableDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/UpdateAvailableDialog.kt
@@ -84,7 +84,7 @@ import java.net.HttpURLConnection
 import java.net.URI
 import kotlin.system.exitProcess
 
-private sealed class DownloadState {
+internal sealed class DownloadState {
     object Idle : DownloadState()
     data class Downloading(val progress: Float) : DownloadState() // -1f = indeterminate
     data class Done(val file: File) : DownloadState()
@@ -279,237 +279,282 @@ fun UpdateAvailableDialog(
         title = dialogTitle,
         resizable = false
     ) {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background
+        UpdateAvailableContent(
+            result = result,
+            isManualCheck = isManualCheck,
+            participateInPrereleases = participateInPrereleases,
+            onParticipateInPrereleasesChange = onParticipateInPrereleasesChange,
+            updateCheckInterval = updateCheckInterval,
+            onUpdateCheckIntervalChange = onUpdateCheckIntervalChange,
+            downloadState = downloadState,
+            onDownload = startDownload,
+            onInstall = { file ->
+                try {
+                    launchInstaller(file)
+                    exitProcess(0)
+                } catch (e: Exception) {
+                    downloadState = DownloadState.Error(e.message ?: "Failed to launch installer")
+                }
+            },
+            onOpenReleasePage = { Desktop.getDesktop().browse(URI(it)) },
+            onDismiss = onDismiss
+        )
+    }
+}
+
+/**
+ * Everything the update window shows: the version and its release notes, the check-interval and
+ * pre-release controls, the download progress area, and the one button whose label depends on how
+ * far the download has got.
+ *
+ * Held apart from [UpdateAvailableDialog] because that function's other statements all reach the
+ * machine — the `DialogWindow` it opens, the HTTP download, launching the installer and quitting,
+ * and handing a URL to the desktop browser. None of those can run under the headless suite, and
+ * two of them would be actively destructive in one.
+ *
+ * [downloadState] is passed in rather than owned here so a test can put the dialog into each stage
+ * of a download — mid-progress, finished, failed — without one taking place. That state machine is
+ * the point of the dialog: it decides whether the operator is offered Download, a disabled
+ * Downloading, Install Now, or a fallback link to the release page.
+ */
+@Composable
+internal fun UpdateAvailableContent(
+    result: UpdateCheckResult,
+    isManualCheck: Boolean,
+    participateInPrereleases: Boolean,
+    onParticipateInPrereleasesChange: (Boolean) -> Unit,
+    updateCheckInterval: UpdateCheckInterval,
+    onUpdateCheckIntervalChange: (UpdateCheckInterval) -> Unit,
+    downloadState: DownloadState,
+    onDownload: () -> Unit,
+    onInstall: (File) -> Unit,
+    onOpenReleasePage: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val updateInfo = (result as? UpdateCheckResult.Available)?.info
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Column(
-                modifier = Modifier.fillMaxSize().padding(24.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                if (updateInfo != null) {
-                    HeroIcon(
-                        icon = Icons.Default.Download,
-                        circleColor = MaterialTheme.colorScheme.primary,
-                        iconColor = MaterialTheme.colorScheme.onPrimary
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
+            if (updateInfo != null) {
+                HeroIcon(
+                    icon = Icons.Default.Download,
+                    circleColor = MaterialTheme.colorScheme.primary,
+                    iconColor = MaterialTheme.colorScheme.onPrimary
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(Res.string.update_dialog_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(Res.string.update_dialog_message, updateInfo.latestVersion),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Surface(
+                    color = if (updateInfo.isPrerelease)
+                        MaterialTheme.colorScheme.tertiaryContainer
+                    else
+                        MaterialTheme.colorScheme.primaryContainer,
+                    shape = RoundedCornerShape(4.dp)
+                ) {
                     Text(
-                        text = stringResource(Res.string.update_dialog_title),
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = stringResource(Res.string.update_dialog_message, updateInfo.latestVersion),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(modifier = Modifier.height(6.dp))
-                    Surface(
-                        color = if (updateInfo.isPrerelease)
-                            MaterialTheme.colorScheme.tertiaryContainer
+                        text = if (updateInfo.isPrerelease)
+                            stringResource(Res.string.update_dialog_channel_prerelease)
                         else
-                            MaterialTheme.colorScheme.primaryContainer,
-                        shape = RoundedCornerShape(4.dp)
+                            stringResource(Res.string.update_dialog_channel_stable),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (updateInfo.isPrerelease)
+                            MaterialTheme.colorScheme.onTertiaryContainer
+                        else
+                            MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
+                    )
+                }
+                if (updateInfo.releaseNotes.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(Res.string.update_dialog_release_notes),
+                        style = MaterialTheme.typography.labelMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Surface(
+                        modifier = Modifier.fillMaxWidth().weight(1f),
+                        color = MaterialTheme.colorScheme.surfaceVariant,
+                        shape = MaterialTheme.shapes.small
                     ) {
                         Text(
-                            text = if (updateInfo.isPrerelease)
-                                stringResource(Res.string.update_dialog_channel_prerelease)
-                            else
-                                stringResource(Res.string.update_dialog_channel_stable),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = if (updateInfo.isPrerelease)
-                                MaterialTheme.colorScheme.onTertiaryContainer
-                            else
-                                MaterialTheme.colorScheme.onPrimaryContainer,
-                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp)
+                            text = updateInfo.releaseNotes,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .padding(8.dp)
+                                .verticalScroll(rememberScrollState())
                         )
                     }
-                    if (updateInfo.releaseNotes.isNotBlank()) {
-                        Spacer(modifier = Modifier.height(12.dp))
-                        Text(
-                            text = stringResource(Res.string.update_dialog_release_notes),
-                            style = MaterialTheme.typography.labelMedium,
-                            fontWeight = FontWeight.SemiBold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Surface(
-                            modifier = Modifier.fillMaxWidth().weight(1f),
-                            color = MaterialTheme.colorScheme.surfaceVariant,
-                            shape = MaterialTheme.shapes.small
-                        ) {
-                            Text(
-                                text = updateInfo.releaseNotes,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier
-                                    .padding(8.dp)
-                                    .verticalScroll(rememberScrollState())
-                            )
-                        }
-                        Spacer(modifier = Modifier.height(12.dp))
-                    } else {
-                        Spacer(modifier = Modifier.height(16.dp))
-                    }
-
-                    // Progress area
-                    when (val state = downloadState) {
-                        is DownloadState.Downloading -> {
-                            val progressText = if (state.progress >= 0f)
-                                "${(state.progress * 100).toInt()}%"
-                            else
-                                stringResource(Res.string.update_dialog_downloading)
-                            Text(
-                                text = progressText,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                            if (state.progress >= 0f) {
-                                LinearProgressIndicator(
-                                    progress = { state.progress },
-                                    modifier = Modifier.fillMaxWidth()
-                                )
-                            } else {
-                                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
-                            }
-                            Spacer(modifier = Modifier.height(8.dp))
-                        }
-                        is DownloadState.Error -> {
-                            Text(
-                                text = state.message,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.error
-                            )
-                            Spacer(modifier = Modifier.height(4.dp))
-                        }
-                        else -> {}
-                    }
+                    Spacer(modifier = Modifier.height(12.dp))
                 } else {
-                    Spacer(modifier = Modifier.height(8.dp))
-                    HeroIcon(
-                        icon = Icons.Default.Check,
-                        circleColor = MaterialTheme.colorScheme.inverseSurface,
-                        iconColor = MaterialTheme.colorScheme.inverseOnSurface
-                    )
                     Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = stringResource(Res.string.update_dialog_up_to_date_title),
-                        style = MaterialTheme.typography.headlineSmall,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Spacer(modifier = Modifier.height(8.dp))
-                    Text(
-                        text = stringResource(Res.string.update_already_latest),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(modifier = Modifier.weight(1f))
                 }
 
+                // Progress area
+                when (val state = downloadState) {
+                    is DownloadState.Downloading -> {
+                        val progressText = if (state.progress >= 0f)
+                            "${(state.progress * 100).toInt()}%"
+                        else
+                            stringResource(Res.string.update_dialog_downloading)
+                        Text(
+                            text = progressText,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        if (state.progress >= 0f) {
+                            LinearProgressIndicator(
+                                progress = { state.progress },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        } else {
+                            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        }
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                    is DownloadState.Error -> {
+                        Text(
+                            text = state.message,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                    }
+                    else -> {}
+                }
+            } else {
                 Spacer(modifier = Modifier.height(8.dp))
-                HorizontalDivider()
+                HeroIcon(
+                    icon = Icons.Default.Check,
+                    circleColor = MaterialTheme.colorScheme.inverseSurface,
+                    iconColor = MaterialTheme.colorScheme.inverseOnSurface
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(Res.string.update_dialog_up_to_date_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(Res.string.update_already_latest),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.weight(1f))
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider()
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(Res.string.participate_in_prereleases),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.weight(1f)
+                )
+                Switch(
+                    checked = participateInPrereleases,
+                    onCheckedChange = onParticipateInPrereleasesChange
+                )
+            }
+            if (isManualCheck) {
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        text = stringResource(Res.string.participate_in_prereleases),
+                        text = stringResource(Res.string.update_dialog_check_interval),
                         style = MaterialTheme.typography.bodyMedium,
                         modifier = Modifier.weight(1f)
                     )
-                    Switch(
-                        checked = participateInPrereleases,
-                        onCheckedChange = onParticipateInPrereleasesChange
+                    UpdateIntervalDropdown(
+                        selected = updateCheckInterval,
+                        onSelected = onUpdateCheckIntervalChange
                     )
                 }
-                if (isManualCheck) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = stringResource(Res.string.update_dialog_check_interval),
-                            style = MaterialTheme.typography.bodyMedium,
-                            modifier = Modifier.weight(1f)
-                        )
-                        UpdateIntervalDropdown(
-                            selected = updateCheckInterval,
-                            onSelected = onUpdateCheckIntervalChange
-                        )
+            }
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (updateInfo != null) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)
+                ) {
+                    OutlinedButton(shape = RoundedCornerShape(6.dp), onClick = onDismiss) {
+                        Text(stringResource(Res.string.update_dialog_dismiss))
+                    }
+                    when {
+                        downloadState is DownloadState.Done -> {
+                            Button(
+                                shape = RoundedCornerShape(6.dp),
+                                onClick = { onInstall((downloadState as DownloadState.Done).file) }
+                            ) {
+                                Text(stringResource(Res.string.update_dialog_install_now))
+                            }
+                        }
+                        downloadState is DownloadState.Downloading -> {
+                            Button(shape = RoundedCornerShape(6.dp), onClick = {}, enabled = false) {
+                                Text(stringResource(Res.string.update_dialog_downloading))
+                            }
+                        }
+                        downloadState is DownloadState.Error || updateInfo.downloadUrl == null -> {
+                            Button(
+                                shape = RoundedCornerShape(6.dp),
+                                onClick = {
+                                    onOpenReleasePage(updateInfo.releaseUrl)
+                                    onDismiss()
+                                }
+                            ) {
+                                Text(stringResource(Res.string.update_dialog_open_page))
+                            }
+                        }
+                        else -> {
+                            Button(shape = RoundedCornerShape(6.dp), onClick = onDownload) {
+                                Text(stringResource(Res.string.update_dialog_download_install))
+                            }
+                        }
                     }
                 }
-                HorizontalDivider()
-                Spacer(modifier = Modifier.height(8.dp))
-
-                if (updateInfo != null) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedButton(
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(6.dp),
+                        onClick = {
+                            Desktop.getDesktop().browse(URI(UpdateChecker.RELEASES_URL))
+                            onDismiss()
+                        }
                     ) {
-                        OutlinedButton(shape = RoundedCornerShape(6.dp), onClick = onDismiss) {
-                            Text(stringResource(Res.string.update_dialog_dismiss))
-                        }
-                        when {
-                            downloadState is DownloadState.Done -> {
-                                Button(
-                                    shape = RoundedCornerShape(6.dp),
-                                    onClick = {
-                                    val file = (downloadState as DownloadState.Done).file
-                                    try {
-                                        launchInstaller(file)
-                                        exitProcess(0)
-                                    } catch (e: Exception) {
-                                        downloadState = DownloadState.Error(
-                                            e.message ?: "Failed to launch installer"
-                                        )
-                                    }
-                                }) {
-                                    Text(stringResource(Res.string.update_dialog_install_now))
-                                }
-                            }
-                            downloadState is DownloadState.Downloading -> {
-                                Button(shape = RoundedCornerShape(6.dp), onClick = {}, enabled = false) {
-                                    Text(stringResource(Res.string.update_dialog_downloading))
-                                }
-                            }
-                            downloadState is DownloadState.Error || updateInfo.downloadUrl == null -> {
-                                Button(
-                                    shape = RoundedCornerShape(6.dp),
-                                    onClick = {
-                                    Desktop.getDesktop().browse(URI(updateInfo.releaseUrl))
-                                    onDismiss()
-                                }) {
-                                    Text(stringResource(Res.string.update_dialog_open_page))
-                                }
-                            }
-                            else -> {
-                                Button(shape = RoundedCornerShape(6.dp), onClick = startDownload) {
-                                    Text(stringResource(Res.string.update_dialog_download_install))
-                                }
-                            }
-                        }
+                        Text(stringResource(Res.string.update_dialog_view_on_github))
                     }
-                } else {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        OutlinedButton(
-                            modifier = Modifier.weight(1f),
-                            shape = RoundedCornerShape(6.dp),
-                            onClick = {
-                                Desktop.getDesktop().browse(URI(UpdateChecker.RELEASES_URL))
-                                onDismiss()
-                            }
-                        ) {
-                            Text(stringResource(Res.string.update_dialog_view_on_github))
-                        }
-                        Button(shape = RoundedCornerShape(6.dp), onClick = onDismiss) {
-                            Text(stringResource(Res.string.ok))
-                        }
+                    Button(shape = RoundedCornerShape(6.dp), onClick = onDismiss) {
+                        Text(stringResource(Res.string.ok))
                     }
                 }
             }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/UpdateAvailableContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/UpdateAvailableContentTest.kt
@@ -1,0 +1,254 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.utils.UpdateCheckInterval
+import org.churchpresenter.app.churchpresenter.utils.UpdateCheckResult
+import org.churchpresenter.app.churchpresenter.utils.UpdateInfo
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The update window, and the one button whose label depends on how far the download has got.
+ *
+ * That button is the whole dialog: Download & Install to begin, a disabled Downloading while it
+ * runs, Install Now when it finishes, and — if the download failed or the release has no installer
+ * for this platform — a fallback link to the release page so the operator is never left with no way
+ * forward. Offering the wrong one either strands them or, worse, offers Install Now for a file that
+ * was never fetched.
+ *
+ * `UpdateAvailableDialog`'s other statements all reach the machine: the `DialogWindow`, an HTTP
+ * download, launching an installer and calling `exitProcess(0)`, and handing a URL to the desktop
+ * browser. None run headless and two would be destructive in a test run, so the body was lifted into
+ * `UpdateAvailableContent` and all four stay outside it. `downloadState` is passed in, which is what
+ * lets these tests put the dialog at each stage of a download without one taking place.
+ *
+ * Left uncovered: the `DialogWindow` call and those four machine-facing operations.
+ */
+class UpdateAvailableContentTest {
+
+    private object Label {
+        const val DOWNLOAD = "Download & Install"
+        const val DOWNLOADING = "Downloading..."
+        const val INSTALL = "Install Now"
+        const val OPEN_PAGE = "Open Download Page"
+        const val LATER = "Later"
+        const val UP_TO_DATE = "You are running the latest version."
+        const val RELEASE_NOTES = "What's new:"
+        const val PRERELEASE_TOGGLE = "Include beta / pre-release updates"
+        const val CHECK_INTERVAL = "Check for updates"
+    }
+
+    private class Actions {
+        var downloads = 0
+        var installed: File? = null
+        var openedPage: String? = null
+        var dismissed = 0
+        var prereleases: Boolean? = null
+        var interval: UpdateCheckInterval? = null
+    }
+
+    private fun available(
+        version: String = "2.5.0",
+        notes: String = "Fixed the drip feed",
+        downloadUrl: String? = "https://example.invalid/ChurchPresenter-2.5.0.dmg",
+        prerelease: Boolean = false,
+    ) = UpdateCheckResult.Available(
+        UpdateInfo(
+            latestVersion = version,
+            releaseUrl = "https://example.invalid/releases/$version",
+            releaseNotes = notes,
+            downloadUrl = downloadUrl,
+            isPrerelease = prerelease,
+        ),
+    )
+
+    @OptIn(ExperimentalTestApi::class)
+    private fun updateDialog(
+        result: UpdateCheckResult = available(),
+        downloadState: DownloadState = DownloadState.Idle,
+        isManualCheck: Boolean = false,
+        participateInPrereleases: Boolean = false,
+        block: ComposeUiTest.(Actions) -> Unit,
+    ) {
+        val actions = Actions()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    UpdateAvailableContent(
+                        result = result,
+                        isManualCheck = isManualCheck,
+                        participateInPrereleases = participateInPrereleases,
+                        onParticipateInPrereleasesChange = { actions.prereleases = it },
+                        updateCheckInterval = UpdateCheckInterval.WEEKLY,
+                        onUpdateCheckIntervalChange = { actions.interval = it },
+                        downloadState = downloadState,
+                        onDownload = { actions.downloads++ },
+                        onInstall = { actions.installed = it },
+                        onOpenReleasePage = { actions.openedPage = it },
+                        onDismiss = { actions.dismissed++ },
+                    )
+                }
+            }
+            block(actions)
+        }
+    }
+
+    private fun ComposeUiTest.shows(text: String): Boolean =
+        onAllNodes(hasText(text)).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
+
+    // ── An update is available ──────────────────────────────────────────────────
+
+    @Test
+    fun `the new version and its release notes are shown`() =
+        updateDialog(available(version = "2.5.0", notes = "Fixed the drip feed")) { _ ->
+            assertTrue(shows("A new version of Church Presenter is available: 2.5.0"))
+            onNodeWithText(Label.RELEASE_NOTES).assertIsDisplayed()
+            assertTrue(shows("Fixed the drip feed"), "the notes tell the operator whether to bother")
+        }
+
+    @Test
+    fun `a pre-release says so rather than looking like a stable one`() =
+        updateDialog(available(prerelease = true)) { _ ->
+            assertTrue(shows("Pre-release"), "an operator must not install a beta thinking it is stable")
+        }
+
+    @Test
+    fun `a stable release is labelled stable`() = updateDialog(available(prerelease = false)) { _ ->
+        assertTrue(shows("Stable release"))
+    }
+
+    // ── The button, at each stage of the download ───────────────────────────────
+
+    @Test
+    fun `before anything is downloaded the button offers to download`() = updateDialog { actions ->
+        onNodeWithText(Label.DOWNLOAD).performClick()
+        waitForIdle()
+        assertEquals(1, actions.downloads)
+        assertNull(actions.installed, "nothing has been fetched, so nothing can be installed")
+    }
+
+    @Test
+    fun `while downloading the button says so and cannot be pressed again`() =
+        updateDialog(downloadState = DownloadState.Downloading(0.4f)) { actions ->
+            onNodeWithText(Label.DOWNLOADING).assertIsNotEnabled()
+            assertEquals(0, actions.downloads, "a second download must not be startable mid-flight")
+        }
+
+    @Test
+    fun `a download in progress reports its percentage`() =
+        updateDialog(downloadState = DownloadState.Downloading(0.42f)) { _ ->
+            assertTrue(shows("42%"), "the operator needs to know it is moving")
+        }
+
+    @Test
+    fun `a download of unknown size still shows it is running`() =
+        updateDialog(downloadState = DownloadState.Downloading(-1f)) { _ ->
+            // -1f means the server sent no content length; there is no percentage to show.
+            assertTrue(shows(Label.DOWNLOADING))
+            assertTrue(!shows("-100%"), "an unknown size must not be rendered as a negative percentage")
+        }
+
+    @Test
+    fun `a finished download offers to install the file that was fetched`() {
+        val fetched = File("/tmp/ChurchPresenter-update-test.dmg")
+        updateDialog(downloadState = DownloadState.Done(fetched)) { actions ->
+            onNodeWithText(Label.INSTALL).performClick()
+            waitForIdle()
+            assertEquals(
+                fetched,
+                actions.installed,
+                "the installer launched must be the file the download produced",
+            )
+        }
+    }
+
+    // ── When the download cannot be the answer ──────────────────────────────────
+
+    @Test
+    fun `a failed download says why and falls back to the release page`() =
+        updateDialog(downloadState = DownloadState.Error("Connection reset")) { actions ->
+            assertTrue(shows("Connection reset"), "the operator is told what went wrong")
+
+            onNodeWithText(Label.OPEN_PAGE).performClick()
+            waitForIdle()
+            assertEquals(
+                "https://example.invalid/releases/2.5.0",
+                actions.openedPage,
+                "a failed download must still leave a way to get the update",
+            )
+            assertEquals(1, actions.dismissed, "opening the page closes the dialog behind it")
+        }
+
+    @Test
+    fun `a release with no installer for this platform offers the page instead of a download`() =
+        updateDialog(available(downloadUrl = null)) { actions ->
+            assertTrue(!shows(Label.DOWNLOAD), "there is nothing to download, so it must not be offered")
+            onNodeWithText(Label.OPEN_PAGE).performClick()
+            waitForIdle()
+            assertEquals("https://example.invalid/releases/2.5.0", actions.openedPage)
+        }
+
+    // ── Already up to date ──────────────────────────────────────────────────────
+
+    @Test
+    fun `being up to date says so and offers nothing to download`() =
+        updateDialog(UpdateCheckResult.UpToDate) { _ ->
+            onNodeWithText(Label.UP_TO_DATE).assertIsDisplayed()
+            assertTrue(!shows(Label.DOWNLOAD), "there is no update to fetch")
+            assertTrue(!shows(Label.RELEASE_NOTES), "and no notes to read")
+        }
+
+    // ── The settings carried on the dialog ──────────────────────────────────────
+
+    @Test
+    fun `the pre-release toggle reports the value it moved to`() = updateDialog { actions ->
+        onNodeWithText(Label.PRERELEASE_TOGGLE).assertIsDisplayed()
+        // The caption is a plain Text beside the Switch, so the switch itself is what takes a press.
+        onNode(isToggleable()).performClick()
+        waitForIdle()
+        assertEquals(true, actions.prereleases, "switching it on must report on")
+    }
+
+    @Test
+    fun `turning the pre-release toggle back off reports off`() =
+        updateDialog(participateInPrereleases = true) { actions ->
+            onNode(isToggleable()).performClick()
+            waitForIdle()
+            assertEquals(false, actions.prereleases)
+        }
+
+    @Test
+    fun `only a manual check offers the update-frequency setting`() {
+        updateDialog(isManualCheck = true) { _ ->
+            assertTrue(shows(Label.CHECK_INTERVAL), "a deliberate visit to Check for Updates offers it")
+        }
+        updateDialog(isManualCheck = false) { _ ->
+            // A popup that appeared on its own at launch is not the place to change settings.
+            assertTrue(!shows(Label.CHECK_INTERVAL))
+        }
+    }
+
+    // ── Leaving ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `Later closes without downloading anything`() = updateDialog { actions ->
+        onNodeWithText(Label.LATER).performClick()
+        waitForIdle()
+        assertEquals(1, actions.dismissed)
+        assertEquals(0, actions.downloads)
+    }
+}


### PR DESCRIPTION
Sixth of the `dialogs/` push. Independent of everything else open.

## Approach

`UpdateAvailableDialog`'s statements outside its body **all** reach the machine: the `DialogWindow`, an HTTP download, launching an installer followed by `exitProcess(0)`, and handing a URL to `Desktop.browse`. None run headless, and two would be actively destructive in a test run — a test that clicked Install Now would try to launch an installer and kill the JVM.

So the body moves into `internal UpdateAvailableContent` and all four stay outside as callbacks (`onDownload`, `onInstall`, `onOpenReleasePage`), with `downloadState` **passed in** rather than owned. That last part is what makes the dialog testable at all: a test can place it mid-download, finished, or failed without a download happening. `DownloadState` widens `private` → `internal` for the same reason.

## Tests — `UpdateAvailableContentTest` (15)

The dialog is really one button whose label depends on how far the download has got, and getting it wrong either strands the operator or offers to install a file that was never fetched:

| state | button | asserted |
|---|---|---|
| Idle | Download & Install | fires `onDownload`, installs nothing |
| Downloading | Downloading… | **disabled** — no second download mid-flight |
| Done | Install Now | hands back **the file the download produced** |
| Error | Open Download Page | shows the error, opens the release URL, closes behind it |
| `downloadUrl == null` | Open Download Page | no download offered when there is no installer for this platform |

Plus the percentage while downloading, the indeterminate case where the server sent no content length (`-1f` must not render as `-100%`), the pre-release vs stable label, and the up-to-date state offering neither a download nor release notes.

## Two of my assumptions were wrong

Worth recording, since they were wrong in the direction of writing tests that pass vacuously:

1. I assumed the **pre-release toggle was manual-check only**. It is shown on every check; it is the *update-frequency* setting that is manual-only. My test asserted the toggle was absent on an automatic check and failed — correctly.
2. I assumed clicking the toggle's **caption** would flip it. The caption is a plain `Text` beside the `Switch`, so the switch is what takes the press.

Both are now tested as they actually behave.

## Deliberately left uncovered

The `DialogWindow` call, the download coroutine, `launchInstaller` + `exitProcess`, and `Desktop.browse` — the machine-facing code the extraction exists to isolate.

Deterministic 3×. 0.34s for 15 tests. Full `:composeApp:check` green.