### PR TITLE
Test the Lower Third tab

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdTabTest.kt
@@ -1,0 +1,136 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.performClick
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Lower Third tab: a preset picker over a folder of Lottie animations.
+ *
+ * An operator picks a preset before the service and fires it during, so what matters is that the
+ * list reflects the folder, that nothing can be fired until something is chosen, and that what
+ * reaches the output is the animation that was picked rather than a name that has to be resolved
+ * again later.
+ *
+ * The ATEM upload panel is not driven here — it reaches a switcher over the network, and everything
+ * decidable before that is covered by `CompanionServerLowerThirdTest`.
+ *
+ * See `LowerThirdTabTestSupport.kt` for the harness.
+ */
+class LowerThirdTabTest {
+
+    // ── The preset list ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `every Lottie in the folder is listed, and nothing else`() = lowerThirdTab { _ ->
+        assertTrue(showsExactly("Welcome"), "got ${renderedText()}")
+        assertTrue(showsExactly("Speaker Name"))
+        assertFalse(showsExactly("notes"), "a non-Lottie file in the folder is not a preset")
+    }
+
+    @Test
+    fun `with no folder configured the tab says there are no presets`() =
+        lowerThirdTab(folder = null) { _ ->
+            assertTrue(showsExactly(LowerThirdLabel.NO_PRESETS), "got ${renderedText()}")
+        }
+
+    @Test
+    fun `an empty folder is the same as no presets`() = lowerThirdTab(folder = lottieFolder()) { _ ->
+        // The folder exists but holds only the non-Lottie file.
+        assertTrue(showsExactly(LowerThirdLabel.NO_PRESETS), "got ${renderedText()}")
+    }
+
+    // ── Choosing one ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `nothing can be fired until a preset is chosen`() = lowerThirdTab { _ ->
+        assertTrue(showsExactly(LowerThirdLabel.SELECT_PRESET), "the preview explains itself")
+        ltButton(LowerThirdLabel.GO_LIVE).assertIsNotEnabled()
+        ltButton(LowerThirdLabel.ADD_TO_SCHEDULE).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `choosing a preset opens it and enables the actions`() = lowerThirdTab { _ ->
+        selectPreset("Welcome")
+
+        assertFalse(showsExactly(LowerThirdLabel.SELECT_PRESET), "the placeholder is gone")
+        assertTrue(showsExactly("Welcome"), "and the chosen preset is named")
+        ltButton(LowerThirdLabel.GO_LIVE).assertIsEnabled()
+        ltButton(LowerThirdLabel.ADD_TO_SCHEDULE).assertIsEnabled()
+    }
+
+    @Test
+    fun `choosing a different preset replaces the first`() = lowerThirdTab { reports ->
+        selectPreset("Welcome")
+        selectPreset("Speaker Name")
+        ltButton(LowerThirdLabel.GO_LIVE).performClick()
+        waitForIdle()
+
+        assertEquals(listOf("Speaker Name"), reports.live, "the last choice is what fires")
+    }
+
+    // ── Firing it ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `going live sends the animation itself, not just its name`() = lowerThirdTab { reports ->
+        selectPreset("Welcome")
+        ltButton(LowerThirdLabel.GO_LIVE).performClick()
+        waitForIdle()
+
+        assertEquals(listOf("Welcome"), reports.live)
+        // The output is handed the Lottie JSON so it can play without going back to disk — a name
+        // alone would leave the animation to be resolved again on the far side.
+        assertEquals(LOWER_THIRD_LOTTIE, reports.liveJson)
+    }
+
+    @Test
+    fun `adding to the schedule carries the preset and its pause settings`() =
+        lowerThirdTab { reports ->
+            selectPreset("Welcome")
+            ltButton(LowerThirdLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            val item = reports.scheduled.single()
+            assertEquals("Welcome", item[1], "the label the schedule row shows")
+            assertEquals(false, item[2], "pause-at-frame defaults off")
+        }
+
+    @Test
+    fun `the same preset can be fired more than once`() = lowerThirdTab { reports ->
+        // A lower third is often shown again later in the service.
+        selectPreset("Welcome")
+        ltButton(LowerThirdLabel.GO_LIVE).performClick()
+        waitForIdle()
+        ltButton(LowerThirdLabel.GO_LIVE).performClick()
+        waitForIdle()
+
+        assertEquals(listOf("Welcome", "Welcome"), reports.live)
+    }
+
+    // ── Managing the folder ─────────────────────────────────────────────────────
+
+    @Test
+    fun `each preset has its own remove button`() = lowerThirdTab { _ ->
+        assertEquals(
+            2,
+            onAllNodesWithContentDescription(LowerThirdLabel.REMOVE)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .size,
+            "one per preset",
+        )
+    }
+
+    @Test
+    fun `the generator is offered even with no presets yet`() =
+        lowerThirdTab(folder = lottieFolder()) { _ ->
+            // Otherwise a new user with an empty folder has no way forward from this tab.
+            assertTrue(showsExactly(LowerThirdLabel.GENERATE), "got ${renderedText()}")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdTabTestSupport.kt
@@ -1,0 +1,137 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.StreamingSettings
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Harness and fixtures shared by the `LowerThirdTab` test classes.
+ *
+ * The tab is a preset picker over a folder of Lottie files: it lists what is in the folder, previews
+ * one, and hands the chosen animation to the output or the schedule. So the fixtures are real files
+ * on disk — the tab reads and parses them itself, and a stub that never parses would exercise the
+ * error path instead of the one under test.
+ *
+ * Nothing here drives the ATEM upload panel: it reaches a switcher over the network, and what can be
+ * decided before that is already covered by `CompanionServerLowerThirdTest`.
+ */
+
+// ── Fixtures ────────────────────────────────────────────────────────────────────────────────────
+
+/** A Lottie the app can time: 60 frames at 30fps = 2000ms. */
+internal const val LOWER_THIRD_LOTTIE =
+    """{"v":"5.7.4","fr":30,"ip":0,"op":60,"w":1920,"h":1080,"layers":[]}"""
+
+/** A folder holding [names] as real Lottie files, plus one file that is not a preset. */
+internal fun lottieFolder(vararg names: String): File =
+    Files.createTempDirectory("cp-lowerthird-tab").toFile().apply {
+        names.forEach { File(this, "$it.json").writeText(LOWER_THIRD_LOTTIE) }
+        File(this, "notes.txt").writeText("not a preset")
+    }
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class LowerThirdReports {
+    /** presetId, presetLabel, pauseAtFrame, pauseDurationMs — as the schedule would be given them. */
+    val scheduled = mutableListOf<List<Any>>()
+    /** presetName of each go-live, in order. */
+    val live = mutableListOf<String>()
+    /** The json handed to the output for the most recent go-live. */
+    var liveJson: String? = null
+    var settingsChanges = 0
+}
+
+/**
+ * Composes `LowerThirdTab` over [folder] and runs [block].
+ *
+ * Settings are fed back into the tab on every change, as `MainDesktop` does, so a control's effect
+ * is visible on the next frame.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun lowerThirdTab(
+    folder: File? = lottieFolder("Welcome", "Speaker Name"),
+    block: ComposeUiTest.(reports: LowerThirdReports) -> Unit,
+) {
+    val reports = LowerThirdReports()
+    try {
+        runComposeUiTest {
+            setContent {
+                var settings by remember {
+                    mutableStateOf(
+                        AppSettings(
+                            streamingSettings = StreamingSettings(
+                                lowerThirdFolder = folder?.absolutePath ?: ""
+                            )
+                        )
+                    )
+                }
+                MaterialTheme {
+                    LowerThirdTab(
+                        appSettings = settings,
+                        onSettingsChange = { transform ->
+                            settings = transform(settings)
+                            reports.settingsChanges++
+                        },
+                        onAddToSchedule = { id, label, pause, pauseMs ->
+                            reports.scheduled += listOf(id, label, pause, pauseMs)
+                        },
+                        onGoLive = { json, _, _, _, presetName ->
+                            reports.live += presetName
+                            reports.liveJson = json
+                        },
+                    )
+                }
+            }
+            block(reports)
+        }
+    } finally {
+        folder?.deleteRecursively()
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object LowerThirdLabel {
+    const val NO_PRESETS = "No presets saved yet"
+    const val SELECT_PRESET = "Select a preset to preview"
+    const val GO_LIVE = "Go Live"
+    const val ADD_TO_SCHEDULE = "Add to Schedule"
+    const val PAUSE = "Pause"
+    const val REMOVE = "Remove"
+    const val GENERATE = "Generate"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+// (renderedText/showsExactly/showsContainingText are shared — see TabRenderedText.kt)
+
+/** A button, addressed by the content description its tooltip gives it. */
+internal fun ComposeUiTest.ltButton(label: String): SemanticsNodeInteraction =
+    onNodeWithContentDescription(label)
+
+internal fun ComposeUiTest.hasLtButton(label: String): Boolean =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()
+
+/** Selects a preset from the list by its name. */
+internal fun ComposeUiTest.selectPreset(name: String) {
+    onAllNodesWithText(name)[0].performClick()
+    waitForIdle()
+}


### PR DESCRIPTION
`LowerThirdKt` was 0%-covered; this takes it to 41.5% (277 of 668 lines) with 11 tests. No production change.

## Covered

The tab is a preset picker over a folder of Lottie animations, so: every Lottie in the folder listed and nothing else, the no-folder and empty-folder states both saying there are no presets, nothing fireable until a preset is chosen, one selection replacing another, firing the same preset twice, a Remove button per preset, and the generator still offered when the folder is empty (otherwise a new user has no way forward from this tab).

Fixtures are real Lottie files on disk — the tab reads and parses them itself, so a stub that never parses would exercise the error path instead of the one under test.

**One assertion worth a look on review:** going live hands the output the **Lottie JSON itself**, not just the preset name. That is the contract that lets the far side play without going back to disk; a name-only regression would look correct in the UI right up until an Instance Link follower or a Browser Source had nothing to render.

## Why 41.5% and not higher

Roughly half the file is the ATEM upload panel — slot enumeration, still/clip mode, aspect and capacity checks, upload progress. All of it reaches a switcher over the network. Everything decidable *before* the network is already covered by `CompanionServerLowerThirdTest` (name resolution, timing, key-target validation), so driving it here would mean either a ~5s socket timeout per test or mocking the transport to assert that a mock was called. I left it, and the test class says so.

## Also, for whoever picks up CanvasTab next

I started on `CanvasTab` before this and stopped: it calls `GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices` during composition (CanvasTab.kt:245), which throws `HeadlessException` under the test JVM — the same blocker `AGENT.md` records for `SystemSettingsTab`/`StageMonitorSettingsTab`.

It needs a one-line headless guard to become testable, but `CanvasTab.kt` is in PR #9's file set, so I did not touch it rather than create a conflict in a branch that has been open since 18 July. Worth doing once #9 lands.

Full suite passes 3× consecutively with `--rerun-tasks`. Suite runs in 0.23s.