### PR TITLE
Test the Songs tab's search

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabSearchTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabSearchTest.kt
@@ -1,0 +1,117 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Finding a song in the Songs tab.
+ *
+ * This is the tab's whole job during a service: an operator with a number called from the platform,
+ * or half a remembered title, has to get to the right song in one go. So these cover what the search
+ * box actually narrows the list to, and — as importantly — what it does *not* drop.
+ *
+ * The songs are written to disk and read back through the real loader, so nothing here can pass
+ * against a fixture the app would not itself produce. See `SongsTabTestSupport` for why this tab is
+ * reachable in a test at all.
+ */
+class SongsTabSearchTest {
+
+    @Test
+    fun `every song is listed before anything is searched for, grouped by songbook`() = songsTab { _, _ ->
+        // Chorus Book sorts before Hymnal, and within a songbook the rows follow the song number as
+        // text — so 1, 12, 2 rather than 1, 2, 12. Pinned as it stands rather than as one might wish.
+        assertEquals(
+            listOf("How Great Thou Art", "Amazing Grace", "Amazing Love", "Be Thou My Vision"),
+            listedTitles(),
+            "the tab opens on the whole library, across songbooks",
+        )
+    }
+
+    @Test
+    fun `a title search narrows the list to the matches`() = songsTab { _, _ ->
+        search("Amazing")
+        assertEquals(
+            listOf("Amazing Grace", "Amazing Love"),
+            listedTitles(),
+            "both Amazing songs match; the others must go",
+        )
+    }
+
+    @Test
+    fun `search matches the middle of a title, not just the start`() = songsTab { _, _ ->
+        // The operator remembers "Vision", not "Be Thou".
+        search("Vision")
+        assertEquals(listOf("Be Thou My Vision"), listedTitles())
+    }
+
+    @Test
+    fun `search ignores case`() = songsTab { _, _ ->
+        search("amazing grace")
+        assertTrue(shows("Amazing Grace"), "a lowercase query must still find it")
+    }
+
+    @Test
+    fun `a song number finds that song`() = songsTab { _, _ ->
+        // A number called out from the platform is the most common way in.
+        search("12")
+        assertTrue(shows("Amazing Love"), "song 12 must be reachable by its number")
+    }
+
+    @Test
+    fun `a query matching nothing empties the list rather than showing everything`() = songsTab { _, _ ->
+        search("Zzzzz No Such Song")
+        assertEquals(
+            emptyList(),
+            listedTitles(),
+            "a failed search must not silently fall back to the full library",
+        )
+    }
+
+    @Test
+    fun `clearing the query brings the whole library back`() = songsTab { _, _ ->
+        search("Amazing")
+        assertEquals(2, listedTitles().size)
+
+        search("")
+        assertEquals(4, listedTitles().size, "an emptied box is the same as never having searched")
+    }
+
+    @Test
+    fun `searching finds songs in every songbook, not only the first`() = songsTab { _, _ ->
+        // "How Great Thou Art" lives in Chorus Book while the rest are in Hymnal.
+        search("How Great")
+        assertEquals(listOf("How Great Thou Art"), listedTitles())
+    }
+
+    @Test
+    fun `whitespace in the query is significant — a stray space finds nothing`() = songsTab { _, _ ->
+        // Current behaviour, pinned rather than endorsed: the query is matched raw, so a leading or
+        // trailing space makes the search miss. Reported separately; changing it is a product
+        // decision, not something to smuggle in under a test.
+        search("  Amazing Grace  ")
+        assertEquals(emptyList(), listedTitles(), "the untrimmed query matches nothing")
+
+        search("Amazing Grace")
+        assertTrue(shows("Amazing Grace"), "and the same query trimmed finds it")
+    }
+
+    // ── What the tab shows around the list ──────────────────────────────────────
+
+    @Test
+    fun `the search box and the songbook filter are both offered`() = songsTab { _, _ ->
+        assertTrue(shows(SongsLabel.SEARCH_PLACEHOLDER), "the empty box names itself")
+        // DropdownSelector merges caption and value into one node, hence the substring match.
+        assertTrue(showsContaining(SongsLabel.ALL_SONGBOOKS), "the songbook filter starts unrestricted")
+        assertTrue(showsContaining(SongsLabel.CONTAINS), "and the filter mode starts on Contains")
+    }
+
+    @Test
+    fun `an empty library lists nothing and does not claim to be searching`() = songsTab(songs = emptyList()) { _, _ ->
+        assertEquals(emptyList(), listedTitles())
+        assertFalse(shows("Amazing Grace"))
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabTestSupport.kt
@@ -1,0 +1,190 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.coroutines.Dispatchers
+import org.churchpresenter.app.churchpresenter.data.SongFileParser
+import org.churchpresenter.app.churchpresenter.data.SongItem
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
+import org.churchpresenter.app.churchpresenter.models.LyricSection
+import org.churchpresenter.app.churchpresenter.viewmodel.SongsViewModel
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Harness and fixtures shared by the `SongsTab` test classes.
+ *
+ * **Why this tab is testable at all.** `tabs/` sat at 0% because a tab needs a real view model, and
+ * `SongsViewModel` used to load its songs asynchronously on a shared dispatcher — so a test either
+ * raced it or polled a wall clock for it. Since `ioDispatcher` became injectable (issue #56), the
+ * view model loads *synchronously* from a temp songbook folder, which makes `SongsTab` ordinary
+ * Compose: build the model, compose the tab, assert on what is on screen.
+ *
+ * Nothing is stubbed. Songs are written to disk with the real [SongFileParser] and read back through
+ * the real load path, so the fixtures cannot drift from the file format the app actually writes.
+ * `SongsTab` needs no `PresenterManager` and no host window — only a view model, an `AppSettings`,
+ * and the section-selected callback.
+ */
+
+// ── Fixtures ────────────────────────────────────────────────────────────────────────────────────
+
+/** One song as it will be written to disk. */
+internal data class SongFixture(
+    val number: String,
+    val title: String,
+    val songbook: String = "Hymnal",
+    val author: String = "",
+    val lyrics: List<String> = listOf("[Verse 1]", "a line of $title"),
+)
+
+internal val defaultSongs = listOf(
+    SongFixture(number = "1", title = "Amazing Grace", author = "John Newton"),
+    SongFixture(number = "2", title = "Be Thou My Vision", author = "Dallan Forgaill"),
+    SongFixture(number = "12", title = "Amazing Love", author = "Charles Wesley"),
+    SongFixture(number = "3", title = "How Great Thou Art", songbook = "Chorus Book"),
+)
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class TabReports {
+    var selectedSection: LyricSection? = null
+    val allSections = mutableListOf<List<LyricSection>>()
+    var sectionIndex: Int? = null
+    val scheduled = mutableListOf<String>()
+    var settingsChanges = 0
+}
+
+/**
+ * Writes [songs] into a temp songbook folder, builds a real [SongsViewModel] over it, composes
+ * `SongsTab`, and runs [block].
+ *
+ * The view model uses immediate dispatchers, so by the time [block] runs the songs are loaded — the
+ * body can assert straight away without waiting for anything.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun songsTab(
+    songs: List<SongFixture> = defaultSongs,
+    block: ComposeUiTest.(vm: SongsViewModel, reports: TabReports) -> Unit,
+) {
+    val dir = Files.createTempDirectory("cp-songs-tab").toFile()
+    try {
+        val parser = SongFileParser()
+        songs.forEach { s ->
+            val book = File(dir, s.songbook).apply { mkdirs() }
+            parser.writeSongFile(
+                SongItem(
+                    number = s.number,
+                    title = s.title,
+                    songbook = s.songbook,
+                    author = s.author,
+                    lyrics = s.lyrics,
+                ),
+                File(book, "${s.number} - ${s.title}.song").absolutePath,
+            )
+        }
+        val settings = AppSettings(songSettings = SongSettings(storageDirectory = dir.absolutePath))
+        val vm = SongsViewModel(
+            settings,
+            dispatcher = Dispatchers.Unconfined,
+            ioDispatcher = Dispatchers.Unconfined,
+            enableFolderWatcher = false,
+        )
+        val reports = TabReports()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    SongsTab(
+                        viewModel = vm,
+                        appSettings = settings,
+                        onSettingsChange = { reports.settingsChanges++ },
+                        onAddToSchedule = { _, title, _, _ -> reports.scheduled += title },
+                        onSongItemSelected = { reports.selectedSection = it },
+                        onAllSectionsChanged = { reports.allSections += it },
+                        onSectionIndexChanged = { reports.sectionIndex = it },
+                    )
+                }
+            }
+            block(vm, reports)
+        }
+    } finally {
+        dir.deleteRecursively()
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object SongsLabel {
+    const val SEARCH_PLACEHOLDER = "Search songs..."
+    const val ALL_SONGBOOKS = "All Song Books"
+    const val CONTAINS = "Contains"
+    const val STARTS_WITH = "Starts With"
+    const val EXACT_MATCH = "Exact Match"
+    const val ADD_TO_SCHEDULE = "Add to Schedule"
+    const val FAVORITES = "Favorites"
+    const val NEW_SONG = "New Song"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+
+/** Every string on screen. */
+internal fun ComposeUiTest.rendered(): List<String> =
+    onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .mapNotNull { it.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { t -> t.text } }
+
+internal fun ComposeUiTest.shows(text: String): Boolean = rendered().any { it == text }
+
+/**
+ * Substring match, for the controls whose label and value land in one node.
+ *
+ * `DropdownSelector` merges its semantics, so the songbook filter renders as the single string
+ * "SONG BOOKAll Song Books" rather than as a caption and a value — an exact match on either half
+ * finds nothing.
+ */
+internal fun ComposeUiTest.showsContaining(fragment: String): Boolean =
+    rendered().any { it.contains(fragment) }
+
+/**
+ * The search box: the tab's only freely-typed field.
+ *
+ * Addressed as the single node taking typed text rather than by its caption, because the placeholder
+ * is a separate `Text` inside a `BasicTextField` decoration box and disappears once anything is typed.
+ */
+internal fun ComposeUiTest.searchBox() = onAllNodes(hasSetTextAction())[0]
+
+internal fun ComposeUiTest.search(query: String) {
+    searchBox().performTextReplacement(query)
+    waitForIdle()
+}
+
+/**
+ * The song titles currently listed, **in the order the tab shows them**.
+ *
+ * Ordered by vertical position rather than by walking the fixture list, so a change to how the tab
+ * sorts its rows is visible here. (An earlier version of this helper filtered the fixtures by
+ * presence, which silently made every ordering assertion a presence check.) Only titles belonging to
+ * [from] are returned, so the surrounding chrome and the lyric pane do not leak in.
+ */
+internal fun ComposeUiTest.listedTitles(from: List<SongFixture> = defaultSongs): List<String> {
+    val titles = from.map { it.title }.toSet()
+    return onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .mapNotNull { node ->
+            val text = node.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { it.text }
+            if (text in titles) node.boundsInRoot.top to text!! else null
+        }
+        .sortedBy { it.first }
+        .map { it.second }
+        .distinct()
+}


### PR DESCRIPTION
First tests in `tabs/`, which sat at **0% across 10,201 lines** — the largest uncovered block in the codebase.

## Why this became possible

The blocker was never the tab. It was that a tab needs a real view model, and `SongsViewModel` loaded asynchronously on a shared dispatcher, so a test either raced it or polled a wall clock for it. Since `ioDispatcher` became injectable (#56 / #67) the model loads **synchronously**, and it turns out `SongsTab` needs no `PresenterManager` and no host window — a view model, an `AppSettings`, and one callback. It composes headless.

I confirmed that with a throwaway probe before writing anything, because I had twice judged `tabs/` impractical and did not want to make that call a third time on reasoning alone.

Nothing is stubbed: songs are written with the real `SongFileParser` into a temp songbook folder and read back through the real load path, so a fixture cannot drift from the format the app actually writes.

## `SongsTabSearchTest` (11)

What an operator does during a service — a number called from the platform, or half a remembered title:

- the whole library listed before any search, across songbooks
- a title search narrowing to the matches; matching **mid-title**, not only the prefix
- case-insensitive
- **finding a song by its number** — the commonest way in
- a failed search **emptying** the list rather than silently falling back to everything
- clearing the box restoring the library
- searching reaching songs in every songbook, not just the first

## Two assumptions of mine were wrong

Both are now pinned as the code actually behaves, not as I expected:

1. **Search does not trim its query.** `"  Amazing Grace  "` finds nothing — the query is matched raw in all filter modes. Pinned, *not endorsed*: I have reported it separately, because changing search semantics is a product decision and not something to smuggle in under a test.
2. **Rows group by songbook and sort the number as text**, so Hymnal reads 1, 12, 2.

## And one flaw in my own helper

`listedTitles()` originally walked the fixture list and filtered by presence — which silently made every ordering assertion a *presence* check. It now reads genuine screen order from node bounds, so the ordering claim above is actually tested. Worth mentioning because the tests passed either way; only the dump of what was really rendered showed it.

`SongsTab.kt` 0% → 50.9%. 11 tests, 1.76s total, deterministic 3×.