### PR TITLE
Test the Pictures tab

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabSettingsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabSettingsTest.kt
@@ -1,0 +1,142 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.models.AnimationType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The slideshow settings on the Pictures tab: how long each image is held, how long the transition
+ * takes, and which transition it is.
+ *
+ * Each of these lives in two places at once — the view model drives the slideshow now, and the
+ * settings are persisted by the host for next time — so every test checks both, because a control
+ * that updates only one of them either fails to take effect or silently forgets itself on restart.
+ *
+ * See `PicturesTabTestSupport.kt` for the harness.
+ */
+class PicturesTabSettingsTest {
+
+    @Test
+    fun `the current interval and transition are shown before anything is changed`() =
+        picturesTab { _, _ ->
+            // The shipped defaults: hold for 5s, transition over 500ms.
+            // Caption and value are merged into one node, so these are substring checks.
+            assertTrue(showsContainingText("AUTO-SCROLL INTERVAL:5 s"), "the hold time: ${renderedText()}")
+            assertTrue(showsContainingText("TRANSITION DURATION:500 ms"), "the transition: ${renderedText()}")
+            assertTrue(showsContainingText("ANIMATION TYPE:Crossfade"), "the transition style")
+        }
+
+    @Test
+    fun `setting the interval applies it now and asks for it to be remembered`() =
+        picturesTab { vm, reports ->
+            openIntervalEditor()
+            editorField().performTextReplacement("12")
+            onNodeWithText("OK").performClick()
+            waitForIdle()
+
+            assertEquals(12f, vm.autoScrollInterval, "the running slideshow picks it up")
+            assertEquals(
+                12f,
+                reports.settingsAfterChange?.pictureSettings?.autoScrollInterval,
+                "and the host is asked to store it",
+            )
+        }
+
+    @Test
+    fun `cancelling the interval editor changes nothing`() = picturesTab { vm, reports ->
+        openIntervalEditor()
+        editorField().performTextReplacement("12")
+        onNodeWithText("Cancel").performClick()
+        waitForIdle()
+
+        assertEquals(5f, vm.autoScrollInterval, "the slideshow is untouched")
+        assertEquals(0, reports.settingsChanges, "and nothing was persisted")
+    }
+
+    @Test
+    fun `an interval longer than the maximum is clamped rather than refused`() =
+        picturesTab { vm, _ ->
+            // Half a minute is the cap; a typo of 300 should not park the slideshow for five
+            // minutes, and rejecting it outright would leave the operator with no feedback.
+            openIntervalEditor()
+            editorField().performTextReplacement("300")
+            onNodeWithText("OK").performClick()
+            waitForIdle()
+
+            assertEquals(30f, vm.autoScrollInterval)
+        }
+
+    @Test
+    fun `an interval below the minimum is clamped too`() = picturesTab { vm, _ ->
+        openIntervalEditor()
+        editorField().performTextReplacement("0")
+        onNodeWithText("OK").performClick()
+        waitForIdle()
+
+        assertEquals(1f, vm.autoScrollInterval, "one second is as fast as it goes")
+    }
+
+    @Test
+    fun `text that is not a number leaves the interval alone`() = picturesTab { vm, reports ->
+        openIntervalEditor()
+        editorField().performTextReplacement("soon")
+        onNodeWithText("OK").performClick()
+        waitForIdle()
+
+        assertEquals(5f, vm.autoScrollInterval, "the slideshow keeps running as it was")
+        assertNull(reports.settingsAfterChange, "and nothing is persisted")
+    }
+
+    @Test
+    fun `setting the transition duration applies it and asks for it to be remembered`() =
+        picturesTab { vm, reports ->
+            openTransitionEditor()
+            editorField().performTextReplacement("900")
+            onNodeWithText("OK").performClick()
+            waitForIdle()
+
+            assertEquals(900f, vm.transitionDuration)
+            assertEquals(
+                900f,
+                reports.settingsAfterChange?.pictureSettings?.transitionDuration,
+            )
+        }
+
+    @Test
+    fun `choosing an animation applies it and asks for it to be remembered`() =
+        picturesTab { vm, reports ->
+            openAnimationDropdown()
+            onNodeWithText("Slide Left").performClick()
+            waitForIdle()
+
+            assertEquals(AnimationType.SLIDE_LEFT, vm.animationType)
+            assertEquals(
+                Constants.ANIMATION_SLIDE_LEFT,
+                reports.settingsAfterChange?.pictureSettings?.animationType,
+                "stored as the constant, not as the translated label",
+            )
+        }
+
+    @Test
+    fun `turning the animation off is a choice like any other`() = picturesTab { vm, reports ->
+        // "None" has to round-trip as a real value rather than as an absent one, or the setting
+        // reads as "never configured" and the default crossfade comes back.
+        openAnimationDropdown()
+        onNodeWithText("None").performClick()
+        waitForIdle()
+
+        assertEquals(AnimationType.NONE, vm.animationType)
+        assertEquals(
+            Constants.ANIMATION_NONE,
+            reports.settingsAfterChange?.pictureSettings?.animationType,
+        )
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTest.kt
@@ -1,0 +1,173 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Pictures tab: the image grid, the transport controls under it, and what the tab hands its
+ * host.
+ *
+ * The tab is a slideshow remote — an operator picks a folder before the service and then drives it
+ * with three buttons, so what matters is that the counter and the buttons agree with each other and
+ * with what is on screen, and that the folder handed to the schedule is the one being viewed.
+ *
+ * See `PicturesTabTestSupport.kt` for the harness.
+ */
+class PicturesTabTest {
+
+    // ── With no folder chosen ───────────────────────────────────────────────────
+
+    @Test
+    fun `with no folder chosen the tab says so and offers to pick one`() =
+        picturesTab(folder = null) { vm, _ ->
+            assertTrue(vm.images.isEmpty())
+            assertTrue(showsExactly(PictureLabel.NO_FOLDER), "the folder line is a placeholder")
+            assertTrue(showsExactly(PictureLabel.EMPTY_GRID), "and the grid explains itself")
+            assertTrue(showsExactly(PictureLabel.SELECT_FOLDER), "with the way out on screen")
+        }
+
+    // ── Loading a folder ────────────────────────────────────────────────────────
+
+    @Test
+    fun `choosing a folder loads its images and nothing else`() = picturesTab { vm, _ ->
+        assertEquals(
+            listOf("one.png", "three.jpg", "two.png"),
+            vm.images.map { it.name },
+            "every image, sorted by name — and the text file is not one",
+        )
+    }
+
+    @Test
+    fun `the chosen folder's path is shown, not a placeholder`() = picturesTab { vm, _ ->
+        assertTrue(
+            showsExactly(vm.selectedFolder!!.absolutePath),
+            "the operator can see which folder is loaded: ${renderedText().take(6)}",
+        )
+        assertFalse(showsExactly(PictureLabel.NO_FOLDER))
+    }
+
+    @Test
+    fun `every image gets a thumbnail`() = picturesTab { _, _ ->
+        awaitThumbnails("one.png", "two.png", "three.jpg")
+
+        assertEquals(
+            3,
+            drawnThumbnails().distinct().size,
+            "one thumbnail per image: ${drawnThumbnails()}",
+        )
+    }
+
+    // ── The counter ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the counter reads one-based, so it matches what an operator would say`() =
+        picturesTab { vm, _ ->
+            assertEquals(0, vm.selectedImageIndex, "internally the first image is index 0")
+            assertTrue(showsExactly("Image 1 of 3"), "but it reads as image 1: ${renderedText()}")
+        }
+
+    @Test
+    fun `stepping forward moves the counter and the selection together`() = picturesTab { vm, _ ->
+        pictureButton(PictureLabel.NEXT).performClick()
+        waitForIdle()
+
+        assertEquals(1, vm.selectedImageIndex)
+        assertTrue(showsExactly("Image 2 of 3"), "got ${renderedText()}")
+    }
+
+    @Test
+    fun `stepping back from the first image wraps to the last`() = picturesTab { vm, _ ->
+        // Looping is on by default, so the slideshow never dead-ends mid-service.
+        assertTrue(vm.isLooping)
+
+        pictureButton(PictureLabel.PREVIOUS).performClick()
+        waitForIdle()
+
+        assertEquals(2, vm.selectedImageIndex)
+        assertTrue(showsExactly("Image 3 of 3"))
+    }
+
+    @Test
+    fun `stepping past the last image wraps to the first`() = picturesTab { vm, _ ->
+        repeat(3) {
+            pictureButton(PictureLabel.NEXT).performClick()
+            waitForIdle()
+        }
+
+        assertEquals(0, vm.selectedImageIndex, "three steps through three images comes home")
+        assertTrue(showsExactly("Image 1 of 3"))
+    }
+
+    // ── Play and pause ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `the play button becomes a pause button once it is running`() = picturesTab { vm, _ ->
+        assertTrue(hasPictureButton(PictureLabel.PLAY), "stopped to begin with")
+
+        pictureButton(PictureLabel.PLAY).performClick()
+        waitForIdle()
+
+        assertTrue(vm.isPlaying)
+        assertTrue(hasPictureButton(PictureLabel.PAUSE), "the same button now offers to stop")
+        assertFalse(hasPictureButton(PictureLabel.PLAY), "and no longer offers to start")
+    }
+
+    @Test
+    fun `pausing stops it again`() = picturesTab { vm, _ ->
+        pictureButton(PictureLabel.PLAY).performClick()
+        waitForIdle()
+        pictureButton(PictureLabel.PAUSE).performClick()
+        waitForIdle()
+
+        assertFalse(vm.isPlaying)
+        assertTrue(hasPictureButton(PictureLabel.PLAY))
+    }
+
+    // ── Handing the folder on ───────────────────────────────────────────────────
+
+    @Test
+    fun `adding to the schedule hands over the folder, not the current image`() =
+        picturesTab { vm, reports ->
+            // A schedule item is the whole slideshow — stepping first must not narrow it.
+            pictureButton(PictureLabel.NEXT).performClick()
+            waitForIdle()
+            pictureButton(PictureLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            val folder = vm.selectedFolder!!
+            assertEquals(
+                listOf(Triple(folder.absolutePath, folder.name, 3)),
+                reports.scheduled,
+            )
+        }
+
+    @Test
+    fun `with no folder chosen there is nothing to add to the schedule`() =
+        picturesTab(folder = null) { _, reports ->
+            pictureButton(PictureLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            assertTrue(reports.scheduled.isEmpty(), "got ${reports.scheduled}")
+        }
+
+    // ── Selecting from the grid ─────────────────────────────────────────────────
+
+    @Test
+    fun `clicking a thumbnail selects that image`() = picturesTab { vm, _ ->
+        awaitThumbnails("two.png")
+
+        // "two.png" sorts last of the three, so this also pins that the grid is in sorted order
+        // rather than in whatever order the filesystem listed.
+        onNodeWithContentDescription("two.png").performClick()
+        waitForIdle()
+
+        assertEquals(2, vm.selectedImageIndex)
+        assertTrue(showsExactly("Image 3 of 3"))
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTestSupport.kt
@@ -1,0 +1,183 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.PictureSettings
+import org.churchpresenter.app.churchpresenter.viewmodel.PicturesViewModel
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+
+/**
+ * Harness and fixtures shared by the `PicturesTab` test classes.
+ *
+ * The tab is driven through a real [PicturesViewModel] over a real folder of real image files —
+ * written with `ImageIO` rather than as stub bytes, because the view model decodes each one into a
+ * thumbnail and a file that will not decode would exercise the error path instead of the one under
+ * test.
+ *
+ * The folder listing is synchronous, so by the time a test body runs the grid is populated;
+ * thumbnails decode on a background scope, so anything asserting on a *drawn* thumbnail waits for
+ * that image to appear rather than assuming it is there.
+ */
+
+// ── Fixtures ────────────────────────────────────────────────────────────────────────────────────
+
+/** Writes a real, decodable image so the view model's thumbnail load succeeds. */
+internal fun writeImage(dir: File, name: String) {
+    val image = BufferedImage(4, 4, BufferedImage.TYPE_INT_RGB)
+    ImageIO.write(image, name.substringAfterLast('.'), File(dir, name))
+}
+
+/** Three images plus a file that is not one, to pin what counts as a picture. */
+internal fun pictureFolder(): File =
+    Files.createTempDirectory("cp-pictures-tab").toFile().apply {
+        writeImage(this, "one.png")
+        writeImage(this, "two.png")
+        writeImage(this, "three.jpg")
+        File(this, "notes.txt").writeText("not an image")
+    }
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class PictureReports {
+    /** folderPath, folderName, imageCount — exactly what the schedule would be given. */
+    val scheduled = mutableListOf<Triple<String, String, Int>>()
+    var settingsChanges = 0
+    var settingsAfterChange: AppSettings? = null
+}
+
+/**
+ * Builds a real [PicturesViewModel] over [folder], composes `PicturesTab`, and runs [block].
+ *
+ * `storageDirectory` points at the folder so nothing resolves under the real `user.home`. Pass
+ * `folder = null` for the no-folder-selected state.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun picturesTab(
+    folder: File? = pictureFolder(),
+    settings: (AppSettings) -> AppSettings = { it },
+    block: ComposeUiTest.(vm: PicturesViewModel, reports: PictureReports) -> Unit,
+) {
+    val appSettings = settings(
+        AppSettings(
+            pictureSettings = PictureSettings(storageDirectory = folder?.absolutePath ?: "")
+        )
+    )
+    val vm = PicturesViewModel(appSettings)
+    try {
+        folder?.let { vm.selectFolder(it) }
+        val reports = PictureReports()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    PicturesTab(
+                        viewModel = vm,
+                        appSettings = appSettings,
+                        onAddToSchedule = { path, name, count ->
+                            reports.scheduled += Triple(path, name, count)
+                        },
+                        onSettingsChange = { transform ->
+                            reports.settingsChanges++
+                            reports.settingsAfterChange = transform(appSettings)
+                        },
+                    )
+                }
+            }
+            block(vm, reports)
+        }
+    } finally {
+        runCatching { vm.dispose() }
+        folder?.deleteRecursively()
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object PictureLabel {
+    const val SELECT_FOLDER = "Select Folder"
+    const val NO_FOLDER = "No folder selected"
+    const val EMPTY_GRID = "Select a folder to view images"
+    const val ADD_TO_SCHEDULE = "Add to Schedule"
+    const val GO_LIVE = "Go Live"
+    const val PREVIOUS = "Previous Image"
+    const val NEXT = "Next Image"
+    const val PLAY = "Play"
+    const val PAUSE = "Pause"
+    const val LOADING = "Loading..."
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+
+internal fun ComposeUiTest.renderedText(): List<String> =
+    onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .mapNotNull { it.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { t -> t.text } }
+
+internal fun ComposeUiTest.showsExactly(text: String): Boolean = renderedText().any { it == text }
+
+internal fun ComposeUiTest.showsContainingText(fragment: String): Boolean =
+    renderedText().any { it.contains(fragment) }
+
+/** A button, addressed by the content description its tooltip gives it. */
+internal fun ComposeUiTest.pictureButton(label: String) = onNodeWithContentDescription(label)
+
+internal fun ComposeUiTest.hasPictureButton(label: String): Boolean =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()
+
+/**
+ * The thumbnails currently drawn, by file name — each `Image` is described by the file it came from.
+ *
+ * Thumbnails decode on a background scope, so a test that needs them waits for this to fill rather
+ * than assuming the first frame has them.
+ */
+internal fun ComposeUiTest.drawnThumbnails(): List<String> =
+    onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.ContentDescription))
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .mapNotNull { it.config.getOrNull(SemanticsProperties.ContentDescription)?.firstOrNull() }
+        .filter { it.endsWith(".png") || it.endsWith(".jpg") }
+
+/**
+ * Opens a settings tile's editor by clicking it.
+ *
+ * Each tile merges its caption and its value into one node ("AUTO-SCROLL INTERVAL:5 s"), so it is
+ * addressed by the caption as a substring rather than by an exact match — the value changes, the
+ * caption does not.
+ */
+internal fun ComposeUiTest.openTile(caption: String) {
+    onNodeWithText(caption, substring = true).performClick()
+    waitForIdle()
+}
+
+internal fun ComposeUiTest.openIntervalEditor() = openTile("AUTO-SCROLL INTERVAL")
+
+internal fun ComposeUiTest.openTransitionEditor() = openTile("TRANSITION DURATION")
+
+/** Opens the animation dropdown, which is merged into one node the same way the tiles are. */
+internal fun ComposeUiTest.openAnimationDropdown() = openTile("ANIMATION TYPE")
+
+/** The number field inside whichever editor dialog is open — the only field taking typed text. */
+internal fun ComposeUiTest.editorField() = onAllNodes(hasSetTextAction())[0]
+
+/** Waits until every one of [names] has been decoded and drawn. */
+internal fun ComposeUiTest.awaitThumbnails(vararg names: String) =
+    waitUntil("thumbnails for ${names.toList()}") {
+        drawnThumbnails().containsAll(names.toList())
+    }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTestSupport.kt
@@ -124,15 +124,8 @@ internal object PictureLabel {
 
 // ── Reading and driving what was rendered ───────────────────────────────────────────────────────
 
-internal fun ComposeUiTest.renderedText(): List<String> =
-    onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
-        .fetchSemanticsNodes(atLeastOneRootRequired = false)
-        .mapNotNull { it.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { t -> t.text } }
-
-internal fun ComposeUiTest.showsExactly(text: String): Boolean = renderedText().any { it == text }
-
-internal fun ComposeUiTest.showsContainingText(fragment: String): Boolean =
-    renderedText().any { it.contains(fragment) }
+// renderedText/showsExactly/showsContainingText live in TabRenderedText.kt — they are shared with
+// the other tab suites in this package.
 
 /** A button, addressed by the content description its tooltip gives it. */
 internal fun ComposeUiTest.pictureButton(label: String) = onNodeWithContentDescription(label)


### PR DESCRIPTION
`PicturesTabKt` was 0%-covered; this takes it to 66.6% (404 of 607 lines) with 22 tests, driven through a real `PicturesViewModel` over a real folder of real image files.

The images are written with `ImageIO` rather than as stub bytes: the view model decodes each one into a thumbnail, so a file that will not decode would exercise the error path instead of the one under test.

## The tab (13 tests)

The tab is a slideshow remote — an operator picks a folder before the service and then drives it with three buttons — so these pin that the counter, the buttons and the grid agree with each other:

- The no-folder state: a placeholder for the path, an explanatory grid, and the way out on screen.
- Loading: images only (a `.txt` in the folder is not one), sorted by name.
- The counter is one-based against a zero-based index, so it reads the way an operator would say it.
- Next/previous including wrap-around in both directions, since looping is the default and a slideshow must not dead-end mid-service.
- Play swapping to Pause and back — the same button, so both states are checked for presence *and* absence.
- Adding to the schedule hands over the whole folder even after stepping through it, rather than narrowing to the current image.

## The settings (9 tests)

Hold interval, transition duration and animation type. Each lives in two places at once — the view model drives the slideshow now, the host persists it for next time — so every test asserts **both**: a control that updates only one either fails to take effect or silently forgets itself on restart.

Also covers the clamping an operator relies on after a typo (300s → 30, 0 → 1), non-numeric input leaving the running slideshow alone, and Cancel changing nothing. The animation type is checked to round-trip as its `Constants` value rather than the translated label, and "None" specifically, since it has to persist as a real value rather than read as "never configured".

## Note for whoever runs this locally

While verifying, the whole test JVM started failing to load classes (`NoClassDefFoundError` on synthetic lambdas, every class reporting "Test process encountered an unexpected problem"). It was a corrupted incremental-compile state — an internal Kotlin compiler error had left a partial `build/classes`. Deleting that directory was not enough because the build cache restored the partial set; `./gradlew :composeApp:clean` fixed it. Same smell as the tooling issue already recorded in `DEVELOPMENT_GUIDE.md`'s decision log. Nothing to do with these tests, but worth knowing.

Full suite passes 3× consecutively with `--rerun-tasks` from a clean state. Every test ≤0.1s except the first in each class, which pays one-off Compose warm-up.