### PR TITLE
Fix wmctrl window titles and the unreachable theme pills

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -1686,18 +1686,19 @@ internal fun xpropWindow(windowId: String, nameOutput: String): WindowInfo? {
 /**
  * The windows in `wmctrl -l`, whose columns are id, desktop, host, then the title.
  *
- * Note: `wmctrl -l` prints *four* columns, so splitting with `limit = 5` and taking `parts[4]` drops
- * the first word of every title, and drops one-word titles altogether. `SourcePropertiesDeviceListingTest`
- * pins that behaviour as it stands; changing it changes which windows Linux capture can address.
+ * The title is the **fourth** column and holds the rest of the line, spaces and all — so the split
+ * is capped at four parts. It previously asked for five, which silently spent one part on the first
+ * word of every title ("Mozilla Firefox" listed as "Firefox") and dropped one-word titles such as
+ * "Terminal" entirely, because those lines then had only four parts and failed the size guard.
  */
 internal fun parseWmctrlWindows(output: String): List<WindowInfo> =
     output.lines()
         .filter { it.isNotBlank() }
         .mapNotNull { line ->
-            val parts = line.split(Regex("\\s+"), limit = 5)
-            if (parts.size >= 5) {
+            val parts = line.split(Regex("\\s+"), limit = 4)
+            if (parts.size >= 4) {
                 val id = parts[0].removePrefix("0x").toLongOrNull(16) ?: 0L
-                val title = parts[4]
+                val title = parts[3]
                 if (title.isNotBlank()) WindowInfo(title, id) else null
             } else null
         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardDialog.kt
@@ -522,8 +522,13 @@ private fun ThemeStep(
             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
         )
         Spacer(modifier = Modifier.height(4.dp))
+        // Scrolls for the same reason the language step does: ten pills wrap to more rows than the
+        // fixed 700x620 window leaves room for, and the window is not resizable — without this the
+        // lower themes cannot be reached at all.
         FlowRow(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesDeviceListingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesDeviceListingTest.kt
@@ -473,7 +473,7 @@ class SourcePropertiesDeviceListingTest {
      * the maintainer; nothing else in this file is a characterisation test.
      */
     @Test
-    fun `wmctrl titles lose their first word — known defect`() {
+    fun `a wmctrl title keeps every word, including a one-word one`() {
         val windows = parseWmctrlWindows(
             """
             0x02200003  0 hostname Mozilla Firefox — Church Presenter
@@ -482,9 +482,9 @@ class SourcePropertiesDeviceListingTest {
         )
 
         assertEquals(
-            listOf("Firefox — Church Presenter"),
+            listOf("Mozilla Firefox — Church Presenter", "Terminal"),
             windows.map { it.title },
-            "\"Mozilla\" is eaten as if it were a column, and one-word \"Terminal\" vanishes entirely",
+            "the title is the fourth column and runs to end of line; a one-word title is still a window",
         )
         assertEquals(0x02200003L, windows.first().id, "the id is still read correctly")
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardContentTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
@@ -207,12 +208,27 @@ class SetupWizardContentTest {
     }
 
     @Test
+    fun `both picker steps can be scrolled, so no choice is unreachable`() {
+        // The window is a fixed 700x620 and not resizable. Ten theme pills wrap to more rows than
+        // that leaves room for, so without a scroll the lower ones cannot be reached — which is
+        // exactly what happened before: the language step scrolled and the theme step did not.
+        wizard { _ ->
+            assertEquals(1, onAllNodesCount(hasScrollAction()), "the language step scrolls")
+            next()
+            assertEquals(1, onAllNodesCount(hasScrollAction()), "and so must the theme step")
+        }
+    }
+
+    @Test
     fun `walking the whole wizard never reports a language or theme by itself`() = wizard { choices ->
         repeat(Label.LAST_STEP - 1) { next() }
         assertNull(choices.language, "merely passing the language step must not choose one")
         assertNull(choices.theme, "merely passing the theme step must not choose one")
         assertEquals(0, choices.dismissed, "walking to the end must not close the wizard on its own")
     }
+
+    private fun ComposeUiTest.onAllNodesCount(matcher: androidx.compose.ui.test.SemanticsMatcher): Int =
+        onAllNodes(matcher).fetchSemanticsNodes(atLeastOneRootRequired = false).size
 
     private fun ComposeUiTest.onAllNodesWithTextCount(text: String): Int =
         onAllNodes(androidx.compose.ui.test.hasText(text)).fetchSemanticsNodes(atLeastOneRootRequired = false).size


### PR DESCRIPTION
Closes #54, closes #55.

## #54 — wmctrl titles lose their first word

`wmctrl -l` prints **four** columns — id, desktop, host, title — and the title runs to end of line:

```
0x02200003  0 hostname Mozilla Firefox — Church Presenter
```

The split asked for five parts and read `parts[4]`, so one part was silently spent on the first word of every title ("Mozilla Firefox" listed as "Firefox"), and one-word titles like "Terminal" vanished entirely — those lines have only four parts, so they failed the `size >= 5` guard and were dropped.

Now `limit = 4` / `parts[3]`, with the guard at 4.

The existing test pinned the defect on purpose (`wmctrl titles lose their first word — known defect`), so it is **inverted rather than deleted** — same fixture, now asserting both titles survive whole.

## #55 — theme pills unreachable

`ThemeStep` put ten pills in a `FlowRow` with **no scroll**, inside a window fixed at 700×620 and `resizable = false`. Any pill wrapping past the available height could not be reached at all. `LanguageStep` already scrolled; this applies the same one-line treatment.

**The new test was checked against the unfixed code first.** It fails with `and so must the theme step expected:<1> but was:<0>` — so it pins the bug, not the fix. Worth stating because a scroll-parity assertion is exactly the kind that can pass vacuously.

## Not verified on hardware

Both were found by reading, and I want that on the record rather than buried:

- **#54** — this machine takes the macOS `osascript` path, so the Linux branch never runs here. Someone on Linux/X11 should confirm the column count; `wmctrl -l` output varies with `-x` and across window managers. If it turns out five columns are right on some setup, this fix is wrong for them.
- **#55** — the overflow was never reproduced on a real display. The scroll is harmless if nothing was actually being clipped, so this is safe either way, but I have not *seen* the bug.

Full `:composeApp:jvmTest` green.