### PR TITLE
Test the Dictionary tab

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTabTest.kt
@@ -1,0 +1,219 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.performClick
+import org.churchpresenter.app.churchpresenter.viewmodel.DictionaryFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Strong's dictionary tab: finding an entry, reading it, and sending it somewhere.
+ *
+ * Built on [DictionaryFixture]'s miniature corpus rather than the bundled 14k entries, so every
+ * assertion is about data a reader of the test can see. See `DictionaryTabTestSupport.kt`.
+ */
+class DictionaryTabTest {
+
+    // ── The list ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the tab opens on the whole dictionary with nothing selected`() = dictionaryTab { vm, _ ->
+        assertTrue(vm.entries.isNotEmpty(), "the fixture loaded")
+        assertTrue(showsExactly(DictionaryLabel.SEARCH_HINT), "the search box invites a query")
+        assertTrue(
+            showsExactly(DictionaryLabel.SELECT_ENTRY),
+            "and the detail pane explains itself until something is picked",
+        )
+    }
+
+    @Test
+    fun `every entry is listed by its word`() = dictionaryTab { _, _ ->
+        assertTrue(listShows(DictionaryFixture.elohim), "the Hebrew entry")
+        assertTrue(listShows(DictionaryFixture.agape), "the Greek one")
+    }
+
+    @Test
+    fun `the entry count reflects what is listed`() = dictionaryTab { vm, _ ->
+        assertTrue(
+            showsExactly("${vm.entries.size} entries"),
+            "the count matches the corpus: ${renderedText().take(8)}",
+        )
+    }
+
+    // ── Searching ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `searching by Strong's number finds that entry`() = dictionaryTab { _, _ ->
+        dictSearch("G26")
+
+        assertTrue(listShows(DictionaryFixture.agape), "the match is listed")
+        assertFalse(listShows(DictionaryFixture.elohim), "and the rest is filtered out")
+    }
+
+    @Test
+    fun `searching by transliteration finds the entry behind it`() = dictionaryTab { _, _ ->
+        // An operator who cannot type Greek searches for what they can read.
+        dictSearch("agape")
+
+        assertTrue(listShows(DictionaryFixture.agape))
+        assertFalse(listShows(DictionaryFixture.elohim))
+    }
+
+    @Test
+    fun `searching by a word in the definition finds it too`() = dictionaryTab { _, _ ->
+        dictSearch("benevolence")
+
+        assertTrue(listShows(DictionaryFixture.agape), "matched on the definition")
+    }
+
+    @Test
+    fun `a search matching nothing says so rather than showing everything`() = dictionaryTab { _, _ ->
+        dictSearch("nothingmatchesthisquery")
+
+        assertTrue(showsExactly(DictionaryLabel.NO_RESULTS))
+        assertFalse(listShows(DictionaryFixture.agape), "the list really is empty")
+    }
+
+    @Test
+    fun `clearing the search brings the whole dictionary back`() = dictionaryTab { _, _ ->
+        dictSearch("G26")
+        assertFalse(listShows(DictionaryFixture.elohim), "filtered to begin with")
+
+        dictSearch("")
+
+        assertTrue(listShows(DictionaryFixture.elohim), "everything is listed again")
+    }
+
+    // ── Filtering by language ───────────────────────────────────────────────────
+
+    @Test
+    fun `the Hebrew filter hides the Greek entries, and the reverse`() = dictionaryTab { _, _ ->
+        clickLanguageFilter(DictionaryLabel.HEBREW)
+        assertTrue(listShows(DictionaryFixture.elohim), "Hebrew stays")
+        assertFalse(listShows(DictionaryFixture.agape), "Greek goes")
+
+        clickLanguageFilter(DictionaryLabel.GREEK)
+        assertTrue(listShows(DictionaryFixture.agape), "Greek stays")
+        assertFalse(listShows(DictionaryFixture.elohim), "Hebrew goes")
+
+        clickLanguageFilter(DictionaryLabel.ALL)
+        assertTrue(listShows(DictionaryFixture.elohim), "and All brings both back")
+        assertTrue(listShows(DictionaryFixture.agape))
+    }
+
+    @Test
+    fun `the language filter and the search narrow together`() = dictionaryTab { _, _ ->
+        clickLanguageFilter(DictionaryLabel.GREEK)
+        dictSearch("elohiym")
+
+        // A Hebrew word searched for under the Greek filter must not surface.
+        assertTrue(showsExactly(DictionaryLabel.NO_RESULTS), "got ${renderedText().take(8)}")
+    }
+
+    // ── Reading an entry ────────────────────────────────────────────────────────
+
+    @Test
+    fun `selecting an entry shows every field of it`() = dictionaryTab { _, _ ->
+        selectEntry(DictionaryFixture.agape)
+
+        assertFalse(showsExactly(DictionaryLabel.SELECT_ENTRY), "the placeholder is gone")
+        // The pronunciation, definition and KJV usage appear only in the detail pane; the number,
+        // word and transliteration are on every list row too, so they prove nothing here.
+        assertTrue(showsContainingText(DictionaryFixture.agape.pronunciation), "pronunciation")
+        assertTrue(showsContainingText(DictionaryFixture.agape.definition), "definition")
+        assertTrue(showsContainingText(DictionaryFixture.agape.kjvUsage), "KJV usage")
+    }
+
+    @Test
+    fun `the detail pane is labelled, so the fields are readable without guessing`() =
+        dictionaryTab { _, _ ->
+            selectEntry(DictionaryFixture.agape)
+
+            assertTrue(showsExactly(DictionaryLabel.TRANSLITERATION))
+            assertTrue(showsExactly(DictionaryLabel.PRONUNCIATION))
+            assertTrue(showsExactly(DictionaryLabel.DEFINITION))
+            assertTrue(showsExactly(DictionaryLabel.KJV_USAGE))
+        }
+
+    @Test
+    fun `an entry is badged with the language it comes from`() = dictionaryTab { _, _ ->
+        selectEntry(DictionaryFixture.agape)
+        assertTrue(showsExactly(DictionaryLabel.GREEK.uppercase()), "got ${renderedText().take(10)}")
+
+        selectEntry(DictionaryFixture.elohim)
+        assertTrue(showsExactly(DictionaryLabel.HEBREW.uppercase()))
+    }
+
+    @Test
+    fun `selecting a different entry replaces the one on show`() = dictionaryTab { _, _ ->
+        selectEntry(DictionaryFixture.agape)
+        selectEntry(DictionaryFixture.elohim)
+
+        assertTrue(detailShows(DictionaryFixture.elohim), "the new entry is open")
+        assertFalse(detailShows(DictionaryFixture.agape), "and the old one is not still open")
+    }
+
+    // ── History ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `there is nothing to go back to until a second entry is opened`() = dictionaryTab { _, _ ->
+        dictButton(DictionaryLabel.BACK).assertIsNotEnabled()
+        dictButton(DictionaryLabel.FORWARD).assertIsNotEnabled()
+
+        selectEntry(DictionaryFixture.agape)
+        dictButton(DictionaryLabel.BACK).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `back returns to the previous entry and forward comes again`() = dictionaryTab { _, _ ->
+        selectEntry(DictionaryFixture.agape)
+        selectEntry(DictionaryFixture.elohim)
+
+        dictButton(DictionaryLabel.BACK).performClick()
+        waitForIdle()
+        assertTrue(detailShows(DictionaryFixture.agape), "back to the first entry")
+
+        dictButton(DictionaryLabel.FORWARD).performClick()
+        waitForIdle()
+        assertTrue(detailShows(DictionaryFixture.elohim), "and forward again")
+    }
+
+    // ── Sending an entry on ─────────────────────────────────────────────────────
+
+    @Test
+    fun `going live hands the host the whole entry`() = dictionaryTab { _, reports ->
+        selectEntry(DictionaryFixture.agape)
+        dictButton(DictionaryLabel.GO_LIVE).performClick()
+        waitForIdle()
+
+        assertEquals(listOf(DictionaryFixture.agape), reports.live)
+    }
+
+    @Test
+    fun `adding to the schedule hands over the fields a schedule row needs`() =
+        dictionaryTab { _, reports ->
+            selectEntry(DictionaryFixture.agape)
+            dictButton(DictionaryLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf(
+                    DictionaryFixture.agape.number,
+                    DictionaryFixture.agape.word,
+                    DictionaryFixture.agape.transliteration,
+                    DictionaryFixture.agape.definition,
+                ),
+                reports.scheduled.single(),
+            )
+        }
+
+    @Test
+    fun `with nothing selected there is nothing to send`() = dictionaryTab { _, _ ->
+        dictButton(DictionaryLabel.GO_LIVE).assertIsNotEnabled()
+        dictButton(DictionaryLabel.ADD_TO_SCHEDULE).assertIsNotEnabled()
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTabTestSupport.kt
@@ -1,0 +1,188 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runComposeUiTest
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkObject
+import org.churchpresenter.app.churchpresenter.data.InterlinearRepository
+import org.churchpresenter.app.churchpresenter.data.StrongsEntry
+import org.churchpresenter.app.churchpresenter.viewmodel.DictionaryFixture
+import org.churchpresenter.app.churchpresenter.viewmodel.DictionaryViewModel
+
+/**
+ * Harness and fixtures shared by the `DictionaryTab` test classes.
+ *
+ * The real dictionary is ~14k entries across four bundled JSON files, so these reuse
+ * [DictionaryFixture] — the same miniature corpus the `DictionaryViewModel*` suites are built on.
+ * That keeps every assertion about data a reader of the test can actually see, and keeps the load
+ * off the critical path.
+ *
+ * `InterlinearRepository` is stubbed the same way [DictionaryViewModelInterlinearTest] stubs it: the
+ * real one reads 4–8 MB of bundled JSON, and letting the tab pull it once per test exhausted the
+ * test JVM's heap — which surfaced as `OutOfMemoryError` in whatever unrelated class happened to run
+ * next, not here.
+ *
+ * `DictionaryViewModel.load()` is asynchronous, so the harness waits for the entries to arrive
+ * before running the test body — on the entries themselves, not on a timer.
+ */
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class DictionaryReports {
+    /** number, word, transliteration, definition — exactly what the schedule would be given. */
+    val scheduled = mutableListOf<List<String>>()
+    val live = mutableListOf<StrongsEntry>()
+    val wordClicks = mutableListOf<String>()
+    val verseClicks = mutableListOf<Triple<Int, Int, Int>>()
+}
+
+/**
+ * Stubs the bundled dictionary files, builds a real [DictionaryViewModel], composes `DictionaryTab`
+ * over it once its entries have loaded, and runs [block].
+ *
+ * The mock on `Res` is a JVM-wide object mock, so it is always removed again — leaving it installed
+ * would leak into whatever test class runs next.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun dictionaryTab(
+    block: ComposeUiTest.(vm: DictionaryViewModel, reports: DictionaryReports) -> Unit,
+) {
+    DictionaryFixture.stubResources()
+    mockkConstructor(InterlinearRepository::class)
+    coEvery { anyConstructed<InterlinearRepository>().ensureGreekLoaded() } returns Unit
+    coEvery { anyConstructed<InterlinearRepository>().ensureHebrewLoaded() } returns Unit
+    every { anyConstructed<InterlinearRepository>().getVersesForEntry(any()) } returns emptyList()
+    every { anyConstructed<InterlinearRepository>().getBooksWithGreekData() } returns emptyList()
+    every { anyConstructed<InterlinearRepository>().getBooksWithHebrewData() } returns emptyList()
+    every { anyConstructed<InterlinearRepository>().getChaptersForBook(any()) } returns emptyList()
+    every { anyConstructed<InterlinearRepository>().getVersesInChapter(any(), any()) } returns emptyList()
+    every { anyConstructed<InterlinearRepository>().getStrongsForBookChapter(any(), any(), any()) } returns emptySet()
+    val vm = DictionaryViewModel()
+    val reports = DictionaryReports()
+    try {
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    DictionaryTab(
+                        viewModel = vm,
+                        onAddToSchedule = { number, word, transliteration, definition ->
+                            reports.scheduled += listOf(number, word, transliteration, definition)
+                        },
+                        onGoLive = { reports.live += it },
+                        onWordClick = { reports.wordClicks += it },
+                        onVerseClick = { book, chapter, verse ->
+                            reports.verseClicks += Triple(book, chapter, verse)
+                        },
+                    )
+                }
+            }
+            // The tab kicks off the load itself; wait for the entries rather than for a duration.
+            waitUntil("the dictionary to load") { vm.entries.isNotEmpty() }
+            block(vm, reports)
+        }
+    } finally {
+        runCatching { vm.dispose() }
+        unmockkConstructor(InterlinearRepository::class)
+        unmockkObject(churchpresenter.composeapp.generated.resources.Res)
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object DictionaryLabel {
+    const val SEARCH_HINT = "Search by number, word, or definition…"
+    const val ALL = "All"
+    const val HEBREW = "Hebrew"
+    const val GREEK = "Greek"
+    const val NO_RESULTS = "No results found"
+    const val SELECT_ENTRY = "Select an entry to view details"
+    const val TRANSLITERATION = "Transliteration:"
+    const val PRONUNCIATION = "Pronunciation:"
+    const val DEFINITION = "Definition"
+    const val KJV_USAGE = "KJV Usage"
+    const val BACK = "Back"
+    const val FORWARD = "Forward"
+    const val GO_LIVE = "Go Live"
+    const val ADD_TO_SCHEDULE = "Add to Schedule"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+// (renderedText/showsExactly/showsContainingText are shared — see TabRenderedText.kt)
+
+/** A button, addressed by the content description its tooltip gives it. */
+internal fun ComposeUiTest.dictButton(label: String): SemanticsNodeInteraction =
+    onNodeWithContentDescription(label)
+
+internal fun ComposeUiTest.hasDictButton(label: String): Boolean =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()
+
+/** The search box — the tab's only freely-typed field. */
+internal fun ComposeUiTest.dictSearchField() = onAllNodes(hasSetTextAction())[0]
+
+internal fun ComposeUiTest.dictSearch(query: String) {
+    dictSearchField().performTextReplacement(query)
+    waitForIdle()
+}
+
+/**
+ * Matches the list row for [entry].
+ *
+ * A row merges its number, word and transliteration into one node, but they stay *separate* text
+ * entries inside it — so a match on the concatenation finds nothing, and a match on any one of them
+ * also hits the detail pane, which repeats all three. Requiring two of them together identifies the
+ * row and nothing else.
+ */
+internal fun rowOf(entry: StrongsEntry) =
+    hasText(entry.number) and hasText(entry.transliteration)
+
+/** Whether [entry] is in the list right now. */
+internal fun ComposeUiTest.listShows(entry: StrongsEntry): Boolean =
+    onAllNodes(rowOf(entry)).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
+
+/**
+ * Whether the detail pane is showing [entry].
+ *
+ * Keyed on the pronunciation because the number, word and transliteration are on the list row too —
+ * asserting on those would pass whether or not the entry was ever opened, and would fail when
+ * checking that a *previous* entry is no longer on show.
+ */
+internal fun ComposeUiTest.detailShows(entry: StrongsEntry): Boolean =
+    showsContainingText(entry.pronunciation)
+
+/**
+ * Clicks one of the three language chips above the list.
+ *
+ * Addressed as the topmost node with that label: once interlinear data is available the tab also
+ * shows book and chapter filters, which have an "All" of their own, so a bare lookup is ambiguous.
+ */
+internal fun ComposeUiTest.clickLanguageFilter(label: String) {
+    val nodes = onAllNodesWithText(label).fetchSemanticsNodes(atLeastOneRootRequired = false)
+    val topmost = nodes.indices.minByOrNull { nodes[it].boundsInRoot.top }
+        ?: error("no chip labelled \"$label\" is on screen")
+    onAllNodesWithText(label)[topmost].performClick()
+    waitForIdle()
+}
+
+/** Opens an entry from the list. */
+internal fun ComposeUiTest.selectEntry(entry: StrongsEntry) {
+    onNode(rowOf(entry)).performClick()
+    waitForIdle()
+}


### PR DESCRIPTION
`DictionaryTabKt` was 0%-covered; this takes it to 65.7% (490 of 746 lines) with 19 tests. No production change.

Built on `DictionaryFixture`'s miniature corpus — the same one the `DictionaryViewModel*` suites use — rather than the bundled ~14k entries, so every assertion is about data a reader of the test can actually see.

## Covered

- **The list** — every entry shown, and the count matching what is listed.
- **Search** — by Strong's number, by transliteration (what an operator who cannot type Greek reaches for), and by a word in the definition; no-results; and clearing to get the whole dictionary back.
- **Language filters** — Hebrew hiding Greek and the reverse, All restoring both, and the filter narrowing *together* with the search rather than either winning.
- **The detail pane** — every field and its label, the language badge, and one entry replacing another.
- **History** — Back and Forward disabled until there is somewhere to go, then walking back and forward.
- **Sending an entry on** — Go Live handing over the whole entry, Add to Schedule handing over the four fields a schedule row needs, and both disabled with nothing selected.

## The one that matters for future tests in here

The tab constructs a real `InterlinearRepository` — 4–8 MB of bundled JSON — and my first version let it. Alone, the class passed. In the full suite it caused `OutOfMemoryError`, surfacing in an unrelated Pictures test rather than in these, and the class took 16.8s.

`DictionaryViewModelInterlinearTest` already stubs the repository with `mockkConstructor` for exactly this reason; the harness now does the same. That took the class to 3.5s with every test ≤0.33s and removed the heap pressure. Anyone adding to this file should keep the stub.

Two Compose lookup notes are recorded in the harness alongside it:

- A merged node's texts stay **separate entries**, so a list row cannot be matched on the concatenation (`"G26ἀγάπηagape"`) even though `renderedText()` prints it that way. Rows are matched by two of their texts instead.
- Stubbing the repository makes the interlinear book/chapter filters appear, and their "All" chip makes a bare language-filter lookup ambiguous — so those are addressed as the topmost match.

Detail-pane assertions key on the **pronunciation**: the number, word and transliteration are on every list row too, so asserting on those would pass whether or not an entry was ever opened.

Full suite passes 3× consecutively with `--rerun-tasks`.