### PR TITLE
Trim the song search query so a stray space cannot lose the song

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
@@ -593,19 +593,26 @@ class SongsViewModel(
             }
         }
 
-        // Filter by search query
-        if (_searchQuery.value.isNotEmpty()) {
+        // Filter by search query.
+        //
+        // Matched trimmed, while the box keeps what was typed: a query pasted from a service plan or
+        // an email routinely carries a leading or trailing space, and matching it raw made the search
+        // come back empty with nothing on screen to explain why — the worst possible moment being
+        // mid-service. Only the ends are trimmed; whitespace inside a title is still significant, so
+        // "Be Thou  My Vision" and "Be Thou My Vision" remain different queries.
+        val query = _searchQuery.value.trim()
+        if (query.isNotEmpty()) {
             filtered = when (_filterType.value) {
                 Constants.CONTAINS -> filtered.filter {
-                    "${it.number}. ${it.title}".contains(_searchQuery.value, ignoreCase = true)
+                    "${it.number}. ${it.title}".contains(query, ignoreCase = true)
                 }
                 Constants.STARTS_WITH -> filtered.filter {
-                    it.title.startsWith(_searchQuery.value, ignoreCase = true) ||
-                    it.number.startsWith(_searchQuery.value, ignoreCase = true)
+                    it.title.startsWith(query, ignoreCase = true) ||
+                    it.number.startsWith(query, ignoreCase = true)
                 }
                 Constants.EXACT_MATCH -> filtered.filter {
-                    it.title.equals(_searchQuery.value, ignoreCase = true) ||
-                    it.number.equals(_searchQuery.value, ignoreCase = true)
+                    it.title.trim().equals(query, ignoreCase = true) ||
+                    it.number.trim().equals(query, ignoreCase = true)
                 }
                 else -> filtered
             }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabSearchTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabSearchTest.kt
@@ -88,15 +88,35 @@ class SongsTabSearchTest {
     }
 
     @Test
-    fun `whitespace in the query is significant — a stray space finds nothing`() = songsTab { _, _ ->
-        // Current behaviour, pinned rather than endorsed: the query is matched raw, so a leading or
-        // trailing space makes the search miss. Reported separately; changing it is a product
-        // decision, not something to smuggle in under a test.
+    fun `a stray space around the query does not lose the song`() = songsTab { _, _ ->
+        // Was issue #70: the query was matched raw, so a query pasted from a service plan or an
+        // email came back empty with nothing on screen to explain why. Only the ends are trimmed.
         search("  Amazing Grace  ")
-        assertEquals(emptyList(), listedTitles(), "the untrimmed query matches nothing")
+        assertTrue(shows("Amazing Grace"), "a leading and trailing space must not lose the match")
 
-        search("Amazing Grace")
-        assertTrue(shows("Amazing Grace"), "and the same query trimmed finds it")
+        search("Amazing Grace  ")
+        assertTrue(shows("Amazing Grace"), "nor a trailing one alone")
+
+        search("  Amazing")
+        assertEquals(
+            listOf("Amazing Grace", "Amazing Love"),
+            listedTitles(),
+            "a leading space must not change which songs match either",
+        )
+    }
+
+    @Test
+    fun `whitespace inside a query is still significant`() = songsTab { _, _ ->
+        // Only the ends are trimmed. A doubled space in the middle is a different query, so this
+        // still finds nothing — trimming must not quietly become "normalise all whitespace".
+        search("Amazing  Grace")
+        assertEquals(emptyList(), listedTitles(), "the inner double space is part of what was asked for")
+    }
+
+    @Test
+    fun `a query of nothing but spaces lists everything, as an empty box does`() = songsTab { _, _ ->
+        search("     ")
+        assertEquals(4, listedTitles().size, "whitespace alone is not a search")
     }
 
     // ── What the tab shows around the list ──────────────────────────────────────

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsFilteringTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsFilteringTest.kt
@@ -144,6 +144,63 @@ class SongsFilteringTest {
         assertEquals(listOf("Amazing Grace", "Great Is Thy Faithfulness", "Amazing Love"), vm.titles)
     }
 
+    // ── Whitespace around the query (issue #70) ─────────────────────────────────
+
+    @Test
+    fun `contains ignores space around the query`() {
+        // A query pasted from a service plan or an email routinely carries one. Matching it raw
+        // returned nothing, with nothing on screen to say why — mid-service, that reads as "the
+        // song is missing".
+        val vm = vmWith(*defaultCatalog)
+        vm.updateFilterType(Constants.CONTAINS)
+        vm.updateSearchQuery("  amazing  ")
+        assertEquals(listOf("Amazing Grace", "Amazing Love"), vm.titles)
+    }
+
+    @Test
+    fun `starts-with ignores space around the query`() {
+        val vm = vmWith(*defaultCatalog)
+        vm.updateFilterType(Constants.STARTS_WITH)
+        vm.updateSearchQuery(" Great ")
+        assertEquals(listOf("Great Is Thy Faithfulness"), vm.titles, "still anchored, just not by the space")
+    }
+
+    @Test
+    fun `exact match ignores space around the query`() {
+        val vm = vmWith(*defaultCatalog)
+        vm.updateFilterType(Constants.EXACT_MATCH)
+        vm.updateSearchQuery("  Amazing Grace  ")
+        assertEquals(listOf("Amazing Grace"), vm.titles)
+    }
+
+    @Test
+    fun `exact match still reaches a title stored with its own stray space`() {
+        // The objection to trimming was that a title carrying real leading or trailing whitespace
+        // would become unreachable under exact match. Both sides are trimmed, so it stays findable
+        // — which is the behaviour an operator would expect, since the space is invisible on screen.
+        val vm = vmWith("Hymnal" to listOf("1" to "Amazing Grace "))
+        vm.updateFilterType(Constants.EXACT_MATCH)
+        vm.updateSearchQuery("Amazing Grace")
+        assertEquals(listOf("Amazing Grace "), vm.titles)
+    }
+
+    @Test
+    fun `space inside the query is still part of it`() {
+        // Only the ends are trimmed; this must not become "normalise all whitespace".
+        val vm = vmWith(*defaultCatalog)
+        vm.updateFilterType(Constants.CONTAINS)
+        vm.updateSearchQuery("Amazing  Grace")
+        assertEquals(emptyList(), vm.titles, "the doubled inner space is part of what was asked for")
+    }
+
+    @Test
+    fun `a query of only spaces is the same as an empty box`() {
+        val vm = vmWith(*defaultCatalog)
+        vm.updateFilterType(Constants.CONTAINS)
+        vm.updateSearchQuery("   ")
+        assertEquals(5, vm.filteredSongItems.value.size, "whitespace alone is not a search")
+    }
+
     // ── Exact match ─────────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Closes #70.

## The problem

The query was matched **raw** in all three filter modes, so `"  Amazing Grace  "` returned nothing.

The failure mode is the bad kind: an empty list with nothing on screen explaining why, at the moment an operator is hunting for a song mid-service. The likely ways in are a paste from a service plan or an email, or a stray space bar under time pressure.

## The fix

Only the ends are trimmed, and only at comparison — the box keeps what was typed, so the operator still sees their own query.

## The reason this was filed rather than fixed on the spot

**Exact match.** A title stored with real leading or trailing whitespace would become unreachable if only the *query* were trimmed — that was the objection in #70, and it is a real one.

So both sides are trimmed there:

```kotlin
Constants.EXACT_MATCH -> filtered.filter {
    it.title.trim().equals(query, ignoreCase = true) ||
    it.number.trim().equals(query, ignoreCase = true)
}
```

A title saved as `"Amazing Grace "` is still found by typing `Amazing Grace`, which is what anyone would expect given the space is invisible on screen. That is tested directly.

## What did *not* change

Whitespace **inside** a query stays significant — `"Amazing  Grace"` still matches nothing. This trims; it does not normalise. Also tested, so the distinction cannot erode later.

## Tests

- The pinning test in `SongsTabSearchTest` that asserted the old behaviour is **inverted rather than deleted**, so the change reads as deliberate in the history rather than as a test quietly disappearing.
- `SongsFilteringTest` covers all three modes, the stored-whitespace title, the inner-space case, and a query of nothing but spaces behaving as an empty box.

Full `:composeApp:jvmTest` green; deterministic 3×.