### PR TITLE
Remove two port/handshake races from the test suite

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterDownloadTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterDownloadTest.kt
@@ -39,9 +39,20 @@ class PlanningCenterDownloadTest {
     private lateinit var dir: File
     private lateinit var server: FakeAttachmentHost
 
-    /** A stand-in for the attachment host: a few fixed routes covering the outcomes that matter. */
-    private class FakeAttachmentHost(val port: Int, val payload: ByteArray) {
-        private val engine = embeddedServer(Netty, port = port) {
+    /**
+     * A stand-in for the attachment host: a few fixed routes covering the outcomes that matter.
+     *
+     * Binds port 0 and asks the engine what it got, rather than picking a free port up front and
+     * binding it a moment later — between the probe socket closing and Netty binding, anything else
+     * in the suite that starts a server can take the port, and this one then dies with
+     * `BindException: Address already in use`.
+     */
+    private class FakeAttachmentHost(val payload: ByteArray) {
+        /** Valid only after [start]; port 0 means "whatever the OS gives us". */
+        var port: Int = 0
+            private set
+
+        private val engine = embeddedServer(Netty, port = 0) {
             routing {
                 get("/attachment.pdf") { call.respondBytes(payload) }
                 get("/empty") { call.respondBytes(ByteArray(0)) }
@@ -51,7 +62,13 @@ class PlanningCenterDownloadTest {
             }
         }
 
-        fun start() = engine.start(wait = false)
+        fun start() {
+            engine.start(wait = false)
+            // resolvedConnectors() suspends until the bind completes, so the port it reports is the
+            // one Netty is actually listening on.
+            port = runBlocking { engine.engine.resolvedConnectors().first().port }
+        }
+
         fun stop() = engine.stop(0, 0)
         fun url(path: String) = "http://127.0.0.1:$port$path"
     }
@@ -62,7 +79,7 @@ class PlanningCenterDownloadTest {
     @BeforeTest
     fun startHost() {
         dir = Files.createTempDirectory("cp-pco-download-test").toFile()
-        server = FakeAttachmentHost(ServerSocket(0).use { it.localPort }, payload)
+        server = FakeAttachmentHost(payload)
         server.start()
         awaitListening(server.port)
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
@@ -11,7 +11,6 @@ import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
 import kotlinx.coroutines.runBlocking
-import java.net.ServerSocket
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -45,13 +44,24 @@ class BibleEngineClientLinkTest {
     private val created = mutableListOf<BibleEngineClient>()
     private lateinit var engine: FakeEngine
 
-    /** A stand-in for the engine's `/bible-engine` endpoint: records what it is sent, pushes back on demand. */
-    private class FakeEngine(val port: Int) {
+    /**
+     * A stand-in for the engine's `/bible-engine` endpoint: records what it is sent, pushes back on
+     * demand.
+     *
+     * Binds port 0 and reports back what it got, rather than taking a port picked from a probe
+     * socket that was already closed: in the gap before the bind, anything else in the suite that
+     * starts a server can take that port and this one dies with `Address already in use`.
+     */
+    private class FakeEngine {
         val received = LinkedBlockingQueue<String>()
         val sessions = CopyOnWriteArrayList<DefaultWebSocketServerSession>()
         val connectionCount = AtomicInteger()
 
-        private val server = embeddedServer(Netty, port = port) {
+        /** Valid only after [start]. */
+        var port: Int = 0
+            private set
+
+        private val server = embeddedServer(Netty, port = 0) {
             install(WebSockets)
             routing {
                 webSocket("/bible-engine") {
@@ -66,7 +76,13 @@ class BibleEngineClientLinkTest {
             }
         }
 
-        fun start() = server.start(wait = false)
+        fun start() {
+            server.start(wait = false)
+            // resolvedConnectors() suspends until the bind completes, so this is the port Netty is
+            // actually listening on.
+            port = runBlocking { server.engine.resolvedConnectors().first().port }
+        }
+
         fun push(text: String) = runBlocking { sessions.toList().forEach { it.send(Frame.Text(text)) } }
         fun dropConnections() = runBlocking { sessions.toList().forEach { it.close() } }
         fun stop() = server.stop(0, 0)
@@ -74,7 +90,7 @@ class BibleEngineClientLinkTest {
 
     @BeforeTest
     fun startEngine() {
-        engine = FakeEngine(freePort())
+        engine = FakeEngine()
         engine.start()
     }
 
@@ -86,21 +102,26 @@ class BibleEngineClientLinkTest {
         detections.clear()
     }
 
-    private fun freePort(): Int = ServerSocket(0).use { it.localPort }
-
     private fun client(): BibleEngineClient =
         BibleEngineClient(
             onScripture = { e -> detections.add(Detection(e.bookId, e.chapter, e.verseStart, e.verseText)) },
             onVersion = {},
         ).also { created.add(it) }
 
-    /** Connects [this] to the fake engine (no in-process engine) and waits for the link to come up. */
+    /**
+     * Connects [this] to the fake engine (no in-process engine) and waits for the link to come up.
+     *
+     * Waits for the engine to have registered the session as well as for the client to report
+     * itself connected: the two happen on opposite ends of the handshake, and `push` sends to the
+     * sessions the engine currently holds, so pushing on the strength of the client's view alone
+     * can deliver a frame to nobody and leave the test waiting for something already dropped.
+     */
     private fun BibleEngineClient.connect(level: String = "balanced", speed: String = "balanced") {
         start(
             sttUrl = "http://127.0.0.1:1", bibleRoot = "", bibleFiles = emptyList(),
             runLocal = false, host = "127.0.0.1", port = engine.port, level = level, continuationSpeed = speed
         )
-        awaitUntil("the engine link to come up") { connected.value }
+        awaitUntil("the engine link to come up") { connected.value && engine.sessions.isNotEmpty() }
     }
 
     private fun nextFrame(timeoutSeconds: Long = 10): String =


### PR DESCRIPTION
Two pre-existing flakes, both of which failed a CI run during this batch of merges while passing locally.

**1. `PlanningCenterDownloadTest` — `BindException: Address already in use`.**
`FakeAttachmentHost` asked the OS for a free port via `ServerSocket(0)`, closed that socket, and bound the number a moment later. Anything else in the suite that starts a server in the gap takes the port. Now binds port 0 and reads the port back from `resolvedConnectors()`, which suspends until the bind completes — the port is never knowable-but-unowned. The two tests that deliberately want a *closed* port still use `ServerSocket(0)`, which is the correct use of that idiom.

**2. `BibleEngineClientLinkTest` — `timed out after 15000ms waiting for the engine status to arrive`.**
`connect()` waited only for the client to report itself connected. The client sets that at its end of the handshake; the engine adds the session at the other end. `push()` sends to the sessions the engine holds at that instant, so a frame pushed in between went to nobody and the test then waited out its full timeout for a message that was never delivered. Now waits for both ends. `FakeEngine` gets the same port-0 treatment as above.

Neither wait ends on a timeout expiring any more — both end on the positive signal, with the timeout there only to fail loudly.

No production change. Both suites pass three consecutive runs (`PlanningCenterDownloadTest` 17 tests, `BibleEngineClientLinkTest` 14 tests).