### PR TITLE
Test the Canvas tab

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabTest.kt
@@ -1,0 +1,169 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.performClick
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Canvas tab: the scene compositor's control surface.
+ *
+ * A scene is a stack of sources, and the order of that stack is what the audience sees — so what
+ * these pin is the scene graph each control produces: which scene is current, what is in it, and in
+ * what order. [org.churchpresenter.app.churchpresenter.viewmodel.SceneViewModel]'s own rules are
+ * covered by the `SceneViewModel*` suites; nothing here re-tests those.
+ *
+ * See `CanvasTabTestSupport.kt` for the harness — and note the tab only became testable once
+ * `assignedDisplayBounds` replaced a raw `screenDevices` call that threw headless (PR #88).
+ */
+class CanvasTabTest {
+
+    // ── Scenes ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `with no scenes the tab offers to create one`() = canvasTab { vm, _ ->
+        assertTrue(vm.scenes.isEmpty())
+        assertTrue(showsExactly("No scene selected"), "got ${renderedText()}")
+        assertTrue(showsExactly("Create Scene"), "with the way forward on screen")
+    }
+
+    @Test
+    fun `creating a scene selects it, so sources have somewhere to go`() = canvasTab { vm, _ ->
+        clickCanvasLabel(CanvasLabel.NEW_SCENE)
+
+        assertEquals(1, vm.scenes.size)
+        assertEquals(vm.scenes.single().id, vm.currentSceneId.value, "the new scene is current")
+        assertFalse(showsExactly("No scene selected"), "and the empty state is gone")
+    }
+
+    @Test
+    fun `a second scene becomes the current one`() = canvasTab { vm, _ ->
+        clickCanvasLabel(CanvasLabel.NEW_SCENE)
+        val first = vm.scenes.single().id
+        clickCanvasLabel(CanvasLabel.NEW_SCENE)
+
+        assertEquals(2, vm.scenes.size)
+        assertFalse(vm.currentSceneId.value == first, "the newest scene is the one being edited")
+    }
+
+    @Test
+    fun `removing a scene takes it out of the list`() = canvasTab(seed = { addScene("Only scene") }) { vm, _ ->
+        canvasButton(CanvasLabel.REMOVE_SCENE).performClick()
+        waitForIdle()
+
+        assertTrue(vm.scenes.isEmpty(), "got ${vm.scenes.map { it.name }}")
+        assertTrue(showsExactly("No scene selected"), "and the empty state comes back")
+    }
+
+    // ── Sources ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a source added from the menu lands in the current scene`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.TEXT)
+
+            assertEquals(listOf("Text"), vm.sourceNames())
+        }
+
+    @Test
+    fun `an image source can be added from the menu`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.IMAGE)
+
+            assertEquals(listOf("Image"), vm.sourceNames())
+        }
+
+    @Test
+    fun `a clock source can be added from the menu`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            // One source per test on purpose — see addSourceOfType: the add button cannot be
+            // driven twice in a single test.
+            addSourceOfType(CanvasLabel.CLOCK)
+
+            assertEquals(listOf("Clock"), vm.sourceNames())
+        }
+
+    @Test
+    fun `selecting a source opens its properties`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            assertTrue(
+                showsExactly("Select a source to edit properties"),
+                "nothing selected to begin with",
+            )
+
+            addSourceOfType(CanvasLabel.TEXT)
+
+            // Adding selects it, so the properties panel replaces the placeholder.
+            assertEquals(vm.currentScene?.sources?.single()?.id, vm.selectedSourceId.value)
+            assertFalse(showsExactly("Select a source to edit properties"))
+            assertTrue(showsExactly("Properties"), "got ${renderedText().take(20)}")
+        }
+
+    @Test
+    fun `deleting removes the selected source and leaves the rest`() =
+        canvasTab(seed = { addScene("Scene"); seedSources("Keep", "Drop") }) { vm, _ ->
+            vm.selectSource("src-Drop")
+            waitForIdle()
+
+            canvasButton(CanvasLabel.DELETE_SOURCE).performClick()
+            waitForIdle()
+
+            assertEquals(listOf("Keep"), vm.sourceNames())
+        }
+
+    // ── Layer order ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `moving a source changes which one is drawn on top`() =
+        canvasTab(seed = { addScene("Scene"); seedSources("Lower", "Upper") }) { vm, _ ->
+            vm.selectSource("src-Upper")
+            waitForIdle()
+            val before = vm.sourceNames()
+
+            canvasButton(CanvasLabel.MOVE_BACKWARD).performClick()
+            waitForIdle()
+
+            // The stack order is what the audience sees, so it has to actually change.
+            assertEquals(
+                before.reversed(),
+                vm.sourceNames(),
+                "the two sources swapped places",
+            )
+        }
+
+    @Test
+    fun `moving back and forward returns a source to where it started`() =
+        canvasTab(seed = { addScene("Scene"); seedSources("Lower", "Upper") }) { vm, _ ->
+            vm.selectSource("src-Upper")
+            waitForIdle()
+            val before = vm.sourceNames()
+
+            canvasButton(CanvasLabel.MOVE_BACKWARD).performClick()
+            waitForIdle()
+            canvasButton(CanvasLabel.MOVE_FORWARD).performClick()
+            waitForIdle()
+
+            assertEquals(before, vm.sourceNames())
+        }
+
+    // ── Handing the scene on ────────────────────────────────────────────────────
+
+    @Test
+    fun `adding to the schedule hands over the scene being edited`() =
+        canvasTab(seed = { addScene("Pre-service loop") }) { vm, reports ->
+            canvasButton(CanvasLabel.ADD_TO_SCHEDULE).performClick()
+            waitForIdle()
+
+            val scene = vm.scenes.single()
+            assertEquals(listOf(scene.id to scene.name), reports.scheduled)
+        }
+
+    @Test
+    fun `there is nothing to schedule or show without a scene`() = canvasTab { _, _ ->
+        assertFalse(hasCanvasButton(CanvasLabel.ADD_TO_SCHEDULE), "got ${renderedText()}")
+        assertFalse(hasCanvasButton(CanvasLabel.GO_LIVE))
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabTestSupport.kt
@@ -1,0 +1,167 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.models.SceneSource
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+import org.churchpresenter.app.churchpresenter.viewmodel.SceneViewModel
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Harness and fixtures shared by the `CanvasTab` test classes.
+ *
+ * The tab is the scene compositor's control surface: a list of scenes, the sources inside the
+ * selected one, and the buttons that add, reorder, hide, lock and delete them. What is asserted is
+ * the scene graph that results — [SceneViewModel] is real, and its own rules are covered by the
+ * `SceneViewModel*` suites, so nothing here re-tests those.
+ *
+ * This tab only became testable once `assignedDisplayBounds` replaced a raw `screenDevices` call
+ * (PR #88): the old one threw `HeadlessException` during composition.
+ *
+ * `user.home` is isolated because the view model persists scenes there and would otherwise write
+ * into the developer's own library.
+ */
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class CanvasReports {
+    /** sceneId to sceneName, exactly as the schedule would be given them. */
+    val scheduled = mutableListOf<Pair<String, String>>()
+    var settingsChanges = 0
+}
+
+/**
+ * Builds a real [SceneViewModel] under an isolated `user.home`, seeds it with [seed], composes
+ * `CanvasTab` over it, and runs [block].
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun canvasTab(
+    seed: SceneViewModel.() -> Unit = {},
+    block: ComposeUiTest.(vm: SceneViewModel, reports: CanvasReports) -> Unit,
+) {
+    TestSingletons.latchToTestHome()
+    val realHome = System.getProperty("user.home")
+    val tempHome: File = Files.createTempDirectory("cp-canvas-tab").toFile()
+    System.setProperty("user.home", tempHome.absolutePath)
+    val vm = SceneViewModel()
+    val presenter = PresenterManager()
+    val reports = CanvasReports()
+    try {
+        vm.seed()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    CanvasTab(
+                        appSettings = AppSettings(),
+                        onSettingsChange = { reports.settingsChanges++ },
+                        presenterManager = presenter,
+                        sceneViewModel = vm,
+                        onAddToSchedule = { id, name -> reports.scheduled += id to name },
+                    )
+                }
+            }
+            block(vm, reports)
+        }
+    } finally {
+        realHome?.let { System.setProperty("user.home", it) }
+        tempHome.deleteRecursively()
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object CanvasLabel {
+    const val SCENES = "Scenes"
+    const val SOURCES = "Sources"
+    const val NEW_SCENE = "New"
+    const val RENAME_SCENE = "Rename"
+    const val REMOVE_SCENE = "Remove"
+    const val ADD_SOURCE = "Add source"
+    const val DELETE_SOURCE = "Delete source"
+    const val TOGGLE_VISIBILITY = "Toggle visibility"
+    const val TOGGLE_LOCK = "Toggle lock"
+    const val MOVE_FORWARD = "Move forward"
+    const val MOVE_BACKWARD = "Move backward"
+    const val IMAGE = "Image"
+    const val TEXT = "Text"
+    const val CLOCK = "Clock"
+    const val GO_LIVE = "Go Live"
+    const val ADD_TO_SCHEDULE = "Add to Schedule"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+// (renderedText/showsExactly/showsContainingText are shared — see TabRenderedText.kt)
+
+/** A button, addressed by the content description its tooltip gives it. */
+internal fun ComposeUiTest.canvasButton(label: String): SemanticsNodeInteraction =
+    onNodeWithContentDescription(label)
+
+internal fun ComposeUiTest.hasCanvasButton(label: String): Boolean =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()
+
+internal fun ComposeUiTest.canvasButtonCount(label: String): Int =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .size
+
+/**
+ * The nth button with this label, top to bottom.
+ *
+ * Source rows each carry their own visibility, lock and delete buttons, so a test that means "the
+ * second source's" addresses it by position — which is what the operator is doing too.
+ */
+internal fun ComposeUiTest.canvasButtonAt(label: String, n: Int): SemanticsNodeInteraction {
+    val nodes = onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+    val order = nodes.indices.sortedBy { nodes[it].boundsInRoot.top }
+    return onAllNodesWithContentDescription(label)[order[n]]
+}
+
+/**
+ * Adds a source of the named kind through the add menu, as an operator would.
+ *
+ * Usable **once per test**: after the first use the button keeps its hover tooltip, and a second
+ * click surfaces that instead of reopening the menu — the menu never appears and the item cannot be
+ * found. Tests needing more than one source seed the rest with [seedSources].
+ */
+internal fun ComposeUiTest.addSourceOfType(typeLabel: String) {
+    canvasButton(CanvasLabel.ADD_SOURCE).performClick()
+    waitForIdle()
+    onAllNodesWithText(typeLabel)[0].performClick()
+    waitForIdle()
+}
+
+/** Puts [names] into the current scene as text sources, bottom layer first. */
+internal fun SceneViewModel.seedSources(vararg names: String) {
+    names.forEach { name ->
+        addSource(SceneSource.TextSource(id = "src-$name", name = name))
+    }
+}
+
+/** Clicks a labelled control, taking the topmost when the label repeats. */
+internal fun ComposeUiTest.clickCanvasLabel(label: String) {
+    val nodes = onAllNodesWithText(label).fetchSemanticsNodes(atLeastOneRootRequired = false)
+    val topmost = nodes.indices.minByOrNull { nodes[it].boundsInRoot.top }
+        ?: error("nothing labelled \"$label\" is on screen")
+    onAllNodesWithText(label)[topmost].performClick()
+    waitForIdle()
+}
+
+/** The sources in the current scene, in the order the view model holds them. */
+internal fun SceneViewModel.sourceNames(): List<String> =
+    currentScene?.sources?.map(SceneSource::name) ?: emptyList()


### PR DESCRIPTION
`CanvasTabKt` was 0%-covered; this takes it to 76.7% (437 of 570 lines) with 13 tests. No production change.

This one is a direct follow-on from #88: the tab used to call `GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices` during composition, which threw `HeadlessException` under the test JVM. With `assignedDisplayBounds` in place it composes headless and the whole tab opened up. Thanks for putting that guard in.

## Covered

A scene is a stack of sources, and the order of that stack is what the audience sees — so these pin the scene graph each control produces:

- The no-scene empty state, and that it offers a way forward rather than just being blank.
- Creating a scene (which selects it, so sources have somewhere to go), a second scene becoming current, and removing one.
- Adding a Text, Image or Clock source from the add menu.
- The properties panel replacing its placeholder once something is selected.
- Deleting the **selected** source while leaving the rest.
- Layer reordering, including that back-then-forward returns a source to where it started.
- Nothing to schedule or show without a scene.

## Two quirks recorded in the harness

Both are documented where the next author will hit them rather than silently worked around:

- **The add-source menu can only be driven once per test.** After the first use the button keeps its hover tooltip, and a second click surfaces that instead of reopening the menu — the menu never appears and the item cannot be found. So each source type gets its own test, and tests needing several sources seed them through the view model.
- **Deleting had the same shape.** Driven immediately after the menu, the lingering popup swallowed the click. That test now seeds two sources and deletes the selected one — which also makes it a stronger assertion, since the other source has to survive.

Full suite passes 3× consecutively with `--rerun-tasks`. Suite runs in ~2.7s, all of it the class's one-off Compose warm-up.