### PR TITLE
Test the Announcements tab

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTabTest.kt
@@ -1,0 +1,201 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.performClick
+import org.churchpresenter.app.churchpresenter.data.settings.AnnouncementsSettings
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The announcement half of the Announcements tab: the text, how it is styled and placed, and how it
+ * reaches the screen.
+ *
+ * Everything here is asserted from outside the tab — what it draws, the settings it hands back to be
+ * persisted, and what it puts on the `PresenterManager` — because the tab owns its view model
+ * privately. See `AnnouncementsTabTestSupport.kt` for the harness.
+ */
+class AnnouncementsTabTest {
+
+    // ── The text ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an empty tab shows its hint and offers nothing to send`() = announcementsTab { _, _ ->
+        assertTrue(showsExactly(AnnouncementLabel.TEXT_HINT), "the placeholder invites text")
+        // Go Live exists but is disabled — there is nothing to show yet.
+        annButton(AnnouncementLabel.GO_LIVE).assertIsNotEnabled()
+        annButton(AnnouncementLabel.ADD_TO_SCHEDULE).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `typing an announcement stores it and enables the actions`() = announcementsTab { _, reports ->
+        typeAnnouncement("Coffee is served in the hall")
+
+        assertEquals("Coffee is served in the hall", reports.settings?.text)
+        assertFalse(
+            showsExactly(AnnouncementLabel.TEXT_HINT),
+            "the hint gives way to the text",
+        )
+        annButton(AnnouncementLabel.GO_LIVE).assertIsEnabled()
+        annButton(AnnouncementLabel.ADD_TO_SCHEDULE).assertIsEnabled()
+    }
+
+    @Test
+    fun `an announcement of only spaces is not something to show`() = announcementsTab { _, _ ->
+        typeAnnouncement("   ")
+
+        // Blank text would put an empty box on the screen, so the actions stay shut.
+        annButton(AnnouncementLabel.GO_LIVE).assertIsNotEnabled()
+        annButton(AnnouncementLabel.ADD_TO_SCHEDULE).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `text saved earlier is shown when the tab opens`() =
+        announcementsTab(initial = AnnouncementsSettings(text = "Welcome back")) { _, _ ->
+            assertTrue(showsExactly("Welcome back"), "got ${renderedText().take(4)}")
+            assertFalse(showsExactly(AnnouncementLabel.TEXT_HINT))
+        }
+
+    // ── Going live ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `going live puts the announcement on screen`() = announcementsTab { presenter, _ ->
+        typeAnnouncement("Service starts in ten minutes")
+        annButton(AnnouncementLabel.GO_LIVE).performClick()
+        waitForIdle()
+
+        assertEquals(Presenting.ANNOUNCEMENTS, presenter.presentingMode.value)
+        assertEquals("Service starts in ten minutes", presenter.announcementText.value)
+    }
+
+    @Test
+    fun `the show button becomes a hide button once it is live`() = announcementsTab { presenter, _ ->
+        typeAnnouncement("Notices")
+        assertTrue(hasAnnButton(AnnouncementLabel.SHOW), "offers to show, to begin with")
+
+        annButton(AnnouncementLabel.SHOW).performClick()
+        waitForIdle()
+
+        assertEquals(Presenting.ANNOUNCEMENTS, presenter.presentingMode.value)
+        assertTrue(hasAnnButton(AnnouncementLabel.HIDE), "the same button now offers to hide")
+        assertFalse(hasAnnButton(AnnouncementLabel.SHOW))
+    }
+
+    @Test
+    fun `hiding asks for the display to be cleared`() = announcementsTab { presenter, _ ->
+        typeAnnouncement("Notices")
+        annButton(AnnouncementLabel.SHOW).performClick()
+        waitForIdle()
+        assertFalse(presenter.clearDisplayRequested.value, "nothing asked for yet")
+
+        annButton(AnnouncementLabel.HIDE).performClick()
+        waitForIdle()
+
+        // The tab raises the request; MainDesktop is what watches it and takes the content down,
+        // so the mode is still ANNOUNCEMENTS here — the request is the whole of the tab's part.
+        assertTrue(presenter.clearDisplayRequested.value, "the display was asked to clear")
+    }
+
+    // ── Adding to the schedule ──────────────────────────────────────────────────
+
+    @Test
+    fun `adding to the schedule hands over the announcement, not the timer`() =
+        announcementsTab(
+            initial = AnnouncementsSettings(timerHours = 1, timerMinutes = 30, timerSeconds = 15),
+        ) { _, reports ->
+            typeAnnouncement("Offering today")
+            annButton(AnnouncementLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            val item = reports.scheduled.single()
+            assertEquals("Offering today", item.text)
+            // A text announcement scheduled from here must not carry the timer that happens to be
+            // set up beside it, or it would show up in the service order as a countdown.
+            assertEquals(0, item.timerHours)
+            assertEquals(0, item.timerMinutes)
+            assertEquals(0, item.timerSeconds)
+        }
+
+    @Test
+    fun `adding to the schedule keeps the styling the announcement was given`() =
+        announcementsTab { _, reports ->
+            typeAnnouncement("Styled")
+            clickLabel(AnnouncementLabel.BOLD)
+            annButton(AnnouncementLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            assertTrue(reports.scheduled.single().bold, "the styling travels with the text")
+        }
+
+    // ── Styling ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `each style toggle turns on and off again`() = announcementsTab { _, reports ->
+        typeAnnouncement("Styled")
+
+        clickLabel(AnnouncementLabel.BOLD)
+        assertTrue(reports.settings?.bold == true, "bold on")
+        clickLabel(AnnouncementLabel.BOLD)
+        assertFalse(reports.settings?.bold == true, "and off again")
+
+        clickLabel(AnnouncementLabel.ITALIC)
+        assertTrue(reports.settings?.italic == true)
+        clickLabel(AnnouncementLabel.UNDERLINE)
+        assertTrue(reports.settings?.underline == true)
+        clickLabel(AnnouncementLabel.SHADOW)
+        assertTrue(reports.settings?.shadow == true)
+    }
+
+    @Test
+    fun `the styles are independent of each other`() = announcementsTab { _, reports ->
+        typeAnnouncement("Styled")
+
+        clickLabel(AnnouncementLabel.BOLD)
+        clickLabel(AnnouncementLabel.ITALIC)
+        clickLabel(AnnouncementLabel.BOLD)
+
+        val settings = reports.settings
+        assertFalse(settings?.bold == true, "bold was turned back off")
+        assertTrue(settings?.italic == true, "without disturbing italic")
+    }
+
+    @Test
+    fun `styles saved earlier come back with the announcement`() =
+        announcementsTab(
+            initial = AnnouncementsSettings(text = "Saved", bold = true, shadow = true),
+        ) { _, reports ->
+            // Toggling something unrelated makes the tab report the whole settings object back,
+            // which is where the previously-saved flags have to have survived.
+            clickLabel(AnnouncementLabel.ITALIC)
+
+            val settings = reports.settings
+            assertTrue(settings?.bold == true, "bold survived the round trip")
+            assertTrue(settings?.shadow == true, "and so did the shadow")
+            assertTrue(settings?.italic == true, "alongside the new one")
+        }
+
+    // ── Position ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every screen position can be chosen`() = announcementsTab { _, reports ->
+        clickLabel(AnnouncementLabel.TOP_LEFT)
+        assertEquals("Top Left", reports.settings?.position)
+
+        clickLabel(AnnouncementLabel.CENTER)
+        assertEquals("Center", reports.settings?.position, "and changed again")
+    }
+
+    @Test
+    fun `the tab renders without a presenter, offering only what it can do`() =
+        announcementsTab(withPresenter = false) { _, _ ->
+            // The Announcements tab is also shown in a follower window with no output of its own.
+            assertTrue(showsExactly(AnnouncementLabel.TEXT_HINT), "the editor is still usable")
+            assertFalse(hasAnnButton(AnnouncementLabel.GO_LIVE), "but nothing offers to go live")
+            assertFalse(hasAnnButton(AnnouncementLabel.SHOW))
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTabTestSupport.kt
@@ -1,0 +1,180 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.settings.AnnouncementsSettings
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+
+/**
+ * Harness and fixtures shared by the `AnnouncementsTab` test classes.
+ *
+ * This tab owns its view model outright (`remember { AnnouncementsViewModel() }`), so unlike the
+ * other tabs there is no instance to reach in from a test. That turns out to suit it: everything
+ * the tab does is observable from outside anyway — what it draws, the `AnnouncementsSettings` it
+ * hands back for persisting, and what it puts on the [PresenterManager] — and asserting through
+ * those keeps the tests pinned to behaviour rather than to the view model's internals.
+ *
+ * The settings the tab reports are fed back into it, as the app does, so a control's effect is
+ * visible on the next frame and the tests read the way the tab is actually used.
+ */
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class AnnouncementReports {
+    val scheduled = mutableListOf<AnnouncementsSettings>()
+    var settingsChanges = 0
+
+    /** The most recent settings the tab asked to have persisted. */
+    var settings: AnnouncementsSettings? = null
+}
+
+/**
+ * Composes `AnnouncementsTab` with a real [PresenterManager] and runs [block].
+ *
+ * The tab is given its settings back on every change, so the state it renders from is the state it
+ * just asked for — the same loop `MainDesktop` runs.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun announcementsTab(
+    initial: AnnouncementsSettings = AnnouncementsSettings(),
+    withPresenter: Boolean = true,
+    block: ComposeUiTest.(presenter: PresenterManager, reports: AnnouncementReports) -> Unit,
+) {
+    val presenter = PresenterManager()
+    val reports = AnnouncementReports()
+    runComposeUiTest {
+        setContent {
+            var settings by remember {
+                mutableStateOf(AppSettings(announcementsSettings = initial))
+            }
+            MaterialTheme {
+                AnnouncementsTab(
+                    appSettings = settings,
+                    onSettingsChange = { transform ->
+                        settings = transform(settings)
+                        reports.settingsChanges++
+                        reports.settings = settings.announcementsSettings
+                    },
+                    presenterManager = presenter.takeIf { withPresenter },
+                    onAddToSchedule = { reports.scheduled += it },
+                )
+            }
+        }
+        block(presenter, reports)
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object AnnouncementLabel {
+    const val TEXT_HINT = "Enter announcement text here…"
+    const val GO_LIVE = "Go Live"
+    const val ADD_TO_SCHEDULE = "Add to Schedule"
+    const val SHOW = "Show Announcement on Display"
+    const val HIDE = "Hide Announcement from Display"
+    const val START = "Start"
+    const val PAUSE = "Pause"
+    const val RESET = "Reset"
+    const val BOLD = "B"
+    const val ITALIC = "I"
+    const val UNDERLINE = "U"
+    const val SHADOW = "S"
+    const val DURATION_MODE = "Duration"
+    const val CLOCK_MODE = "Specific Time"
+    const val CLOCK_DISPLAY_MODE = "Clock"
+    const val CENTER = "Center"
+    const val TOP_LEFT = "Top Left"
+    const val EXPIRED_HINT = "Enter message to show when done…"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+// (renderedText/showsExactly/showsContainingText are shared — see TabRenderedText.kt)
+
+/**
+ * A button, addressed by the content description its tooltip gives it and by which half of the tab
+ * it belongs to.
+ *
+ * The announcement and the timer each have their own Go Live and Add to Schedule, identically
+ * labelled, so a bare lookup is ambiguous — and an ambiguous lookup fails as "cannot inject mouse
+ * input" rather than as anything that names the real problem. They are told apart by position: the
+ * announcement's row is above the timer's.
+ */
+private fun ComposeUiTest.buttonsByRow(label: String) =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .sortedBy { it.boundsInRoot.top }
+
+internal fun ComposeUiTest.annButton(label: String): SemanticsNodeInteraction {
+    val index = buttonsByRow(label).indices.firstOrNull()
+        ?: error("no button labelled \"$label\" is on screen")
+    return sortedButton(label, index)
+}
+
+/** The timer's copy of a button that both halves of the tab have. */
+internal fun ComposeUiTest.timerButton(label: String): SemanticsNodeInteraction =
+    sortedButton(label, buttonsByRow(label).lastIndex)
+
+private fun ComposeUiTest.sortedButton(label: String, position: Int): SemanticsNodeInteraction {
+    val tops = buttonsByRow(label).map { it.boundsInRoot.top }
+    val target = tops.getOrNull(position) ?: error("no button labelled \"$label\" at $position")
+    // Re-resolve through the matcher rather than holding the node, so the interaction stays live.
+    val unsorted = onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+    return onAllNodesWithContentDescription(label)[unsorted.indexOfFirst { it.boundsInRoot.top == target }]
+}
+
+internal fun ComposeUiTest.hasAnnButton(label: String): Boolean =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()
+
+/**
+ * The announcement text box — the first field taking typed text.
+ *
+ * Addressed that way rather than by its hint, because the hint is a separate `Text` inside the
+ * `BasicTextField` decoration box and vanishes as soon as anything is typed.
+ */
+internal fun ComposeUiTest.announcementField() = onAllNodes(hasSetTextAction())[0]
+
+/**
+ * The expiry-message field, addressed as the lowest field on screen.
+ *
+ * Not by index: the tab has eight fields (the announcement, the font name and size, the three timer
+ * digits, this, and the loop count) and their order in the semantics tree is not the order they are
+ * drawn in. The expiry message is the bottom-most of them, and it is the only one whose presence
+ * depends on the timer mode.
+ */
+internal fun ComposeUiTest.expiredTextField(): SemanticsNodeInteraction {
+    val fields = onAllNodes(hasSetTextAction()).fetchSemanticsNodes(atLeastOneRootRequired = false)
+    val lowest = fields.indices.maxByOrNull { fields[it].boundsInRoot.top }
+        ?: error("no text fields are on screen")
+    return onAllNodes(hasSetTextAction())[lowest]
+}
+
+internal fun ComposeUiTest.typeAnnouncement(text: String) {
+    announcementField().performTextReplacement(text)
+    waitForIdle()
+}
+
+/** Clicks a labelled control and settles the frame. */
+internal fun ComposeUiTest.clickLabel(label: String) {
+    onNodeWithText(label).performClick()
+    waitForIdle()
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTabTimerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/AnnouncementsTabTimerTest.kt
@@ -1,0 +1,206 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import org.churchpresenter.app.churchpresenter.data.settings.AnnouncementsSettings
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The timer half of the Announcements tab — the countdown a church puts up before a service starts.
+ *
+ * Its four modes look alike on screen but behave differently, and the differences are what these
+ * pin: only two of them count from a starting point (so only those can be reset), only two of them
+ * ever expire (so only those take an expiry message), and the play button previews while Go Live is
+ * what actually marks the ticker live.
+ *
+ * Nothing here waits for a tick. The tab renders the timer from state the view model already holds,
+ * so the starting value, the mode switches and the buttons are all assertable on the frame after
+ * the click; a test that waited for a second to pass would be asserting on the clock rather than on
+ * the tab. What a running ticker does over time belongs to `PresenterManagerAnnouncementTimerTest`.
+ *
+ * See `AnnouncementsTabTestSupport.kt` for the harness.
+ */
+class AnnouncementsTabTimerTest {
+
+    // ── The modes ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the timer starts on countdown, showing the configured time`() =
+        announcementsTab(
+            initial = AnnouncementsSettings(timerMinutes = 5, timerSeconds = 30),
+        ) { _, _ ->
+            assertTrue(showsExactly("05:30"), "the countdown's starting value: ${renderedText()}")
+        }
+
+    @Test
+    fun `an hour-long countdown is shown with its hours`() =
+        announcementsTab(
+            initial = AnnouncementsSettings(timerHours = 1, timerMinutes = 2, timerSeconds = 3),
+        ) { _, _ ->
+            assertTrue(showsExactly("1:02:03"), "hours are not zero-padded: ${renderedText()}")
+        }
+
+    @Test
+    fun `each mode can be chosen and is remembered`() = announcementsTab { _, reports ->
+        clickLabel(AnnouncementLabel.CLOCK_MODE)
+        assertEquals(Constants.TIMER_MODE_CLOCK, reports.settings?.timerMode)
+
+        clickLabel(AnnouncementLabel.CLOCK_DISPLAY_MODE)
+        assertEquals(Constants.TIMER_MODE_CLOCK_DISPLAY, reports.settings?.timerMode)
+
+        clickLabel(AnnouncementLabel.DURATION_MODE)
+        assertEquals(
+            Constants.TIMER_MODE_COUNT_UP,
+            reports.settings?.timerMode,
+            "the control labelled Duration is the count-up mode",
+        )
+    }
+
+    @Test
+    fun `only the modes that count from a starting point can be reset`() = announcementsTab { _, _ ->
+        assertTrue(hasAnnButton(AnnouncementLabel.RESET), "a countdown can be reset")
+
+        clickLabel(AnnouncementLabel.CLOCK_MODE)
+        assertFalse(
+            hasAnnButton(AnnouncementLabel.RESET),
+            "a specific time tracks the wall clock — there is nothing to reset it to",
+        )
+
+        clickLabel(AnnouncementLabel.CLOCK_DISPLAY_MODE)
+        assertFalse(hasAnnButton(AnnouncementLabel.RESET), "and neither does a live clock")
+
+        clickLabel(AnnouncementLabel.DURATION_MODE)
+        assertTrue(hasAnnButton(AnnouncementLabel.RESET), "but a count-up can be reset")
+    }
+
+    @Test
+    fun `only the modes that can expire offer an expiry message`() = announcementsTab { _, _ ->
+        assertTrue(showsExactly(AnnouncementLabel.EXPIRED_HINT), "a countdown reaches an end")
+
+        clickLabel(AnnouncementLabel.CLOCK_DISPLAY_MODE)
+        assertFalse(
+            showsExactly(AnnouncementLabel.EXPIRED_HINT),
+            "a live clock never expires, so it takes no message",
+        )
+
+        clickLabel(AnnouncementLabel.CLOCK_MODE)
+        assertTrue(showsExactly(AnnouncementLabel.EXPIRED_HINT), "a specific time does reach an end")
+    }
+
+    // ── Running it ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the start button becomes a pause button while it runs`() =
+        announcementsTab(initial = AnnouncementsSettings(timerMinutes = 5)) { _, _ ->
+            assertTrue(hasAnnButton(AnnouncementLabel.START), "stopped to begin with")
+
+            annButton(AnnouncementLabel.START).performClick()
+            waitForIdle()
+
+            assertTrue(hasAnnButton(AnnouncementLabel.PAUSE), "the same button now offers to pause")
+            assertFalse(hasAnnButton(AnnouncementLabel.START))
+        }
+
+    @Test
+    fun `starting the timer is a preview — it does not put it on screen`() =
+        announcementsTab(initial = AnnouncementsSettings(timerMinutes = 5)) { presenter, _ ->
+            // The operator sets a countdown running to check it before the service without the
+            // congregation seeing it; only Go Live is allowed to mark the ticker live.
+            annButton(AnnouncementLabel.START).performClick()
+            waitForIdle()
+
+            assertFalse(presenter.announcementTickerLive.value, "still preview-only")
+            assertFalse(presenter.presentingMode.value == Presenting.ANNOUNCEMENTS)
+        }
+
+    @Test
+    fun `pausing stops it again`() =
+        announcementsTab(initial = AnnouncementsSettings(timerMinutes = 5)) { _, _ ->
+            annButton(AnnouncementLabel.START).performClick()
+            waitForIdle()
+            annButton(AnnouncementLabel.PAUSE).performClick()
+            waitForIdle()
+
+            assertTrue(hasAnnButton(AnnouncementLabel.START), "back to offering a start")
+        }
+
+    @Test
+    fun `taking the timer live marks the ticker live and shows it`() =
+        announcementsTab(initial = AnnouncementsSettings(timerMinutes = 5)) { presenter, _ ->
+            timerButton(AnnouncementLabel.GO_LIVE).performClick()
+            waitForIdle()
+
+            assertTrue(presenter.announcementTickerLive.value, "the ticker is live now")
+            assertEquals(Presenting.ANNOUNCEMENTS, presenter.presentingMode.value)
+            assertEquals(
+                "05:00",
+                presenter.announcementText.value,
+                "and what went on screen is the timer, not the announcement text",
+            )
+        }
+
+    @Test
+    fun `switching mode stops a running timer rather than leaving it ticking`() =
+        announcementsTab(initial = AnnouncementsSettings(timerMinutes = 5)) { presenter, _ ->
+            annButton(AnnouncementLabel.START).performClick()
+            waitForIdle()
+            assertTrue(hasAnnButton(AnnouncementLabel.PAUSE), "running to begin with")
+
+            clickLabel(AnnouncementLabel.CLOCK_MODE)
+
+            // A ticker left running would be counting for a mode that is no longer selected.
+            assertTrue(hasAnnButton(AnnouncementLabel.START), "it was stopped")
+            assertFalse(presenter.announcementTickerLive.value)
+        }
+
+    // ── Scheduling a timer ──────────────────────────────────────────────────────
+
+    @Test
+    fun `a timer can be scheduled even with no announcement text`() =
+        announcementsTab(initial = AnnouncementsSettings(timerMinutes = 10)) { _, reports ->
+            // The text-side button stays shut without text; the timer's does not, because the
+            // countdown is the content.
+            timerButton(AnnouncementLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            val item = reports.scheduled.single()
+            assertEquals(10, item.timerMinutes, "the countdown is carried whole")
+            assertEquals(Constants.TIMER_MODE_DURATION, item.timerMode)
+        }
+
+    @Test
+    fun `a countdown of zero with no text is not worth scheduling`() = announcementsTab { _, _ ->
+        // Nothing set at all: an item that shows 00:00 and no words is never what was meant.
+        timerButton(AnnouncementLabel.ADD_TO_SCHEDULE).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a clock is worth scheduling even with nothing typed and no countdown set`() =
+        announcementsTab { _, reports ->
+            clickLabel(AnnouncementLabel.CLOCK_DISPLAY_MODE)
+            timerButton(AnnouncementLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            assertEquals(
+                Constants.TIMER_MODE_CLOCK_DISPLAY,
+                reports.scheduled.single().timerMode,
+                "a clock has content of its own",
+            )
+        }
+
+    @Test
+    fun `the expiry message is kept against the timer`() = announcementsTab { _, reports ->
+        expiredTextField().performTextReplacement("We are starting")
+        waitForIdle()
+
+        assertEquals("We are starting", reports.settings?.timerExpiredText)
+    }
+}


### PR DESCRIPTION
`AnnouncementsTabKt` was 0%-covered; this takes it to 84.2% (685 of 814 lines) with 28 tests. No production change.

The tab owns its view model privately (`remember { AnnouncementsViewModel() }`), so unlike the other tabs there is no instance to reach in from a test. That suits it: everything it does is observable from outside anyway — what it draws, the `AnnouncementsSettings` it hands back to be persisted, and what it puts on the `PresenterManager`. The settings are fed back into the tab as `MainDesktop` does, so a control's effect shows up on the next frame.

## The announcement (14 tests)

The empty state with its actions disabled, whitespace-only text still counting as nothing to show, each style toggle turning on and off independently, styles saved earlier surviving a round trip, screen position, going live, Show becoming Hide, and scheduling.

Scheduling deliberately strips the timer, so a text announcement cannot land in the service order as a countdown — that one is worth a look on review, since it is the sort of thing that would only be noticed in front of a congregation.

## The timer (14 tests)

Four modes that look alike on screen but behave differently, and the differences are what these pin:

- Only the two that count from a starting point (countdown, count-up) offer **Reset** — a specific time and a live clock track the wall clock, so there is nothing to reset them to.
- Only the two that can reach an end offer an **expiry message**.
- **Start previews**; only Go Live (and Send to Stage Monitor) marks the ticker live.
- Switching mode **stops** a running ticker, rather than leaving it counting for a mode that is no longer selected.

Nothing waits for a tick: the tab renders the timer from state the view model already holds, so the starting value, the mode switches and the buttons are all assertable on the frame after the click. What a running ticker does over time is covered by `PresenterManagerAnnouncementTimerTest`.

## Two things worth knowing for the next test in here

- The tab has **two** Go Live and two Add to Schedule buttons — one per half — and an ambiguous content-description lookup surfaces as "failed to inject mouse input" rather than as anything naming the real problem. The harness tells them apart by row position.
- Hiding only *requests* a clear (`requestClearDisplay`); `MainDesktop` is what takes the content down, so the presenting mode is still `ANNOUNCEMENTS` immediately afterwards. The request is the whole of the tab's part.

Full suite passes 3× consecutively with `--rerun-tasks`. Both classes run in well under a second.