### PR TITLE
Inject the HTTP client instead of overriding it on a singleton

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClient.kt
@@ -75,11 +75,6 @@ object PlanningCenterClient {
         }
     }
 
-    /** Test seam: when set, requests go here instead of the real network client. Null in production. */
-    internal var httpOverride: HttpClient? = null
-
-    private val http: HttpClient get() = httpOverride ?: defaultHttp
-
     fun redirectUri(): String = "http://127.0.0.1:${Constants.PLANNING_CENTER_OAUTH_PORT}/callback"
 
     fun buildAuthorizationUrl(clientId: String): String {
@@ -95,7 +90,12 @@ object PlanningCenterClient {
         val expires_in: Long = 0L
     )
 
-    suspend fun exchangeCodeForToken(clientId: String, clientSecret: String, code: String): TokenOutcome =
+    suspend fun exchangeCodeForToken(
+        clientId: String,
+        clientSecret: String,
+        code: String,
+        http: HttpClient = defaultHttp,
+    ): TokenOutcome =
         requestToken(
             clientId = clientId,
             clientSecret = clientSecret,
@@ -103,17 +103,24 @@ object PlanningCenterClient {
                 "grant_type" to "authorization_code",
                 "code" to code,
                 "redirect_uri" to redirectUri()
-            )
+            ),
+            http = http,
         )
 
-    suspend fun refreshAccessToken(clientId: String, clientSecret: String, refreshToken: String): TokenOutcome =
+    suspend fun refreshAccessToken(
+        clientId: String,
+        clientSecret: String,
+        refreshToken: String,
+        http: HttpClient = defaultHttp,
+    ): TokenOutcome =
         requestToken(
             clientId = clientId,
             clientSecret = clientSecret,
             formParams = mapOf(
                 "grant_type" to "refresh_token",
                 "refresh_token" to refreshToken
-            )
+            ),
+            http = http,
         )
 
     /**
@@ -123,7 +130,12 @@ object PlanningCenterClient {
      * includes client_id/secret as body params for servers that only check there — belt and
      * braces, since a mismatch here surfaces as an opaque "unknown client" error either way.
      */
-    private suspend fun requestToken(clientId: String, clientSecret: String, formParams: Map<String, String>): TokenOutcome = withContext(Dispatchers.IO) {
+    private suspend fun requestToken(
+        clientId: String,
+        clientSecret: String,
+        formParams: Map<String, String>,
+        http: HttpClient,
+    ): TokenOutcome = withContext(Dispatchers.IO) {
         try {
             val bodyParams = formParams + mapOf("client_id" to clientId, "client_secret" to clientSecret)
             val body = bodyParams.entries.joinToString("&") { (k, v) -> "$k=${v.encodeURLParameter()}" }
@@ -175,7 +187,7 @@ object PlanningCenterClient {
     @Serializable
     internal data class PersonResponse(val data: PersonData = PersonData())
 
-    suspend fun getCurrentPerson(accessToken: String): PersonOutcome = withContext(Dispatchers.IO) {
+    suspend fun getCurrentPerson(accessToken: String, http: HttpClient = defaultHttp): PersonOutcome = withContext(Dispatchers.IO) {
         try {
             val response = http.get(ME_URL) {
                 header("Authorization", "Bearer $accessToken")
@@ -262,7 +274,7 @@ object PlanningCenterClient {
         data object Failure : ArrangementOutcome
     }
 
-    suspend fun listServiceTypes(accessToken: String): ServiceTypesOutcome = withContext(Dispatchers.IO) {
+    suspend fun listServiceTypes(accessToken: String, http: HttpClient = defaultHttp): ServiceTypesOutcome = withContext(Dispatchers.IO) {
         try {
             val response = http.get("$SERVICES_BASE_URL/service_types") {
                 header("Authorization", "Bearer $accessToken")
@@ -297,7 +309,11 @@ object PlanningCenterClient {
         }
     }
 
-    suspend fun listUpcomingPlans(accessToken: String, serviceTypeId: String): PlansOutcome = withContext(Dispatchers.IO) {
+    suspend fun listUpcomingPlans(
+        accessToken: String,
+        serviceTypeId: String,
+        http: HttpClient = defaultHttp,
+    ): PlansOutcome = withContext(Dispatchers.IO) {
         try {
             val response = http.get("$SERVICES_BASE_URL/service_types/$serviceTypeId/plans") {
                 header("Authorization", "Bearer $accessToken")
@@ -339,7 +355,12 @@ object PlanningCenterClient {
         }
     }
 
-    suspend fun getPlanItems(accessToken: String, serviceTypeId: String, planId: String): PlanItemsOutcome =
+    suspend fun getPlanItems(
+        accessToken: String,
+        serviceTypeId: String,
+        planId: String,
+        http: HttpClient = defaultHttp,
+    ): PlanItemsOutcome =
         withContext(Dispatchers.IO) {
             try {
                 val response = http.get("$SERVICES_BASE_URL/service_types/$serviceTypeId/plans/$planId/items") {
@@ -402,7 +423,12 @@ object PlanningCenterClient {
             }
         }
 
-    suspend fun getArrangementDetail(accessToken: String, songId: String, arrangementId: String): ArrangementOutcome =
+    suspend fun getArrangementDetail(
+        accessToken: String,
+        songId: String,
+        arrangementId: String,
+        http: HttpClient = defaultHttp,
+    ): ArrangementOutcome =
         withContext(Dispatchers.IO) {
             try {
                 val response = http.get("$SERVICES_BASE_URL/songs/$songId/arrangements/$arrangementId") {
@@ -476,7 +502,8 @@ object PlanningCenterClient {
         accessToken: String,
         serviceTypeId: String,
         planId: String,
-        itemId: String
+        itemId: String,
+        http: HttpClient = defaultHttp,
     ): AttachmentsOutcome = withContext(Dispatchers.IO) {
         try {
             val response = http.get(
@@ -523,7 +550,11 @@ object PlanningCenterClient {
      * event on the account as an audit-trail entry, same as any legitimate download — not a
      * destructive or content-modifying call.
      */
-    suspend fun resolveAttachmentDownloadUrl(accessToken: String, attachmentId: String): AttachmentUrlOutcome =
+    suspend fun resolveAttachmentDownloadUrl(
+        accessToken: String,
+        attachmentId: String,
+        http: HttpClient = defaultHttp,
+    ): AttachmentUrlOutcome =
         withContext(Dispatchers.IO) {
             try {
                 val response = http.post("$SERVICES_BASE_URL/attachments/$attachmentId/open") {
@@ -555,7 +586,11 @@ object PlanningCenterClient {
         }
 
     /** Downloads a file's bytes from an already-resolved URL (a pre-signed S3 link — no auth header needed or wanted). */
-    suspend fun downloadFile(url: String, destination: File): FileDownloadOutcome = withContext(Dispatchers.IO) {
+    suspend fun downloadFile(
+        url: String,
+        destination: File,
+        http: HttpClient = defaultHttp,
+    ): FileDownloadOutcome = withContext(Dispatchers.IO) {
         try {
             val response = http.get(url)
             if (response.status.value !in 200..299) {
@@ -580,7 +615,7 @@ object PlanningCenterClient {
     }
 
     /** Fetches raw bytes for an attachment thumbnail preview (public S3 URL, no auth); null on any failure. */
-    suspend fun fetchThumbnailBytes(url: String): ByteArray? = withContext(Dispatchers.IO) {
+    suspend fun fetchThumbnailBytes(url: String, http: HttpClient = defaultHttp): ByteArray? = withContext(Dispatchers.IO) {
         try {
             val response = http.get(url)
             if (response.status.value in 200..299) response.body() else null

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/StockMediaClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/StockMediaClient.kt
@@ -58,17 +58,7 @@ object StockMediaClient {
         }
     }
 
-    /** Test seam: when set, requests go here instead of the real network client. Null in production. */
-    internal var httpOverride: HttpClient? = null
-
-    private val http: HttpClient get() = httpOverride ?: defaultHttp
-
     private val defaultDownloadDir = File(System.getProperty("user.home"), ".churchpresenter/stock-backgrounds")
-
-    /** Test seam: when set, downloads land here instead of under the user's home. Null in production. */
-    internal var downloadDirOverride: File? = null
-
-    private val downloadDir: File get() = downloadDirOverride ?: defaultDownloadDir
 
     // --- Pexels DTOs ---
 
@@ -132,7 +122,8 @@ object StockMediaClient {
         apiKey: String,
         mediaType: StockMediaType,
         query: String,
-        page: Int
+        page: Int,
+        http: HttpClient = defaultHttp,
     ): SearchOutcome = withContext(Dispatchers.IO) {
         if (apiKey.isBlank()) return@withContext SearchOutcome.InvalidKey
         try {
@@ -288,7 +279,7 @@ object StockMediaClient {
     }
 
     /** Fetches raw bytes for a thumbnail preview; returns null on any failure. */
-    suspend fun fetchThumbnailBytes(url: String): ByteArray? = withContext(Dispatchers.IO) {
+    suspend fun fetchThumbnailBytes(url: String, http: HttpClient = defaultHttp): ByteArray? = withContext(Dispatchers.IO) {
         try {
             val response = http.get(url)
             if (response.status.value in 200..299) response.body() else null
@@ -297,7 +288,11 @@ object StockMediaClient {
         }
     }
 
-    suspend fun download(item: StockMediaItem): DownloadOutcome = withContext(Dispatchers.IO) {
+    suspend fun download(
+        item: StockMediaItem,
+        http: HttpClient = defaultHttp,
+        downloadDir: File = defaultDownloadDir,
+    ): DownloadOutcome = withContext(Dispatchers.IO) {
         try {
             val response = http.get(item.downloadUrl)
             if (response.status.value !in 200..299) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClientNetworkTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClientNetworkTest.kt
@@ -24,22 +24,17 @@ import kotlin.test.assertTrue
  * separately by [PlanningCenterDownloadTest]): the OAuth token exchange, `/people/v2/me`, and the
  * Services API for service types, plans, plan items, arrangement lyrics and attachment metadata.
  *
- * Every request here is served by a `MockEngine` swapped in through [PlanningCenterClient.httpOverride],
- * so nothing in this class touches the real Planning Center API. It is reset after every test —
- * [PlanningCenterClient] is a JVM-wide object.
+ * Every request here is served by a `MockEngine` passed to the call under test, so nothing in this
+ * class touches the real Planning Center API. The client is an ordinary instance field: JUnit builds
+ * a new instance of this class per test method, so there is nothing global to reset.
  */
 class PlanningCenterClientNetworkTest {
 
     private val requests = mutableListOf<HttpRequestData>()
-
-    @AfterTest
-    fun resetClient() {
-        PlanningCenterClient.httpOverride = null
-        requests.clear()
-    }
+    private lateinit var http: HttpClient
 
     private fun respondWith(body: String, status: HttpStatusCode = HttpStatusCode.OK) {
-        PlanningCenterClient.httpOverride = HttpClient(
+        http = HttpClient(
             MockEngine { request ->
                 requests.add(request)
                 respond(
@@ -52,7 +47,7 @@ class PlanningCenterClientNetworkTest {
     }
 
     private fun failToConnect() {
-        PlanningCenterClient.httpOverride = HttpClient(
+        http = HttpClient(
             MockEngine { throw java.io.IOException("no route to host") },
         )
     }
@@ -63,7 +58,7 @@ class PlanningCenterClientNetworkTest {
     fun `an authorization code is exchanged for a token set`() {
         respondWith("""{"access_token":"tok-abc","refresh_token":"ref-abc","expires_in":7200}""")
 
-        val outcome = runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "the-code") }
+        val outcome = runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "the-code", http = http) }
 
         val tokens = assertIs<PlanningCenterClient.TokenOutcome.Success>(outcome, "got $outcome").tokens
         assertEquals("tok-abc", tokens.accessToken)
@@ -78,7 +73,7 @@ class PlanningCenterClientNetworkTest {
     fun `the code exchange authenticates with http basic and sends the redirect uri`() {
         respondWith("""{"access_token":"t","refresh_token":"r","expires_in":100}""")
 
-        runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "the-code") }
+        runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "the-code", http = http) }
 
         val request = requests.single()
         val expectedBasic = "Basic " + Base64.getEncoder().encodeToString("cid:csecret".toByteArray())
@@ -95,7 +90,7 @@ class PlanningCenterClientNetworkTest {
     fun `a refresh token is exchanged with the refresh grant instead of a code`() {
         respondWith("""{"access_token":"t2","refresh_token":"r2","expires_in":100}""")
 
-        runBlocking { PlanningCenterClient.refreshAccessToken("cid", "csecret", "old-refresh") }
+        runBlocking { PlanningCenterClient.refreshAccessToken("cid", "csecret", "old-refresh", http = http) }
 
         val body = String((requests.single().body as OutgoingContent.ByteArrayContent).bytes())
         assertTrue(body.contains("grant_type=refresh_token"))
@@ -108,13 +103,13 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{"error":"invalid_client"}""", HttpStatusCode.Unauthorized)
         assertEquals(
             PlanningCenterClient.TokenOutcome.InvalidCredentials,
-            runBlocking { PlanningCenterClient.exchangeCodeForToken("bad", "bad", "code") },
+            runBlocking { PlanningCenterClient.exchangeCodeForToken("bad", "bad", "code", http = http) },
         )
 
         respondWith("""{"error":"invalid_grant"}""", HttpStatusCode.BadRequest)
         assertEquals(
             PlanningCenterClient.TokenOutcome.InvalidCredentials,
-            runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "stale-code") },
+            runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "stale-code", http = http) },
             "a reused or expired code is the same operator-facing problem as a bad credential",
         )
     }
@@ -125,7 +120,7 @@ class PlanningCenterClientNetworkTest {
 
         assertEquals(
             PlanningCenterClient.TokenOutcome.InvalidCredentials,
-            runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "code") },
+            runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "code", http = http) },
         )
     }
 
@@ -135,7 +130,7 @@ class PlanningCenterClientNetworkTest {
 
         assertEquals(
             PlanningCenterClient.TokenOutcome.Failure,
-            runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "code") },
+            runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "code", http = http) },
         )
     }
 
@@ -145,7 +140,7 @@ class PlanningCenterClientNetworkTest {
 
         assertEquals(
             PlanningCenterClient.TokenOutcome.NetworkError,
-            runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "code") },
+            runBlocking { PlanningCenterClient.exchangeCodeForToken("cid", "csecret", "code", http = http) },
         )
     }
 
@@ -155,7 +150,7 @@ class PlanningCenterClientNetworkTest {
     fun `the connected person's name comes from the name attribute when present`() {
         respondWith("""{"data":{"id":"1","attributes":{"name":"Pat Ringer","first_name":"Pat","last_name":"Ringer"}}}""")
 
-        val outcome = runBlocking { PlanningCenterClient.getCurrentPerson("tok") }
+        val outcome = runBlocking { PlanningCenterClient.getCurrentPerson("tok", http = http) }
 
         assertEquals("Pat Ringer", assertIs<PlanningCenterClient.PersonOutcome.Success>(outcome).person.displayName)
     }
@@ -164,7 +159,7 @@ class PlanningCenterClientNetworkTest {
     fun `the connected person falls back to first and last name when name is absent`() {
         respondWith("""{"data":{"id":"1","attributes":{"first_name":"Pat","last_name":"Ringer"}}}""")
 
-        val outcome = runBlocking { PlanningCenterClient.getCurrentPerson("tok") }
+        val outcome = runBlocking { PlanningCenterClient.getCurrentPerson("tok", http = http) }
 
         assertEquals("Pat Ringer", assertIs<PlanningCenterClient.PersonOutcome.Success>(outcome).person.displayName)
     }
@@ -173,7 +168,7 @@ class PlanningCenterClientNetworkTest {
     fun `the connected person falls back to a generic label when no name field is present at all`() {
         respondWith("""{"data":{"id":"1","attributes":{}}}""")
 
-        val outcome = runBlocking { PlanningCenterClient.getCurrentPerson("tok") }
+        val outcome = runBlocking { PlanningCenterClient.getCurrentPerson("tok", http = http) }
 
         assertEquals(
             "Connected",
@@ -186,7 +181,7 @@ class PlanningCenterClientNetworkTest {
     fun `the access token travels as a bearer header`() {
         respondWith("""{"data":{"id":"1","attributes":{"name":"Pat"}}}""")
 
-        runBlocking { PlanningCenterClient.getCurrentPerson("secret-token") }
+        runBlocking { PlanningCenterClient.getCurrentPerson("secret-token", http = http) }
 
         assertEquals("Bearer secret-token", requests.single().headers[HttpHeaders.Authorization])
     }
@@ -196,13 +191,13 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.Unauthorized)
         assertEquals(
             PlanningCenterClient.PersonOutcome.Unauthorized,
-            runBlocking { PlanningCenterClient.getCurrentPerson("tok") },
+            runBlocking { PlanningCenterClient.getCurrentPerson("tok", http = http) },
         )
 
         respondWith("""{}""", HttpStatusCode.Forbidden)
         assertEquals(
             PlanningCenterClient.PersonOutcome.Unauthorized,
-            runBlocking { PlanningCenterClient.getCurrentPerson("tok") },
+            runBlocking { PlanningCenterClient.getCurrentPerson("tok", http = http) },
         )
     }
 
@@ -211,7 +206,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.InternalServerError)
         assertEquals(
             PlanningCenterClient.PersonOutcome.Failure,
-            runBlocking { PlanningCenterClient.getCurrentPerson("tok") },
+            runBlocking { PlanningCenterClient.getCurrentPerson("tok", http = http) },
         )
     }
 
@@ -220,7 +215,7 @@ class PlanningCenterClientNetworkTest {
         failToConnect()
         assertEquals(
             PlanningCenterClient.PersonOutcome.NetworkError,
-            runBlocking { PlanningCenterClient.getCurrentPerson("tok") },
+            runBlocking { PlanningCenterClient.getCurrentPerson("tok", http = http) },
         )
     }
 
@@ -234,7 +229,7 @@ class PlanningCenterClientNetworkTest {
                 {"id":"2","attributes":{"name":"Youth Service"}}]}""",
         )
 
-        val outcome = runBlocking { PlanningCenterClient.listServiceTypes("tok") }
+        val outcome = runBlocking { PlanningCenterClient.listServiceTypes("tok", http = http) }
 
         assertEquals(
             listOf(
@@ -251,7 +246,7 @@ class PlanningCenterClientNetworkTest {
 
         assertTrue(
             assertIs<PlanningCenterClient.ServiceTypesOutcome.Success>(
-                runBlocking { PlanningCenterClient.listServiceTypes("tok") },
+                runBlocking { PlanningCenterClient.listServiceTypes("tok", http = http) },
             ).serviceTypes.isEmpty(),
         )
     }
@@ -261,7 +256,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.Unauthorized)
         assertEquals(
             PlanningCenterClient.ServiceTypesOutcome.Unauthorized,
-            runBlocking { PlanningCenterClient.listServiceTypes("tok") },
+            runBlocking { PlanningCenterClient.listServiceTypes("tok", http = http) },
         )
     }
 
@@ -270,7 +265,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.InternalServerError)
         assertEquals(
             PlanningCenterClient.ServiceTypesOutcome.Failure,
-            runBlocking { PlanningCenterClient.listServiceTypes("tok") },
+            runBlocking { PlanningCenterClient.listServiceTypes("tok", http = http) },
         )
     }
 
@@ -279,7 +274,7 @@ class PlanningCenterClientNetworkTest {
         failToConnect()
         assertEquals(
             PlanningCenterClient.ServiceTypesOutcome.NetworkError,
-            runBlocking { PlanningCenterClient.listServiceTypes("tok") },
+            runBlocking { PlanningCenterClient.listServiceTypes("tok", http = http) },
         )
     }
 
@@ -290,7 +285,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{"data":[{"id":"9","attributes":{"title":"Easter Sunday","dates":"April 12, 2026","series_title":"Easter"}}]}""")
 
         val plans = assertIs<PlanningCenterClient.PlansOutcome.Success>(
-            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1") },
+            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1", http = http) },
         ).plans
 
         assertEquals(PlanningCenterClient.Plan("9", "Easter Sunday", "April 12, 2026"), plans.single())
@@ -301,7 +296,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{"data":[{"id":"9","attributes":{"title":"","series_title":"Easter","dates":""}}]}""")
 
         val plan = assertIs<PlanningCenterClient.PlansOutcome.Success>(
-            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1") },
+            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1", http = http) },
         ).plans.single()
 
         assertEquals("Easter", plan.title, "a blank per-plan title is common; the series still names it")
@@ -312,7 +307,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{"data":[{"id":"9","attributes":{}}]}""")
 
         val plan = assertIs<PlanningCenterClient.PlansOutcome.Success>(
-            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1") },
+            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1", http = http) },
         ).plans.single()
 
         assertEquals("Untitled Plan", plan.title)
@@ -323,7 +318,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.Unauthorized)
         assertEquals(
             PlanningCenterClient.PlansOutcome.Unauthorized,
-            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1") },
+            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1", http = http) },
         )
     }
 
@@ -332,7 +327,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.InternalServerError)
         assertEquals(
             PlanningCenterClient.PlansOutcome.Failure,
-            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1") },
+            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1", http = http) },
         )
     }
 
@@ -341,7 +336,7 @@ class PlanningCenterClientNetworkTest {
         failToConnect()
         assertEquals(
             PlanningCenterClient.PlansOutcome.NetworkError,
-            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1") },
+            runBlocking { PlanningCenterClient.listUpcomingPlans("tok", "svc-1", http = http) },
         )
     }
 
@@ -367,7 +362,7 @@ class PlanningCenterClientNetworkTest {
         )
 
         val item = assertIs<PlanningCenterClient.PlanItemsOutcome.Success>(
-            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1") },
+            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1", http = http) },
         ).items.single()
 
         assertEquals("item-1", item.id)
@@ -393,7 +388,7 @@ class PlanningCenterClientNetworkTest {
         )
 
         val items = assertIs<PlanningCenterClient.PlanItemsOutcome.Success>(
-            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1") },
+            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1", http = http) },
         ).items
 
         assertEquals(listOf("a", "b"), items.map { it.id })
@@ -404,7 +399,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{"data":[{"id":"h1","attributes":{"title":"Welcome"}}],"included":[]}""")
 
         val item = assertIs<PlanningCenterClient.PlanItemsOutcome.Success>(
-            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1") },
+            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1", http = http) },
         ).items.single()
 
         assertEquals("item", item.itemType, "PCO omits item_type for generic items")
@@ -424,7 +419,7 @@ class PlanningCenterClientNetworkTest {
         )
 
         val item = assertIs<PlanningCenterClient.PlanItemsOutcome.Success>(
-            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1") },
+            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1", http = http) },
         ).items.single()
 
         assertEquals("song-missing", item.songId, "the relationship itself is still recorded")
@@ -436,7 +431,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.Unauthorized)
         assertEquals(
             PlanningCenterClient.PlanItemsOutcome.Unauthorized,
-            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1") },
+            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1", http = http) },
         )
     }
 
@@ -445,7 +440,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.InternalServerError)
         assertEquals(
             PlanningCenterClient.PlanItemsOutcome.Failure,
-            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1") },
+            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1", http = http) },
         )
     }
 
@@ -454,7 +449,7 @@ class PlanningCenterClientNetworkTest {
         failToConnect()
         assertEquals(
             PlanningCenterClient.PlanItemsOutcome.NetworkError,
-            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1") },
+            runBlocking { PlanningCenterClient.getPlanItems("tok", "svc-1", "plan-1", http = http) },
         )
     }
 
@@ -467,7 +462,7 @@ class PlanningCenterClientNetworkTest {
         )
 
         val detail = assertIs<PlanningCenterClient.ArrangementOutcome.Success>(
-            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1") },
+            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1", http = http) },
         ).detail
 
         assertEquals("[G]Amazing [C]grace", detail.chordChart)
@@ -479,7 +474,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{"data":{"attributes":{"chord_chart":"[G]Amazing [C]grace","lyrics":""}}}""")
 
         val detail = assertIs<PlanningCenterClient.ArrangementOutcome.Success>(
-            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1") },
+            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1", http = http) },
         ).detail
 
         assertEquals(PlanningCenterLyricsFormatter.stripChords("[G]Amazing [C]grace"), detail.lyrics)
@@ -490,7 +485,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{"data":{"attributes":{"chord_chart":"[G]Amazing [C]grace"}}}""")
 
         val detail = assertIs<PlanningCenterClient.ArrangementOutcome.Success>(
-            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1") },
+            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1", http = http) },
         ).detail
 
         assertEquals("Amazing grace", detail.lyrics)
@@ -501,7 +496,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.Unauthorized)
         assertEquals(
             PlanningCenterClient.ArrangementOutcome.Unauthorized,
-            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1") },
+            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1", http = http) },
         )
     }
 
@@ -510,7 +505,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.InternalServerError)
         assertEquals(
             PlanningCenterClient.ArrangementOutcome.Failure,
-            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1") },
+            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1", http = http) },
         )
     }
 
@@ -519,7 +514,7 @@ class PlanningCenterClientNetworkTest {
         failToConnect()
         assertEquals(
             PlanningCenterClient.ArrangementOutcome.NetworkError,
-            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1") },
+            runBlocking { PlanningCenterClient.getArrangementDetail("tok", "song-1", "arr-1", http = http) },
         )
     }
 
@@ -532,7 +527,7 @@ class PlanningCenterClientNetworkTest {
         )
 
         val attachment = assertIs<PlanningCenterClient.AttachmentsOutcome.Success>(
-            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1") },
+            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1", http = http) },
         ).attachments.single()
 
         assertEquals(PlanningCenterClient.PlanAttachment("att-1", "slides.pdf", "https://s3/thumb.jpg"), attachment)
@@ -543,7 +538,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{"data":[{"id":"att-1","attributes":{"filename":"slides.pdf"}}]}""")
 
         val attachment = assertIs<PlanningCenterClient.AttachmentsOutcome.Success>(
-            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1") },
+            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1", http = http) },
         ).attachments.single()
 
         assertNull(attachment.thumbnailUrl)
@@ -558,7 +553,7 @@ class PlanningCenterClientNetworkTest {
         )
 
         val attachments = assertIs<PlanningCenterClient.AttachmentsOutcome.Success>(
-            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1") },
+            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1", http = http) },
         ).attachments
 
         assertEquals(listOf("att-2"), attachments.map { it.id })
@@ -569,7 +564,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.Unauthorized)
         assertEquals(
             PlanningCenterClient.AttachmentsOutcome.Unauthorized,
-            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1") },
+            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1", http = http) },
         )
     }
 
@@ -578,7 +573,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.InternalServerError)
         assertEquals(
             PlanningCenterClient.AttachmentsOutcome.Failure,
-            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1") },
+            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1", http = http) },
         )
     }
 
@@ -587,7 +582,7 @@ class PlanningCenterClientNetworkTest {
         failToConnect()
         assertEquals(
             PlanningCenterClient.AttachmentsOutcome.NetworkError,
-            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1") },
+            runBlocking { PlanningCenterClient.getItemAttachments("tok", "svc-1", "plan-1", "item-1", http = http) },
         )
     }
 
@@ -597,7 +592,7 @@ class PlanningCenterClientNetworkTest {
     fun `an attachment open resolves to its download url`() {
         respondWith("""{"data":{"attributes":{"attachment_url":"https://s3/signed-link"}}}""")
 
-        val outcome = runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1") }
+        val outcome = runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1", http = http) }
 
         assertEquals("https://s3/signed-link", assertIs<PlanningCenterClient.AttachmentUrlOutcome.Success>(outcome).url)
     }
@@ -608,7 +603,7 @@ class PlanningCenterClientNetworkTest {
 
         assertEquals(
             PlanningCenterClient.AttachmentUrlOutcome.Failure,
-            runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1") },
+            runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1", http = http) },
         )
     }
 
@@ -617,7 +612,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.Unauthorized)
         assertEquals(
             PlanningCenterClient.AttachmentUrlOutcome.Unauthorized,
-            runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1") },
+            runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1", http = http) },
         )
     }
 
@@ -626,7 +621,7 @@ class PlanningCenterClientNetworkTest {
         respondWith("""{}""", HttpStatusCode.InternalServerError)
         assertEquals(
             PlanningCenterClient.AttachmentUrlOutcome.Failure,
-            runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1") },
+            runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1", http = http) },
         )
     }
 
@@ -637,7 +632,7 @@ class PlanningCenterClientNetworkTest {
         failToConnect()
         assertEquals(
             PlanningCenterClient.AttachmentUrlOutcome.Failure,
-            runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1") },
+            runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1", http = http) },
         )
     }
 
@@ -645,7 +640,7 @@ class PlanningCenterClientNetworkTest {
     fun `opening an attachment is a post, not a get`() {
         respondWith("""{"data":{"attributes":{"attachment_url":"https://s3/link"}}}""")
 
-        runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1") }
+        runBlocking { PlanningCenterClient.resolveAttachmentDownloadUrl("tok", "att-1", http = http) }
 
         assertEquals(HttpMethod.Post, requests.single().method)
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClientTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClientTest.kt
@@ -23,7 +23,7 @@ import kotlin.test.assertTrue
  *
  * The rest of this client (token exchange, the Services API, downloads) talks to
  * `api.planningcenteronline.com` with hard-coded URLs, so it is exercised here through
- * [PlanningCenterClient.httpOverride] instead — see [PlanningCenterClientNetworkTest] and
+ * a `MockEngine` passed to the call instead — see [PlanningCenterClientNetworkTest] and
  * [PlanningCenterDownloadTest]. The import flow that consumes all of it end to end is covered by
  * [org.churchpresenter.app.churchpresenter.viewmodel.PlanningCenterImportViewModelTest].
  */

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/StockMediaClientTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/StockMediaClientTest.kt
@@ -32,33 +32,32 @@ import kotlin.test.assertTrue
  * only tell someone to check their key, wait for the quota, or check the network if these three
  * come back distinguishable rather than as one generic failure.
  *
- * Every request here is served by a `MockEngine` swapped in through
- * [StockMediaClient.httpOverride], so nothing in this class touches the network. Downloads are
- * redirected into a temp directory the same way. Both are reset after each test —
- * `StockMediaClient` is a JVM-wide object.
+ * Every request here is served by a `MockEngine` passed to the call under test, so nothing in this
+ * class touches the network, and downloads are directed into a per-test temp directory the same way.
+ * Both are ordinary instance fields: JUnit builds a new instance of this class per test method, so
+ * there is nothing global to reset and no ordering between tests to get wrong.
  */
 class StockMediaClientTest {
 
     private lateinit var dir: File
+    private lateinit var downloadDir: File
+    private lateinit var http: HttpClient
     private val requests = mutableListOf<HttpRequestData>()
 
     @BeforeTest
     fun createDir() {
         dir = Files.createTempDirectory("cp-stock-media-test").toFile()
-        StockMediaClient.downloadDirOverride = File(dir, "stock-backgrounds")
+        downloadDir = File(dir, "stock-backgrounds")
     }
 
     @AfterTest
-    fun resetClient() {
-        StockMediaClient.httpOverride = null
-        StockMediaClient.downloadDirOverride = null
-        requests.clear()
+    fun cleanUp() {
         dir.deleteRecursively()
     }
 
     /** Serves [body] as JSON for every request, recording what was asked for. */
     private fun respondWith(body: String, status: HttpStatusCode = HttpStatusCode.OK) {
-        StockMediaClient.httpOverride = HttpClient(
+        http = HttpClient(
             MockEngine { request ->
                 requests.add(request)
                 respond(
@@ -72,7 +71,7 @@ class StockMediaClientTest {
 
     /** Serves [bytes] as a file body — what a download or a thumbnail fetch gets back. */
     private fun respondWithBytes(bytes: ByteArray, status: HttpStatusCode = HttpStatusCode.OK) {
-        StockMediaClient.httpOverride = HttpClient(
+        http = HttpClient(
             MockEngine { request ->
                 requests.add(request)
                 respond(content = bytes, status = status)
@@ -82,7 +81,7 @@ class StockMediaClientTest {
 
     /** Fails every request the way an unplugged network cable does. */
     private fun failToConnect() {
-        StockMediaClient.httpOverride = HttpClient(
+        http = HttpClient(
             MockEngine { throw java.io.IOException("no route to host") },
         )
     }
@@ -93,7 +92,7 @@ class StockMediaClientTest {
         key: String = "test-key",
         query: String = "mountains",
         page: Int = 1,
-    ) = runBlocking { StockMediaClient.search(source, key, mediaType, query, page) }
+    ) = runBlocking { StockMediaClient.search(source, key, mediaType, query, page, http = http) }
 
     private fun items(outcome: StockMediaClient.SearchOutcome): List<StockMediaClient.StockMediaItem> =
         assertIs<StockMediaClient.SearchOutcome.Success>(outcome, "expected a successful search, got $outcome").items
@@ -393,7 +392,7 @@ class StockMediaClientTest {
     fun `a downloaded photo is written where the app can find it again`() {
         respondWithBytes("jpeg-bytes".toByteArray())
 
-        val outcome = runBlocking { StockMediaClient.download(item()) }
+        val outcome = runBlocking { StockMediaClient.download(item(), http = http, downloadDir = downloadDir) }
 
         val file = assertIs<StockMediaClient.DownloadOutcome.Success>(outcome).file
         assertEquals("pexels_12345.jpg", file.name, "the name has to say where it came from, so two ids never collide")
@@ -405,7 +404,7 @@ class StockMediaClientTest {
     fun `a downloaded video is named as one`() {
         respondWithBytes("mp4-bytes".toByteArray())
 
-        val outcome = runBlocking { StockMediaClient.download(item(id = "77", source = pixabay, isVideo = true, url = "https://v/hd.mp4")) }
+        val outcome = runBlocking { StockMediaClient.download(item(id = "77", source = pixabay, isVideo = true, url = "https://v/hd.mp4"), http = http, downloadDir = downloadDir) }
 
         assertEquals(
             "pixabay_77.mp4",
@@ -416,38 +415,38 @@ class StockMediaClientTest {
 
     @Test
     fun `the download folder is created the first time something is saved`() {
-        StockMediaClient.downloadDirOverride = File(dir, "not/created/yet")
+        downloadDir = File(dir, "not/created/yet")
         respondWithBytes("bytes".toByteArray())
 
-        val outcome = runBlocking { StockMediaClient.download(item()) }
+        val outcome = runBlocking { StockMediaClient.download(item(), http = http, downloadDir = downloadDir) }
 
         assertTrue(assertIs<StockMediaClient.DownloadOutcome.Success>(outcome).file.exists())
     }
 
     @Test
     fun `a refused download is reported as a failure`() {
-        StockMediaClient.httpOverride = HttpClient(MockEngine { respondError(HttpStatusCode.NotFound) })
+        http = HttpClient(MockEngine { respondError(HttpStatusCode.NotFound) })
 
-        assertEquals(StockMediaClient.DownloadOutcome.Failure, runBlocking { StockMediaClient.download(item()) })
+        assertEquals(StockMediaClient.DownloadOutcome.Failure, runBlocking { StockMediaClient.download(item(), http = http, downloadDir = downloadDir) })
     }
 
     @Test
     fun `a download that never connects is told apart from one that was refused`() {
         failToConnect()
 
-        assertEquals(StockMediaClient.DownloadOutcome.NetworkError, runBlocking { StockMediaClient.download(item()) })
+        assertEquals(StockMediaClient.DownloadOutcome.NetworkError, runBlocking { StockMediaClient.download(item(), http = http, downloadDir = downloadDir) })
     }
 
     @Test
     fun `downloading the same picture twice does not leave two copies`() {
         respondWithBytes("bytes".toByteArray())
 
-        runBlocking { StockMediaClient.download(item()) }
-        runBlocking { StockMediaClient.download(item()) }
+        runBlocking { StockMediaClient.download(item(), http = http, downloadDir = downloadDir) }
+        runBlocking { StockMediaClient.download(item(), http = http, downloadDir = downloadDir) }
 
         assertEquals(
             1,
-            StockMediaClient.downloadDirOverride?.listFiles()?.size,
+            downloadDir.listFiles()?.size,
             "the id names the file, so re-downloading overwrites rather than piling up",
         )
     }
@@ -458,19 +457,19 @@ class StockMediaClientTest {
     fun `a thumbnail comes back as bytes`() {
         respondWithBytes("png-bytes".toByteArray())
 
-        val bytes = runBlocking { StockMediaClient.fetchThumbnailBytes("https://img/thumb.jpg") }
+        val bytes = runBlocking { StockMediaClient.fetchThumbnailBytes("https://img/thumb.jpg", http = http) }
 
         assertEquals("png-bytes", bytes?.decodeToString())
     }
 
     @Test
     fun `a thumbnail that cannot be fetched leaves a blank tile rather than failing the grid`() {
-        StockMediaClient.httpOverride = HttpClient(MockEngine { respondError(HttpStatusCode.NotFound) })
-        assertNull(runBlocking { StockMediaClient.fetchThumbnailBytes("https://img/gone.jpg") })
+        http = HttpClient(MockEngine { respondError(HttpStatusCode.NotFound) })
+        assertNull(runBlocking { StockMediaClient.fetchThumbnailBytes("https://img/gone.jpg", http = http) })
 
         failToConnect()
         assertNull(
-            runBlocking { StockMediaClient.fetchThumbnailBytes("https://img/thumb.jpg") },
+            runBlocking { StockMediaClient.fetchThumbnailBytes("https://img/thumb.jpg", http = http) },
             "one unreachable thumbnail must not take the whole search result down",
         )
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PlanningCenterImportViewModelTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PlanningCenterImportViewModelTest.kt
@@ -116,9 +116,9 @@ class PlanningCenterImportViewModelTest {
 
     /** Stubs the plan-items call and loads them into [vm]. */
     private fun loadItems(vm: PlanningCenterImportViewModel, items: List<PlanningCenterClient.PlanItem>) {
-        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any(), any()) } returns
             PlanningCenterClient.PlanItemsOutcome.Success(items)
-        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any(), any()) } returns
             PlanningCenterClient.AttachmentsOutcome.Success(emptyList())
         vm.selectPlan("plan-1")
         awaitUntil("plan items") { !vm.isLoadingItems && vm.planItems.isNotEmpty() }
@@ -128,7 +128,7 @@ class PlanningCenterImportViewModelTest {
 
     @Test
     fun `service types load`() {
-        coEvery { PlanningCenterClient.listServiceTypes(any()) } returns
+        coEvery { PlanningCenterClient.listServiceTypes(any(), any()) } returns
             PlanningCenterClient.ServiceTypesOutcome.Success(
                 listOf(PlanningCenterClient.ServiceType("st-1", "Sunday Morning")),
             )
@@ -142,7 +142,7 @@ class PlanningCenterImportViewModelTest {
 
     @Test
     fun `an expired session surfaces a reconnect message`() {
-        coEvery { PlanningCenterClient.listServiceTypes(any()) } returns
+        coEvery { PlanningCenterClient.listServiceTypes(any(), any()) } returns
             PlanningCenterClient.ServiceTypesOutcome.Unauthorized
         val vm = viewModel()
         vm.loadServiceTypes()
@@ -152,7 +152,7 @@ class PlanningCenterImportViewModelTest {
 
     @Test
     fun `a network failure surfaces an error rather than an empty list`() {
-        coEvery { PlanningCenterClient.listServiceTypes(any()) } returns
+        coEvery { PlanningCenterClient.listServiceTypes(any(), any()) } returns
             PlanningCenterClient.ServiceTypesOutcome.NetworkError
         val vm = viewModel()
         vm.loadServiceTypes()
@@ -162,7 +162,7 @@ class PlanningCenterImportViewModelTest {
 
     @Test
     fun `selecting a service type loads its plans`() {
-        coEvery { PlanningCenterClient.listUpcomingPlans(any(), any()) } returns
+        coEvery { PlanningCenterClient.listUpcomingPlans(any(), any(), any()) } returns
             PlanningCenterClient.PlansOutcome.Success(
                 listOf(PlanningCenterClient.Plan("plan-1", "Sunday", "21 July 2026")),
             )
@@ -178,11 +178,11 @@ class PlanningCenterImportViewModelTest {
 
     @Test
     fun `an expiring token is refreshed before the request`() {
-        coEvery { PlanningCenterClient.refreshAccessToken(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.refreshAccessToken(any(), any(), any(), any()) } returns
             PlanningCenterClient.TokenOutcome.Success(
                 PlanningCenterClient.TokenSet("new-access", "new-refresh", System.currentTimeMillis() + 7_200_000),
             )
-        coEvery { PlanningCenterClient.listServiceTypes(any()) } returns
+        coEvery { PlanningCenterClient.listServiceTypes(any(), any()) } returns
             PlanningCenterClient.ServiceTypesOutcome.Success(emptyList())
 
         // Already inside the 60-second refresh window.
@@ -196,7 +196,7 @@ class PlanningCenterImportViewModelTest {
 
     @Test
     fun `a failed refresh abandons the request`() {
-        coEvery { PlanningCenterClient.refreshAccessToken(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.refreshAccessToken(any(), any(), any(), any()) } returns
             PlanningCenterClient.TokenOutcome.Failure
         val vm = viewModel(expiresInMs = 30_000)
         vm.loadServiceTypes()
@@ -216,7 +216,7 @@ class PlanningCenterImportViewModelTest {
 
     @Test
     fun `a valid token is not refreshed`() {
-        coEvery { PlanningCenterClient.listServiceTypes(any()) } returns
+        coEvery { PlanningCenterClient.listServiceTypes(any(), any()) } returns
             PlanningCenterClient.ServiceTypesOutcome.Success(emptyList())
         val vm = viewModel(expiresInMs = 3_600_000)
         vm.loadServiceTypes()
@@ -339,9 +339,9 @@ class PlanningCenterImportViewModelTest {
     @Test
     fun `attachments load and start selected`() {
         val vm = viewModel()
-        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any(), any()) } returns
             PlanningCenterClient.PlanItemsOutcome.Success(listOf(planItem("i1", "Notices", itemType = "item")))
-        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any(), any()) } returns
             PlanningCenterClient.AttachmentsOutcome.Success(
                 listOf(
                     PlanningCenterClient.PlanAttachment("a1", "slides.pptx"),
@@ -359,9 +359,9 @@ class PlanningCenterImportViewModelTest {
         // The row checkbox is the master for its files; leaving them checked would import files
         // for an item the operator just excluded.
         val vm = viewModel()
-        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any(), any()) } returns
             PlanningCenterClient.PlanItemsOutcome.Success(listOf(planItem("i1", "Notices", itemType = "item")))
-        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any(), any()) } returns
             PlanningCenterClient.AttachmentsOutcome.Success(
                 listOf(PlanningCenterClient.PlanAttachment("a1", "slides.pptx")),
             )
@@ -378,9 +378,9 @@ class PlanningCenterImportViewModelTest {
     @Test
     fun `an individual attachment can be toggled`() {
         val vm = viewModel()
-        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any(), any()) } returns
             PlanningCenterClient.PlanItemsOutcome.Success(listOf(planItem("i1", "Notices", itemType = "item")))
-        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any(), any()) } returns
             PlanningCenterClient.AttachmentsOutcome.Success(
                 listOf(
                     PlanningCenterClient.PlanAttachment("a1", "one.pptx"),

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PlanningCenterScriptureImportTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PlanningCenterScriptureImportTest.kt
@@ -66,7 +66,7 @@ class PlanningCenterScriptureImportTest {
         )
 
         mockkObject(PlanningCenterClient)
-        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getItemAttachments(any(), any(), any(), any(), any()) } returns
             PlanningCenterClient.AttachmentsOutcome.Success(emptyList())
 
     }
@@ -102,7 +102,7 @@ class PlanningCenterScriptureImportTest {
         )
 
     private fun loadPlan(vm: PlanningCenterImportViewModel, items: List<PlanningCenterClient.PlanItem>) {
-        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getPlanItems(any(), any(), any(), any()) } returns
             PlanningCenterClient.PlanItemsOutcome.Success(items)
         vm.selectPlan("plan-1")
         awaitUntil("plan items") { !vm.isLoadingItems && vm.planItems.isNotEmpty() }
@@ -241,7 +241,7 @@ class PlanningCenterScriptureImportTest {
 
     @Test
     fun `an arrangement's lyrics win over the description`() = runBlocking {
-        coEvery { PlanningCenterClient.getArrangementDetail(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getArrangementDetail(any(), any(), any(), any()) } returns
             PlanningCenterClient.ArrangementOutcome.Success(
                 PlanningCenterClient.ArrangementDetail(chordChart = "G C D", lyrics = "Arrangement lyrics"),
             )
@@ -256,7 +256,7 @@ class PlanningCenterScriptureImportTest {
     fun `a blank arrangement falls back to the description`() {
         // PCO returns an arrangement record with no lyrics when nobody filled it in.
         runBlocking {
-            coEvery { PlanningCenterClient.getArrangementDetail(any(), any(), any()) } returns
+            coEvery { PlanningCenterClient.getArrangementDetail(any(), any(), any(), any()) } returns
                 PlanningCenterClient.ArrangementOutcome.Success(
                     PlanningCenterClient.ArrangementDetail(chordChart = "", lyrics = "   "),
                 )
@@ -269,7 +269,7 @@ class PlanningCenterScriptureImportTest {
 
     @Test
     fun `a failed arrangement request falls back to the description`() = runBlocking {
-        coEvery { PlanningCenterClient.getArrangementDetail(any(), any(), any()) } returns
+        coEvery { PlanningCenterClient.getArrangementDetail(any(), any(), any(), any()) } returns
             PlanningCenterClient.ArrangementOutcome.NetworkError
         val detail = viewModel().fetchArrangementForAddSong(
             songItem(description = "Description lyrics", songId = "song-1", arrangementId = "arr-1"),

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/StockMediaViewModelTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/StockMediaViewModelTest.kt
@@ -89,12 +89,12 @@ class StockMediaViewModelTest {
 
     /** Every search returns [outcome]. */
     private fun searchReturns(outcome: StockMediaClient.SearchOutcome) {
-        coEvery { StockMediaClient.search(any(), any(), any(), any(), any()) } returns outcome
+        coEvery { StockMediaClient.search(any(), any(), any(), any(), any(), any()) } returns outcome
     }
 
     /** Searches for page [page] return [outcome]. */
     private fun searchPageReturns(page: Int, outcome: StockMediaClient.SearchOutcome) {
-        coEvery { StockMediaClient.search(any(), any(), any(), any(), page) } returns outcome
+        coEvery { StockMediaClient.search(any(), any(), any(), any(), page, any()) } returns outcome
     }
 
     /** Runs a search that lands, so the view model has results and a known page. */
@@ -129,14 +129,14 @@ class StockMediaViewModelTest {
         vm.search("")
 
         assertFalse(vm.isLoading, "the spinner must not start for a request that will never be made")
-        coVerify(exactly = 0) { StockMediaClient.search(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { StockMediaClient.search(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun `an empty search box is not searched for`() {
         val vm = vm()
         vm.search("api-key")
-        coVerify(exactly = 0) { StockMediaClient.search(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 0) { StockMediaClient.search(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -153,7 +153,7 @@ class StockMediaViewModelTest {
                 StockMediaClient.StockMediaType.VIDEO,
                 "sunrise",
                 1,
-            )
+            any())
         }
     }
 
@@ -253,7 +253,7 @@ class StockMediaViewModelTest {
         vm.searchFor("rivers")
 
         assertEquals(listOf("a"), vm.items.map { it.id }, "a new query must not keep the old query's pages")
-        coVerify(exactly = 2) { StockMediaClient.search(any(), any(), any(), any(), 1) }
+        coVerify(exactly = 2) { StockMediaClient.search(any(), any(), any(), any(), 1, any()) }
     }
 
     // ── Paging ──────────────────────────────────────────────────────────────────
@@ -296,7 +296,7 @@ class StockMediaViewModelTest {
         settle()
 
         assertEquals(listOf("a", "b", "c"), vm.items.map { it.id })
-        coVerify(exactly = 1) { StockMediaClient.search(any(), any(), any(), any(), 3) }
+        coVerify(exactly = 1) { StockMediaClient.search(any(), any(), any(), any(), 3, any()) }
     }
 
     @Test
@@ -306,7 +306,7 @@ class StockMediaViewModelTest {
 
         vm.loadMore("api-key")
 
-        coVerify(exactly = 1) { StockMediaClient.search(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 1) { StockMediaClient.search(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -318,7 +318,7 @@ class StockMediaViewModelTest {
         vm.query = ""
         vm.loadMore("api-key")
 
-        coVerify(exactly = 1) { StockMediaClient.search(any(), any(), any(), any(), any()) }
+        coVerify(exactly = 1) { StockMediaClient.search(any(), any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -343,12 +343,12 @@ class StockMediaViewModelTest {
         // assume. "mountains" hangs until released; "rivers" answers at once.
         val slowSearchStarted = CompletableDeferred<Unit>()
         val releaseSlowSearch = CompletableDeferred<Unit>()
-        coEvery { StockMediaClient.search(any(), any(), any(), "mountains", any()) } coAnswers {
+        coEvery { StockMediaClient.search(any(), any(), any(), "mountains", any(), any()) } coAnswers {
             slowSearchStarted.complete(Unit)
             releaseSlowSearch.await()
             success("stale")
         }
-        coEvery { StockMediaClient.search(any(), any(), any(), "rivers", any()) } returns success("fresh")
+        coEvery { StockMediaClient.search(any(), any(), any(), "rivers", any(), any()) } returns success("fresh")
         val vm = vm()
 
         vm.query = "mountains"
@@ -375,7 +375,7 @@ class StockMediaViewModelTest {
     @Test
     fun `downloading hands back the saved file`() {
         val saved = File(dir, "sunrise.jpg").also { it.writeText("x") }
-        coEvery { StockMediaClient.download(any()) } returns StockMediaClient.DownloadOutcome.Success(saved)
+        coEvery { StockMediaClient.download(any(), any(), any()) } returns StockMediaClient.DownloadOutcome.Success(saved)
         val vm = vm()
         var handedBack: String? = null
 
@@ -394,7 +394,7 @@ class StockMediaViewModelTest {
             StockMediaClient.DownloadOutcome.Failure to StockDownloadError.FAILURE,
         )
         cases.forEach { (outcome, expected) ->
-            coEvery { StockMediaClient.download(any()) } returns outcome
+            coEvery { StockMediaClient.download(any(), any(), any()) } returns outcome
             val vm = vm()
             var handedBack: String? = null
 
@@ -411,7 +411,7 @@ class StockMediaViewModelTest {
     fun `the tile being downloaded is marked while it runs`() {
         val parked = CompletableDeferred<Unit>()
         val saved = File(dir, "sunrise.jpg").also { it.writeText("x") }
-        coEvery { StockMediaClient.download(any()) } coAnswers {
+        coEvery { StockMediaClient.download(any(), any(), any()) } coAnswers {
             parked.await()
             StockMediaClient.DownloadOutcome.Success(saved)
         }
@@ -426,13 +426,13 @@ class StockMediaViewModelTest {
 
     @Test
     fun `a retry clears the previous download failure`() {
-        coEvery { StockMediaClient.download(any()) } returns StockMediaClient.DownloadOutcome.NetworkError
+        coEvery { StockMediaClient.download(any(), any(), any()) } returns StockMediaClient.DownloadOutcome.NetworkError
         val vm = vm()
         vm.download(item("a")) { }
         settle()
 
         val saved = File(dir, "sunrise.jpg").also { it.writeText("x") }
-        coEvery { StockMediaClient.download(any()) } returns StockMediaClient.DownloadOutcome.Success(saved)
+        coEvery { StockMediaClient.download(any(), any(), any()) } returns StockMediaClient.DownloadOutcome.Success(saved)
         var handedBack: String? = null
         vm.download(item("a")) { handedBack = it }
 
@@ -443,7 +443,7 @@ class StockMediaViewModelTest {
     @Test
     fun `searching and downloading do not report each other's errors`() {
         searchReturns(StockMediaClient.SearchOutcome.RateLimited)
-        coEvery { StockMediaClient.download(any()) } returns StockMediaClient.DownloadOutcome.Failure
+        coEvery { StockMediaClient.download(any(), any(), any()) } returns StockMediaClient.DownloadOutcome.Failure
         val vm = vm().searchFor("mountains")
 
         vm.download(item("a")) { }


### PR DESCRIPTION
Follow-up to #60. Removes the three mutable test seams the codebase had accumulated.

## Why

`AGENT.md` names this shape under what must **not** be done to reach coverage — *"adding a mutable `internal var` seam on a singleton (leaks between tests)"* — and there were three:

| seam | since |
|---|---|
| `StockMediaClient.httpOverride` | `953fc5ef` |
| `StockMediaClient.downloadDirOverride` | `953fc5ef` |
| `PlanningCenterClient.httpOverride` | #60, following the above |

All three are JVM-wide mutable state shared by every test in the suite, kept correct only by `@AfterTest` discipline.

**Nothing is broken today** — the suite is single-threaded and the resets are in place. The failure mode is a test that throws before its reset runs, or the day `maxParallelForks` gets set, at which point it stops being latent. Worth removing while it is still cheap.

## What

A defaulted parameter on each call instead: `http: HttpClient = defaultHttp`, plus `downloadDir: File = defaultDownloadDir` on `download()`.

- **Production call sites are untouched** — the defaults cover them.
- Tests pass their own `MockEngine` client per call.
- There is no global to reset, so the `@AfterTest` blocks that existed purely for that are gone.
- The `MockEngine` now lives in an ordinary **instance field**. JUnit builds a new test-class instance per method, so isolation is structural rather than maintained by cleanup code.

## The hazard this introduces, and the check for it

A default means a test that *omits* the client compiles fine and silently reaches the real network. Verified none do — every call in `StockMediaClientTest` and `PlanningCenterClientNetworkTest` passes an explicit client. Worth re-checking if calls are added later.

## Collateral

Three ViewModel test files stub these clients through MockK, which matches on arity, so each `coEvery` needed the extra `any()`. That ripple is precisely why this was **not** folded into #60 — it would have expanded a test-only PR into files it never touched.

Full `:composeApp:jvmTest` green.