### PR TITLE
Remove redundant fully-qualified names and unblock CanvasTab under a headless test

### DIFF
--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -217,10 +217,21 @@ object Constants {
 | Debug prints | ~8 | VideoPlayer.kt, LowerThirdSettingsTab.kt, WebsitePresenter.kt | All `System.err.println` for error diagnostics — kept intentionally |
 | Non-null assertions (`!!`) | 0 | — | Replaced with smart casts and `getValue()` ✅ |
 | Hardcoded UI strings | 0 | — | "OK" moved to strings.xml; emojis kept (not translatable) ✅ |
+| Fully qualified `androidx.compose.*` | 0 | — | 20 sites removed 2026-07-28; the verification grep below returns nothing ✅ |
+| Fully qualified `java.*` where the import exists | 0 | — | 27 redundant sites removed 2026-07-28 ✅ |
+| Fully qualified `java.*` with no import | ~164 | Widespread | **Kept deliberately** — see the decision log |
 
 ### Decision Log
 
 **Kept intentionally:**
+- Fully qualified `java.*` references that have **no** matching import (~164, audited 2026-07-28).
+  Unlike the redundant ones, these are not automatic: many exist to disambiguate against a Compose
+  type of the same simple name — `java.awt.Window` (×8) against Compose's `Window`,
+  `java.awt.image.BufferedImage` (×7) — and
+  `java.awt.Toolkit.getDefaultToolkit().systemClipboard` is the settled form for the clipboard
+  one-liner in five files. Shortening them would need a per-site judgement and could make the code
+  less clear, not more. The zero-tolerance rule is about writing the long form when an import
+  already binds the name; that count is now 0.
 - Singular/plural verse API in PresenterManager — convenience accessors
 - `System.err.println` in VideoPlayer/WebsitePresenter/LowerThirdSettingsTab — error diagnostics for VLC/JCEF/WebView issues
 - Emoji strings — not translatable, no benefit to moving to resources

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
@@ -252,7 +252,7 @@ fun MainDesktop(
     nextSlideFlow: Flow<Unit>? = null,
     previousSlideFlow: Flow<Unit>? = null,
     /** Emits a presentation [File] uploaded by a mobile client — loaded into [PresentationViewModel] automatically. */
-    uploadPresentationFlow: Flow<java.io.File>? = null,
+    uploadPresentationFlow: Flow<File>? = null,
     serverUrl: String = "",
     /** Persistent "Following <host>" badge shown above the Schedule panel while connected via Instance Link. */
     instanceLinkConnectionStatus: InstanceLinkStatus = InstanceLinkStatus.DISCONNECTED,
@@ -714,7 +714,7 @@ fun MainDesktop(
     // Load picture folder when a picture schedule item is selected (works even before Pictures tab is composed)
     LaunchedEffect(selectedPictureItem) {
         selectedPictureItem?.let { pictureItem ->
-            val folder = java.io.File(pictureItem.folderPath)
+            val folder = File(pictureItem.folderPath)
             if (folder.exists() && folder.isDirectory) {
                 picturesViewModel.selectFolder(folder)
             }
@@ -1380,7 +1380,7 @@ fun MainDesktop(
                             presenting(Presenting.ANNOUNCEMENTS)
                         },
                         onPresentLowerThird = { item ->
-                            val lottieFolder = java.io.File(appSettings.streamingSettings.lowerThirdFolder)
+                            val lottieFolder = File(appSettings.streamingSettings.lowerThirdFolder)
                             val lottieFile = lottieFolder.listFiles()?.find {
                                 it.nameWithoutExtension == item.presetLabel || it.nameWithoutExtension == item.presetId
                             }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Surface
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -48,6 +49,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -378,7 +380,7 @@ private fun TextProperties(source: SceneSource.TextSource, onUpdate: (SceneSourc
             title = stringResource(Res.string.canvas_text_content),
             resizable = true
         ) {
-            androidx.compose.material3.Surface(
+            Surface(
                 modifier = Modifier.fillMaxSize(),
                 color = MaterialTheme.colorScheme.background
             ) {
@@ -797,7 +799,7 @@ private fun ClockProperties(source: SceneSource.ClockSource, onUpdate: (SceneSou
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.fillMaxWidth(),
-            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+            textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(4.dp))
         Row(
@@ -1861,7 +1863,7 @@ private fun BibleProperties(
     val bibleDisplayNames = remember(storageDir, bibleFiles) {
         bibleFiles.associateWith { fileName ->
             try {
-                java.io.File(storageDir, fileName).bufferedReader(java.nio.charset.StandardCharsets.UTF_8).use { reader ->
+                File(storageDir, fileName).bufferedReader(java.nio.charset.StandardCharsets.UTF_8).use { reader ->
                     repeat(10) {
                         val line = reader.readLine() ?: return@use fileName.removeSuffix(".spb")
                         if (line.startsWith("##Title:")) return@use line.substring(8).trim()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/PresentationRemoteDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/PresentationRemoteDialog.kt
@@ -1,6 +1,7 @@
 package org.churchpresenter.app.churchpresenter.dialogs
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -142,7 +143,7 @@ internal fun PresentationRemoteDialogContent(
     onStartTunnel: () -> Unit,
     onStopTunnel: () -> Unit,
     onDismiss: () -> Unit,
-    scrollState: androidx.compose.foundation.ScrollState = rememberScrollState(),
+    scrollState: ScrollState = rememberScrollState(),
     copyText: (String) -> Unit = { text ->
         java.awt.Toolkit.getDefaultToolkit().systemClipboard
             .setContents(java.awt.datatransfer.StringSelection(text), null)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
@@ -582,7 +582,7 @@ fun ProjectionSettingsTab(
                                     text = currentOption.shortLabel,
                                     style = MaterialTheme.typography.labelSmall,
                                     maxLines = 1,
-                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
                         }
@@ -596,7 +596,7 @@ fun ProjectionSettingsTab(
                                 text = currentOption.shortLabel,
                                 style = MaterialTheme.typography.labelSmall,
                                 maxLines = 1,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                overflow = TextOverflow.Ellipsis
                             )
                         }
                     }
@@ -738,7 +738,7 @@ fun ProjectionSettingsTab(
                                     text = currentKeyOption.shortLabel,
                                     style = MaterialTheme.typography.labelSmall,
                                     maxLines = 1,
-                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
                         }
@@ -752,7 +752,7 @@ fun ProjectionSettingsTab(
                                 text = currentKeyOption.shortLabel,
                                 style = MaterialTheme.typography.labelSmall,
                                 maxLines = 1,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                overflow = TextOverflow.Ellipsis
                             )
                         }
                     }
@@ -1114,7 +1114,7 @@ fun ProjectionSettingsTab(
                                     text = displayModes.find { it.second == output.displayMode }?.first ?: fullScreenLabel,
                                     style = MaterialTheme.typography.labelSmall,
                                     maxLines = 1,
-                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
                             DropdownMenu(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTab.kt
@@ -722,7 +722,7 @@ fun ServerSettingsTab(
                             Text(
                                 text = stringResource(Res.string.companion_atem_key_section),
                                 style = MaterialTheme.typography.titleSmall,
-                                fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+                                fontWeight = FontWeight.SemiBold,
                                 color = MaterialTheme.colorScheme.primary
                             )
                             Text(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -859,7 +859,7 @@ fun main() {
         // Secret keypress unlock (press D seven times) — reveals the Developer menu in a
         // packaged build for this session only. See MainDesktop's onPreviewKeyEvent.
         var developerMenuUnlocked by remember { mutableStateOf(false) }
-        var lottieGenOutputDir by remember { mutableStateOf<java.io.File?>(null) }
+        var lottieGenOutputDir by remember { mutableStateOf<File?>(null) }
         var lottieGenOnFileSaved by remember { mutableStateOf<(() -> Unit)?>(null) }
         var pendingUpdateResult by remember { mutableStateOf<UpdateCheckResult?>(null) }
         var pendingUpdateCheckWasManual by remember { mutableStateOf(false) }
@@ -1952,8 +1952,8 @@ fun main() {
                                         presenterManager.requestClearDisplay()
                                     },
                                     onOpenLottieGen = { outputDir, onSaved ->
-                                        if (outputDir.isNotEmpty() && java.io.File(outputDir).isDirectory) {
-                                            lottieGenOutputDir = java.io.File(outputDir)
+                                        if (outputDir.isNotEmpty() && File(outputDir).isDirectory) {
+                                            lottieGenOutputDir = File(outputDir)
                                             lottieGenOnFileSaved = onSaved
                                             showLottieGenWindow = true
                                         } else {
@@ -2017,8 +2017,8 @@ fun main() {
                                         presenterManager.identifyBrowserSourceOutput(index)
                                     },
                                     onOpenLottieGen = { outputDir, onSaved ->
-                                        if (outputDir.isNotEmpty() && java.io.File(outputDir).isDirectory) {
-                                            lottieGenOutputDir = java.io.File(outputDir)
+                                        if (outputDir.isNotEmpty() && File(outputDir).isDirectory) {
+                                            lottieGenOutputDir = File(outputDir)
                                             lottieGenOnFileSaved = onSaved
                                             showLottieGenWindow = true
                                         } else {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
@@ -1051,8 +1051,8 @@ class CompanionServer {
     }
 
     /** Lottie files in the configured lower-third folder. */
-    private fun lowerThirdFiles(): List<java.io.File> =
-        java.io.File(_lowerThirdFolder).takeIf { _lowerThirdFolder.isNotEmpty() && it.isDirectory }
+    private fun lowerThirdFiles(): List<File> =
+        File(_lowerThirdFolder).takeIf { _lowerThirdFolder.isNotEmpty() && it.isDirectory }
             ?.listFiles { f -> f.extension.lowercase() == "json" && isLottieFile(f) }
             ?.sortedBy { it.nameWithoutExtension.lowercase() } ?: emptyList()
 
@@ -1497,7 +1497,7 @@ class CompanionServer {
             // ── Songs ──────────────────────────────────────────────────────────
             if (songStorageDir.isNotEmpty()) {
                 try {
-                    val dir = java.io.File(songStorageDir)
+                    val dir = File(songStorageDir)
                     if (dir.exists() && dir.isDirectory) {
                         val songs = Songs()
                         dir.listFiles { f -> f.extension.lowercase() == Constants.EXTENSION_SPS }
@@ -1529,7 +1529,7 @@ class CompanionServer {
             // ── Bible ──────────────────────────────────────────────────────────
             if (bibleStorageDir.isNotEmpty() && primaryBibleFileName.isNotEmpty()) {
                 try {
-                    val file = java.io.File(bibleStorageDir, primaryBibleFileName)
+                    val file = File(bibleStorageDir, primaryBibleFileName)
                     if (file.exists()) {
                         val bible = Bible()
                         bible.loadFromSpb(file.absolutePath)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
@@ -98,6 +98,7 @@ import org.churchpresenter.app.churchpresenter.composables.ColorPickerField
 import org.churchpresenter.app.churchpresenter.composables.SceneCanvas
 import org.churchpresenter.app.churchpresenter.composables.SourcePropertiesPanel
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.utils.assignedDisplayBounds
 import org.churchpresenter.app.churchpresenter.utils.formatAspectRatio
 import org.churchpresenter.app.churchpresenter.models.SceneSource
 import org.churchpresenter.app.churchpresenter.models.SourceTransform
@@ -241,19 +242,7 @@ fun CanvasTab(
             // Resolve live presentation display for aspect ratio checks
             val presentationAssignment0 = appSettings.projectionSettings.getAssignment(0)
             val presentationBounds0 = remember(presentationAssignment0.targetDisplay, presentationAssignment0.targetBoundsX, presentationAssignment0.targetBoundsY) {
-                val ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment()
-                val screens = ge.screenDevices
-                val matched = if (presentationAssignment0.targetBoundsX != Int.MIN_VALUE) {
-                    screens.firstOrNull { sd ->
-                        val b = sd.defaultConfiguration.bounds
-                        b.x == presentationAssignment0.targetBoundsX && b.y == presentationAssignment0.targetBoundsY
-                    }
-                } else null
-                val device = matched
-                    ?: screens.getOrNull(presentationAssignment0.targetDisplay)
-                    ?: screens.firstOrNull { it != ge.defaultScreenDevice }
-                    ?: ge.defaultScreenDevice
-                device.defaultConfiguration.bounds
+                assignedDisplayBounds(presentationAssignment0)
             }
             val displayAr0 = if (presentationBounds0.height > 0) presentationBounds0.width.toFloat() / presentationBounds0.height else 0f
 
@@ -832,19 +821,7 @@ fun CanvasTab(
                 // Aspect ratio mismatch warning
                 val presentationAssignment = appSettings.projectionSettings.getAssignment(0)
                 val presentationBounds = remember(presentationAssignment.targetDisplay, presentationAssignment.targetBoundsX, presentationAssignment.targetBoundsY) {
-                    val ge = java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment()
-                    val screens = ge.screenDevices
-                    val matched = if (presentationAssignment.targetBoundsX != Int.MIN_VALUE) {
-                        screens.firstOrNull { sd ->
-                            val b = sd.defaultConfiguration.bounds
-                            b.x == presentationAssignment.targetBoundsX && b.y == presentationAssignment.targetBoundsY
-                        }
-                    } else null
-                    val device = matched
-                        ?: screens.getOrNull(presentationAssignment.targetDisplay)
-                        ?: screens.firstOrNull { it != ge.defaultScreenDevice }
-                        ?: ge.defaultScreenDevice
-                    device.defaultConfiguration.bounds
+                    assignedDisplayBounds(presentationAssignment)
                 }
                 val displayW = presentationBounds.width
                 val displayH = presentationBounds.height

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
@@ -1,6 +1,7 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.ui.text.font.FontWeight
 import kotlinx.serialization.json.Json
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.TooltipArea
@@ -148,8 +149,8 @@ import kotlinx.coroutines.delay
 
 private object RecentPictureFolders {
     private const val MAX = 10
-    private val file = java.io.File(System.getProperty("user.home"), ".churchpresenter/recent_picture_folders.json")
-    private val pinnedFile = java.io.File(System.getProperty("user.home"), ".churchpresenter/pinned_picture_folders.json")
+    private val file = File(System.getProperty("user.home"), ".churchpresenter/recent_picture_folders.json")
+    private val pinnedFile = File(System.getProperty("user.home"), ".churchpresenter/pinned_picture_folders.json")
     val folders = androidx.compose.runtime.mutableStateListOf<String>()
     val pinned = androidx.compose.runtime.mutableStateListOf<String>()
 
@@ -370,7 +371,7 @@ fun PicturesTab(
                     stringResource(Res.string.select_folder),
                     style = MaterialTheme.typography.labelMedium.copy(
                         fontSize = TextUnit(12.5f, TextUnitType.Sp),
-                        fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold
+                        fontWeight = FontWeight.SemiBold
                     )
                 )
             }
@@ -380,7 +381,7 @@ fun PicturesTab(
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
                 modifier = Modifier.weight(1f),
                 maxLines = 1,
-                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis
             )
             if (onAddToSchedule != null) {
                 AddToScheduleButton(
@@ -413,7 +414,7 @@ fun PicturesTab(
             ) {
                 Text(
                     text = stringResource(Res.string.recent),
-                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.Medium),
+                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
                 )
                 TooltipArea(
@@ -456,7 +457,7 @@ fun PicturesTab(
                                         RoundedCornerShape(6.dp)
                                     )
                                     .clickable {
-                                        val folder = java.io.File(path)
+                                        val folder = File(path)
                                         if (folder.exists() && folder.isDirectory) {
                                             viewModel.selectFolder(folder)
                                             onSettingsChange { s -> s.copy(pictureSettings = s.pictureSettings.copy(storageDirectory = path)) }
@@ -467,8 +468,8 @@ fun PicturesTab(
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
-                                    text = java.io.File(path).name,
-                                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.Medium),
+                                    text = File(path).name,
+                                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
                                     color = if (isActive) MaterialTheme.colorScheme.onSurface
                                             else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
                                     maxLines = 1
@@ -624,7 +625,7 @@ fun PicturesTab(
                         text = stringResource(Res.string.auto_scroll_interval).uppercase(),
                         fontSize = TextUnit(8f, TextUnitType.Sp),
                         lineHeight = TextUnit(9f, TextUnitType.Sp),
-                        fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+                        fontWeight = FontWeight.SemiBold,
                         letterSpacing = 0.9.sp,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                         maxLines = 1
@@ -634,7 +635,7 @@ fun PicturesTab(
                             text = "${appSettings.pictureSettings.autoScrollInterval.toInt()} ${stringResource(Res.string.unit_s)}",
                             style = MaterialTheme.typography.bodySmall.copy(
                                 fontSize = 12.sp,
-                                fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
+                                fontWeight = FontWeight.Medium
                             ),
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1
@@ -687,7 +688,7 @@ fun PicturesTab(
                         text = stringResource(Res.string.transition_duration).uppercase(),
                         fontSize = TextUnit(8f, TextUnitType.Sp),
                         lineHeight = TextUnit(9f, TextUnitType.Sp),
-                        fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold,
+                        fontWeight = FontWeight.SemiBold,
                         letterSpacing = 0.9.sp,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
                         maxLines = 1
@@ -697,7 +698,7 @@ fun PicturesTab(
                             text = "${appSettings.pictureSettings.transitionDuration.toInt()} ${stringResource(Res.string.unit_ms)}",
                             style = MaterialTheme.typography.bodySmall.copy(
                                 fontSize = 12.sp,
-                                fontWeight = androidx.compose.ui.text.font.FontWeight.Medium
+                                fontWeight = FontWeight.Medium
                             ),
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1
@@ -948,13 +949,13 @@ fun PicturesTab(
                                     text = imageFile.nameWithoutExtension,
                                     style = MaterialTheme.typography.labelSmall.copy(
                                         fontSize = TextUnit(11.5f, TextUnitType.Sp),
-                                        fontWeight = if (isSelected) androidx.compose.ui.text.font.FontWeight.SemiBold
-                                                     else androidx.compose.ui.text.font.FontWeight.Medium
+                                        fontWeight = if (isSelected) FontWeight.SemiBold
+                                                     else FontWeight.Medium
                                     ),
                                     color = if (isSelected) MaterialTheme.colorScheme.onSurface
                                             else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.62f),
                                     maxLines = 1,
-                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
                         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
@@ -588,7 +588,7 @@ fun PresentationTab(
                                     )
                                     .border(1.dp, if (isActive) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(6.dp))
                                     .clickable {
-                                        val f = java.io.File(path)
+                                        val f = File(path)
                                         if (f.exists()) {
                                             viewModel.addPresentation(f)
                                             RecentPresentationFiles.add(path)
@@ -598,7 +598,7 @@ fun PresentationTab(
                                 contentAlignment = Alignment.Center
                             ) {
                                 Text(
-                                    text = java.io.File(path).name,
+                                    text = File(path).name,
                                     style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium),
                                     color = if (isActive) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f),
                                     maxLines = 1

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATab.kt
@@ -508,8 +508,8 @@ fun QATab(
                                 if (path != null) {
                                     val export = filteredQuestions.joinToString("\n") { q ->
                                         val status = q.status.name.lowercase().replaceFirstChar { it.uppercase() }
-                                        val time = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.getDefault())
-                                            .format(java.util.Date(q.timestamp))
+                                        val time = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+                                            .format(Date(q.timestamp))
                                         "[$time] [$status] ${q.text}"
                                     }
                                     try {
@@ -643,7 +643,7 @@ fun QATab(
                                         withContext(Dispatchers.IO) {
                                             path.toFile().writeText(
                                                 toExport.joinToString("\n") { q ->
-                                                    "[${java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault()).format(java.util.Date(q.timestamp))}] [${q.status}] ${q.text}"
+                                                    "[${SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date(q.timestamp))}] [${q.status}] ${q.text}"
                                                 }
                                             )
                                         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTab.kt
@@ -639,7 +639,7 @@ fun WebTab(
                             .pointerInput(liveBrowser) {
                                 // Forward mouse events via CefBrowser_N.sendMouseEvent (reflection)
                                 if (liveBrowser == null) return@pointerInput
-                                val sendMouse = findMethod(liveBrowser, "sendMouseEvent", java.awt.event.MouseEvent::class.java)
+                                val sendMouse = findMethod(liveBrowser, "sendMouseEvent", MouseEvent::class.java)
                                 var lastMoveTime = 0L
                                 awaitPointerEventScope {
                                     while (true) {
@@ -714,7 +714,7 @@ fun WebTab(
                             .pointerInput(liveBrowser) {
                                 // Forward scroll via CefBrowser_N.sendMouseWheelEvent (reflection)
                                 if (liveBrowser == null) return@pointerInput
-                                val sendWheel = findMethod(liveBrowser, "sendMouseWheelEvent", java.awt.event.MouseWheelEvent::class.java)
+                                val sendWheel = findMethod(liveBrowser, "sendMouseWheelEvent", MouseWheelEvent::class.java)
                                 awaitPointerEventScope {
                                     while (true) {
                                         val event = awaitPointerEvent()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.delay
+import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
 import java.awt.GraphicsDevice
 import java.awt.GraphicsEnvironment
 import java.awt.HeadlessException
@@ -50,6 +51,49 @@ fun presenterScreenBounds(): Rectangle {
 
 internal fun presenterBoundsOf(screens: Array<GraphicsDevice>, primary: GraphicsDevice): Rectangle =
     (screens.firstOrNull { it != primary } ?: primary).defaultConfiguration.bounds
+
+/**
+ * Bounds of the display [assignment] targets, or 1080p when there is no display to ask (headless).
+ *
+ * Used for aspect-ratio comparisons against content that will be shown there — a scene built 16:9
+ * on a 4:3 output is worth warning about before it goes live, and that check has to keep working on
+ * a machine with no second screen attached.
+ */
+fun assignedDisplayBounds(assignment: ScreenAssignment): Rectangle {
+    val screens = safeScreenDevices()
+    if (screens.isEmpty()) return HEADLESS_PRESENTER_BOUNDS
+    return try {
+        assignedBoundsOf(screens, GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice, assignment)
+    } catch (_: HeadlessException) {
+        HEADLESS_PRESENTER_BOUNDS
+    }
+}
+
+/**
+ * Which of [screens] an assignment resolves to, most specific first: the screen whose top-left
+ * corner matches the stored bounds, else the stored index, else any screen that is not [primary],
+ * else [primary] itself.
+ *
+ * Stored bounds win over the index because a display's index shifts when another is plugged in or
+ * removed, while its position on the desktop usually does not.
+ */
+internal fun assignedBoundsOf(
+    screens: Array<GraphicsDevice>,
+    primary: GraphicsDevice,
+    assignment: ScreenAssignment,
+): Rectangle {
+    val matched = if (assignment.targetBoundsX != Int.MIN_VALUE) {
+        screens.firstOrNull { device ->
+            val bounds = device.defaultConfiguration.bounds
+            bounds.x == assignment.targetBoundsX && bounds.y == assignment.targetBoundsY
+        }
+    } else null
+    val device = matched
+        ?: screens.getOrNull(assignment.targetDisplay)
+        ?: screens.firstOrNull { it != primary }
+        ?: primary
+    return device.defaultConfiguration.bounds
+}
 
 /** Find a screen index by stored bounds. Returns null if no match. */
 fun findScreenIndexByBounds(screens: Array<GraphicsDevice>, x: Int, y: Int, w: Int, h: Int): Int? {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabSmokeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabSmokeTest.kt
@@ -1,0 +1,99 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.ProjectionSettings
+import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+import org.churchpresenter.app.churchpresenter.viewmodel.SceneViewModel
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * That `CanvasTab` composes at all on a machine with no display.
+ *
+ * It did not until [assignedDisplayBounds][org.churchpresenter.app.churchpresenter.utils.assignedDisplayBounds]
+ * existed: the tab asked `GraphicsEnvironment` for the assigned output's bounds twice during
+ * composition — once for the scene list's per-row aspect-ratio badge and once for the mismatch
+ * warning under the canvas — and `screenDevices` throws `HeadlessException` when there is no screen.
+ * That single call made the whole tab unreachable from a test.
+ *
+ * This is deliberately only a smoke test. It pins the thing that was actually broken — the tab
+ * renders headlessly, with an assignment carrying stored bounds that match no real screen, which is
+ * the shape that used to reach the throwing branch. Driving the compositor's controls is separate
+ * work; what matters here is that it is now possible.
+ */
+class CanvasTabSmokeTest {
+
+    private fun canvasTab(settings: AppSettings, assertions: ComposeUiTest.(SceneViewModel) -> Unit) {
+        TestSingletons.latchToTestHome()
+        val realHome = System.getProperty("user.home")
+        val tempHome: File = Files.createTempDirectory("cp-canvas-tab").toFile()
+        System.setProperty("user.home", tempHome.absolutePath)
+        try {
+            val scenes = SceneViewModel()
+            // A scene named distinctly enough that finding it on screen proves the tab drew its
+            // list, and one whose 4:3 shape mismatches every display the fallback can return, so
+            // the aspect-ratio branch that used to throw is the one being exercised.
+            scenes.addScene("Smoke Scene")
+            scenes.updateCanvasSize(1024, 768)
+            val presenter = PresenterManager()
+            runComposeUiTest {
+                setContent {
+                    MaterialTheme {
+                        CanvasTab(
+                            appSettings = settings,
+                            presenterManager = presenter,
+                            sceneViewModel = scenes,
+                            onAddToSchedule = { _, _ -> },
+                        )
+                    }
+                }
+                waitForIdle()
+                assertions(scenes)
+            }
+        } finally {
+            realHome?.let { System.setProperty("user.home", it) }
+            tempHome.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `the tab composes with no display attached`() {
+        canvasTab(AppSettings()) { scenes ->
+            assertTrue(
+                showsExactly("Smoke Scene"),
+                "the scene list should have drawn; on screen was ${renderedText()}",
+            )
+            assertEquals(1, scenes.scenes.size)
+        }
+    }
+
+    @Test
+    fun `an assignment pointing at a screen that is not there still composes`() {
+        // Stored bounds for a projector that was unplugged, plus an index past the end of the list:
+        // both of the fallbacks the aspect-ratio check relies on, exercised through the real tab.
+        val settings = AppSettings(
+            projectionSettings = ProjectionSettings(
+                screenAssignments = listOf(
+                    ScreenAssignment(targetDisplay = 4, targetBoundsX = 3840, targetBoundsY = 0)
+                )
+            )
+        )
+        canvasTab(settings) { _ ->
+            assertTrue(
+                showsExactly("Smoke Scene"),
+                "the tab must still draw when the assigned display cannot be found; on screen was ${renderedText()}",
+            )
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/AssignedDisplayBoundsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/AssignedDisplayBoundsTest.kt
@@ -1,0 +1,102 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import io.mockk.every
+import io.mockk.mockk
+import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
+import java.awt.GraphicsConfiguration
+import java.awt.GraphicsDevice
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Which display an output assignment resolves to, and what happens when there is no display at all.
+ *
+ * The precedence matters in a real building: an operator sets the projector up once, and the stored
+ * bounds have to keep winning over the stored index, because plugging in or unplugging any other
+ * screen renumbers the indices while the projector stays where it is on the desktop. Getting that
+ * backwards would silently move the audience output to the wrong screen after a cable change.
+ *
+ * The headless case is not hypothetical either — it is what lets `CanvasTab` be composed in a test
+ * at all. The tab compares its scene's aspect ratio against the assigned display's, and used to ask
+ * `GraphicsEnvironment` for that directly, which throws on a machine with no screen.
+ *
+ * Real `GraphicsDevice`s cannot be constructed and the test JVM is headless, so the topology is
+ * faked with MockK, as in [PresenterScreenBoundsTest] and `FindScreenIndexTest`.
+ */
+class AssignedDisplayBoundsTest {
+
+    private fun screen(x: Int, y: Int, w: Int, h: Int): GraphicsDevice {
+        val config = mockk<GraphicsConfiguration>()
+        every { config.bounds } returns Rectangle(x, y, w, h)
+        val device = mockk<GraphicsDevice>()
+        every { device.defaultConfiguration } returns config
+        return device
+    }
+
+    private val primary = screen(0, 0, 1920, 1080)
+    private val projector = screen(1920, 0, 1280, 720)
+    private val stage = screen(-1080, 0, 1080, 1920)
+    private val all = arrayOf(primary, projector, stage)
+
+    @Test
+    fun `stored bounds pick the screen sitting at that position`() {
+        val assignment = ScreenAssignment(targetDisplay = 0, targetBoundsX = 1920, targetBoundsY = 0)
+        assertEquals(Rectangle(1920, 0, 1280, 720), assignedBoundsOf(all, primary, assignment))
+    }
+
+    @Test
+    fun `stored bounds win over a stale index`() {
+        // The operator chose the projector when it was index 1; another screen has since renumbered
+        // it. The position is what still identifies it.
+        val assignment = ScreenAssignment(targetDisplay = 0, targetBoundsX = -1080, targetBoundsY = 0)
+        assertEquals(
+            Rectangle(-1080, 0, 1080, 1920),
+            assignedBoundsOf(all, primary, assignment),
+            "the screen at the stored position must win over the one at the stored index",
+        )
+    }
+
+    @Test
+    fun `the index is used when no bounds were stored`() {
+        val assignment = ScreenAssignment(targetDisplay = 2)
+        assertEquals(Rectangle(-1080, 0, 1080, 1920), assignedBoundsOf(all, primary, assignment))
+    }
+
+    @Test
+    fun `bounds that match nothing fall through to the index`() {
+        val assignment = ScreenAssignment(targetDisplay = 1, targetBoundsX = 9999, targetBoundsY = 9999)
+        assertEquals(
+            Rectangle(1920, 0, 1280, 720),
+            assignedBoundsOf(all, primary, assignment),
+            "an unplugged screen's stored position must not strand the assignment",
+        )
+    }
+
+    @Test
+    fun `an out-of-range index falls back to the first non-primary screen`() {
+        val assignment = ScreenAssignment(targetDisplay = 7)
+        assertEquals(Rectangle(1920, 0, 1280, 720), assignedBoundsOf(all, primary, assignment))
+    }
+
+    @Test
+    fun `the auto assignment takes the first non-primary screen`() {
+        // targetDisplay defaults to -1 (auto), which is not a valid index.
+        assertEquals(Rectangle(1920, 0, 1280, 720), assignedBoundsOf(all, primary, ScreenAssignment()))
+    }
+
+    @Test
+    fun `a single-display machine falls back to the primary`() {
+        assertEquals(
+            Rectangle(0, 0, 1920, 1080),
+            assignedBoundsOf(arrayOf(primary), primary, ScreenAssignment()),
+        )
+    }
+
+    @Test
+    fun `with no displays at all the bounds are 1080p rather than an exception`() {
+        // No mocking: the test JVM is genuinely headless, so this exercises the real fallback the
+        // CanvasTab aspect-ratio check depends on.
+        assertEquals(Rectangle(0, 0, 1920, 1080), assignedDisplayBounds(ScreenAssignment()))
+    }
+}


### PR DESCRIPTION
Two cleanups flagged during the recent review batch but not fixed there, since neither belonged to the PR under review.

## Fully-qualified names — 47 sites

`DEVELOPMENT_GUIDE.md` lists these as zero-tolerance and its cleanup table recorded the count as clean. It wasn't:

- **20 `androidx.compose.*` references** — precisely what the guide's own verification grep looks for. `PicturesTab` (11), `ProjectionSettingsTab` (5), `SourcePropertiesPanel` (2), `PresentationRemoteDialog` (1), `ServerSettingsTab` (1).
- **27 more where the import was already at the top of the file** and the code still spelled out the package — the literal case the mantra *"never use fully qualified type names when import exists"* forbids. Mostly `java.io.File`.

Neither set can change name resolution, so both are mechanical. The guide's grep now returns nothing:

```
grep -rn "androidx\.compose\.[a-z][a-z.]*\.[A-Z]" composeApp/src/jvmMain/kotlin | grep -v ":import "
```

**Deliberately not touched: the ~164 fully-qualified `java.*` uses that have no import.** Many exist to disambiguate against a Compose type of the same simple name (`java.awt.Window` ×8 against Compose's `Window`, `java.awt.image.BufferedImage` ×7), and `java.awt.Toolkit.getDefaultToolkit().systemClipboard` is the settled form for the clipboard one-liner in five files. Shortening those needs a per-site judgement and could easily make the code less clear. The table and decision log now record that split honestly instead of claiming a clean count.

## CanvasTab could not be composed in a test

It resolved the assigned output's bounds by calling `GraphicsEnvironment` directly — the **same 14 lines duplicated at two points in the file** — ending on `?: ge.defaultScreenDevice`, which throws `HeadlessException` when there is no display. That one call made the entire tab unreachable from a test, the only tab blocked rather than merely un-started.

No new guard was needed. `utils/Constants.kt` already had both halves — `safeScreenDevices()` (returns empty on `HeadlessException`) and `HEADLESS_PRESENTER_BOUNDS` (1080p, documented for exactly this) — and already had the shape to copy in the `presenterScreenBounds`/`presenterBoundsOf` pair. So this adds `assignedDisplayBounds(assignment)` beside them, with the precedence rules split out into a pure `assignedBoundsOf(screens, primary, assignment)` that a test can drive directly. Both call sites in `CanvasTab` collapse to one line each, removing the duplication.

Stored bounds deliberately keep winning over the stored index: plugging or unplugging any other screen renumbers the indices while the projector stays where it is on the desktop.

## Tests

- `AssignedDisplayBoundsTest` — 8 tests over each precedence rule, plus the genuinely headless fallback (no mocking; the test JVM has no display, so it exercises the real path).
- `CanvasTabSmokeTest` — 2 tests composing the real tab, including with an assignment whose stored bounds and index both point at screens that aren't there.

**I checked these have teeth:** with the old `GraphicsEnvironment` call restored, both smoke tests fail with `java.awt.HeadlessException`. Full suite on this branch: **5693 tests, 0 failures.**

Building out real `CanvasTab` coverage is follow-on work — this only makes it possible.