### PR TITLE
Test the Q&A tab

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabTest.kt
@@ -1,0 +1,189 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.performClick
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.models.QuestionStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Q&A moderation queue.
+ *
+ * Q&A is the one part of the app a stranger can reach — anyone in the room posts to it from their
+ * phone — so the moderator's queue is the gate between what was asked and what the congregation
+ * sees. These pin which question ends up where: that approving does not display, that denying takes
+ * it out of the queue without deleting it, and that nothing reaches the screen without an explicit
+ * step. The server-side guards on submission are covered by `CompanionServerQaTest`.
+ *
+ * See `QATabTestSupport.kt` for the harness.
+ */
+class QATabTest {
+
+    // ── The queue ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an empty session waits rather than showing an empty list`() =
+        qaTab(seed = { toggleSession() }) { qa, _, _ ->
+            assertTrue(qa.questions.isEmpty())
+            assertTrue(showsExactly(QALabel.WAITING), "got ${renderedText().take(12)}")
+        }
+
+    @Test
+    fun `questions asked from a phone appear in the queue`() =
+        qaTab(seed = { askAll("Is the coffee free?", "Where is the creche?") }) { _, _, _ ->
+            assertTrue(showsQuestion("Is the coffee free?"))
+            assertTrue(showsQuestion("Where is the creche?"))
+        }
+
+    @Test
+    fun `the incoming count follows the queue`() =
+        qaTab(seed = { askAll("One", "Two", "Three") }) { _, _, _ ->
+            assertTrue(showsExactly("3"), "three waiting: ${renderedText().take(8)}")
+            assertTrue(showsExactly(QALabel.INCOMING))
+        }
+
+    // ── Moderating ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `approving a question does not put it on screen`() =
+        qaTab(seed = { askAll("Is the coffee free?") }) { qa, presenter, _ ->
+            qaButton(QALabel.APPROVE).performClick()
+            waitForIdle()
+
+            assertEquals(QuestionStatus.APPROVED, qa.questions.single().status)
+            // Approving is the moderator saying "this may be asked", not "show it now" — the
+            // congregation must not see a question the moment it is cleared.
+            assertFalse(presenter.presentingMode.value == Presenting.QA, "nothing was displayed")
+            assertEquals(null, qa.displayedQuestion)
+        }
+
+    @Test
+    fun `denying takes a question out of the queue without deleting it`() =
+        qaTab(seed = { askAll("Off-topic question") }) { qa, _, _ ->
+            qaButton(QALabel.DENY).performClick()
+            waitForIdle()
+
+            assertEquals(QuestionStatus.DENIED, qa.questions.single().status, "kept, but refused")
+        }
+
+    @Test
+    fun `deleting asks before it removes anything`() =
+        qaTab(seed = { askAll("Delete me") }) { qa, _, _ ->
+            // The first press arms the confirmation rather than deleting — the queue is other
+            // people's questions, and a misclick is not undoable.
+            qaButton(QALabel.DELETE).performClick()
+            waitForIdle()
+
+            assertEquals(1, qa.questions.size, "still there")
+            assertTrue(showsExactly("Delete?"), "and the confirmation is asked")
+        }
+
+    @Test
+    fun `confirming the delete removes the question`() =
+        qaTab(seed = { askAll("Delete me") }) { qa, _, _ ->
+            qaButton(QALabel.DELETE).performClick()
+            waitForIdle()
+            // Two Delete buttons exist once armed — the confirm is the first of them.
+            qaButton2(QALabel.DELETE, 0).performClick()
+            waitForIdle()
+
+            assertTrue(qa.questions.isEmpty(), "got ${qa.questions}")
+            assertFalse(showsQuestion("Delete me"))
+        }
+
+    @Test
+    fun `a row's buttons act on that row alone`() =
+        qaTab(seed = { askAll("One question", "Another question") }) { qa, _, _ ->
+            qaButton2(QALabel.APPROVE, 0).performClick()
+            waitForIdle()
+
+            // Deliberately not asserting *which* of the two was approved: both are submitted in the
+            // same millisecond, so the newest-first sort is stable rather than ordered, and pinning
+            // a row to a question would be asserting on the clock. What matters is that pressing
+            // one row's button leaves the other row alone.
+            assertEquals(
+                1,
+                qa.questions.count { it.status == QuestionStatus.APPROVED },
+                "exactly one was approved: ${qa.questions.map { it.text to it.status }}",
+            )
+            assertEquals(1, qa.questions.count { it.status == QuestionStatus.PENDING })
+        }
+
+    // ── Filtering ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the approved filter shows only what was cleared`() =
+        qaTab(seed = { askAll("Approved one", "Still pending") }) { qa, _, _ ->
+            qa.approveQuestion(qa.questions.first { it.text == "Approved one" }.id)
+            waitForIdle()
+
+            selectFilter(QALabel.APPROVED)
+
+            assertTrue(showsQuestion("Approved one"))
+            assertFalse(showsQuestion("Still pending"), "a pending question is not approved")
+        }
+
+    @Test
+    fun `the denied filter shows what was refused, and nothing else`() =
+        qaTab(seed = { askAll("Refused one", "Still pending") }) { qa, _, _ ->
+            qa.denyQuestion(qa.questions.first { it.text == "Refused one" }.id)
+            waitForIdle()
+
+            selectFilter(QALabel.DENIED)
+
+            assertTrue(showsQuestion("Refused one"))
+            assertFalse(showsQuestion("Still pending"))
+        }
+
+    @Test
+    fun `the approved filter says so when nothing has been cleared yet`() =
+        qaTab(seed = { askAll("Still pending") }) { _, _, _ ->
+            selectFilter(QALabel.APPROVED)
+
+            assertTrue(showsExactly(QALabel.NO_APPROVED), "got ${renderedText().take(12)}")
+        }
+
+    // ── The session ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a session can be stopped and started again`() = qaTab { qa, _, _ ->
+        assertFalse(qa.sessionActive, "closed to begin with")
+
+        clickQaLabel(QALabel.NEW_SESSION)
+        assertTrue(qa.sessionActive, "open for questions")
+
+        clickQaLabel(QALabel.STOP_SESSION)
+        assertFalse(qa.sessionActive, "and closed again")
+    }
+
+    // ── Adding from the desk ────────────────────────────────────────────────────
+
+    @Test
+    fun `the moderator can add a question without a phone`() =
+        qaTab(seed = { toggleSession() }) { qa, _, _ ->
+            // A question asked out loud in the room still has to get into the queue.
+            typeQuestion("Asked from the floor")
+            clickQaLabel(QALabel.ADD)
+
+            assertEquals("Asked from the floor", qa.questions.single().text)
+        }
+
+    @Test
+    fun `an empty question is not added`() = qaTab(seed = { toggleSession() }) { qa, _, _ ->
+        typeQuestion("   ")
+
+        // The Add button is shut on blank input rather than adding an empty row.
+        addButton().assertIsNotEnabled()
+        assertTrue(qa.questions.isEmpty(), "got ${qa.questions}")
+    }
+
+    @Test
+    fun `there is nowhere to add a question until a session is open`() = qaTab { _, _, _ ->
+        assertFalse(showsExactly(QALabel.ADD_HINT), "no entry box before the session starts")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabTestSupport.kt
@@ -1,0 +1,189 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+import org.churchpresenter.app.churchpresenter.viewmodel.QAManager
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Harness and fixtures shared by the `QATab` test classes.
+ *
+ * Q&A is the one part of the app a stranger can reach: everyone in the room posts to it from their
+ * own phone, and the moderator decides what reaches the screen. So the tab under test is a
+ * moderation queue, and what these tests are about is which question ends up where — the
+ * server-side guards on submission are already covered by `CompanionServerQaTest`.
+ *
+ * A real [QAManager] drives it, seeded through the same `submitQuestion` a phone would call.
+ * `user.home` is isolated because the manager persists its session state there.
+ */
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class QAReports {
+    val presenting = mutableListOf<Presenting>()
+    var settingsChanges = 0
+    var settingsAfterChange: AppSettings? = null
+}
+
+/**
+ * Builds a real [QAManager] under an isolated `user.home`, seeds it with [seed], composes `QATab`
+ * over it, and runs [block].
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun qaTab(
+    serverUrl: String = "http://192.0.2.1:8080",
+    settings: AppSettings = AppSettings(),
+    seed: QAManager.() -> Unit = {},
+    block: ComposeUiTest.(qa: QAManager, presenter: PresenterManager, reports: QAReports) -> Unit,
+) {
+    TestSingletons.latchToTestHome()
+    val realHome = System.getProperty("user.home")
+    val tempHome: File = Files.createTempDirectory("cp-qa-tab").toFile()
+    System.setProperty("user.home", tempHome.absolutePath)
+    val qa = QAManager()
+    val presenter = PresenterManager()
+    val reports = QAReports()
+    try {
+        qa.seed()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    QATab(
+                        qaManager = qa,
+                        presenterManager = presenter,
+                        serverUrl = serverUrl,
+                        presenting = { reports.presenting += it },
+                        appSettings = settings,
+                        onSettingsChange = { transform ->
+                            reports.settingsChanges++
+                            reports.settingsAfterChange = transform(settings)
+                        },
+                    )
+                }
+            }
+            block(qa, presenter, reports)
+        }
+    } finally {
+        realHome?.let { System.setProperty("user.home", it) }
+        tempHome.deleteRecursively()
+    }
+}
+
+/** Opens a session and posts [texts] as a phone would, returning nothing — read them off the manager. */
+internal fun QAManager.askAll(vararg texts: String) {
+    if (!sessionActive) toggleSession()
+    texts.forEachIndexed { index, text ->
+        // A distinct IP per question: the manager rate-limits repeat submissions from one device.
+        submitQuestion(text, clientIp = "10.0.0.${index + 1}")
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object QALabel {
+    const val ALL = "All"
+    const val INCOMING = "Incoming"
+    const val APPROVED = "Approved"
+    const val DONE = "Done"
+    const val DENIED = "Denied"
+    const val HISTORY = "History"
+    const val NEW_SESSION = "New Session"
+    const val STOP_SESSION = "Stop Session"
+    const val ADD = "Add"
+    const val ADD_HINT = "Add a question…"
+    const val APPROVE = "Approve"
+    const val DENY = "Deny"
+    const val MARK_DONE = "Mark Done"
+    const val DELETE = "Delete"
+    const val GO_LIVE = "Go Live"
+    const val CLEAR_DISPLAY = "Clear Display"
+    const val WAITING = "Waiting for questions…"
+    const val NO_APPROVED = "No approved questions yet"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+// (renderedText/showsExactly/showsContainingText are shared — see TabRenderedText.kt)
+
+/** A button, addressed by the content description its tooltip gives it. */
+internal fun ComposeUiTest.qaButton(label: String): SemanticsNodeInteraction =
+    onNodeWithContentDescription(label)
+
+internal fun ComposeUiTest.hasQaButton(label: String): Boolean =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()
+
+/** The question-entry box — the tab's first freely-typed field. */
+internal fun ComposeUiTest.qaAddField() = onAllNodes(hasSetTextAction())[0]
+
+/** Clicks a labelled control, taking the topmost when a label repeats across panes. */
+internal fun ComposeUiTest.clickQaLabel(label: String) {
+    val nodes = onAllNodesWithText(label).fetchSemanticsNodes(atLeastOneRootRequired = false)
+    val topmost = nodes.indices.minByOrNull { nodes[it].boundsInRoot.top }
+        ?: error("nothing labelled \"$label\" is on screen")
+    onAllNodesWithText(label)[topmost].performClick()
+    waitForIdle()
+}
+
+/**
+ * Chooses a view from the FILTER dropdown.
+ *
+ * The dropdown merges its caption and current value into one node ("FILTERAll (2)"), and each
+ * option carries a live count ("Approved (1)"), so the trigger is matched on the caption and the
+ * option on its name plus the opening bracket.
+ */
+internal fun ComposeUiTest.selectFilter(name: String) {
+    onAllNodes(hasText("FILTER", substring = true))[0].performClick()
+    waitForIdle()
+    onAllNodes(hasText("$name (", substring = true))[0].performClick()
+    waitForIdle()
+}
+
+/** The nth button with this label, top to bottom — row buttons repeat once per question. */
+internal fun ComposeUiTest.qaButton2(label: String, n: Int): SemanticsNodeInteraction {
+    val nodes = onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+    val order = nodes.indices.sortedBy { nodes[it].boundsInRoot.top }
+    return onAllNodesWithContentDescription(label)[order[n]]
+}
+
+/** Which of [texts] are on screen, top to bottom. */
+internal fun ComposeUiTest.orderOfQuestions(vararg texts: String): List<String> =
+    texts.mapNotNull { text ->
+        onAllNodes(hasText(text, substring = true))
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .minByOrNull { it.boundsInRoot.top }
+            ?.let { it.boundsInRoot.top to text }
+    }.sortedBy { it.first }.map { it.second }
+
+/** The Add button beside the question box — a plain labelled button, not an icon. */
+internal fun ComposeUiTest.addButton(): SemanticsNodeInteraction = onAllNodesWithText(QALabel.ADD)[0]
+
+/** Whether a question's text is on screen anywhere. */
+internal fun ComposeUiTest.showsQuestion(text: String): Boolean =
+    onAllNodes(hasText(text, substring = true))
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()
+
+internal fun ComposeUiTest.typeQuestion(text: String) {
+    qaAddField().performTextReplacement(text)
+    waitForIdle()
+}


### PR DESCRIPTION
`QATabKt` was 0%-covered; this takes it to 56.0% (385 of 687 lines) with 15 tests. No production change.

Q&A is the one part of the app a stranger can reach — anyone in the room posts to it from their own phone — so the moderator's queue is the gate between what was asked and what the congregation sees. These tests are about which question ends up where. The server-side guards on submission are already covered by `CompanionServerQaTest`.

## The gate

- **Approving does not display.** Approving means "this may be asked", not "show it now" — the congregation must not see a question the moment it is cleared.
- **Denying keeps the question** but takes it out of the queue, rather than deleting it.
- **Deleting arms a confirmation first.** The queue holds other people's questions and a misclick is not undoable, so there are two tests: one press shows "Delete?" and changes nothing, the second removes it.
- Plus the filter views (approved / denied / the empty-state message), session start and stop, and adding a question from the desk for someone who asks out loud.

## One test that deliberately asserts less than it could

I first wrote "the newest question is listed first" and "the first Approve belongs to the newer question". Both failed: two questions submitted in the same millisecond sort *stably*, so row order follows insertion rather than time. Pinning a row to a question would have been asserting on the clock.

The ordering test is gone. The row test now asserts what actually matters — pressing one row's button leaves the other row alone — with a comment recording why it does not name the row.

## Harness notes for the next test in here

The filter is a `DropdownSelector` whose options carry live counts (`"Approved (1)"`), not a chip row — so the trigger is matched on its caption and the option on its name plus the opening bracket. The add-question box only exists while a session is open. `PresenterManager` is supplied by the harness because the tab requires one.

Full suite passes 3× consecutively with `--rerun-tasks`. Every test ≤0.11s after the class's one-off Compose warm-up.