### PR TITLE
Test the Schedule tab

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
@@ -807,7 +807,13 @@ fun ScheduleTab(
     }
 }
 
-private fun handleDroppedFiles(files: List<File>, viewModel: ScheduleViewModel) {
+/**
+ * Adds each dropped file to the schedule as whatever [classifyDroppedFile] says it is.
+ *
+ * `internal` rather than private so the drop handling can be tested directly: the drop itself
+ * arrives through an AWT `DropTarget` on the real window, which a headless test cannot deliver.
+ */
+internal fun handleDroppedFiles(files: List<File>, viewModel: ScheduleViewModel) {
     for (file in files) {
         if (file.isDirectory) {
             // Folder dropped — count image files inside and add as pictures

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabActionsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabActionsTest.kt
@@ -1,0 +1,282 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The buttons: the toolbar across the top and the per-row actions.
+ *
+ * These are the controls an operator uses live, so each test drives the real button and asserts the
+ * schedule that results — a button wired to the wrong view-model call, or to the wrong row, is the
+ * kind of mistake that only shows up in front of a congregation.
+ *
+ * See `ScheduleTabTestSupport.kt` for the harness.
+ */
+class ScheduleTabActionsTest {
+
+    // ── Reordering ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `moving an item down swaps it with the one below`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            // The song is second; sending it down puts the verse second instead.
+            buttonAt(ScheduleLabel.MOVE_DOWN, 1).performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "John 3:16", "42 - Amazing Grace", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+            )
+            assertEquals(
+                listOf("Welcome", "John 3:16", "Amazing Grace", "Notices"),
+                orderOf("Welcome", "John 3:16", "Amazing Grace", "Notices"),
+                "and the list redraws in the new order",
+            )
+        }
+
+    @Test
+    fun `moving an item up swaps it with the one above`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            buttonAt(ScheduleLabel.MOVE_UP, 3).performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "42 - Amazing Grace", "Notices", "John 3:16"),
+                vm.scheduleItems.map { it.displayText },
+            )
+        }
+
+    @Test
+    fun `the first item cannot be moved off the top, nor the last off the bottom`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            val before = vm.scheduleItems.map { it.displayText }
+
+            buttonAt(ScheduleLabel.MOVE_UP, 0).performClick()
+            buttonAt(ScheduleLabel.MOVE_DOWN, 3).performClick()
+            waitForIdle()
+
+            assertEquals(before, vm.scheduleItems.map { it.displayText }, "the order is untouched")
+        }
+
+    // ── Removing ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a row's remove button removes that row and no other`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            buttonAt(ScheduleLabel.REMOVE, 1).performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+            )
+        }
+
+    @Test
+    fun `the toolbar's remove takes the selected row`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            onNodeWithText("Notices").performClick()
+            waitForIdle()
+            button(ScheduleLabel.REMOVE_SELECTED).performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "42 - Amazing Grace", "John 3:16"),
+                vm.scheduleItems.map { it.displayText },
+            )
+        }
+
+    @Test
+    fun `the toolbar's remove does nothing when nothing is selected`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            button(ScheduleLabel.REMOVE_SELECTED).performClick()
+            waitForIdle()
+
+            assertEquals(4, vm.scheduleItems.size, "no row is removed at random")
+        }
+
+    @Test
+    fun `clearing empties the whole schedule`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            button(ScheduleLabel.CLEAR).performClick()
+            waitForIdle()
+
+            assertTrue(vm.scheduleItems.isEmpty())
+            assertTrue(showsExactly(ScheduleLabel.DROP_HINT), "and the empty state comes back")
+        }
+
+    @Test
+    fun `starting a new schedule empties it too`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            button(ScheduleLabel.NEW).performClick()
+            waitForIdle()
+
+            assertTrue(vm.scheduleItems.isEmpty())
+        }
+
+    // ── Undo and redo ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `undo puts back a row removed by mistake`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            buttonAt(ScheduleLabel.REMOVE, 1).performClick()
+            waitForIdle()
+            button(ScheduleLabel.UNDO).performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "42 - Amazing Grace", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+                "the song is back where it was",
+            )
+        }
+
+    @Test
+    fun `redo takes it away again`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            buttonAt(ScheduleLabel.REMOVE, 1).performClick()
+            waitForIdle()
+            button(ScheduleLabel.UNDO).performClick()
+            waitForIdle()
+            button(ScheduleLabel.REDO).performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+            )
+        }
+
+    // ── Going live ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a row's go-live hands the host that item`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            // Go Live is only on presentable rows, so index 0 is the song, not the label.
+            buttonAt(ScheduleLabel.GO_LIVE, 0).performClick()
+            waitForIdle()
+
+            assertEquals(listOf(vm.scheduleItems[1]), reports.presented, "the song went live")
+        }
+
+    @Test
+    fun `each row goes live through its own kind of handler`() =
+        scheduleTab(seed = { seedService() }) { _, reports ->
+            buttonAt(ScheduleLabel.GO_LIVE, 1).performClick()   // the verse
+            waitForIdle()
+            buttonAt(ScheduleLabel.GO_LIVE, 2).performClick()   // the website
+            waitForIdle()
+
+            assertTrue(
+                reports.presented[0] is ScheduleItem.BibleVerseItem &&
+                    reports.presented[1] is ScheduleItem.WebsiteItem,
+                "each item reached the handler for its own type: ${reports.presented}",
+            )
+        }
+
+    @Test
+    fun `with no handler for a type the tab just switches the output to it`() =
+        // A host that does not take pictures itself still gets the output switched, so the operator
+        // is not left looking at the previous content with nothing having visibly happened.
+        scheduleTab(
+            seed = { addPicture(folderPath = "/tmp/slides", folderName = "Slides", imageCount = 3) }
+        ) { _, reports ->
+            buttonAt(ScheduleLabel.GO_LIVE, 0).performClick()
+            waitForIdle()
+
+            assertEquals(listOf(Presenting.PICTURES), reports.presenting)
+            assertTrue(reports.presented.isEmpty(), "no handler was given one to call")
+        }
+
+    @Test
+    fun `editing a label asks the host to open the label editor for that label`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            button(ScheduleLabel.EDIT_LABEL).performClick()
+            waitForIdle()
+
+            assertEquals(listOf(vm.scheduleItems[0]), reports.editedLabels)
+        }
+
+    @Test
+    fun `adding a label is the host's job, not the tab's`() =
+        scheduleTab { vm, reports ->
+            button(ScheduleLabel.ADD_LABEL).performClick()
+            waitForIdle()
+
+            // The tab cannot add one itself — the colour/text dialog lives above it.
+            assertEquals(1, reports.addLabelRequests)
+            assertTrue(vm.scheduleItems.isEmpty(), "and nothing is added until that dialog returns")
+        }
+
+    // ── Notes ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a note written on a row is kept against that row`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            buttonAt(ScheduleLabel.NOTE, 1).performClick()
+            waitForIdle()
+
+            noteField().performTextReplacement("Capo 3, two verses only")
+            // Typing alone is not a commit — the note is kept when the tick is pressed, so a
+            // half-typed thought does not overwrite what was there. (No waitForIdle while the
+            // field is open: its cursor blinks forever, so the composition never goes idle.)
+            button(ScheduleLabel.NOTE_SAVE).performClick()
+
+            val song = vm.scheduleItems[1]
+            assertEquals("Capo 3, two verses only", vm.getNote(song.id))
+            assertEquals("", vm.getNote(vm.scheduleItems[2].id), "and not against its neighbour")
+        }
+
+    @Test
+    fun `a note is not kept until it is saved`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            buttonAt(ScheduleLabel.NOTE, 1).performClick()
+            waitForIdle()
+            noteField().performTextReplacement("half a thought")
+
+            // Clearing writes an empty note through the same callback the tick uses, so it is the
+            // positive signal that a commit has happened — had typing alone committed, the text
+            // above would have been written before this one.
+            button(ScheduleLabel.NOTE_CLEAR).performClick()
+            waitForIdle()
+
+            assertEquals("", vm.getNote(vm.scheduleItems[1].id))
+        }
+
+    // ── Zoom ────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `zooming asks the host to store the new size`() =
+        scheduleTab(itemZoomPercent = 100, seed = { seedService() }) { _, reports ->
+            button(ScheduleLabel.ZOOM_IN).performClick()
+            waitForIdle()
+
+            // The tab holds no zoom state of its own — it is passed in and reported back out, so a
+            // rung of the ladder is the whole observable effect.
+            assertEquals(1, reports.zoomChanges.size)
+            assertTrue(
+                reports.zoomChanges.single() > 100,
+                "zooming in asks for a larger size: ${reports.zoomChanges}",
+            )
+        }
+
+    @Test
+    fun `zooming out asks for a smaller size`() =
+        scheduleTab(itemZoomPercent = 100, seed = { seedService() }) { _, reports ->
+            button(ScheduleLabel.ZOOM_OUT).performClick()
+            waitForIdle()
+
+            assertTrue(
+                reports.zoomChanges.single() < 100,
+                "got ${reports.zoomChanges}",
+            )
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabDroppedFilesTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabDroppedFilesTest.kt
@@ -1,0 +1,153 @@
+package org.churchpresenter.app.churchpresenter.tabs
+
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.viewmodel.ScheduleViewModel
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Dropping files onto the schedule.
+ *
+ * This is how most content gets into a service order in the first place — an operator drags a
+ * folder of slides, a video and a deck onto the panel and expects three usable items. What decides
+ * the type is `classifyDroppedFile` (covered by `DroppedFileClassifierTest`); what is pinned here
+ * is the step after it, which is where the surprises live: an image is added as *its whole folder*
+ * rather than as one picture, a folder with no images is ignored rather than added empty, and a
+ * file of an unknown type is skipped rather than added as something wrong.
+ *
+ * `handleDroppedFiles` is called directly because the drop itself arrives through an AWT
+ * `DropTarget` installed on the real window, which a headless test cannot deliver. Everything below
+ * it — the classification, the view-model calls, the resulting schedule — is the real thing.
+ *
+ * `user.home` is isolated because the view model resolves its autosave path at construction.
+ */
+class ScheduleTabDroppedFilesTest {
+
+    private lateinit var tempHome: File
+    private lateinit var dropDir: File
+    private var realHome: String? = null
+    private lateinit var vm: ScheduleViewModel
+
+    @BeforeTest
+    fun isolateHome() {
+        TestSingletons.latchToTestHome()
+        realHome = System.getProperty("user.home")
+        tempHome = Files.createTempDirectory("cp-schedule-drop-home").toFile()
+        System.setProperty("user.home", tempHome.absolutePath)
+        dropDir = Files.createTempDirectory("cp-schedule-drop").toFile()
+        vm = ScheduleViewModel()
+    }
+
+    @AfterTest
+    fun restoreHome() {
+        runCatching { vm.dispose() }
+        realHome?.let { System.setProperty("user.home", it) }
+        tempHome.deleteRecursively()
+        dropDir.deleteRecursively()
+    }
+
+    private fun file(name: String): File =
+        File(dropDir, name).apply { parentFile.mkdirs(); writeBytes(byteArrayOf(1, 2, 3)) }
+
+    private fun folder(name: String, vararg children: String): File =
+        File(dropDir, name).apply {
+            mkdirs()
+            children.forEach { File(this, it).writeBytes(byteArrayOf(1)) }
+        }
+
+    private fun drop(vararg files: File) = handleDroppedFiles(files.toList(), vm)
+
+    @Test
+    fun `a deck is added as a presentation, keeping its type`() {
+        drop(file("sermon.pptx"))
+
+        val item = vm.scheduleItems.single() as ScheduleItem.PresentationItem
+        assertEquals("sermon", item.fileName, "named without the extension")
+        assertEquals("pptx", item.fileType, "the type is kept so the right renderer is used")
+        assertTrue(item.filePath.endsWith("sermon.pptx"))
+    }
+
+    @Test
+    fun `a video is added as local media`() {
+        drop(file("bumper.mp4"))
+
+        val item = vm.scheduleItems.single() as ScheduleItem.MediaItem
+        assertEquals("bumper", item.mediaTitle)
+        assertEquals("local", item.mediaType, "a dropped file is on disk, not a stream")
+    }
+
+    @Test
+    fun `dropping one image adds the folder it lives in, not just that image`() {
+        // An operator dropping a photo means "show these photos" — a one-image slideshow would be
+        // useless, so the whole folder becomes the picture source.
+        val photos = folder("photos", "a.jpg", "b.jpg", "c.png")
+
+        drop(File(photos, "b.jpg"))
+
+        val item = vm.scheduleItems.single() as ScheduleItem.PictureItem
+        assertEquals(photos.absolutePath, item.folderPath)
+        assertEquals("photos", item.folderName)
+        assertEquals(3, item.imageCount, "every image in the folder is counted, not just the one")
+    }
+
+    @Test
+    fun `dropping a folder adds it with a count of the images inside`() {
+        val photos = folder("slides", "one.jpg", "two.jpeg", "notes.txt")
+
+        drop(photos)
+
+        val item = vm.scheduleItems.single() as ScheduleItem.PictureItem
+        assertEquals(2, item.imageCount, "the text file is not an image")
+    }
+
+    @Test
+    fun `a folder with no images is ignored rather than added empty`() {
+        drop(folder("documents", "readme.txt", "notes.md"))
+
+        assertTrue(
+            vm.scheduleItems.isEmpty(),
+            "an empty picture item would present a blank screen: ${vm.scheduleItems}",
+        )
+    }
+
+    @Test
+    fun `a lottie file is added as a lower third`() {
+        drop(file("welcome.json"))
+
+        val item = vm.scheduleItems.single() as ScheduleItem.LowerThirdItem
+        assertEquals("welcome", item.presetLabel)
+    }
+
+    @Test
+    fun `a file of an unknown type is skipped, not added as something wrong`() {
+        drop(file("accounts.xlsx"), file("archive.zip"))
+
+        assertTrue(vm.scheduleItems.isEmpty(), "got ${vm.scheduleItems}")
+    }
+
+    @Test
+    fun `dropping several files at once adds each of them, in the order dropped`() {
+        val photos = folder("gallery", "x.jpg")
+
+        drop(file("talk.pdf"), file("music.mp3"), photos)
+
+        assertEquals(
+            listOf("PresentationItem", "MediaItem", "PictureItem"),
+            vm.scheduleItems.map { it::class.simpleName },
+        )
+    }
+
+    @Test
+    fun `the ones it understands are added even when the drop also holds junk`() {
+        drop(file("notes.txt"), file("sermon.key"), file("unknown.xyz"))
+
+        assertEquals(1, vm.scheduleItems.size, "got ${vm.scheduleItems}")
+        assertTrue(vm.scheduleItems.single() is ScheduleItem.PresentationItem)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabListTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabListTest.kt
@@ -1,0 +1,115 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What `ScheduleTab` draws for a service order, and what selecting a row does.
+ *
+ * See `ScheduleTabTestSupport.kt` for the harness.
+ */
+class ScheduleTabListTest {
+
+    @Test
+    fun `an empty schedule invites the operator to drop files on it`() = scheduleTab { vm, _ ->
+        assertTrue(vm.scheduleItems.isEmpty())
+        assertTrue(showsExactly(ScheduleLabel.DROP_HINT), "the empty-state hint is shown")
+    }
+
+    @Test
+    fun `the hint gives way to the items once there are any`() =
+        scheduleTab(seed = { seedService() }) { _, _ ->
+            assertFalse(showsExactly(ScheduleLabel.DROP_HINT), "the hint is gone")
+        }
+
+    @Test
+    fun `every item is listed, in the order of service`() =
+        scheduleTab(seed = { seedService() }) { _, _ ->
+            assertEquals(
+                listOf("Welcome", "Amazing Grace", "John 3:16", "Notices"),
+                orderOf("Welcome", "Amazing Grace", "John 3:16", "Notices"),
+                "each item drawn once, in schedule order",
+            )
+        }
+
+    @Test
+    fun `a song row breaks out the number and songbook the operator picks it by`() =
+        scheduleTab(seed = { seedService() }) { _, _ ->
+            // Deliberately three fields rather than one "42 - Amazing Grace" line: the number and
+            // songbook are what disambiguate two songs with the same title.
+            assertTrue(showsExactly("42"), "the song number")
+            assertTrue(showsExactly("Amazing Grace"), "the title")
+            assertTrue(showsExactly("Hymnal"), "the songbook")
+        }
+
+    @Test
+    fun `each kind of item shows its own supporting detail`() =
+        scheduleTab(seed = { seedService() }) { _, _ ->
+            // The row renderer branches per item type; these are the lines it draws below the title.
+            assertTrue(
+                showsContainingText("For God so loved the world."),
+                "a verse shows its text: ${renderedText()}",
+            )
+            assertTrue(
+                showsContainingText("https://example.org"),
+                "a website shows its address: ${renderedText()}",
+            )
+        }
+
+    @Test
+    fun `clicking a row selects it and tells the host which item it was`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            onNodeWithText("Amazing Grace").performClick()
+            waitForIdle()
+
+            val song = vm.scheduleItems[1]
+            assertEquals(song.id, vm.selectedItemId, "the row is selected in the view model")
+            assertEquals(listOf(song), reports.clicked, "and the host is handed the item itself")
+            assertTrue(
+                reports.selectionChanges.contains(song.id),
+                "the selection change is reported: ${reports.selectionChanges}",
+            )
+        }
+
+    @Test
+    fun `selecting a different row moves the selection rather than adding one`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            onNodeWithText("Amazing Grace").performClick()
+            waitForIdle()
+            onNodeWithText("Notices").performClick()
+            waitForIdle()
+
+            assertEquals(vm.scheduleItems[3].id, vm.selectedItemId, "only the last click is selected")
+        }
+
+    @Test
+    fun `a countdown is listed by its duration rather than by empty text`() =
+        scheduleTab(
+            seed = {
+                addAnnouncement(
+                    text = "", textColor = "#FFFFFF", backgroundColor = "#000000", fontSize = 48,
+                    animationType = "none", animationDuration = 0,
+                    isTimer = true, timerHours = 0, timerMinutes = 5, timerSeconds = 30,
+                )
+            }
+        ) { vm, _ ->
+            // An announcement with no text would otherwise render as a blank row.
+            assertEquals("Timer 05:30", vm.scheduleItems.single().displayText)
+            assertTrue(showsExactly("Timer 05:30"), "and that is what the row draws: ${renderedText()}")
+        }
+
+    @Test
+    fun `every row can be removed, but only content rows can go live`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            assertEquals(vm.scheduleItems.size, buttonCount(ScheduleLabel.REMOVE), "one Remove per row")
+            // A label is a section heading, not something to put on screen — it offers Edit instead.
+            assertEquals(3, buttonCount(ScheduleLabel.GO_LIVE), "one per presentable item")
+            assertEquals(1, buttonCount(ScheduleLabel.EDIT_LABEL), "and the label row edits instead")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabTestSupport.kt
@@ -1,0 +1,201 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.viewmodel.ScheduleViewModel
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Harness and fixtures shared by the `ScheduleTab` test classes.
+ *
+ * The tab is driven through a real [ScheduleViewModel] — the same one the app builds — so what is
+ * exercised is the wiring between the two: which view-model call a button makes, and what the list
+ * renders from the resulting state. The view model's own rules (undo history, move semantics,
+ * remote following) are already covered by the `ScheduleViewModel*` suites, so nothing here
+ * re-tests those; these tests assert the schedule the operator ends up with.
+ *
+ * `user.home` is isolated per test because the view model resolves its autosave path at
+ * construction and `newSchedule()` deletes that file. [TestSingletons.latchToTestHome] pins the
+ * JVM-wide loggers to the real test home first, so they do not latch onto a temp dir that is then
+ * deleted.
+ */
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class ScheduleReports {
+    val presenting = mutableListOf<Presenting>()
+    val clicked = mutableListOf<ScheduleItem>()
+    val presented = mutableListOf<ScheduleItem>()
+    val editedLabels = mutableListOf<ScheduleItem.LabelItem>()
+    val selectionChanges = mutableListOf<String?>()
+    var addLabelRequests = 0
+    var addWebsiteRequests = 0
+    val zoomChanges = mutableListOf<Int>()
+}
+
+/**
+ * Builds a real [ScheduleViewModel] under an isolated `user.home`, seeds it with [seed], composes
+ * `ScheduleTab` over it, and runs [block].
+ *
+ * The view model is created before composition and passed in, so a test can seed it without racing
+ * the tab's first frame — and so `block` can read the schedule back from the same instance the tab
+ * is driving.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun scheduleTab(
+    itemZoomPercent: Int = 100,
+    seed: ScheduleViewModel.() -> Unit = {},
+    block: ComposeUiTest.(vm: ScheduleViewModel, reports: ScheduleReports) -> Unit,
+) {
+    TestSingletons.latchToTestHome()
+    val realHome = System.getProperty("user.home")
+    val tempHome: File = Files.createTempDirectory("cp-schedule-tab").toFile()
+    System.setProperty("user.home", tempHome.absolutePath)
+    val vm = ScheduleViewModel()
+    try {
+        vm.seed()
+        val reports = ScheduleReports()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    ScheduleTab(
+                        scheduleViewModel = vm,
+                        itemZoomPercent = itemZoomPercent,
+                        onItemZoomChange = { reports.zoomChanges += it },
+                        onPresenting = { reports.presenting += it },
+                        onItemClick = { reports.clicked += it },
+                        onEditLabel = { reports.editedLabels += it },
+                        onSelectedItemChanged = { reports.selectionChanges += it },
+                        onAddLabel = { reports.addLabelRequests++ },
+                        onAddWebsite = { reports.addWebsiteRequests++ },
+                        onPresentSong = { reports.presented += it },
+                        onPresentBible = { reports.presented += it },
+                        onPresentWebsite = { reports.presented += it },
+                        onPresentAnnouncement = { reports.presented += it },
+                        onPresentMedia = { reports.presented += it },
+                        onPresentLowerThird = { reports.presented += it },
+                        onPresentDictionary = { reports.presented += it },
+                    )
+                }
+            }
+            block(vm, reports)
+        }
+    } finally {
+        runCatching { vm.dispose() }
+        realHome?.let { System.setProperty("user.home", it) }
+        tempHome.deleteRecursively()
+    }
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────────────────────────────
+
+/** A service order with one of each item type the row renderer draws differently. */
+internal fun ScheduleViewModel.seedService() {
+    addLabel("Welcome", "#FFFFFF", "#203040")
+    addSong(songNumber = 42, title = "Amazing Grace", songbook = "Hymnal")
+    addBibleVerse(
+        bookName = "John", chapter = 3, verseNumber = 16,
+        verseText = "For God so loved the world.",
+    )
+    addWebsite(url = "https://example.org", title = "Notices")
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object ScheduleLabel {
+    const val TITLE = "Schedule"
+    const val NEW = "New Schedule"
+    const val UNDO = "Undo (Ctrl+Z)"
+    const val REDO = "Redo (Ctrl+Shift+Z)"
+    const val ADD_LABEL = "Add Label"
+    const val REMOVE_SELECTED = "Remove from Schedule"
+    const val CLEAR = "Clear Schedule"
+    const val ZOOM_IN = "Zoom In"
+    const val ZOOM_OUT = "Zoom Out"
+    const val DROP_HINT = "Drag files here to add to schedule"
+    const val MOVE_UP = "Move Up"
+    const val MOVE_DOWN = "Move Down"
+    const val GO_LIVE = "Go Live"
+    const val REMOVE = "Remove"
+    const val NOTE = "Note"
+    const val EDIT_LABEL = "Edit Label"
+    const val NOTE_SAVE = "Save note"
+    const val NOTE_CLEAR = "Clear note"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+
+/** Every string on screen. */
+internal fun ComposeUiTest.renderedText(): List<String> =
+    onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .mapNotNull { it.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { t -> t.text } }
+
+internal fun ComposeUiTest.showsExactly(text: String): Boolean = renderedText().any { it == text }
+
+internal fun ComposeUiTest.showsContainingText(fragment: String): Boolean =
+    renderedText().any { it.contains(fragment) }
+
+/**
+ * A toolbar or row button, addressed by the content description [TooltipIconButton] gives it —
+ * which is its tooltip text, so the label a user would see is also the test's selector.
+ */
+internal fun ComposeUiTest.button(label: String) = onNodeWithContentDescription(label)
+
+/**
+ * The [n]th button with this label, top to bottom.
+ *
+ * Row buttons repeat once per schedule item, so a test that means "the second item's Go Live"
+ * addresses it by position — which is also what the operator is doing.
+ */
+internal fun ComposeUiTest.buttonAt(label: String, n: Int) = onAllNodesWithContentDescription(label)[n]
+
+internal fun ComposeUiTest.buttonCount(label: String): Int =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .size
+
+/**
+ * The note editor, which only exists once a row's note has been opened.
+ *
+ * Addressed as the node taking typed text rather than by its placeholder: the placeholder is drawn
+ * separately and disappears as soon as anything is typed.
+ */
+internal fun ComposeUiTest.noteField() = onAllNodes(hasSetTextAction())[0]
+
+/**
+ * Where [labels] appear on screen, top to bottom, ignoring any that are absent.
+ *
+ * Ordered by vertical position rather than by walking the schedule, so a change to the order the
+ * tab draws rows in is visible here. Takes explicit labels because a row is not one node: a song
+ * draws its number, title and songbook separately, so there is no single node carrying the item's
+ * `displayText`.
+ */
+internal fun ComposeUiTest.orderOf(vararg labels: String): List<String> {
+    val wanted = labels.toSet()
+    return onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .mapNotNull { node ->
+            val text = node.config.getOrNull(SemanticsProperties.Text)
+                ?.joinToString("") { it.text } ?: return@mapNotNull null
+            if (text in wanted) node.boundsInRoot.top to text else null
+        }
+        .sortedBy { it.first }
+        .map { it.second }
+        .distinct()
+}


### PR DESCRIPTION
`ScheduleTabKt` was 0%-covered. 37 tests over a real `ScheduleViewModel` — the same one the app builds — so what is exercised is the wiring between the two: which view-model call each control makes, and what the list draws from the resulting state. The view model's own rules (undo history, move semantics, remote following) are already covered by the `ScheduleViewModel*` suites, so nothing here re-tests those.

## The list (9 tests)

The empty-state hint and its disappearance once there are items, the supporting detail each row type draws, row selection and what the host is told about it, and that every row offers Remove while only presentable ones offer Go Live — a label offers Edit instead.

A song row draws its number, title and songbook as three separate nodes rather than one `displayText` line (the number and songbook are what disambiguate two songs with the same title), so the ordering helper takes explicit labels rather than assuming one node per row.

## The controls (19 tests)

Move up/down including the no-op at either end, per-row and toolbar remove, clear, new, undo and redo, go-live routing, label editing, notes, and zoom.

Worth noting for review: `presentItem` is written as `handler?.invoke(item) ?: onPresenting(type)`, and `invoke` returns `Unit`, so the `onPresenting` fallback fires **only** when no handler was supplied. That is two separate tests here — a handler receives the item, and a type with no handler still gets the output switched so the operator is not left looking at the previous content.

## Dropped files (9 tests)

`handleDroppedFiles` becomes `internal` (with a comment saying why) so the drop handling can be tested directly: the drop itself arrives through an AWT `DropTarget` installed on the real window, which a headless test cannot deliver. Everything below it — classification, the view-model calls, the resulting schedule — is the real thing.

What it pins is the step after classification, where the surprises live: dropping a single image adds *its whole folder* as the picture source (a one-image slideshow would be useless), a folder with no images is ignored rather than added as an empty picture item that would present a blank screen, and an unrecognised file is skipped rather than added as the wrong type.

## Timing

Every test is ≤0.09s except the first one in each class, which pays ~1.6s of one-off Compose warm-up regardless of which test it happens to be. Full suite passes 3× consecutively with `--rerun-tasks`.