### PR TITLE
Stop showing the word "null" in live captions

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/JsonExt.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/JsonExt.kt
@@ -1,0 +1,30 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * String accessors that treat a JSON `null` as absent.
+ *
+ * `JSONObject.optString` does **not** return the supplied default for a JSON `null` — it returns the
+ * four-character string `"null"`. So the natural-looking
+ * `optString(key, "").takeIf { it.isNotEmpty() }` quietly accepts `"null"` as a real value, and
+ * `optString(key, "").ifBlank { … }` never reaches its fallback.
+ *
+ * This is not hypothetical. The STT server emits `"segment_id": null`, which reached the Bible
+ * engine's detection log and ChurchPresenter's operator-flag log as `"segmentId":"null"` — a
+ * correlation key that then joins every such row to every other. The same coercion on a caption's
+ * `text` field would put the literal word "null" on screen in front of a congregation.
+ *
+ * Use these anywhere a JSON string field is optional.
+ */
+fun JSONObject.stringOr(key: String, default: String = ""): String =
+    if (!has(key) || isNull(key)) default else optString(key, default)
+
+/** Null-safe [stringOr] for array elements; a JSON `null` entry yields [default]. */
+fun JSONArray.stringOr(index: Int, default: String = ""): String =
+    if (isNull(index)) default else optString(index, default)
+
+/** The value, or null when the key is absent, JSON `null`, or blank. */
+fun JSONObject.stringOrNull(key: String): String? =
+    stringOr(key).trim().takeIf { it.isNotEmpty() }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManager.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.churchpresenter.app.churchpresenter.utils.TrainingDataLogger
+import org.churchpresenter.app.churchpresenter.utils.stringOr
+import org.churchpresenter.app.churchpresenter.utils.stringOrNull
 import org.json.JSONObject
 import java.io.File
 import java.net.URI
@@ -242,8 +244,8 @@ class STTManager {
                 _segments.add(
                     STTSegment(
                         id = seg.optInt("id", i),
-                        timestamp = seg.optString("timestamp", ""),
-                        text = seg.optString("text", ""),
+                        timestamp = seg.stringOr("timestamp"),
+                        text = seg.stringOr("text"),
                         start = seg.optDouble("start", 0.0),
                         end = seg.optDouble("end", 0.0),
                         completed = seg.optBoolean("completed", true)
@@ -267,13 +269,13 @@ class STTManager {
             for (i in 0 until segmentsArray.length()) {
                 val seg = segmentsArray.getJSONObject(i)
                 // STT app sends "translated_text" for translation segments
-                val text = seg.optString("translated_text", "").ifBlank {
-                    seg.optString("text", "")
+                val text = seg.stringOr("translated_text").ifBlank {
+                    seg.stringOr("text")
                 }
                 _translationSegments.add(
                     STTSegment(
                         id = seg.optInt("id", i),
-                        timestamp = seg.optString("timestamp", ""),
+                        timestamp = seg.stringOr("timestamp"),
                         text = text,
                         start = seg.optDouble("start", 0.0),
                         end = seg.optDouble("end", 0.0),
@@ -286,13 +288,13 @@ class STTManager {
         // in_progress can be a string or a JSON object with "translated_text"
         val inProgress = data.opt("in_progress")
         _inProgressTranslation.value = when (inProgress) {
-            is JSONObject -> inProgress.optString("translated_text", "")
+            is JSONObject -> inProgress.stringOr("translated_text")
             is String -> inProgress
             null, JSONObject.NULL -> ""
             else -> inProgress.toString()
         }
 
-        _translationLanguage.value = data.optString("target_language_name", "")
+        _translationLanguage.value = data.stringOr("target_language_name")
     }
 
     private fun handleWordHighlightingUpdate(data: JSONObject) {
@@ -302,7 +304,7 @@ class STTManager {
         val disabledArray = data.optJSONArray("disabled_colors")
         if (disabledArray != null) {
             for (i in 0 until disabledArray.length()) {
-                disabledColors.add(disabledArray.optString(i, ""))
+                disabledColors.add(disabledArray.stringOr(i))
             }
         }
 
@@ -311,11 +313,11 @@ class STTManager {
         if (wordsArray != null) {
             for (i in 0 until wordsArray.length()) {
                 val w = wordsArray.getJSONObject(i)
-                val color = w.optString("color", "#ffff00")
+                val color = w.stringOr("color", "#ffff00")
                 if (color in disabledColors) continue
                 _highlightedWords.add(
                     HighlightedWord(
-                        word = w.optString("word", ""),
+                        word = w.stringOr("word"),
                         color = color,
                         caseSensitive = w.optBoolean("case_sensitive", false),
                         isRegex = w.optBoolean("is_regex", false)
@@ -341,7 +343,7 @@ class STTManager {
                     val disabledArray = json.optJSONArray("disabled_colors")
                     if (disabledArray != null) {
                         for (i in 0 until disabledArray.length()) {
-                            disabledColors.add(disabledArray.optString(i, ""))
+                            disabledColors.add(disabledArray.stringOr(i))
                         }
                     }
 
@@ -352,12 +354,12 @@ class STTManager {
                         if (wordsArray != null) {
                             for (i in 0 until wordsArray.length()) {
                                 val w = wordsArray.getJSONObject(i)
-                                val color = w.optString("color", "#ffff00")
+                                val color = w.stringOr("color", "#ffff00")
                                 // Skip words whose color group is disabled
                                 if (color in disabledColors) continue
                                 _highlightedWords.add(
                                     HighlightedWord(
-                                        word = w.optString("word", ""),
+                                        word = w.stringOr("word"),
                                         color = color,
                                         caseSensitive = w.optBoolean("case_sensitive", false),
                                         isRegex = w.optBoolean("is_regex", false)
@@ -406,7 +408,7 @@ class STTManager {
         val statusResponse = client.send(statusRequest, HttpResponse.BodyHandlers.ofString())
         if (statusResponse.statusCode() != 200) return
         val state = JSONObject(statusResponse.body()).optJSONObject("state") ?: return
-        val dbName = state.optString("db_name", "").takeIf { it.isNotBlank() } ?: return
+        val dbName = state.stringOrNull("db_name") ?: return
 
         val encodedPath = URLEncoder.encode(dbName, "UTF-8")
         val downloadRequest = HttpRequest.newBuilder()

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/JsonExtTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/JsonExtTest.kt
@@ -1,0 +1,92 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import org.json.JSONArray
+import org.json.JSONObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Reading optional JSON strings without inheriting org.json's `null` handling.
+ *
+ * `optString` returns the four-character string `"null"` for a JSON null rather than the default it
+ * is handed, which silently defeats both `takeIf { it.isNotEmpty() }` and `ifBlank { … }`. Every
+ * assertion here is really the same one: a JSON null must be indistinguishable from an absent key.
+ */
+class JsonExtTest {
+
+    // ── The behaviour being corrected ────────────────────────────────────────────
+
+    @Test
+    fun `org_json really does coerce null to the string null`() {
+        // Pins the platform behaviour these helpers exist to hide. If a future org.json version
+        // fixes this, this test fails and the helpers can be reconsidered.
+        assertEquals("null", JSONObject("""{"k":null}""").optString("k", "fallback"))
+    }
+
+    // ── JSONObject ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a json null yields the default, not the word null`() {
+        assertEquals("", JSONObject("""{"k":null}""").stringOr("k"))
+        assertEquals("dflt", JSONObject("""{"k":null}""").stringOr("k", "dflt"))
+    }
+
+    @Test
+    fun `an absent key yields the default`() {
+        assertEquals("dflt", JSONObject("{}").stringOr("k", "dflt"))
+    }
+
+    @Test
+    fun `a real value is returned untouched`() {
+        assertEquals("hello", JSONObject("""{"k":"hello"}""").stringOr("k", "dflt"))
+    }
+
+    @Test
+    fun `an empty string is a real value and is not replaced by the default`() {
+        // Distinct from absent: the server said "", and callers use ifBlank to decide what that means.
+        assertEquals("", JSONObject("""{"k":""}""").stringOr("k", "dflt"))
+    }
+
+    @Test
+    fun `whitespace and surrounding spaces are preserved`() {
+        assertEquals("  a b  ", JSONObject("""{"k":"  a b  "}""").stringOr("k"))
+    }
+
+    @Test
+    fun `non-string scalars still coerce as org_json does`() {
+        // Deliberately unchanged: only the null case is corrected.
+        assertEquals("42", JSONObject("""{"k":42}""").stringOr("k"))
+        assertEquals("true", JSONObject("""{"k":true}""").stringOr("k"))
+    }
+
+    // ── JSONArray ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a null array entry yields the default`() {
+        val a = JSONArray("""["red",null,"blue"]""")
+        assertEquals("red", a.stringOr(0))
+        assertEquals("", a.stringOr(1))
+        assertEquals("blue", a.stringOr(2))
+    }
+
+    @Test
+    fun `an out-of-range index yields the default`() {
+        assertEquals("dflt", JSONArray("[]").stringOr(3, "dflt"))
+    }
+
+    // ── stringOrNull ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `stringOrNull treats null, absent, empty and blank alike`() {
+        assertNull(JSONObject("""{"k":null}""").stringOrNull("k"))
+        assertNull(JSONObject("{}").stringOrNull("k"))
+        assertNull(JSONObject("""{"k":""}""").stringOrNull("k"))
+        assertNull(JSONObject("""{"k":"   "}""").stringOrNull("k"))
+    }
+
+    @Test
+    fun `stringOrNull trims a real value`() {
+        assertEquals("2026-07-27", JSONObject("""{"k":"  2026-07-27  "}""").stringOrNull("k"))
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManagerParsingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManagerParsingTest.kt
@@ -176,6 +176,73 @@ class STTManagerParsingTest {
         assertTrue(stt.highlightedWords.isEmpty(), "each update replaces the previous word list")
     }
 
+    // ── JSON null is absence, never the string "null" ────────────────────────────
+    // org.json's optString returns "null" for a JSON null instead of the supplied default, so a
+    // server sending an explicit null used to put the literal word on screen.
+
+    @Test
+    fun `a null caption text does not put the word null on screen`() {
+        val stt = manager()
+
+        stt.transcription("""{"segments":[{"id":1,"text":null,"timestamp":null}]}""")
+
+        val seg = stt.segments.single()
+        assertEquals("", seg.text, "a null text must read as empty, not as \"null\"")
+        assertEquals("", seg.timestamp)
+    }
+
+    @Test
+    fun `a null translated_text falls back to the original text`() {
+        // Doubly broken before: "null" is not blank, so ifBlank never reached the fallback AND
+        // the word "null" was shown in place of the translation.
+        val stt = manager()
+
+        stt.translation("""{"segments":[{"id":1,"translated_text":null,"text":"original"}]}""")
+
+        assertEquals("original", stt.translationSegments.single().text)
+    }
+
+    @Test
+    fun `a null in-progress translation is empty`() {
+        val stt = manager()
+
+        stt.translation("""{"in_progress":{"translated_text":null}}""")
+
+        assertEquals("", stt.inProgressTranslation.value)
+    }
+
+    @Test
+    fun `a null target language reads as unset`() {
+        val stt = manager()
+
+        stt.translation("""{"target_language_name":null}""")
+
+        assertEquals("", stt.translationLanguage.value)
+    }
+
+    @Test
+    fun `a null highlighted word and colour do not become the string null`() {
+        val stt = manager()
+
+        stt.highlighting("""{"words":[{"word":null,"color":null}]}""")
+
+        val w = stt.highlightedWords.single()
+        assertEquals("", w.word, "a null word must not highlight every occurrence of \"null\"")
+        assertEquals("#ffff00", w.color, "a null colour falls back to the default, not to \"null\"")
+    }
+
+    @Test
+    fun `a null colour is not silently disabled by a null entry in disabled_colors`() {
+        // Both nulls used to collapse to the same string "null", so the word matched the disabled
+        // set and vanished from the captions entirely — a dropped highlight, not just a cosmetic one.
+        val stt = manager()
+
+        stt.highlighting("""{"words":[{"word":"grace","color":null}],"disabled_colors":[null]}""")
+
+        assertEquals(listOf("grace"), stt.highlightedWords.map { it.word }, "the word must survive")
+        assertEquals("#ffff00", stt.highlightedWords.single().color)
+    }
+
     // ── Trivial state ────────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
`org.json`'s `optString` returns the four-character string `"null"` for a JSON null rather than the default it is handed:

```kotlin
JSONObject("""{"k":null}""").optString("k", "fallback")   // "null", not "fallback"
```

`STTManager` read every optional string field that way, so an STT server sending an explicit null put the literal word into whatever that field fed. This isn't theoretical — the same coercion was found live in the Bible engine, where a null `segment_id` reached the detection log and the operator-flag log as `"segmentId":"null"`, a correlation key that then joins every such row to every other during triage.

### What was breaking

| Field | Effect of a JSON null |
|---|---|
| `text` / `translated_text` | **The word "null" displayed to the congregation.** `translated_text` was doubly broken: `"null"` isn't blank, so the `ifBlank { text }` fallback never ran and the real text was discarded in favour of the placeholder. |
| `color` + `disabled_colors` entry | Both collapsed to the same `"null"`, so the word matched the disabled set and **vanished from the captions entirely** — a dropped highlight, not a cosmetic one. |
| `word` | Highlighted every occurrence of the literal word "null". |
| `db_name` | `.takeIf { it.isNotBlank() }` accepted `"null"` as a real database name and built a snapshot URL from it. |
| `timestamp`, `target_language_name` | Displayed as "null". |

### The fix

New `utils/JsonExt.kt` with `stringOr` / `stringOrNull`, which check `isNull` before `optString`, and `STTManager` routed through it — no bare `optString` remains in the file. It's a shared util rather than a private helper because the bug class recurs; the Bible engine's `SttPayload.kt` already carries the same fix from the version-detection work.

Deliberately narrow: only the null case changes. Empty strings stay distinct from absent (callers use `ifBlank` to decide what `""` means), whitespace is preserved, and non-string scalars still coerce exactly as before.

### Verification

`./gradlew :composeApp:check` — **4884 tests, 0 failures.**

Six new `STTManagerParsingTest` cases drive the real private handlers through the existing reflection harness. All six were confirmed to **fail without the fix and pass with it** by reverting `STTManager.kt` alone and re-running — the first version of the `disabled_colors` test passed either way, so it was rewritten until it discriminated.

`JsonExtTest` covers the helper directly, including a test that pins org.json's actual coercion behaviour, so if a future version fixes it upstream this becomes visible rather than silently redundant.

`cleanup_check.sh` unchanged from the `main` baseline (110 fully-qualified names is pre-existing; none in the new files).