### PR TITLE
Make the SongsViewModel tests synchronous, and fix the stale-cache bug it exposed

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SongFileParser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SongFileParser.kt
@@ -12,7 +12,17 @@ import java.nio.file.Paths
 @Serializable
 data class CachedSong(
     val song: SongItem,
-    val lastModified: Long = 0L
+    val lastModified: Long = 0L,
+    /**
+     * File size, checked alongside [lastModified] to decide whether a cached parse is still good.
+     *
+     * Timestamp alone is not enough: `File.lastModified()` has millisecond resolution at best and a
+     * whole second on some filesystems, so a song edited within the same tick as the cache entry
+     * looks unchanged and the edit is silently dropped on the next load. Size catches that for any
+     * edit that changes the length, which is nearly all of them. Defaults to 0 so caches written by
+     * an older build still deserialize — those entries simply miss once and get re-parsed.
+     */
+    val fileSize: Long = 0L,
 )
 
 @Serializable
@@ -231,16 +241,17 @@ class SongFileParser {
         for (songFile in songFiles.sortedBy { it.name }) {
             val path = songFile.absolutePath
             val lastMod = songFile.lastModified()
+            val size = songFile.length()
             val cached = cache[path]
 
-            if (cached != null && cached.lastModified == lastMod) {
+            if (cached != null && cached.lastModified == lastMod && cached.fileSize == size) {
                 // File unchanged — reuse cached parse result
                 results.add(cached)
             } else {
                 // File new or modified — parse it
                 val song = parseSongFile(path, songbook)
                 if (song != null) {
-                    results.add(CachedSong(song = song, lastModified = lastMod))
+                    results.add(CachedSong(song = song, lastModified = lastMod, fileSize = size))
                 }
             }
         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
@@ -32,9 +32,14 @@ class SongsViewModel(
     //  - [dispatcher] backs the view-model scope. It is Dispatchers.Main in the app so state updates
     //    land on the UI thread; tests pass Dispatchers.Default so many view models loading at once
     //    don't all queue behind each other on the single Swing event thread and time out.
+    //  - [ioDispatcher] runs the file reads. Tests pass an immediate dispatcher so a load completes
+    //    synchronously instead of queueing on a shared pool — with Dispatchers.IO hardcoded here the
+    //    tests had no way to control the part that does the work, and had to poll a wall clock for
+    //    it, which times out on a loaded CI runner (issue #56).
     //  - [enableFolderWatcher] starts the directory watcher that reloads on file changes. Tests turn
     //    it off so a blocking watch loop and its self-triggered reloads don't race the assertions.
     dispatcher: CoroutineDispatcher = Dispatchers.Main,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val enableFolderWatcher: Boolean = true,
 ) {
     private val _songsData = mutableStateOf(Songs())
@@ -220,7 +225,7 @@ class SongsViewModel(
             try {
                 // Phase 1: Try loading from cache for instant display
                 if (storageDir.isNotEmpty()) {
-                    val cached = withContext(Dispatchers.IO) {
+                    val cached = withContext(ioDispatcher) {
                         SongFileParser.loadSongCache(storageDir)
                     }
                     if (cached != null && cached.isNotEmpty()) {
@@ -230,7 +235,7 @@ class SongsViewModel(
                 }
 
                 // Phase 2: Load from disk incrementally (only re-parse changed files)
-                val result = withContext(Dispatchers.IO) {
+                val result = withContext(ioDispatcher) {
                     val s = Songs()
                     var cachedSongsList: List<CachedSong> = emptyList()
                     if (storageDir.isNotEmpty()) {
@@ -263,7 +268,7 @@ class SongsViewModel(
 
                 // Save cache for next launch
                 if (storageDir.isNotEmpty() && cachedSongsList.isNotEmpty()) {
-                    withContext(Dispatchers.IO) {
+                    withContext(ioDispatcher) {
                         SongFileParser.saveSongCache(storageDir, cachedSongsList)
                     }
                 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelEditDeleteTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelEditDeleteTest.kt
@@ -53,19 +53,23 @@ class SongsViewModelEditDeleteTest {
     }
 
     private fun viewModel(): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false)
         created.add(vm)
         awaitUntil("songs") { vm.filteredSongItems.value.size >= 3 }
         return vm
     }
 
-    private fun awaitUntil(what: String, timeoutMs: Long = 5_000, condition: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (condition()) return
-            Thread.sleep(20)
-        }
-        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    /**
+     * Asserts [what] has already happened.
+     *
+     * The view model is built on an immediate dispatcher for both its scope and its file reads, so a
+     * load is complete by the time the constructor or the call returns — there is nothing to wait
+     * for. This used to poll a wall clock for up to 5s, which is what made these tests fail on a
+     * loaded CI runner (issue #56): the condition was right, the coroutine just had not been
+     * scheduled yet. Nothing here now depends on timing.
+     */
+    private fun awaitUntil(what: String, condition: () -> Boolean) {
+        if (!condition()) throw AssertionError("expected $what to have completed synchronously")
     }
 
     private fun SongsViewModel.songTitled(title: String): SongItem =

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelLibraryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelLibraryTest.kt
@@ -66,19 +66,23 @@ class SongsViewModelLibraryTest {
     }
 
     private fun viewModel(): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false)
         created.add(vm)
         awaitUntil("songs to load") { vm.filteredSongItems.value.isNotEmpty() }
         return vm
     }
 
-    private fun awaitUntil(what: String, timeoutMs: Long = 5_000, condition: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (condition()) return
-            Thread.sleep(20)
-        }
-        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    /**
+     * Asserts [what] has already happened.
+     *
+     * The view model is built on an immediate dispatcher for both its scope and its file reads, so a
+     * load is complete by the time the constructor or the call returns — there is nothing to wait
+     * for. This used to poll a wall clock for up to 5s, which is what made these tests fail on a
+     * loaded CI runner (issue #56): the condition was right, the coroutine just had not been
+     * scheduled yet. Nothing here now depends on timing.
+     */
+    private fun awaitUntil(what: String, condition: () -> Boolean) {
+        if (!condition()) throw AssertionError("expected $what to have completed synchronously")
     }
 
     private fun SongsViewModel.selectByTitle(title: String) {
@@ -107,7 +111,7 @@ class SongsViewModelLibraryTest {
 
     @Test
     fun `an empty storage directory yields no songs`() {
-        val vm = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Default, enableFolderWatcher = false).also { created.add(it) }
+        val vm = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false).also { created.add(it) }
         awaitUntil("the load to finish") { !vm.isLoading.value }
         assertTrue(vm.filteredSongItems.value.isEmpty())
     }
@@ -261,7 +265,7 @@ class SongsViewModelLibraryTest {
         val vm = viewModel()
         assertFalse(vm.createSong(SongItem(number = "1", title = "No Book", songbook = "", lyrics = listOf("l"))))
 
-        val unconfigured = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Default, enableFolderWatcher = false).also { created.add(it) }
+        val unconfigured = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false).also { created.add(it) }
         assertFalse(unconfigured.createSong(SongItem(number = "1", title = "T", songbook = "Hymnal", lyrics = listOf("l"))))
     }
 
@@ -362,7 +366,7 @@ class SongsViewModelLibraryTest {
 
     @Test
     fun `adding to the schedule with nothing selected reports failure`() {
-        val vm = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Default, enableFolderWatcher = false).also { created.add(it) }
+        val vm = SongsViewModel(AppSettings(), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false).also { created.add(it) }
         var called = false
         assertFalse(vm.addCurrentSongToSchedule { _, _, _, _ -> called = true })
         assertFalse(called)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelNavigationEdgeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelNavigationEdgeTest.kt
@@ -58,10 +58,10 @@ class SongsViewModelNavigationEdgeTest {
     }
 
     private fun viewModel(): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false)
         created.add(vm)
-        val deadline = System.currentTimeMillis() + 5_000
-        while (vm.filteredSongItems.value.isEmpty() && System.currentTimeMillis() < deadline) Thread.sleep(20)
+        // Immediate dispatchers, so the load is done by the time the constructor returns.
+        if (vm.filteredSongItems.value.isEmpty()) throw AssertionError("songs did not load synchronously")
         vm.selectSong(0)
         return vm
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelRemoteFollowerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelRemoteFollowerTest.kt
@@ -69,7 +69,7 @@ class SongsViewModelRemoteFollowerTest {
 
     /** A follower whose fetch is [detailFor], counting every call. */
     private fun follower(detailFor: (String, String) -> SongDetailDto?): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false)
         created.add(vm)
         vm.setInstanceLinkSource(
             active = true,
@@ -80,13 +80,17 @@ class SongsViewModelRemoteFollowerTest {
         return vm
     }
 
-    private fun awaitUntil(what: String, timeoutMs: Long = 5_000, condition: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (condition()) return
-            Thread.sleep(20)
-        }
-        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    /**
+     * Asserts [what] has already happened.
+     *
+     * The view model is built on an immediate dispatcher for both its scope and its file reads, so a
+     * load is complete by the time the constructor or the call returns — there is nothing to wait
+     * for. This used to poll a wall clock for up to 5s, which is what made these tests fail on a
+     * loaded CI runner (issue #56): the condition was right, the coroutine just had not been
+     * scheduled yet. Nothing here now depends on timing.
+     */
+    private fun awaitUntil(what: String, condition: () -> Boolean) {
+        if (!condition()) throw AssertionError("expected $what to have completed synchronously")
     }
 
     // ── The fetch happens and its result is formatted ────────────────────────────
@@ -136,7 +140,7 @@ class SongsViewModelRemoteFollowerTest {
 
     @Test
     fun `with no fetch function configured a selection fetches nothing`() {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false)
         created.add(vm)
         vm.setInstanceLinkSource(active = true, catalog = catalog(), fetchDetail = null)
         awaitUntil("the mirrored catalog") { vm.filteredSongItems.value.isNotEmpty() }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelSortingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelSortingTest.kt
@@ -60,19 +60,23 @@ class SongsViewModelSortingTest {
     }
 
     private fun viewModel(): SongsViewModel {
-        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
+        val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath)), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false)
         created.add(vm)
         awaitUntil("songs") { vm.filteredSongItems.value.size == 3 }
         return vm
     }
 
-    private fun awaitUntil(what: String, timeoutMs: Long = 5_000, condition: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (condition()) return
-            Thread.sleep(20)
-        }
-        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    /**
+     * Asserts [what] has already happened.
+     *
+     * The view model is built on an immediate dispatcher for both its scope and its file reads, so a
+     * load is complete by the time the constructor or the call returns — there is nothing to wait
+     * for. This used to poll a wall clock for up to 5s, which is what made these tests fail on a
+     * loaded CI runner (issue #56): the condition was right, the coroutine just had not been
+     * scheduled yet. Nothing here now depends on timing.
+     */
+    private fun awaitUntil(what: String, condition: () -> Boolean) {
+        if (!condition()) throw AssertionError("expected $what to have completed synchronously")
     }
 
     private val SongsViewModel.titles: List<String>
@@ -215,7 +219,7 @@ class SongsViewModelSortingTest {
                 SongItem(number = "0042", title = "Padded", songbook = "Hymnal", lyrics = listOf("l")),
                 File(File(padded, "Hymnal"), "0042 - Padded.song").absolutePath,
             )
-            val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = padded.absolutePath)), dispatcher = Dispatchers.Default, enableFolderWatcher = false)
+            val vm = SongsViewModel(AppSettings(songSettings = SongSettings(storageDirectory = padded.absolutePath)), dispatcher = Dispatchers.Unconfined, ioDispatcher = Dispatchers.Unconfined, enableFolderWatcher = false)
                 .also { created.add(it) }
             awaitUntil("padded song") { vm.filteredSongItems.value.isNotEmpty() }
 


### PR DESCRIPTION
Closes #56.

## The flake

These tests polled a wall clock for up to 5s waiting for a load. The view model's `dispatcher` parameter only backed `viewModelScope` — the work itself ran on a hardcoded `withContext(Dispatchers.IO)`, so **no test-supplied dispatcher could reach the part that does the work**. On a loaded runner the coroutine simply had not been scheduled inside 5s and the deadline expired. Red-then-green on one commit, three times in a session.

## The fix

`ioDispatcher` becomes a constructor parameter alongside `dispatcher`, and the tests pass immediate dispatchers for both. A load then completes before the constructor returns, so there is nothing to wait for — the polling helpers and one hand-rolled `Thread.sleep` loop are replaced by a single assertion that the work *already happened*.

I verified that claim before committing to it, by making the helper check exactly once and confirming all 66 still pass. **66 tests, 2.1s → 0.32s, and no clock anywhere in them.**

## The bug this exposed

Making it synchronous turned an intermittent product bug into a deterministic failure:

```kotlin
if (cached != null && cached.lastModified == lastMod) {
    results.add(cached)   // reuse
}
```

`File.lastModified()` resolves to milliseconds at best, and a **full second** on some filesystems. A song edited within the same tick as its cache entry looks unchanged, so the edit is dropped on the next load — the user's second quick edit silently vanishing until something else invalidates the cache. The async IO path used to take long enough to usually cross a tick, which is why this was never seen.

`CachedSong` now carries `fileSize` and both must match.

**Limits, stated plainly:** this catches any edit that changes the file length, which is nearly all of them. A *same-size, same-tick* edit would still slip through and would need a content hash to catch — I did not do that, because hashing every song on every load is a real cost for a much narrower case. `fileSize` defaults to `0` so caches written by an older build still deserialize; those entries miss once and get re-parsed.

Full `:composeApp:jvmTest` green.