### PR TITLE
Follow-ups to the multi-translation Bible work: #96, #97, #98, #95, and the picker's lost tests

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SettingsTextField.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SettingsTextField.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.composables
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -22,6 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,11 +56,19 @@ fun SettingsTextField(
     fillWidth: Boolean = false,
 ) {
     val hasLabel = label.isNotEmpty()
-    val borderColor = if (isError) MaterialTheme.colorScheme.error
-                      else MaterialTheme.colorScheme.outlineVariant
+    val interactionSource = remember { MutableInteractionSource() }
+    // The one thing on this field that says which of the two dozen boxes on a settings screen a
+    // keystroke is about to land in. Both branches below draw the same 1dp outline whatever the
+    // state, so without this, tabbing through a settings tab moved an invisible caret: the
+    // interaction source was built and handed to BasicTextField, and then never read.
+    val focused by interactionSource.collectIsFocusedAsState()
+    val borderColor = when {
+        isError -> MaterialTheme.colorScheme.error
+        focused -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.outlineVariant
+    }
     val textColor = if (enabled) MaterialTheme.colorScheme.onSurface
                     else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
-    val interactionSource = remember { MutableInteractionSource() }
 
     Column(modifier = modifier) {
         if (hasLabel) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -199,6 +199,7 @@ import org.churchpresenter.app.churchpresenter.utils.WindowsWindowCapture
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.FileManager
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.rememberDialogState
 import org.jetbrains.compose.resources.painterResource
@@ -1854,15 +1855,18 @@ private fun BibleProperties(
 ) {
     val availableFonts = remember { Utils.getAvailableSystemFonts() }
 
-    // Available bible files
+    // Available bible files, each paired with the name to show for it.
+    //
+    // Listing the folder and reading a `##Title:` out of every module in it are both file I/O, and
+    // neither belongs in composition: this panel recomposes on every canvas selection and property
+    // edit, and the folder can hold a hundred modules. The selector below simply waits for the list.
     val storageDir = appSettings?.bibleSettings?.storageDirectory ?: ""
-    val bibleFiles = remember(storageDir) {
-        if (storageDir.isEmpty()) emptyList()
-        else FileManager()
-            .getBibleFilesInDirectory(storageDir)
-    }
-    val bibleDisplayNames = remember(storageDir, bibleFiles) {
-        bibleFiles.associateWith { fileName -> readTranslationTitle(File(storageDir, fileName)) }
+    val bibleOptions by produceState(emptyList<Pair<String, String>>(), storageDir) {
+        value = withContext(Dispatchers.IO) {
+            if (storageDir.isEmpty()) emptyList()
+            else FileManager().getBibleFilesInDirectory(storageDir)
+                .map { fileName -> fileName to readTranslationTitle(File(storageDir, fileName)) }
+        }
     }
 
     // Selected bible version
@@ -1885,11 +1889,11 @@ private fun BibleProperties(
     Text(stringResource(Res.string.canvas_source_bible), style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
 
     // Bible version selector
-    if (bibleFiles.isNotEmpty()) {
+    if (bibleOptions.isNotEmpty()) {
         DropdownSelector(
             label = stringResource(Res.string.canvas_bible_version),
             value = selectedBibleFile,
-            options = bibleFiles.map { it to (bibleDisplayNames[it] ?: it.removeSuffix(".spb")) },
+            options = bibleOptions,
             onValueChange = { selectedBibleFile = it },
             modifier = Modifier.fillMaxWidth()
         )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -206,6 +206,7 @@ import java.io.File
 import javax.swing.filechooser.FileNameExtensionFilter
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
+import org.churchpresenter.app.churchpresenter.data.readTranslationTitle
 
 @Composable
 fun SourcePropertiesPanel(
@@ -1861,17 +1862,7 @@ private fun BibleProperties(
             .getBibleFilesInDirectory(storageDir)
     }
     val bibleDisplayNames = remember(storageDir, bibleFiles) {
-        bibleFiles.associateWith { fileName ->
-            try {
-                File(storageDir, fileName).bufferedReader(java.nio.charset.StandardCharsets.UTF_8).use { reader ->
-                    repeat(10) {
-                        val line = reader.readLine() ?: return@use fileName.removeSuffix(".spb")
-                        if (line.startsWith("##Title:")) return@use line.substring(8).trim()
-                    }
-                    fileName.removeSuffix(".spb")
-                }
-            } catch (_: Exception) { fileName.removeSuffix(".spb") }
-        }
+        bibleFiles.associateWith { fileName -> readTranslationTitle(File(storageDir, fileName)) }
     }
 
     // Selected bible version

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Bible.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Bible.kt
@@ -621,12 +621,33 @@ class Bible {
         private val NEW_TESTAMENT_BOOK_IDS = 40..66
 
         /**
+         * How far in to keep looking for header content: the `##` block plus a full 66-book list,
+         * with room to spare. The stop conditions below (`-----`, a verse line) are what normally
+         * ends the scan; this is the backstop for a module that has neither, where without it a
+         * "header scan" would read the whole multi-megabyte file.
+         */
+        const val HEADER_SCAN_LINE_LIMIT = 120
+
+        /**
+         * Far enough to pass the `##` block of any real module, and the limit the title-only callers
+         * use. A title further in than this is not looked for -- scanning a folder of large modules
+         * for one would stall the pickers that do it per file.
+         */
+        const val TITLE_SCAN_LINE_LIMIT = 10
+
+        /**
          * Fast path like [loadBooksOnly]: reads only the header block of an SPB file -- its
          * `##Title:` line and which book IDs appear -- stopping at the first verse line, so a
          * caller can show a translation's title and OT/NT coverage without the full verse parse
          * [loadFromSpb] requires.
+         *
+         * [maxLines] bounds how far in it will look. A caller that only wants the title can pass
+         * [TITLE_SCAN_LINE_LIMIT] and skip the book list entirely.
          */
-        fun readTranslationSummary(resourcePath: String): TranslationSummary? {
+        fun readTranslationSummary(
+            resourcePath: String,
+            maxLines: Int = HEADER_SCAN_LINE_LIMIT,
+        ): TranslationSummary? {
             try {
                 val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
                 val reader = if (inputStream != null) {
@@ -640,11 +661,15 @@ class Bible {
                 var title: String? = null
                 var hasOld = false
                 var hasNew = false
+                var scanned = 0
                 reader.use { r ->
                     for (rawLine in r.lineSequence()) {
+                        if (++scanned > maxLines) break
                         val line = rawLine.trimEnd('\r', '\n')
                         if (line.startsWith("##Title:")) {
-                            title = line.substring(8).trim()
+                            // The converter writes a TAB after the colon and hand-made modules often
+                            // write a space, so the separator is trimmed rather than counted.
+                            title = line.removePrefix("##Title:").trim()
                             continue
                         }
                         if (line.startsWith("##")) continue

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleTranslationNames.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleTranslationNames.kt
@@ -1,0 +1,54 @@
+package org.churchpresenter.app.churchpresenter.data
+
+import java.io.File
+
+/**
+ * Naming installed `.spb` translations for the user.
+ *
+ * Four places used to hand-roll the same `##Title:` scan — the Bible settings picker, the dictionary's
+ * bible list, the canvas source panel and the Bible tab's stack reorder dropdown — each with its own
+ * copy of the fallback rules and its own idea of how many lines to read. They all go through
+ * [readTranslationTitle] now, which reads the header through [Bible.readTranslationSummary]: one
+ * parser for the format, in the same file as the format's other reader.
+ *
+ * The rules these callers all want, and which the single reader keeps:
+ *  - a `##Title:` header names the translation, whether the value is separated by a tab (what the
+ *    converter writes) or a space (what plenty of hand-made modules have);
+ *  - **no** `##Title:` line, or a file that cannot be read at all, falls back to the file's stem;
+ *  - a `##Title:` line with nothing after it stays blank, which is what the full loader does too —
+ *    an empty title is a module that says its name is nothing, not a module that never said;
+ *  - a title buried past the header block is not looked for. These callers scan whole folders, and
+ *    reading through a directory of multi-megabyte modules would stall the picker doing it.
+ */
+fun readTranslationTitle(file: File): String =
+    Bible.readTranslationSummary(file.absolutePath, maxLines = Bible.TITLE_SCAN_LINE_LIMIT)?.title
+        ?: file.nameWithoutExtension
+
+/**
+ * Names every file in [files] (relative to [directory]) for a picker, keyed by file name.
+ *
+ * Reads one header per file, so keep this off the composition thread — the Bible tab reaches it
+ * through `produceState`, the settings and dictionary view models from their own coroutines.
+ */
+fun bibleDisplayNames(directory: String, files: List<String>): Map<String, String> {
+    if (directory.isEmpty()) return emptyMap()
+    return uniqueDisplayNames(files.associateWith { readTranslationTitle(File(directory, it)) })
+}
+
+/**
+ * Qualifies repeated titles so no two files end up sharing a display name.
+ *
+ * A picker reverse-maps the chosen name back to its file, so these have to be unique — and two files
+ * genuinely can carry the same `##Title:`: a collection nests one folder per translation and commonly
+ * holds several editions of one version. The folder is what distinguishes them to the user as well,
+ * so that is what a repeat is qualified with; two files sharing both a title and a folder can only be
+ * told apart by their file names.
+ */
+internal fun uniqueDisplayNames(titles: Map<String, String>): Map<String, String> {
+    val duplicated = titles.values.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+    return titles.mapValues { (path, title) ->
+        if (title !in duplicated) return@mapValues title
+        val folder = path.substringBeforeLast('/', "")
+        if (folder.isEmpty()) "$title  ($path)" else "$title  ($folder)"
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/BibleSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/BibleSettings.kt
@@ -246,7 +246,11 @@ data class BibleSettings(
         }
 
     fun withTranslations(value: List<BibleTranslationSettings>): BibleSettings {
-        val cleaned = value.filter { it.fileName.isNotBlank() }.distinctBy { it.fileName }
+        // Capped here rather than only at [addTranslation], so a hand-edited or rolled-forward
+        // settings file is bounded by the same rule the UI is.
+        val cleaned = value.filter { it.fileName.isNotBlank() }
+            .distinctBy { it.fileName }
+            .take(Constants.MAX_BIBLE_TRANSLATIONS)
         // The retained legacy names track the first two of the stack. Their styling is deliberately
         // left frozen at whatever the conversion wrote -- but keeping the *selection* current is
         // cheap, and it is what makes the rollback story true rather than nominal: an older build
@@ -265,8 +269,14 @@ data class BibleSettings(
     }
 
     fun addTranslation(fileName: String): BibleSettings {
-        if (fileName.isBlank() || translationList().any { it.fileName == fileName }) return this
-        return withTranslations(translationList() + BibleTranslationSettings(fileName = fileName))
+        val current = translationList()
+        // Refused rather than added-and-truncated: dropping the entry the operator just picked while
+        // the picker reports success is the one outcome worse than not offering the add at all.
+        if (fileName.isBlank() ||
+            current.size >= Constants.MAX_BIBLE_TRANSLATIONS ||
+            current.any { it.fileName == fileName }
+        ) return this
+        return withTranslations(current + BibleTranslationSettings(fileName = fileName))
     }
 
     fun removeTranslation(index: Int): BibleSettings =

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BibleSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BibleSettingsTab.kt
@@ -127,6 +127,8 @@ import org.jetbrains.compose.resources.stringResource
 import java.awt.GraphicsEnvironment
 import java.io.File
 
+/** [ActionIconButton]'s own default size, which the reorder buttons take and their gaps stand in for. */
+private val REORDER_BUTTON_SIZE = 34.dp
 
 @Composable
 fun BibleSettingsTab(
@@ -295,6 +297,12 @@ private fun LeftColumn(
                             }
                         },
                     )
+                    // The first row has no "up" and the last no "down", so from three rows up a gap
+                    // has to stand in for the missing button or the delete buttons step in and out
+                    // along the column instead of forming one straight edge. One or two rows need
+                    // no gap: every row is already short of the same one button, so they line up as
+                    // they are and a placeholder would only add dead space.
+                    val padsReorderButtons = translations.size > 2
                     if (index > 0) {
                         ActionIconButton(
                             onClick = { onSettingsChange { app ->
@@ -303,6 +311,8 @@ private fun LeftColumn(
                             tooltipText = stringResource(Res.string.move_translation_up),
                             painter = painterResource(Res.drawable.ic_arrow_up),
                         )
+                    } else if (padsReorderButtons) {
+                        Spacer(modifier = Modifier.size(REORDER_BUTTON_SIZE))
                     }
                     if (index < translations.lastIndex) {
                         ActionIconButton(
@@ -312,6 +322,8 @@ private fun LeftColumn(
                             tooltipText = stringResource(Res.string.move_translation_down),
                             painter = painterResource(Res.drawable.ic_arrow_down),
                         )
+                    } else if (padsReorderButtons) {
+                        Spacer(modifier = Modifier.size(REORDER_BUTTON_SIZE))
                     }
                     ActionIconButton(
                         onClick = { onSettingsChange { app ->
@@ -325,7 +337,9 @@ private fun LeftColumn(
             val unselectedFiles = bibleFilesInDirectory.filter { candidate ->
                 translations.none { it.fileName == candidate }
             }
-            if (unselectedFiles.isNotEmpty()) {
+            // Hidden at the cap as well as when nothing is left to add: `addTranslation` refuses past
+            // it, and a picker that answers a selection by doing nothing is worse than no picker.
+            if (unselectedFiles.isNotEmpty() && translations.size < Constants.MAX_BIBLE_TRANSLATIONS) {
                 DropdownSettingsField(
                     width = pickerWidth,
                     label = addTranslationLabel,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
@@ -64,6 +64,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -178,7 +179,10 @@ import churchpresenter.composeapp.generated.resources.browser_source_website_sna
 import churchpresenter.composeapp.generated.resources.projection_web_decklink_tooltip
 import churchpresenter.composeapp.generated.resources.vlc_path_invalid
 import churchpresenter.composeapp.generated.resources.window_position
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
 import org.churchpresenter.app.churchpresenter.composables.DeckLinkManager
 import org.churchpresenter.app.churchpresenter.composables.NumberSettingsTextField
 import org.churchpresenter.app.churchpresenter.composables.SettingsSection
@@ -449,25 +453,43 @@ fun ProjectionSettingsTab(
     val otNtPortionLabel = stringResource(Res.string.content_bible_translation_portion_ot_nt)
     val ntPortionLabel = stringResource(Res.string.content_bible_translation_portion_nt)
     val otPortionLabel = stringResource(Res.string.content_bible_translation_portion_ot)
-    val translationDisplays = remember(settings.bibleSettings.translations, settings.bibleSettings.storageDirectory, otNtPortionLabel, ntPortionLabel, otPortionLabel) {
-        settings.bibleSettings.translationList().map { t ->
-            val code = t.fileName.substringBeforeLast('.')
-            val storageDir = settings.bibleSettings.storageDirectory
-            val path = if (storageDir.isNotEmpty()) java.io.File(storageDir, t.fileName).absolutePath else t.fileName
-            val summary = Bible.readTranslationSummary(path)
-            val portion = when {
-                summary?.hasOldTestament == true && summary.hasNewTestament -> otNtPortionLabel
-                summary?.hasNewTestament == true -> ntPortionLabel
-                summary?.hasOldTestament == true -> otPortionLabel
-                else -> ""
+    val translationStack = settings.bibleSettings.translations
+    val storageDirectory = settings.bibleSettings.storageDirectory
+    // What the picker shows until the headers have been read: one row per configured translation,
+    // each named by its file stem. Same shape and length as the finished list, so the picker's row
+    // count and the positions a selection stores are right from the first frame.
+    val unreadTranslationDisplays = remember(translationStack, storageDirectory) {
+        translationNames.map { BibleTranslationDisplay(code = it, title = it, portion = "") }
+    }
+    // Reading a header is file I/O and has no business happening during composition. Kept null while
+    // in flight -- and reset to null whenever the stack changes -- so a list read for the previous
+    // stack is never shown against the current one, which would put the wrong number of rows in the
+    // picker and misalign the positions a selection is stored as.
+    val readTranslationDisplays by produceState<List<BibleTranslationDisplay>?>(
+        initialValue = null,
+        translationStack, storageDirectory, otNtPortionLabel, ntPortionLabel, otPortionLabel,
+    ) {
+        value = null
+        value = withContext(Dispatchers.IO) {
+            settings.bibleSettings.translationList().map { t ->
+                val code = t.fileName.substringBeforeLast('.')
+                val path = if (storageDirectory.isNotEmpty()) File(storageDirectory, t.fileName).absolutePath else t.fileName
+                val summary = Bible.readTranslationSummary(path)
+                val portion = when {
+                    summary?.hasOldTestament == true && summary.hasNewTestament -> otNtPortionLabel
+                    summary?.hasNewTestament == true -> ntPortionLabel
+                    summary?.hasOldTestament == true -> otPortionLabel
+                    else -> ""
+                }
+                BibleTranslationDisplay(
+                    code = code,
+                    title = summary?.title?.takeIf { it.isNotBlank() } ?: code,
+                    portion = portion,
+                )
             }
-            BibleTranslationDisplay(
-                code = code,
-                title = summary?.title?.takeIf { it.isNotBlank() } ?: code,
-                portion = portion,
-            )
         }
     }
+    val translationDisplays = readTranslationDisplays ?: unreadTranslationDisplays
     val songLangModes = listOf(Constants.SONG_LANG_OFF to offLabel, Constants.SONG_LANG_PRIMARY to lang1Label, Constants.SONG_LANG_SECONDARY to lang2Label, Constants.SONG_LANG_BOTH to bothLabel)
 
     // Shared column widths — used by both the Screen Assignment table (Card 1) and the
@@ -1751,14 +1773,27 @@ private fun ContentTranslationCell(
      */
     onShowAndSelect: (List<Int>) -> Unit,
 ) {
-    val allSelected = selected.isEmpty() || selected.size == translations.size
-    val enabledCount = if (!showing) 0 else if (selected.isEmpty()) translations.size else selected.size
+    // Which translations this output actually shows, as positions that exist in the stack it is being
+    // shown against. Everything below counts, labels, ticks and writes from this rather than from
+    // `selected`, so a position past the end of the stack -- left in a settings file written before
+    // the stack edits started remapping selections, or by hand -- is ignored consistently. Counting
+    // one used to make the menu claim "2 of 3 translations enabled" over a single ticked row, while
+    // the preview chip beside it named just the one.
+    //
+    // A stored selection that has been emptied this way shows nothing, not everything: it named
+    // translations that have gone, which is not the same statement as the empty "all of them", and
+    // reading it as "all" would put every language on a screen deliberately narrowed to one. That is
+    // the same call TranslationStackEdits makes when a remap leaves an output with nothing.
+    val tickedPositions = if (selected.isEmpty()) translations.indices.toList()
+                          else selected.filter { it in translations.indices }
+    val allSelected = tickedPositions.size == translations.size
+    val enabledCount = if (!showing) 0 else tickedPositions.size
     val selectAll: () -> Unit = { onShowAndSelect(emptyList()) }
     val dividerColor = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f)
     var dropdownOpen by remember { mutableStateOf(false) }
 
-    val selectionCount = if (selected.isEmpty()) translations.size else selected.size
-    val primaryIndex = selected.minOrNull() ?: 0
+    val selectionCount = tickedPositions.size
+    val primaryIndex = tickedPositions.minOrNull() ?: 0
     // null while off, not just when there's nothing configured: otherwise this kept previewing
     // the last-selected translation's code/portion after Bible was switched off for this output,
     // instead of reflecting that nothing is actually showing right now.
@@ -1985,7 +2020,7 @@ private fun ContentTranslationCell(
             HorizontalDivider(color = dividerColor)
             Column(modifier = Modifier.padding(vertical = 4.dp)) {
                 translations.forEachIndexed { index, info ->
-                    val selectedIn = selected.isEmpty() || index in selected
+                    val selectedIn = index in tickedPositions
                     // Off means every row reads as unticked, matching the master row's own
                     // checkbox -- the underlying selection is still remembered in `selected`,
                     // just not shown as active while Bible is off for this output.
@@ -2001,13 +2036,12 @@ private fun ContentTranslationCell(
                             // the moment any one of them was clicked.
                             onShowAndSelect(listOf(index))
                         } else if (!selectedIn) {
-                            val next = (selected + index).distinct().sorted()
+                            val next = (tickedPositions + index).distinct().sorted()
                             // Everything ticked is stored as "all", so a translation added later
                             // shows up here too rather than needing to be ticked on every output.
                             onSelectedChange(if (next.size == translations.size) emptyList() else next)
                         } else {
-                            val current = if (selected.isEmpty()) translations.indices.toList() else selected
-                            val next = current.filterNot { it == index }
+                            val next = tickedPositions.filterNot { it == index }
                             if (next.isEmpty()) {
                                 // Unchecking the last remaining translation would store the same
                                 // empty list that means "all" everywhere else in this cell -- next

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
@@ -72,6 +72,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -1705,6 +1706,24 @@ private fun ContentToggleCell(
 }
 
 /**
+ * Test tags for the per-output Bible translation picker.
+ *
+ * Every part of this cell names itself with derived text — the trigger shows a summary of the
+ * current selection, and each row shows a code and title read out of the .spb file — so a caption
+ * is not a stable way to address any of them. These tags name what a control *is* instead.
+ */
+internal object TranslationPickerTags {
+    /** The collapsed trigger segment that opens the picker. */
+    const val TRIGGER = "contentOutputs_bibleTranslationTrigger"
+
+    /** The master on/off row at the top of the open picker. */
+    const val MASTER = "contentOutputs_bibleTranslationMaster"
+
+    /** The row for the translation at stack position [index]. */
+    fun row(index: Int) = "contentOutputs_bibleTranslationRow_$index"
+}
+
+/**
  * Bible content cell: a compact two-segment trigger button (on/off, then the current translation
  * pick) that opens a floating panel with the full translation list -- collapsed by default rather
  * than always showing the full picker inline, so it reads the same as any other content-outputs
@@ -1799,6 +1818,10 @@ private fun ContentTranslationCell(
                     // this on translations.isNotEmpty() would leave no way at all to reach it in
                     // that case.
                     .clickable { dropdownOpen = true }
+                    // Tagged rather than found by caption: this segment's text is a derived summary
+                    // ("All Bibles", a code, "+N more") that changes with the selection, and a
+                    // single-selection caption repeats the code its own menu row shows.
+                    .testTag(TranslationPickerTags.TRIGGER)
                     .padding(horizontal = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
@@ -1911,6 +1934,7 @@ private fun ContentTranslationCell(
                     },
                     onClick = { if (showing) onShowingChange(false) else selectAll() },
                 )
+                .testTag(TranslationPickerTags.MASTER)
                 .padding(horizontal = 14.dp, vertical = 10.dp),
             horizontalArrangement = Arrangement.spacedBy(11.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -2004,6 +2028,9 @@ private fun ContentTranslationCell(
                             .fillMaxWidth()
                             .background(if (ticked) MaterialTheme.colorScheme.primary.copy(alpha = 0.09f) else Color.Transparent)
                             .clickable(onClick = toggle)
+                            // Tagged by stack position, which is what a selection actually stores;
+                            // the code and title beside it are file-derived and repeat elsewhere.
+                            .testTag(TranslationPickerTags.row(index))
                             .padding(start = 30.dp, end = 14.dp, top = 8.dp, bottom = 8.dp),
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                         verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenter.kt
@@ -52,13 +52,30 @@ import org.churchpresenter.app.churchpresenter.data.settings.BibleTranslationSet
 import org.churchpresenter.app.churchpresenter.models.SelectedVerse
 import org.churchpresenter.app.churchpresenter.composables.LoopingVideoBackground
 import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.utils.MIN_AUTO_FIT_FONT_SIZE
 import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
 import org.churchpresenter.app.churchpresenter.utils.Utils.systemFontFamilyOrDefault
 import org.jetbrains.skia.Image
 import java.io.File
 import kotlin.math.min
 
-private fun binarySearchFitScale(
+/**
+ * The lowest scale the parallel translation stack may shrink itself to.
+ *
+ * Expressed as a font size rather than as a scale, so it means the same thing whatever the stack is
+ * configured at: no line ends up under [MIN_AUTO_FIT_FONT_SIZE], the size every other auto-fit in the
+ * app bottoms out at. [smallestFontSize] is the smallest configured size in the stack — the first line
+ * to become unreadable — and [scaleFactor] is the output's own resolution scaling, already applied to
+ * every size before the fit scale multiplies it.
+ *
+ * A fixed 15% floor was enough for two translations but could leave a fourth block below the frame;
+ * dropping it to 3% instead traded that for eight translations rendering at around 2sp, which fits and
+ * cannot be read (issue #97). Past this floor the stack overflows and is clipped instead.
+ */
+internal fun multiTranslationMinFitScale(smallestFontSize: Int, scaleFactor: Float): Float =
+    (MIN_AUTO_FIT_FONT_SIZE / (smallestFontSize.coerceAtLeast(1) * scaleFactor)).coerceIn(0.01f, 1f)
+
+internal fun binarySearchFitScale(
     minScale: Float = 0.15f,
     iterations: Int = 8,
     fits: (scale: Float) -> Boolean
@@ -566,7 +583,10 @@ fun BiblePresenter(
                             ?: BibleTranslationSettings(fileName = verse.translationFileName)
                         verse to style
                     }
-                    BoxWithConstraints(modifier = innerModifier) {
+                    // Clipped, unlike the single-language paths that never needed it: a stack the fit
+                    // scale cannot get under the frame height (see the floor below) would otherwise
+                    // draw straight through the configured margins and off the output.
+                    BoxWithConstraints(modifier = innerModifier.clipToBounds()) {
                         val widthConstraint = Constraints(maxWidth = constraints.maxWidth)
                         fun alignment(value: String) = when (value) {
                             Constants.LEFT -> TextAlign.Start
@@ -621,11 +641,14 @@ fun BiblePresenter(
                             }
                             return contentHeight + gapCount * (gapHeight + dividerHeight)
                         }
+                        val minScale = multiTranslationMinFitScale(
+                            smallestFontSize = visible.minOf { (_, item) ->
+                                minOf(item.textFontSize, item.referenceFontSize)
+                            },
+                            scaleFactor = scaleFactor,
+                        )
                         val fitScale = if (totalHeight(1f) > constraints.maxHeight) {
-                            // A fixed 15% floor was enough for two translations but could leave the
-                            // fourth block below the clip boundary. Parallel stacks prioritise
-                            // keeping every configured translation on screen.
-                            binarySearchFitScale(minScale = 0.03f, iterations = 10) { scale ->
+                            binarySearchFitScale(minScale = minScale, iterations = 10) { scale ->
                                 totalHeight(scale) <= constraints.maxHeight
                             }
                         } else 1f

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenter.kt
@@ -598,10 +598,17 @@ fun BiblePresenter(
                             ?: BibleTranslationSettings(fileName = verse.translationFileName)
                         verse to style
                     }
-                    // Clipped, unlike the single-language paths that never needed it: a stack the fit
-                    // scale cannot get under the frame height (see the floor below) would otherwise
-                    // draw straight through the configured margins and off the output.
-                    BoxWithConstraints(modifier = innerModifier.clipToBounds()) {
+                    // Fills the frame rather than hugging its text: each translation gets an equal
+                    // band of the height and is aligned inside it, which is what the 50/50 split this
+                    // replaced did for two. Hugging left every translation bunched against the
+                    // configured alignment with the whole remainder as one empty strip -- with two
+                    // bibles and the default bottom alignment, an empty top half that read as a
+                    // section of its own.
+                    //
+                    // Clipped, unlike the single-language paths that never needed it: the fit search
+                    // below is measured against the bands, so anything it cannot get under would
+                    // otherwise draw through the configured margins and off the output.
+                    BoxWithConstraints(modifier = innerModifier.fillMaxSize().clipToBounds()) {
                         val widthConstraint = Constraints(maxWidth = constraints.maxWidth)
                         fun alignment(value: String) = when (value) {
                             Constants.LEFT -> TextAlign.Start
@@ -636,15 +643,16 @@ fun BiblePresenter(
                                 shadow = shadow,
                             )
                         }
-                        fun totalHeight(scale: Float): Int {
-                            val contentHeight = visible.sumOf { (verse, item) ->
-                                val textSize = (item.textFontSize * scaleFactor * scale).sp
-                                val refSize = (item.referenceFontSize * scaleFactor * scale).sp
-                                val textFont = systemFontFamilyOrDefault(item.textFontType)
-                                val refFont = systemFontFamilyOrDefault(item.referenceFontType)
-                                textMeasurer.measure(verse.verseText, textStyle(item).copy(fontFamily = textFont, fontSize = textSize), constraints = widthConstraint).size.height +
-                                    textMeasurer.measure(buildRefText(verse, item.showAbbreviation), referenceStyle(item).copy(fontFamily = refFont, fontSize = refSize), constraints = widthConstraint).size.height
-                            }
+                        fun blockHeight(verse: SelectedVerse, item: BibleTranslationSettings, scale: Float): Int {
+                            val textSize = (item.textFontSize * scaleFactor * scale).sp
+                            val refSize = (item.referenceFontSize * scaleFactor * scale).sp
+                            val textFont = systemFontFamilyOrDefault(item.textFontType)
+                            val refFont = systemFontFamilyOrDefault(item.referenceFontType)
+                            return textMeasurer.measure(verse.verseText, textStyle(item).copy(fontFamily = textFont, fontSize = textSize), constraints = widthConstraint).size.height +
+                                textMeasurer.measure(buildRefText(verse, item.showAbbreviation), referenceStyle(item).copy(fontFamily = refFont, fontSize = refSize), constraints = widthConstraint).size.height
+                        }
+                        // What one translation has to fit in: the frame less the gaps, split evenly.
+                        fun bandHeight(scale: Float): Int {
                             val gapCount = (visible.size - 1).coerceAtLeast(0)
                             val gapHeight = with(density) {
                                 (bs.multiTranslationSpacing * scale).dp.roundToPx()
@@ -654,21 +662,25 @@ fun BiblePresenter(
                             } else {
                                 0
                             }
-                            return contentHeight + gapCount * (gapHeight + dividerHeight)
+                            val gaps = gapCount * (gapHeight + dividerHeight)
+                            return (constraints.maxHeight - gaps) / visible.size.coerceAtLeast(1)
                         }
-                        // No floor: a stack of eight translations shrinks until the whole of every one
-                        // of them is on screen. `totalHeight` measures all of it -- verse text,
-                        // reference lines, gaps, dividers -- and everything but the 1dp dividers
-                        // shrinks with the scale, so a fitting scale always exists to be found.
-                        val fitScale = if (totalHeight(1f) > constraints.maxHeight) {
-                            binarySearchFitScale(iterations = 10) { scale ->
-                                totalHeight(scale) <= constraints.maxHeight
-                            }
-                        } else 1f
-                        Column(
-                            modifier = Modifier.fillMaxWidth().wrapContentHeight(),
-                            verticalArrangement = Arrangement.Top,
-                        ) {
+                        // One scale for the whole stack, so every translation reads at the same size,
+                        // and no floor: eight translations shrink until the whole of every one of them
+                        // is inside its band. Everything measured here scales with the argument bar the
+                        // 1dp dividers, so a fitting scale always exists to be found.
+                        //
+                        // Per band rather than against the total, now that each has its own: a long
+                        // verse can no longer borrow the slack of a short one beside it and push its
+                        // own band's text out through the clip.
+                        fun everyBlockFits(scale: Float): Boolean {
+                            val band = bandHeight(scale)
+                            return visible.all { (verse, item) -> blockHeight(verse, item, scale) <= band }
+                        }
+                        val fitScale = if (everyBlockFits(1f)) 1f else {
+                            binarySearchFitScale(iterations = 10) { scale -> everyBlockFits(scale) }
+                        }
+                        Column(modifier = Modifier.fillMaxSize()) {
                             visible.forEachIndexed { index, (verse, item) ->
                                 val textSize = (item.textFontSize * scaleFactor * fitScale).sp
                                 val refSize = (item.referenceFontSize * scaleFactor * fitScale).sp
@@ -679,12 +691,19 @@ fun BiblePresenter(
                                 val textAlign = alignment(item.textHorizontalAlignment)
                                 val refAlign = alignment(item.referenceHorizontalAlignment)
                                 val refPosition = item.referencePosition
-                                if (refPosition == Constants.POSITION_ABOVE) {
-                                    Text(buildRefText(verse, item.showAbbreviation), Modifier.fillMaxWidth(), color = refColor, fontFamily = refFont, fontSize = refSize, textAlign = refAlign, style = referenceStyle(item))
-                                }
-                                Text(verse.verseText, Modifier.fillMaxWidth(), color = textColor, fontFamily = textFont, fontSize = textSize, textAlign = textAlign, style = textStyle(item))
-                                if (refPosition == Constants.POSITION_BELOW) {
-                                    Text(buildRefText(verse, item.showAbbreviation), Modifier.fillMaxWidth(), color = refColor, fontFamily = refFont, fontSize = refSize, textAlign = refAlign, style = referenceStyle(item))
+                                Box(
+                                    modifier = Modifier.weight(1f).fillMaxWidth().clipToBounds(),
+                                    contentAlignment = contentAlignment,
+                                ) {
+                                    Column(modifier = Modifier.fillMaxWidth().wrapContentHeight()) {
+                                        if (refPosition == Constants.POSITION_ABOVE) {
+                                            Text(buildRefText(verse, item.showAbbreviation), Modifier.fillMaxWidth(), color = refColor, fontFamily = refFont, fontSize = refSize, textAlign = refAlign, style = referenceStyle(item))
+                                        }
+                                        Text(verse.verseText, Modifier.fillMaxWidth(), color = textColor, fontFamily = textFont, fontSize = textSize, textAlign = textAlign, style = textStyle(item))
+                                        if (refPosition == Constants.POSITION_BELOW) {
+                                            Text(buildRefText(verse, item.showAbbreviation), Modifier.fillMaxWidth(), color = refColor, fontFamily = refFont, fontSize = refSize, textAlign = refAlign, style = referenceStyle(item))
+                                        }
+                                    }
                                 }
                                 if (index < visible.lastIndex) {
                                     Spacer(
@@ -783,78 +802,10 @@ fun BiblePresenter(
                             }
                         }
                     }
-                } else if (showParallelLayout && !isLowerThird) {
-                    // Parallel layout: rigid 50/50 split with matched auto-fit — fullscreen only;
-                    // lower-third (either orientation) falls through to the single-column branch
-                    // below, which is constrained to the band via innerModifier.
-                    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-                        val widthConstraint = Constraints(maxWidth = constraints.maxWidth)
-                        val halfH = constraints.maxHeight / 2
-
-                        val primaryRefText = buildRefText(primary, t0.showAbbreviation)
-                        val primaryRefH = textMeasurer.measure(primaryRefText, primaryReferenceTextStyle.copy(fontFamily = primaryBibleReferenceFontStyle, fontSize = scaledPrimaryReferenceSize), constraints = widthConstraint).size.height
-                        val secondaryRefText = buildRefText(secondary, t1.showAbbreviation)
-                        val secondaryRefH = textMeasurer.measure(secondaryRefText, secondaryReferenceTextStyle.copy(fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize), constraints = widthConstraint).size.height
-
-                        // Binary search for the largest scale where both primary and secondary fit their halves
-                        val initialPH = textMeasurer.measure(primary.verseText, primaryBibleTextStyle.copy(fontFamily = primaryBibleFontStyle, fontSize = scaledPrimaryBibleSize), constraints = widthConstraint).size.height
-                        val initialSH = textMeasurer.measure(secondary.verseText, secondaryBibleTextStyle.copy(fontFamily = secondaryBibleFontStyle, fontSize = scaledSecondaryBibleSize), constraints = widthConstraint).size.height
-                        val needsScaling = (primaryRefH + initialPH > halfH) || (secondaryRefH + initialSH > halfH)
-
-                        // References scale with the verse here too -- held at full size they were a
-                        // floor no scale could get under, so a half whose reference alone overfilled it
-                        // had nothing to find and the text ran past the split.
-                        val matchedScale = if (needsScaling) {
-                            binarySearchFitScale { scale ->
-                                val pRefH = textMeasurer.measure(primaryRefText, primaryReferenceTextStyle.copy(fontFamily = primaryBibleReferenceFontStyle, fontSize = scaledPrimaryReferenceSize * scale), constraints = widthConstraint).size.height
-                                val sRefH = textMeasurer.measure(secondaryRefText, secondaryReferenceTextStyle.copy(fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize * scale), constraints = widthConstraint).size.height
-                                val pH = textMeasurer.measure(primary.verseText, primaryBibleTextStyle.copy(fontFamily = primaryBibleFontStyle, fontSize = scaledPrimaryBibleSize * scale), constraints = widthConstraint).size.height
-                                val sH = textMeasurer.measure(secondary.verseText, secondaryBibleTextStyle.copy(fontFamily = secondaryBibleFontStyle, fontSize = scaledSecondaryBibleSize * scale), constraints = widthConstraint).size.height
-                                (pRefH + pH <= halfH) && (sRefH + sH <= halfH)
-                            }
-                        } else 1f
-                        val fittedPrimaryRefSize = scaledPrimaryReferenceSize * matchedScale
-                        val fittedSecondaryRefSize = scaledSecondaryReferenceSize * matchedScale
-                        val pBibleSize = scaledPrimaryBibleSize * matchedScale
-                        val sBibleSize = scaledSecondaryBibleSize * matchedScale
-                        // Use the smaller of the two so both halves display at the same visual size
-                        val matchedBibleSize = if (sBibleSize.value < pBibleSize.value) sBibleSize else pBibleSize
-
-                        Column(modifier = Modifier.fillMaxSize()) {
-                            // ── Top half: primary bible ──
-                            Box(
-                                modifier = Modifier.weight(1f).fillMaxWidth(),
-                                contentAlignment = contentAlignment
-                            ) {
-                                Column(Modifier.fillMaxWidth().wrapContentHeight()) {
-                                    if (primaryBibleReferencePosition == Constants.POSITION_ABOVE) {
-                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = fittedPrimaryRefSize, text = primaryRefText, color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
-                                    }
-                                    Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleHorizontalAlignment, fontFamily = primaryBibleFontStyle, fontSize = matchedBibleSize, text = primary.verseText, color = primaryBibleTextColor, style = primaryBibleTextStyleScaled)
-                                    if (primaryBibleReferencePosition == Constants.POSITION_BELOW) {
-                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = fittedPrimaryRefSize, text = primaryRefText, color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
-                                    }
-                                }
-                            }
-                            // ── Bottom half: secondary bible ──
-                            Box(
-                                modifier = Modifier.weight(1f).fillMaxWidth(),
-                                contentAlignment = contentAlignment
-                            ) {
-                                Column(Modifier.fillMaxWidth().wrapContentHeight()) {
-                                    if (secondaryBibleReferencePosition == Constants.POSITION_ABOVE) {
-                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = fittedSecondaryRefSize, text = secondaryRefText, color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
-                                    }
-                                    Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleHorizontalAlignment, fontFamily = secondaryBibleFontStyle, fontSize = matchedBibleSize, text = secondary.verseText, color = secondaryBibleTextColor, style = secondaryBibleTextStyleScaled)
-                                    if (secondaryBibleReferencePosition == Constants.POSITION_BELOW) {
-                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = fittedSecondaryRefSize, text = secondaryRefText, color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
-                                    }
-                                }
-                            }
-                        }
-                    }
                 } else {
-                    // Original single-column layout (no secondary, or lower-third)
+                    // Single-column layout: the lower third, in either orientation, with or without a
+                    // second language. Full screen never reaches here -- the stack above returns for
+                    // every !isLowerThird case, whatever the stack holds.
                     BoxWithConstraints(
                         modifier = innerModifier,
                         contentAlignment = if (isLowerThird) Alignment.BottomCenter else contentAlignment

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenter.kt
@@ -52,7 +52,6 @@ import org.churchpresenter.app.churchpresenter.data.settings.BibleTranslationSet
 import org.churchpresenter.app.churchpresenter.models.SelectedVerse
 import org.churchpresenter.app.churchpresenter.composables.LoopingVideoBackground
 import org.churchpresenter.app.churchpresenter.utils.Constants
-import org.churchpresenter.app.churchpresenter.utils.MIN_AUTO_FIT_FONT_SIZE
 import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
 import org.churchpresenter.app.churchpresenter.utils.Utils.systemFontFamilyOrDefault
 import org.jetbrains.skia.Image
@@ -60,27 +59,43 @@ import java.io.File
 import kotlin.math.min
 
 /**
- * The lowest scale the parallel translation stack may shrink itself to.
+ * The smallest scale the search below will go down to before giving up.
  *
- * Expressed as a font size rather than as a scale, so it means the same thing whatever the stack is
- * configured at: no line ends up under [MIN_AUTO_FIT_FONT_SIZE], the size every other auto-fit in the
- * app bottoms out at. [smallestFontSize] is the smallest configured size in the stack — the first line
- * to become unreadable — and [scaleFactor] is the output's own resolution scaling, already applied to
- * every size before the fit scale multiplies it.
- *
- * A fixed 15% floor was enough for two translations but could leave a fourth block below the frame;
- * dropping it to 3% instead traded that for eight translations rendering at around 2sp, which fits and
- * cannot be read (issue #97). Past this floor the stack overflows and is clipped instead.
+ * Only a backstop against a `fits` predicate that can never be satisfied — one whose height does not
+ * actually depend on the scale it is handed. It sits four orders of magnitude below full size, which
+ * is far past anything real: the worst genuine case, every translation of a long passage crammed into
+ * a lower-third band, overflows by tens of times, not thousands. Nothing legible lives down here; a
+ * fit found anywhere near it means the layout has a problem no fit scale can solve.
  */
-internal fun multiTranslationMinFitScale(smallestFontSize: Int, scaleFactor: Float): Float =
-    (MIN_AUTO_FIT_FONT_SIZE / (smallestFontSize.coerceAtLeast(1) * scaleFactor)).coerceIn(0.01f, 1f)
+private const val MIN_FIT_SCALE = 0.0001f
 
+/**
+ * The largest scale at or below 1 whose content fits, per [fits].
+ *
+ * **Fitting is the guarantee.** Verse text shrinks to stay whole; it is never cut off to keep a size,
+ * however many translations are stacked or however long the passage. So this does not take a floor:
+ * full size is returned when it fits, and otherwise it starts from [startScale], halving while that
+ * does not fit — down to [MIN_FIT_SCALE] — before bisecting upward for the largest scale that does.
+ *
+ * That halving is the part it used to be missing. It began at a fixed 15% floor and returned that
+ * floor without ever testing it, so a caller could not tell "the largest scale that fits" from
+ * "nothing in range fits" and got silent overflow for the second (issue #97). Raising the floor made
+ * that worse rather than better: it turned unreadably-small into cut-off.
+ *
+ * A caveat for callers: everything contributing to the measured height has to scale with the argument.
+ * A predicate holding part of its height fixed — a reference line measured once at full size — can be
+ * unsatisfiable at any scale, and no search can rescue that.
+ */
 internal fun binarySearchFitScale(
-    minScale: Float = 0.15f,
+    startScale: Float = 0.15f,
     iterations: Int = 8,
     fits: (scale: Float) -> Boolean
 ): Float {
-    var lo = minScale
+    if (fits(1f)) return 1f
+    var lo = startScale.coerceIn(MIN_FIT_SCALE, 1f)
+    while (lo > MIN_FIT_SCALE && !fits(lo)) {
+        lo = (lo / 2f).coerceAtLeast(MIN_FIT_SCALE)
+    }
     var hi = 1f
     repeat(iterations) {
         val mid = (lo + hi) / 2f
@@ -641,14 +656,12 @@ fun BiblePresenter(
                             }
                             return contentHeight + gapCount * (gapHeight + dividerHeight)
                         }
-                        val minScale = multiTranslationMinFitScale(
-                            smallestFontSize = visible.minOf { (_, item) ->
-                                minOf(item.textFontSize, item.referenceFontSize)
-                            },
-                            scaleFactor = scaleFactor,
-                        )
+                        // No floor: a stack of eight translations shrinks until the whole of every one
+                        // of them is on screen. `totalHeight` measures all of it -- verse text,
+                        // reference lines, gaps, dividers -- and everything but the 1dp dividers
+                        // shrinks with the scale, so a fitting scale always exists to be found.
                         val fitScale = if (totalHeight(1f) > constraints.maxHeight) {
-                            binarySearchFitScale(minScale = minScale, iterations = 10) { scale ->
+                            binarySearchFitScale(iterations = 10) { scale ->
                                 totalHeight(scale) <= constraints.maxHeight
                             }
                         } else 1f
@@ -788,13 +801,20 @@ fun BiblePresenter(
                         val initialSH = textMeasurer.measure(secondary.verseText, secondaryBibleTextStyle.copy(fontFamily = secondaryBibleFontStyle, fontSize = scaledSecondaryBibleSize), constraints = widthConstraint).size.height
                         val needsScaling = (primaryRefH + initialPH > halfH) || (secondaryRefH + initialSH > halfH)
 
+                        // References scale with the verse here too -- held at full size they were a
+                        // floor no scale could get under, so a half whose reference alone overfilled it
+                        // had nothing to find and the text ran past the split.
                         val matchedScale = if (needsScaling) {
                             binarySearchFitScale { scale ->
+                                val pRefH = textMeasurer.measure(primaryRefText, primaryReferenceTextStyle.copy(fontFamily = primaryBibleReferenceFontStyle, fontSize = scaledPrimaryReferenceSize * scale), constraints = widthConstraint).size.height
+                                val sRefH = textMeasurer.measure(secondaryRefText, secondaryReferenceTextStyle.copy(fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize * scale), constraints = widthConstraint).size.height
                                 val pH = textMeasurer.measure(primary.verseText, primaryBibleTextStyle.copy(fontFamily = primaryBibleFontStyle, fontSize = scaledPrimaryBibleSize * scale), constraints = widthConstraint).size.height
                                 val sH = textMeasurer.measure(secondary.verseText, secondaryBibleTextStyle.copy(fontFamily = secondaryBibleFontStyle, fontSize = scaledSecondaryBibleSize * scale), constraints = widthConstraint).size.height
-                                (primaryRefH + pH <= halfH) && (secondaryRefH + sH <= halfH)
+                                (pRefH + pH <= halfH) && (sRefH + sH <= halfH)
                             }
                         } else 1f
+                        val fittedPrimaryRefSize = scaledPrimaryReferenceSize * matchedScale
+                        val fittedSecondaryRefSize = scaledSecondaryReferenceSize * matchedScale
                         val pBibleSize = scaledPrimaryBibleSize * matchedScale
                         val sBibleSize = scaledSecondaryBibleSize * matchedScale
                         // Use the smaller of the two so both halves display at the same visual size
@@ -808,11 +828,11 @@ fun BiblePresenter(
                             ) {
                                 Column(Modifier.fillMaxWidth().wrapContentHeight()) {
                                     if (primaryBibleReferencePosition == Constants.POSITION_ABOVE) {
-                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = scaledPrimaryReferenceSize, text = primaryRefText, color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
+                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = fittedPrimaryRefSize, text = primaryRefText, color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
                                     }
                                     Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleHorizontalAlignment, fontFamily = primaryBibleFontStyle, fontSize = matchedBibleSize, text = primary.verseText, color = primaryBibleTextColor, style = primaryBibleTextStyleScaled)
                                     if (primaryBibleReferencePosition == Constants.POSITION_BELOW) {
-                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = scaledPrimaryReferenceSize, text = primaryRefText, color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
+                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = fittedPrimaryRefSize, text = primaryRefText, color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
                                     }
                                 }
                             }
@@ -823,11 +843,11 @@ fun BiblePresenter(
                             ) {
                                 Column(Modifier.fillMaxWidth().wrapContentHeight()) {
                                     if (secondaryBibleReferencePosition == Constants.POSITION_ABOVE) {
-                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize, text = secondaryRefText, color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
+                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = fittedSecondaryRefSize, text = secondaryRefText, color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
                                     }
                                     Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleHorizontalAlignment, fontFamily = secondaryBibleFontStyle, fontSize = matchedBibleSize, text = secondary.verseText, color = secondaryBibleTextColor, style = secondaryBibleTextStyleScaled)
                                     if (secondaryBibleReferencePosition == Constants.POSITION_BELOW) {
-                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize, text = secondaryRefText, color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
+                                        Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = fittedSecondaryRefSize, text = secondaryRefText, color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
                                     }
                                 }
                             }
@@ -853,10 +873,13 @@ fun BiblePresenter(
                             constraints = widthConstraint
                         ).size.height
 
+                        // Hoisted out of the height calculation below so the fit search can re-measure
+                        // it at each candidate scale. Empty when there is no second language, which is
+                        // the same as the zero height that branch contributes.
+                        val secondaryRefText = secondary?.let { buildRefText(it, t1.showAbbreviation) } ?: ""
                         val secondaryRefH = if (showSecondary) {
-                            val secRefText = buildRefText(secondary, t1.showAbbreviation)
                             textMeasurer.measure(
-                                text = secRefText,
+                                text = secondaryRefText,
                                 style = secondaryReferenceTextStyle.copy(fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize),
                                 constraints = widthConstraint
                             ).size.height
@@ -870,17 +893,26 @@ fun BiblePresenter(
                         } else 0
 
                         val totalH = primaryRefH + primaryVerseH + secondaryRefH + secondaryVerseH
-                        val fixedH = primaryRefH + secondaryRefH
                         val maxH = constraints.maxHeight
+                        // The reference lines scale with the verse rather than staying at full size.
+                        // Held fixed, they were a floor the search could not get under: a band whose
+                        // references alone overfill it had no fitting scale to find, so the text ran off
+                        // the bottom however far the verse shrank. This is also the lower third's path.
                         val fitScale = if (totalH > maxH) {
                             binarySearchFitScale { scale ->
+                                val pRefH = textMeasurer.measure(primaryRefText, primaryReferenceTextStyle.copy(fontFamily = primaryBibleReferenceFontStyle, fontSize = scaledPrimaryReferenceSize * scale), constraints = widthConstraint).size.height
                                 val pH = textMeasurer.measure(primary.verseText, primaryBibleTextStyle.copy(fontFamily = primaryBibleFontStyle, fontSize = scaledPrimaryBibleSize * scale), constraints = widthConstraint).size.height
+                                val sRefH = if (showSecondary) {
+                                    textMeasurer.measure(secondaryRefText, secondaryReferenceTextStyle.copy(fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize * scale), constraints = widthConstraint).size.height
+                                } else 0
                                 val sH = if (showSecondary) {
                                     textMeasurer.measure(secondary.verseText, secondaryBibleTextStyle.copy(fontFamily = secondaryBibleFontStyle, fontSize = scaledSecondaryBibleSize * scale), constraints = widthConstraint).size.height
                                 } else 0
-                                fixedH + pH + sH <= maxH
+                                pRefH + pH + sRefH + sH <= maxH
                             }
                         } else 1f
+                        val fittedPrimaryRefSize = scaledPrimaryReferenceSize * fitScale
+                        val fittedSecondaryRefSize = scaledSecondaryReferenceSize * fitScale
                         val fittedPrimaryBibleSize = scaledPrimaryBibleSize * fitScale
                         val fittedSecondaryBibleSize = scaledSecondaryBibleSize * fitScale
                         // Use the smaller so both primary and secondary display at the same visual size
@@ -892,22 +924,22 @@ fun BiblePresenter(
                         ) {
                             if (primaryBibleReferencePosition == Constants.POSITION_ABOVE) {
                                 val bookNameOrAbbr = if (t0.showAbbreviation && primary.bibleAbbreviation.isNotEmpty()) primary.bibleAbbreviation else ""
-                                Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = scaledPrimaryReferenceSize, text = "$bookNameOrAbbr ${primary.bookName} ${primary.chapter}:$primaryVerseRef", color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
+                                Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = fittedPrimaryRefSize, text = "$bookNameOrAbbr ${primary.bookName} ${primary.chapter}:$primaryVerseRef", color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
                             }
                             Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleHorizontalAlignment, fontFamily = primaryBibleFontStyle, fontSize = matchedFittedSize, text = primary.verseText, color = primaryBibleTextColor, style = primaryBibleTextStyleScaled)
                             if (primaryBibleReferencePosition == Constants.POSITION_BELOW) {
                                 val bookNameOrAbbr = if (t0.showAbbreviation && primary.bibleAbbreviation.isNotEmpty()) primary.bibleAbbreviation else ""
-                                Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = scaledPrimaryReferenceSize, text = "$bookNameOrAbbr ${primary.bookName} ${primary.chapter}:$primaryVerseRef", color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
+                                Text(modifier = Modifier.fillMaxWidth(), textAlign = primaryBibleReferenceHorizontalAlignment, fontFamily = primaryBibleReferenceFontStyle, fontSize = fittedPrimaryRefSize, text = "$bookNameOrAbbr ${primary.bookName} ${primary.chapter}:$primaryVerseRef", color = primaryBibleReferenceTextColor, style = primaryReferenceTextStyleScaled)
                             }
                             if (showSecondary) {
                                 if (secondaryBibleReferencePosition == Constants.POSITION_ABOVE) {
                                     val bookNameOrAbbr = if (t1.showAbbreviation && secondary.bibleAbbreviation.isNotEmpty()) secondary.bibleAbbreviation else ""
-                                    Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize, text = "$bookNameOrAbbr ${secondary.bookName} ${secondary.chapter}:$secondaryVerseRef", color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
+                                    Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = fittedSecondaryRefSize, text = "$bookNameOrAbbr ${secondary.bookName} ${secondary.chapter}:$secondaryVerseRef", color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
                                 }
                                 Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleHorizontalAlignment, fontFamily = secondaryBibleFontStyle, fontSize = matchedFittedSize, text = secondary.verseText, color = secondaryBibleTextColor, style = secondaryBibleTextStyleScaled)
                                 if (secondaryBibleReferencePosition == Constants.POSITION_BELOW) {
                                     val bookNameOrAbbr = if (t1.showAbbreviation && secondary.bibleAbbreviation.isNotEmpty()) secondary.bibleAbbreviation else ""
-                                    Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = scaledSecondaryReferenceSize, text = "$bookNameOrAbbr ${secondary.bookName} ${secondary.chapter}:$secondaryVerseRef", color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
+                                    Text(modifier = Modifier.fillMaxWidth(), textAlign = secondaryBibleReferenceHorizontalAlignment, fontFamily = secondaryBibleReferenceFontStyle, fontSize = fittedSecondaryRefSize, text = "$bookNameOrAbbr ${secondary.bookName} ${secondary.chapter}:$secondaryVerseRef", color = secondaryBibleReferenceTextColor, style = secondaryReferenceTextStyleScaled)
                                 }
                             }
                         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -269,9 +269,10 @@ fun BibleTab(
     bibleEngineClient: BibleEngineClient? = null,
     dialogDismissSignal: Int = 0,
 ) {
-    // Reload the Bible modules whenever the active mode or its ordered file list changes.
-    // Multi mode deliberately leaves legacy primary/secondary fields untouched, so those fields
-    // cannot be used as the only effect keys.
+    // Hand the Bible modules any change to the active mode or its ordered file list. Multi mode
+    // deliberately leaves legacy primary/secondary fields untouched, so those fields cannot be used
+    // as the only effect keys. Whether a given change needs a re-read off disk or just a rearrange
+    // of what is already loaded is BibleViewModel.updateSettings's call, not this key's.
     val isFirstComposition = remember { mutableStateOf(true) }
     val translationSelectionKey = appSettings.bibleSettings.translationSelectionKey()
     LaunchedEffect(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -52,13 +52,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -76,6 +79,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.isSecondary
 import org.churchpresenter.app.churchpresenter.data.StatisticsManager
+import org.churchpresenter.app.churchpresenter.data.bibleDisplayNames
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import java.awt.Cursor
@@ -223,7 +227,6 @@ import org.churchpresenter.app.churchpresenter.models.SelectedVerse
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleSearchMode
 import org.churchpresenter.app.churchpresenter.utils.highlightRanges
-import org.churchpresenter.app.churchpresenter.viewmodel.BibleSettingsViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
 import org.jetbrains.compose.resources.painterResource
@@ -1567,13 +1570,18 @@ fun BibleTab(
                         )
                     } else if (appSettings.bibleSettings.translationList().size > 2) {
                         val translations = appSettings.bibleSettings.translationList()
-                        val translationDisplayNames = remember(
-                            appSettings.bibleSettings.storageDirectory,
+                        // One header read per translation, so it does not belong in a `remember`
+                        // (which runs it during composition) and it certainly does not need a whole
+                        // BibleSettingsViewModel built to reach the helper. Until it lands, the
+                        // options below fall back to file stems on their own.
+                        val storageDirectory = appSettings.bibleSettings.storageDirectory
+                        val translationDisplayNames by produceState(
+                            initialValue = emptyMap<String, String>(),
+                            storageDirectory,
                             translationSelectionKey,
                         ) {
-                            BibleSettingsViewModel().run {
-                                setDirectory(appSettings.bibleSettings.storageDirectory)
-                                fileDisplayNames(translations.map { it.fileName })
+                            value = withContext(Dispatchers.IO) {
+                                bibleDisplayNames(storageDirectory, translations.map { it.fileName })
                             }
                         }
                         DropdownSelector(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/Theme.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/Theme.kt
@@ -127,6 +127,25 @@ val AppTypography = Typography(
     )
 )
 
+/*
+ * Every scheme below sets `surfaceContainer` and `surfaceContainerHigh` explicitly, because the
+ * settings screens are built out of exactly three layers and all three have to be told apart:
+ *
+ *   surfaceVariant       the page a settings tab paints edge to edge
+ *   surfaceContainer     the cards on it (`SettingsSection`)
+ *   surfaceContainerHigh the input fields on those cards (`SettingsTextField`)
+ *
+ * None of the nine schemes used to declare the container roles at all, so both came from the M3
+ * baseline palette instead of the theme's own — a lavender-tinted card and field on a navy or green
+ * page, identical in all nine themes. The contrast that resulted was accidental rather than chosen,
+ * and in the Studio theme the card was *exactly* the luminance of its own page (issue #95).
+ *
+ * The values are derived from each scheme's own `surface`, stepped toward white (dark) or white then
+ * black (light) far enough that the card clears its page and the field clears its card by at least
+ * ~1.12:1 in every theme — the invariant `ThemeSurfaceRampTest` holds them to. Keep any new theme in
+ * that shape: adding one without these two roles silently falls back to the baseline lavender again.
+ */
+
 // Light theme colors — neutral grey palette
 private val LightColorScheme = lightColorScheme(
     primary = Color(0xFF4A5568),           // muted slate-grey
@@ -149,6 +168,8 @@ private val LightColorScheme = lightColorScheme(
     onSurface = Color(0xFF1A1A1A),
     surfaceVariant = Color(0xFFE2E2E5),    // slightly darker grey, no purple
     onSurfaceVariant = Color(0xFF44444A),
+    surfaceContainer = Color(0xFFF9F9FA),
+    surfaceContainerHigh = Color(0xFFEDEDEE),
     outline = Color(0xFF8A8A94),
     outlineVariant = Color(0xFFCCCCD0),
     // Custom colors for buttons
@@ -178,6 +199,8 @@ private val WarmColorScheme = lightColorScheme(
     onSurface = Color(0xFF1E150A),
     surfaceVariant = Color(0xFFEBDFC8),
     onSurfaceVariant = Color(0xFF4A3820),
+    surfaceContainer = Color(0xFFFBF8F0),
+    surfaceContainerHigh = Color(0xFFEEECE4),
     outline = Color(0xFF9C8060),
     outlineVariant = Color(0xFFD9C8A8),
     inverseSurface = Color(0xFF4CAF50),
@@ -206,6 +229,8 @@ private val OceanColorScheme = lightColorScheme(
     onSurface = Color(0xFF0A1A22),
     surfaceVariant = Color(0xFFCCE2EE),
     onSurfaceVariant = Color(0xFF1E3D50),
+    surfaceContainer = Color(0xFFF3F9FC),
+    surfaceContainerHigh = Color(0xFFE7EDEF),
     outline = Color(0xFF5A8FAA),
     outlineVariant = Color(0xFFAAD0E0),
     inverseSurface = Color(0xFF4CAF50),
@@ -234,6 +259,8 @@ private val RoseColorScheme = lightColorScheme(
     onSurface = Color(0xFF1E0A10),
     surfaceVariant = Color(0xFFEDD5DA),
     onSurfaceVariant = Color(0xFF4A2030),
+    surfaceContainer = Color(0xFFFBF6F7),
+    surfaceContainerHigh = Color(0xFFEEEAEB),
     outline = Color(0xFFA06070),
     outlineVariant = Color(0xFFDDB8C0),
     inverseSurface = Color(0xFF4CAF50),
@@ -262,6 +289,8 @@ private val DarkColorScheme = darkColorScheme(
     onSurface = Color(0xFFE6E1E5),
     surfaceVariant = Color(0xFF49454F),
     onSurfaceVariant = Color(0xFFCAC4D0),
+    surfaceContainer = Color(0xFF2E2E2E),
+    surfaceContainerHigh = Color(0xFF363636),
     outline = Color(0xFF938F99),
     outlineVariant = Color(0xFF49454F),
     inverseSurface = Color(0xFF66BB6A),
@@ -292,6 +321,8 @@ private val StudioColorScheme = darkColorScheme(
     onSurface = Color(0xFFE8E4D8),
     surfaceVariant = Color(0xFF182030),
     onSurfaceVariant = Color(0xFFBFBCB0),
+    surfaceContainer = Color(0xFF272A32),
+    surfaceContainerHigh = Color(0xFF30333A),
     outline = Color(0xFF555868),
     outlineVariant = Color(0xFF252830),
     inverseSurface = Color(0xFF66BB6A),
@@ -320,6 +351,8 @@ private val MidnightColorScheme = darkColorScheme(
     onSurface = Color(0xFFDDE4F0),
     surfaceVariant = Color(0xFF1E2A3A),
     onSurfaceVariant = Color(0xFFB0BDD0),
+    surfaceContainer = Color(0xFF2D333D),
+    surfaceContainerHigh = Color(0xFF353B45),
     outline = Color(0xFF5A7090),
     outlineVariant = Color(0xFF1E2A3A),
     inverseSurface = Color(0xFF66BB6A),
@@ -348,6 +381,8 @@ private val ForestColorScheme = darkColorScheme(
     onSurface = Color(0xFFD0E8D8),
     surfaceVariant = Color(0xFF1A2A1E),
     onSurfaceVariant = Color(0xFFA8C8B0),
+    surfaceContainer = Color(0xFF29312A),
+    surfaceContainerHigh = Color(0xFF323933),
     outline = Color(0xFF486858),
     outlineVariant = Color(0xFF1A2A1E),
     inverseSurface = Color(0xFF66BB6A),
@@ -376,6 +411,8 @@ private val MochaColorScheme = darkColorScheme(
     onSurface = Color(0xFFCDD6F4),
     surfaceVariant = Color(0xFF302840),
     onSurfaceVariant = Color(0xFFBAC2E8),
+    surfaceContainer = Color(0xFF36343F),
+    surfaceContainerHigh = Color(0xFF3E3C47),
     outline = Color(0xFF6C7086),
     outlineVariant = Color(0xFF302840),
     inverseSurface = Color(0xFF66BB6A),

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/AutoFitUtils.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/AutoFitUtils.kt
@@ -8,6 +8,16 @@ import androidx.compose.ui.unit.sp
 import org.churchpresenter.app.churchpresenter.models.LyricSection
 
 /**
+ * The smallest font size any auto-fit in the app will settle on, in settings units at the 1920×1080
+ * reference resolution.
+ *
+ * Text below this is not readable from a pew, so a fit that cannot be reached without going under it
+ * stops here and lets the content overflow (clipped) instead — an obviously-too-long verse reads
+ * better cut off than rendered at a size nobody can make out.
+ */
+const val MIN_AUTO_FIT_FONT_SIZE = 8
+
+/**
  * Binary-searches for the largest font size (in settings units, before scaleFactor)
  * whose rendered text fits within [availableWidth] × [availableHeight] pixels
  * at the 1920×1080 reference resolution (scaleFactor = 1).
@@ -25,11 +35,11 @@ fun calculateAutoFitFontSize(
     availableWidth: Int,
     availableHeight: Int,
 ): Int {
-    if (text.isBlank() || availableWidth <= 0 || availableHeight <= 0) return 8
+    if (text.isBlank() || availableWidth <= 0 || availableHeight <= 0) return MIN_AUTO_FIT_FONT_SIZE
     val referenceDensity = Density(1f)
     val lines = text.split("\n")
     val widthConstraints = Constraints(maxWidth = availableWidth)
-    var low = 8
+    var low = MIN_AUTO_FIT_FONT_SIZE
     var high = 300
     while (high - low > 1) {
         val mid = (low + high) / 2
@@ -44,7 +54,7 @@ fun calculateAutoFitFontSize(
         }
         if (totalHeight <= availableHeight) low = mid else high = mid
     }
-    return (low - 1).coerceAtLeast(8)
+    return (low - 1).coerceAtLeast(MIN_AUTO_FIT_FONT_SIZE)
 }
 
 /**
@@ -60,16 +70,16 @@ fun calculateAutoFitForAllSections(
     reservedHeight: Int = 0,
     includeEndIndicator: Boolean = false,
 ): Int {
-    if (sections.isEmpty() || availableWidth <= 0 || availableHeight <= 0) return 8
+    if (sections.isEmpty() || availableWidth <= 0 || availableHeight <= 0) return MIN_AUTO_FIT_FONT_SIZE
     val allLines = sections.flatMap { it.lines }
-    if (allLines.all { it.isBlank() }) return 8
+    if (allLines.all { it.isBlank() }) return MIN_AUTO_FIT_FONT_SIZE
 
     val effectiveHeight = (availableHeight - reservedHeight).coerceAtLeast(1)
     val referenceDensity = Density(1f)
     // Use unconstrained width to measure natural line width (no wrapping)
     val unconstrainedConstraints = Constraints()
 
-    var low = 8
+    var low = MIN_AUTO_FIT_FONT_SIZE
     var high = 300
     while (high - low > 1) {
         val mid = (low + high) / 2
@@ -119,5 +129,5 @@ fun calculateAutoFitForAllSections(
         }
         if (fits) low = mid else high = mid
     }
-    return (low - 1).coerceAtLeast(8)
+    return (low - 1).coerceAtLeast(MIN_AUTO_FIT_FONT_SIZE)
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
@@ -209,6 +209,13 @@ object Constants {
     // and used as the fallback target when a download is started before a folder has been picked.
     const val DEFAULT_BIBLES_DIR = ".churchpresenter/Bibles"
 
+    // How many translations the parallel Bible stack may hold. Full screen gives each one an equal
+    // band of the output height, and auto-fit shrinks the text until it fits its band -- with no
+    // floor, so a deeper stack does not overflow, it just goes on getting smaller. Six bands is
+    // already past what an audience can read; the cap is where that stops being the operator's
+    // problem to notice.
+    const val MAX_BIBLE_TRANSLATIONS = 6
+
     // File Extensions
     const val EXTENSION_SPS = "sps"
     const val EXTENSION_SPB = "spb"

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleSettingsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleSettingsViewModel.kt
@@ -1,8 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
 import androidx.compose.runtime.mutableStateOf
-import java.io.File
-import java.nio.charset.StandardCharsets
+import org.churchpresenter.app.churchpresenter.data.bibleDisplayNames
 
 class BibleSettingsViewModel {
 
@@ -22,26 +21,9 @@ class BibleSettingsViewModel {
     fun filesInDirectory(): List<String> =
         fileManager.getBibleFilesInDirectory(_storageDirectory.value)
 
-    /**
-     * Maps each Bible file to the name shown in the pickers.
-     *
-     * The picker reverse-maps the chosen display name back to its file, so these must be UNIQUE.
-     * Two files can carry the same `##Title:` — a collection nests one folder per translation and
-     * commonly holds several editions of one version — so a repeated title is qualified with the
-     * folder it came from, which is what distinguishes them to the user as well.
-     */
-    fun fileDisplayNames(files: List<String>): Map<String, String> {
-        val dir = _storageDirectory.value
-        if (dir.isEmpty()) return emptyMap()
-        val titles = files.associateWith { extractBibleTitle(File(dir, it).absolutePath) }
-        val duplicated = titles.values.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
-        return titles.mapValues { (path, title) ->
-            if (title !in duplicated) return@mapValues title
-            val folder = path.substringBeforeLast('/', "")
-            // Two files sharing a title AND a folder can only be told apart by their file names.
-            if (folder.isEmpty()) "$title  ($path)" else "$title  ($folder)"
-        }
-    }
+    /** Maps each Bible file to the name shown in the pickers — see [bibleDisplayNames]. */
+    fun fileDisplayNames(files: List<String>): Map<String, String> =
+        bibleDisplayNames(_storageDirectory.value, files)
 
     // ── Actions ──────────────────────────────────────────────────────
 
@@ -63,23 +45,5 @@ class BibleSettingsViewModel {
 
     val fileManager = FileManager()
 
-    private fun extractBibleTitle(filePath: String): String {
-        return try {
-            File(filePath).bufferedReader(StandardCharsets.UTF_8).use { reader ->
-                var title: String? = null
-                repeat(10) {
-                    val line = reader.readLine() ?: return@use (title ?: File(filePath).nameWithoutExtension)
-                    if (line.startsWith("##Title:")) {
-                        val t = line.substring(8).trim()
-                        title = t
-                        return@use t
-                    }
-                }
-                title ?: File(filePath).nameWithoutExtension
-            }
-        } catch (_: Exception) {
-            File(filePath).nameWithoutExtension
-        }
-    }
 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleSettings
 import org.churchpresenter.app.churchpresenter.data.settings.BibleSyncMode
 import org.churchpresenter.app.churchpresenter.data.Bible
 import org.churchpresenter.app.churchpresenter.utils.InstanceLinkLogSide
@@ -431,9 +432,67 @@ class BibleViewModel(
         loadBibles()
     }
 
+    /**
+     * Takes a settings change, reloading from disk only when the change actually calls for it.
+     *
+     * Reordering the stack does not. Every .spb in it is already parsed and held in memory, so a new
+     * order can be applied by permuting what is loaded — see [applyTranslationOrder]. Reloading
+     * instead re-parsed every translation, and because [loadBibles] republishes a books-only bible
+     * while it works, the verse list went blank under whatever was live for as long as that took
+     * (issue #96).
+     */
     fun updateSettings(newSettings: AppSettings) {
+        val previous = appSettings
         appSettings = newSettings
-        loadBibles()
+        if (translationReloadRequired(previous.bibleSettings, newSettings.bibleSettings)) {
+            loadBibles()
+        } else {
+            applyTranslationOrder()
+        }
+    }
+
+    /**
+     * Whether going from [previous] to [next] needs the translations read off disk again.
+     *
+     * Only two things do: a different set of files, and a different navigation bible — the first of
+     * the stack, which supplies the book/chapter/verse lists and the canonical code every other
+     * translation's verse is looked up by, so swapping it is a genuine reload rather than a
+     * rearrangement. Anything else about the stack, its order included, is the same files already in
+     * memory.
+     */
+    internal fun translationReloadRequired(previous: BibleSettings, next: BibleSettings): Boolean {
+        if (previous.storageDirectory != next.storageDirectory) return true
+        val before = previous.translationSelectionKey()
+        val after = next.translationSelectionKey()
+        if (before.firstOrNull() != after.firstOrNull()) return true
+        return before.toSet() != after.toSet()
+    }
+
+    /**
+     * Rearranges the loaded translations to the configured order without touching the filesystem.
+     *
+     * Bails out to a full [loadBibles] if the two cannot be matched up one to one, which would mean
+     * the loaded set and the configured set had drifted apart — the case [updateSettings] reloads
+     * for, reached by some path that did not check.
+     */
+    private fun applyTranslationOrder() {
+        val current = _loadedTranslations.value
+        if (current.isEmpty()) return
+        val desired = appSettings.bibleSettings.translationSelectionKey()
+        val reordered = desired.mapNotNull { fileName -> current.firstOrNull { it.fileName == fileName } }
+        if (reordered.size != current.size) {
+            loadBibles()
+            return
+        }
+        if (reordered == current) return
+        _loadedTranslations.value = reordered
+        _loadedBibles.value = reordered.map { it.bible }
+        // Kept in step for the benefit of everything still reading the legacy pair; the navigation
+        // bible cannot have moved, or this would have been a reload.
+        _secondaryBible.value = reordered.getOrNull(1)?.bible
+        // Re-emits the live selection so what is on screen restacks in the new order. Same bump
+        // loadBibles() ends on, and for the same reason.
+        if (_verses.value.isNotEmpty()) _verseSelectionToken.value++
     }
 
     // ── Instance Link — remote bible ─────────────────────────────────────────

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/DictionaryViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/DictionaryViewModel.kt
@@ -18,7 +18,7 @@ import org.churchpresenter.app.churchpresenter.data.InterlinearVerse
 import org.churchpresenter.app.churchpresenter.data.StrongsEntry
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import java.io.File
-import java.nio.charset.StandardCharsets
+import org.churchpresenter.app.churchpresenter.data.readTranslationTitle
 
 enum class DictionaryLanguageFilter { ALL, HEBREW, GREEK }
 
@@ -213,7 +213,7 @@ class DictionaryViewModel {
                 dir.walkTopDown().maxDepth(FileManager.MAX_BIBLE_SCAN_DEPTH)
                     .filter { it.isFile && it.extension.lowercase() == "spb" }
                     .sortedBy { it.absolutePath }
-                    .map { f -> f.absolutePath to extractBibleTitle(f) }
+                    .map { f -> f.absolutePath to readTranslationTitle(f) }
                     .toList()
             }
         }
@@ -232,20 +232,6 @@ class DictionaryViewModel {
             } finally {
                 isDictBibleLoading = false
             }
-        }
-    }
-
-    private fun extractBibleTitle(file: File): String {
-        return try {
-            file.bufferedReader(StandardCharsets.UTF_8).use { reader ->
-                repeat(10) {
-                    val line = reader.readLine() ?: return@use file.nameWithoutExtension
-                    if (line.startsWith("##Title:")) return@use line.substring(8).trim()
-                }
-                file.nameWithoutExtension
-            }
-        } catch (_: Exception) {
-            file.nameWithoutExtension
         }
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SettingsTextFieldTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SettingsTextFieldTest.kt
@@ -13,21 +13,26 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performImeAction
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -292,5 +297,98 @@ class SettingsTextFieldTest {
             "fillWidth = true must expand to the parent's width (wide=$wideWidth) rather than wrap to the " +
                 "label's intrinsic width (narrow=$narrowWidth)",
         )
+    }
+
+    // ── Focus ───────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Whether any pixel along the node's top edge is [color], within a tolerance for the blending of
+     * a 1dp line.
+     *
+     * The edge is sampled rather than one chosen pixel: which column of it is pure border depends on
+     * the corner radius and on font metrics that differ across the three target platforms, so an
+     * exact coordinate would be a fragile way to ask a question about the whole outline.
+     */
+    private fun ComposeUiTest.topEdgeHas(tag: String, color: Color): Boolean {
+        val pixels = onNodeWithTag(tag).captureToImage().toPixelMap()
+        return (0 until pixels.width).any { x ->
+            val p = pixels[x, 0]
+            abs(p.red - color.red) < 0.02f && abs(p.green - color.green) < 0.02f && abs(p.blue - color.blue) < 0.02f
+        }
+    }
+
+    @Test
+    fun `a field's outline switches to the accent while it holds focus`() = runComposeUiTest {
+        var accent: Color? = null
+        var resting: Color? = null
+        setContent {
+            MaterialTheme {
+                accent = MaterialTheme.colorScheme.primary
+                resting = MaterialTheme.colorScheme.outlineVariant
+                SettingsTextField(
+                    value = "16",
+                    onValueChange = { },
+                    label = "Font size",
+                    modifier = Modifier.testTag("field").width(200.dp),
+                )
+            }
+        }
+
+        assertTrue(topEdgeHas("field", resting!!), "an unfocused field must draw its resting outline")
+        assertTrue(!topEdgeHas("field", accent!!), "an unfocused field must not already look focused")
+
+        onNodeWithText("16").performClick()
+        waitForIdle()
+
+        // Which of two dozen boxes on a settings screen the next keystroke lands in is otherwise
+        // invisible: both variants draw the same 1dp outline in every other state.
+        assertTrue(topEdgeHas("field", accent!!), "a focused field must draw its outline in the accent colour")
+    }
+
+    @Test
+    fun `an invalid field keeps its error outline even while focused`() = runComposeUiTest {
+        var error: Color? = null
+        setContent {
+            MaterialTheme {
+                error = MaterialTheme.colorScheme.error
+                SettingsTextField(
+                    value = "nope",
+                    onValueChange = { },
+                    label = "Port",
+                    isError = true,
+                    modifier = Modifier.testTag("field").width(200.dp),
+                )
+            }
+        }
+
+        onNodeWithText("nope").performClick()
+        waitForIdle()
+
+        // Focus is transient and the error is the thing that needs fixing, so it outranks it.
+        assertTrue(topEdgeHas("field", error!!), "an errored field must keep its error outline when focused")
+    }
+
+    @Test
+    fun `an unlabeled field takes the focus outline too`() = runComposeUiTest {
+        var accent: Color? = null
+        setContent {
+            MaterialTheme {
+                accent = MaterialTheme.colorScheme.primary
+                SettingsTextField(
+                    value = "abc",
+                    onValueChange = { },
+                    modifier = Modifier.testTag("bare").width(200.dp),
+                )
+            }
+        }
+
+        assertTrue(!topEdgeHas("bare", accent!!), "the bare variant must start unfocused")
+
+        onNodeWithText("abc").performClick()
+        waitForIdle()
+
+        // Both variants share one borderColor, but they are separate BasicTextField call sites and
+        // the bare one is what the inline settings rows use.
+        assertTrue(topEdgeHas("bare", accent!!), "the bare variant must show focus as well")
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesBibleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesBibleTest.kt
@@ -89,10 +89,20 @@ class SourcePropertiesBibleTest {
         )
     }
 
-    /** Waits for the module to finish loading, which is what puts the book picker on screen. */
+    /**
+     * Waits for both asynchronous halves of this panel to land.
+     *
+     * The module load is what puts the book picker on screen. The version picker is separate: it is
+     * filled from a listing of the bible folder plus a header read per module, which happen off the
+     * composition thread and so arrive independently — waiting on the book picker alone would leave
+     * every assertion about the version picker racing that read.
+     */
     private fun ComposeUiTest.awaitBibleLoaded() {
         waitUntil("the Bible module must load and put a book picker on screen", timeoutMillis = 5_000) {
             countOf("BOOK") == 1
+        }
+        waitUntil("the bible folder listing must reach the version picker", timeoutMillis = 5_000) {
+            countOf("BIBLE VERSION") == 1
         }
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BibleTranslationNamesTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BibleTranslationNamesTest.kt
@@ -1,0 +1,149 @@
+package org.churchpresenter.app.churchpresenter.data
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The one reader that names an installed `.spb` translation (issue #98).
+ *
+ * Four callers used to hand-roll this scan with four copies of the fallback rules. The rules are
+ * peculiar enough to be worth pinning in one place: the separator after `##Title:` is a tab from the
+ * converter and a space from plenty of hand-made modules, and a header that is present but empty is
+ * NOT the same as no header — the first says the module's name is nothing, the second says it never
+ * gave one, and only the second falls back to the file name.
+ */
+class BibleTranslationNamesTest {
+
+    private lateinit var dir: File
+
+    @BeforeTest
+    fun createDir() {
+        dir = Files.createTempDirectory("cp-bible-names-test").toFile()
+    }
+
+    @AfterTest
+    fun deleteDir() {
+        dir.deleteRecursively()
+    }
+
+    private fun module(name: String, content: String): File =
+        File(dir, name).apply { parentFile.mkdirs(); writeText(content) }
+
+    // ── Reading one title ───────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a tab after the colon is the converter's own output`() {
+        assertEquals(
+            "King James Version",
+            readTranslationTitle(module("ENG_KJV.spb", "##spDataVersion:\t1\n##Title:\tKing James Version\n")),
+        )
+    }
+
+    @Test
+    fun `a space after the colon reads the same`() {
+        assertEquals("Synodal", readTranslationTitle(module("RUS_SYN.spb", "##Title: Synodal\n")))
+    }
+
+    @Test
+    fun `no separator at all still reads the title`() {
+        assertEquals("Luther", readTranslationTitle(module("DEU_LUT.spb", "##Title:Luther\n")))
+    }
+
+    @Test
+    fun `a module with no title header is named by its file stem`() {
+        assertEquals("ENG_ACV", readTranslationTitle(module("ENG_ACV.spb", "1 Genesis 2\n-----\n")))
+    }
+
+    @Test
+    fun `a file that is not there is named by its file stem`() {
+        assertEquals("gone", readTranslationTitle(File(dir, "gone.spb")))
+    }
+
+    @Test
+    fun `an empty title header stays empty rather than falling back`() {
+        // What the full loader does with the same file: a module that says its name is nothing is not
+        // a module that never said.
+        assertEquals("", readTranslationTitle(module("blank.spb", "##Title: \n1 Genesis 1\n-----\n")))
+    }
+
+    @Test
+    fun `a title buried past the header block is not looked for`() {
+        // These callers scan a whole folder, so each file gets a bounded read: a directory of
+        // multi-megabyte modules would otherwise stall the picker listing it.
+        val buried = buildString {
+            repeat(12) { appendLine("filler line $it") }
+            appendLine("##Title:\tBuried Title")
+        }
+        assertEquals("deep", readTranslationTitle(module("deep.spb", buried)))
+    }
+
+    @Test
+    fun `the title is found past the headers that precede it`() {
+        assertEquals(
+            "Berean",
+            readTranslationTitle(
+                module("bsb.spb", "##spDataVersion:\t1\n##Copyright:\tpublic domain\n##Title:\tBerean\n"),
+            ),
+        )
+    }
+
+    // ── Naming a whole folder ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `every file in the folder is named`() {
+        module("a.spb", "##Title:\tFirst\n")
+        module("b.spb", "##Title:\tSecond\n")
+
+        assertEquals(
+            mapOf("a.spb" to "First", "b.spb" to "Second"),
+            bibleDisplayNames(dir.absolutePath, listOf("a.spb", "b.spb")),
+        )
+    }
+
+    @Test
+    fun `with no folder configured there is nothing to name`() {
+        assertEquals(emptyMap(), bibleDisplayNames("", listOf("a.spb")))
+    }
+
+    // ── Keeping the names unique ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `two files sharing a title are told apart by their folders`() {
+        // The shape a real collection has: one folder per language, several holding an edition that
+        // calls itself the same thing.
+        assertEquals(
+            mapOf(
+                "ENG/a.spb" to "Holy Bible  (ENG)",
+                "RUS/b.spb" to "Holy Bible  (RUS)",
+                "unique.spb" to "Only One",
+            ),
+            uniqueDisplayNames(
+                mapOf("ENG/a.spb" to "Holy Bible", "RUS/b.spb" to "Holy Bible", "unique.spb" to "Only One"),
+            ),
+        )
+    }
+
+    @Test
+    fun `two files sharing a title and a folder are told apart by their names`() {
+        assertEquals(
+            mapOf("a.spb" to "Holy Bible  (a.spb)", "b.spb" to "Holy Bible  (b.spb)"),
+            uniqueDisplayNames(mapOf("a.spb" to "Holy Bible", "b.spb" to "Holy Bible")),
+        )
+    }
+
+    @Test
+    fun `a folder of titled modules with a repeat stays reverse-mappable`() {
+        module("ENG/a.spb", "##Title:\tHoly Bible\n")
+        module("RUS/b.spb", "##Title:\tHoly Bible\n")
+        module("unique.spb", "##Title:\tOnly One\n")
+
+        val names = bibleDisplayNames(dir.absolutePath, listOf("ENG/a.spb", "RUS/b.spb", "unique.spb"))
+
+        // The property the pickers actually depend on: a display name identifies one file.
+        assertEquals(names.size, names.values.toSet().size, "display names must be unique: $names")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/settings/SettingsHelpersTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/settings/SettingsHelpersTest.kt
@@ -1,6 +1,7 @@
 package org.churchpresenter.app.churchpresenter.data.settings
 
 import org.churchpresenter.app.churchpresenter.models.CompanionSurfacePlacement
+import org.churchpresenter.app.churchpresenter.utils.Constants
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -329,6 +330,36 @@ class BibleTranslationListTest {
             .addTranslation("first.spb")
 
         assertEquals(listOf("first.spb"), settings.translationList().map { it.fileName })
+    }
+
+    @Test
+    fun `the stack stops accepting translations at the cap`() {
+        val full = (1..Constants.MAX_BIBLE_TRANSLATIONS).fold(BibleSettings()) { settings, index ->
+            settings.addTranslation("bible$index.spb")
+        }
+        val refused = full.addTranslation("one-too-many.spb")
+
+        assertEquals(Constants.MAX_BIBLE_TRANSLATIONS, full.translationList().size)
+        assertEquals(
+            full.translationList().map { it.fileName },
+            refused.translationList().map { it.fileName },
+            "past the cap the add must be refused outright, not applied and then truncated",
+        )
+    }
+
+    @Test
+    fun `a stack written past the cap is trimmed to it, in order`() {
+        val overfull = BibleSettings().withTranslations(
+            (1..Constants.MAX_BIBLE_TRANSLATIONS + 2).map {
+                BibleTranslationSettings(fileName = "bible$it.spb")
+            },
+        )
+
+        assertEquals(
+            (1..Constants.MAX_BIBLE_TRANSLATIONS).map { "bible$it.spb" },
+            overfull.translationList().map { it.fileName },
+            "a hand-edited file keeps its first translations rather than an arbitrary subset",
+        )
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTabSlotsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTabSlotsTest.kt
@@ -175,7 +175,7 @@ class AtemSettingsTabSlotsTest {
     fun `a slot the switcher does not have is marked in error`() = atemTab(
         initial = atemSettings { copy(defaultStillSlot = 4, detectedStillSlots = 20) },
     ) { _ ->
-        val ok = fieldBorderColour(atemFieldUnder(AtemLabel.STILL_SLOT))
+        val ok = focusedFieldBorderColour(atemFieldUnder(AtemLabel.STILL_SLOT))
 
         type(atemFieldUnder(AtemLabel.STILL_SLOT), "99")
         val bad = fieldBorderColour(atemFieldUnder(AtemLabel.STILL_SLOT))
@@ -189,7 +189,7 @@ class AtemSettingsTabSlotsTest {
     fun `a slot that is not a number is marked in error too`() = atemTab(
         initial = atemSettings { copy(defaultStillSlot = 4, detectedStillSlots = 20) },
     ) { _ ->
-        val ok = fieldBorderColour(atemFieldUnder(AtemLabel.STILL_SLOT))
+        val ok = focusedFieldBorderColour(atemFieldUnder(AtemLabel.STILL_SLOT))
 
         type(atemFieldUnder(AtemLabel.STILL_SLOT), "first")
 
@@ -203,7 +203,7 @@ class AtemSettingsTabSlotsTest {
     /** With nothing detected there is no range to judge against, so nothing is flagged. */
     @Test
     fun `no slot is flagged before a Test Connection has run`() = atemTab { _ ->
-        val ok = fieldBorderColour(atemFieldUnder(AtemLabel.STILL_SLOT))
+        val ok = focusedFieldBorderColour(atemFieldUnder(AtemLabel.STILL_SLOT))
 
         type(atemFieldUnder(AtemLabel.STILL_SLOT), "99")
 
@@ -218,7 +218,10 @@ class AtemSettingsTabSlotsTest {
     fun `a background slot outside the still store is marked in error`() = atemTab(
         initial = atemSettings { copy(backgroundSlot1 = 1, detectedStillSlots = 20) },
     ) { _ ->
-        val ok = fieldBorderColour(atemFieldUnder(AtemLabel.BACKGROUND_SLOT_1))
+        // Slot 2 is never touched, so its baseline is a resting one; slot 1's is taken focused
+        // because it is read again after being typed into.
+        val restingNeighbour = fieldBorderColour(atemFieldUnder(AtemLabel.BACKGROUND_SLOT_2))
+        val ok = focusedFieldBorderColour(atemFieldUnder(AtemLabel.BACKGROUND_SLOT_1))
 
         type(atemFieldUnder(AtemLabel.BACKGROUND_SLOT_1), "40")
 
@@ -228,7 +231,7 @@ class AtemSettingsTabSlotsTest {
             "a background upload to a slot the still store does not have must be flagged",
         )
         assertEquals(
-            ok,
+            restingNeighbour,
             fieldBorderColour(atemFieldUnder(AtemLabel.BACKGROUND_SLOT_2)),
             "and its neighbour, still in range, must not be",
         )
@@ -238,7 +241,7 @@ class AtemSettingsTabSlotsTest {
     fun `a clip slot outside the clip banks is marked in error`() = atemTab(
         initial = atemSettings { copy(defaultClipSlot = 0, detectedClipSlots = 2) },
     ) { _ ->
-        val ok = fieldBorderColour(atemFieldUnder(AtemLabel.CLIP_SLOT))
+        val ok = focusedFieldBorderColour(atemFieldUnder(AtemLabel.CLIP_SLOT))
 
         type(atemFieldUnder(AtemLabel.CLIP_SLOT), "5")
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTabTestSupport.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.runComposeUiTest
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
@@ -296,6 +297,21 @@ internal fun ComposeUiTest.fieldBorderColour(field: SemanticsNodeInteraction): I
         if (pixel != fill) return pixel
     }
     error("no border drawn to the left of the box at $bounds")
+}
+
+/**
+ * The outline colour of [field] with the field focused.
+ *
+ * The border carries two states, not one: `SettingsTextField` also draws it in the accent colour while
+ * it holds focus, so that a keyboard user can see which of a screenful of boxes they are typing into.
+ * A baseline read before a field is typed into is therefore unfocused, and comparing it with a reading
+ * taken after typing would differ on focus alone — passing whether or not the error state being tested
+ * does anything. Anything comparing a field against itself across an edit takes its baseline here.
+ */
+internal fun ComposeUiTest.focusedFieldBorderColour(field: SemanticsNodeInteraction): Int {
+    field.performClick()
+    waitForIdle()
+    return fieldBorderColour(field)
 }
 
 /**

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BibleSettingsTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BibleSettingsTabTest.kt
@@ -923,4 +923,84 @@ class BibleSettingsTabTest {
             "and nothing was changed by looking",
         )
     }
+
+    // ── The stack is bounded, and its rows line up ─────────────────────────────
+
+    /** A folder of [count] bibles, and a tab showing the first [stacked] of them as the stack. */
+    private fun ComposeUiTest.showStackOf(count: Int, stacked: Int): Harness {
+        val files = (1..count).map { "bible$it.spb" to "Bible $it" }
+        val dir = bibleFolder(*files.toTypedArray())
+        return showTab(
+            AppSettings(
+                bibleSettings = BibleSettings(storageDirectory = dir.absolutePath).withTranslations(
+                    files.take(stacked).map { BibleTranslationSettings(fileName = it.first) },
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `the add picker is withdrawn once the stack is full`() = runComposeUiTest {
+        // `addTranslation` refuses past the cap, so offering the add anyway would answer a selection
+        // by doing nothing at all.
+        showStackOf(count = Constants.MAX_BIBLE_TRANSLATIONS + 2, stacked = Constants.MAX_BIBLE_TRANSLATIONS)
+        waitForIdle()
+
+        onAllNodesWithText("Add translation", substring = true)
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `the add picker is offered while the stack has room`() = runComposeUiTest {
+        showStackOf(count = Constants.MAX_BIBLE_TRANSLATIONS + 2, stacked = Constants.MAX_BIBLE_TRANSLATIONS - 1)
+        waitForIdle()
+
+        onAllNodesWithText("Add translation", substring = true).onFirst()
+            .assertExists("one short of the cap there is still room, so the add must be offered")
+    }
+
+    /** The left edge of every row's delete button, top row first. */
+    private fun ComposeUiTest.deleteButtonEdges(): List<Float> =
+        onAllNodesWithContentDescription("Remove").fetchSemanticsNodes().map { it.boundsInRoot.left }
+
+    @Test
+    fun `every row's delete button sits at the same edge`() = runComposeUiTest {
+        // The first row has no "up" and the last no "down". Without a gap standing in for the missing
+        // button, delete stepped left on those two rows and the column of buttons came out ragged.
+        showStackOf(count = 3, stacked = 3)
+        waitForIdle()
+
+        val lefts = deleteButtonEdges()
+
+        assertEquals(3, lefts.size, "one delete button per translation")
+        lefts.forEach { left ->
+            assertEquals(
+                lefts.first(), left, 0.5f,
+                "every delete button must share one left edge, got $lefts",
+            )
+        }
+    }
+
+    @Test
+    fun `two rows line up without a placeholder holding space open`() = runComposeUiTest {
+        // Two rows are short of one reorder button each -- the first of "up", the second of "down" --
+        // so they align on their own. Padding them anyway would only open a gap nothing can ever
+        // fill, which is why the placeholder starts at three rows.
+        showStackOf(count = 3, stacked = 2)
+        waitForIdle()
+
+        val lefts = deleteButtonEdges()
+        assertEquals(2, lefts.size, "one delete button per translation")
+        assertEquals(lefts.first(), lefts.last(), 0.5f, "two rows must already share one edge: $lefts")
+
+        // Alignment alone cannot see a placeholder — padding both rows keeps them aligned, just
+        // wider. What it does change is the second row, where the missing button is the last one:
+        // its delete would sit a whole button further from "up" instead of the row's 6dp spacing.
+        val up = onNodeWithContentDescription("Move translation up").fetchSemanticsNode().boundsInRoot
+        val gap = lefts.last() - up.right
+        assertTrue(
+            gap < 34f,
+            "delete must follow the reorder button directly, not across a button-sized gap: $gap",
+        )
+    }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabTestSupport.kt
@@ -16,11 +16,15 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasTextExactly
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.runComposeUiTest
 import org.churchpresenter.app.churchpresenter.composables.isVlcAvailable
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleTranslationSettings
+import org.churchpresenter.app.churchpresenter.data.settings.ProjectionSettings
 import org.churchpresenter.app.churchpresenter.server.CompanionServer
 import kotlin.test.assertEquals
 
@@ -88,6 +92,46 @@ internal fun oneExternalScreen(): List<DetectedScreen> = listOf(
     DetectedScreen(index = 0, isPrimary = true, boundsX = 0, boundsY = 0, boundsW = 1920, boundsH = 1080),
     DetectedScreen(index = 1, isPrimary = false, boundsX = 1920, boundsY = 0, boundsW = 1280, boundsH = 720),
 )
+
+// ── Bible stack fixtures ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Settings carrying a stack of [names]. `withTranslations` keeps the legacy primary/secondary names
+ * in step, so the stack is the shape a real install would have rather than one assembled field by
+ * field.
+ *
+ * No `storageDirectory` is set, so `Bible.readTranslationSummary` finds nothing to read and each
+ * row falls back to naming itself by its file stem — which is also what an install whose .spb
+ * carries no `##Title:` header does.
+ */
+internal fun withBibleStack(vararg names: String, projection: ProjectionSettings = ProjectionSettings()): AppSettings =
+    AppSettings(
+        bibleSettings = BibleSettings().withTranslations(names.map { BibleTranslationSettings(fileName = it) }),
+        projectionSettings = projection,
+    )
+
+/** Three translations: enough for the per-output translation picker to list rows at all. */
+internal fun threeTranslations(projection: ProjectionSettings = ProjectionSettings()): AppSettings =
+    withBibleStack("ENG_KJV.spb", "RUS_SYN.spb", "DEU_LUT.spb", projection = projection)
+
+// ── Translation picker locators ─────────────────────────────────────────────────────────────────
+
+/**
+ * The collapsed trigger that opens the translation picker.
+ *
+ * Addressed by tag: every caption this segment can show is derived from the current selection, and
+ * a cleared trigger reads "None" — which is also what an unassigned target-display dropdown reads.
+ */
+internal fun ComposeUiTest.translationTrigger(): SemanticsNodeInteraction =
+    onNodeWithTag(TranslationPickerTags.TRIGGER)
+
+/** The open picker's master on/off row, which publishes a tri-state toggle. */
+internal fun ComposeUiTest.translationMaster(): SemanticsNodeInteraction =
+    onNodeWithTag(TranslationPickerTags.MASTER)
+
+/** The picker row for stack position [index]. */
+internal fun ComposeUiTest.translationRow(index: Int): SemanticsNodeInteraction =
+    onNodeWithTag(TranslationPickerTags.row(index))
 
 // ── Grid layout ─────────────────────────────────────────────────────────────────────────────────
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabTranslationPickerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabTranslationPickerTest.kt
@@ -1,0 +1,150 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.ProjectionSettings
+import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The per-output Bible translation picker in the Content Outputs dialog.
+ *
+ * Which translations an output shows is stored as [ScreenAssignment.bibleTranslations], a list of
+ * positions in the configured stack, where **empty means all of them** — so that a translation added
+ * later appears on every output rather than having to be ticked on each one. That normalisation is
+ * what these two tests are about: it makes "none selected" unrepresentable as a selection, so
+ * showing none of them has to be stored as `bibleMode = SONG_LANG_OFF` instead, which is the same
+ * statement about the output. Before that, unticking the last box wrote an empty list that read
+ * straight back as *all* and every box silently re-ticked.
+ *
+ * Because clearing switches scripture off, both the trigger and the menu are mounted regardless of
+ * whether scripture is on. Gate them on it — `expanded = dropdownOpen && showing` is all it takes —
+ * and both halves of the second bug come back at once: Clear shuts the menu under the hand that just
+ * pressed it, and because nothing cleared the flag that opened it, switching scripture back on later
+ * pops the menu open again unprompted. That mutation is what the second test below was checked
+ * against; it fails on the first assertion, the one saying Clear left the menu standing.
+ *
+ * This picker was rewritten (`567242f8`) after those fixes landed, which deleted the suite that
+ * guarded them. These are the two cases worth having back, restated for the current UI: the captions
+ * and row structure are all different, and the on/off control now lives inside the menu rather than
+ * beside the trigger.
+ *
+ * The picker's controls are addressed by test tag, not caption: see [TranslationPickerTags]. The
+ * cleared trigger reads "None", which is also what an unassigned target-display dropdown reads, so
+ * text was never a safe way to find it.
+ */
+class ProjectionSettingsTabTranslationPickerTest {
+
+    private fun ComposeUiTest.openContentOutputs(row: Int = 0) {
+        gridButton(Grid.contentOutputs(row)).performScrollTo().performClick()
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.openPicker() {
+        translationTrigger().performScrollTo().performClick()
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.toggleTranslation(index: Int) {
+        translationRow(index).performClick()
+        waitForIdle()
+    }
+
+    /**
+     * Closes the open translation menu the way an operator does: by clicking away from it.
+     *
+     * The click is aimed at the dialog's own "Quick Select" heading — inert text, chosen so that
+     * nothing but the dismissal can happen. The menu's popup spans the whole window and takes the
+     * press as an outside one, so the heading never actually receives it; a later click is needed to
+     * reach anything under the menu. Escape does not work here: this popup does not handle it.
+     */
+    private fun ComposeUiTest.dismissPopup() {
+        onNodeWithText("QUICK SELECT").performClick()
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.assertMenuOpen() =
+        translationRow(0).assertExists("the menu must still be open")
+
+    private fun row0(get: () -> AppSettings): ScreenAssignment =
+        get().projectionSettings.screenAssignments[0]
+
+    @Test
+    fun `unticking the last translation switches the output off`() = projectionTab(
+        initial = threeTranslations(),
+    ) { get ->
+        openContentOutputs()
+        openPicker()
+        assertEquals(emptyList(), row0(get).bibleTranslations, "an untouched output shows all of them")
+
+        toggleTranslation(0)
+        toggleTranslation(1)
+        assertEquals(listOf(2), row0(get).bibleTranslations, "the two unticked ones are gone from the selection")
+
+        toggleTranslation(2)
+
+        // Showing none of them is the same statement as an unticked cell. Storing it as an empty
+        // selection instead is what used to read back as "all" and re-tick every box.
+        assertEquals(Constants.SONG_LANG_OFF, row0(get).bibleMode)
+        translationMaster().assertIsOff()
+        onNodeWithText("0 of 3 translations enabled").assertExists()
+    }
+
+    @Test
+    fun `the menu does not reopen by itself after Clear`() = projectionTab(
+        initial = threeTranslations(),
+    ) { get ->
+        openContentOutputs()
+        openPicker()
+
+        onNodeWithText("Clear").performClick()
+        waitForIdle()
+
+        // Clearing is usually a step towards picking a couple, so the menu has to survive being the
+        // thing that switched scripture off.
+        assertEquals(Constants.SONG_LANG_OFF, row0(get).bibleMode)
+        assertMenuOpen()
+
+        dismissPopup()
+        translationRow(0).assertDoesNotExist()
+
+        // Switching scripture back on from outside the picker — the flag that opens the menu must
+        // not be riding on whether scripture is on.
+        onNodeWithText("Select All").performClick()
+        waitForIdle()
+
+        assertEquals(Constants.SONG_LANG_BOTH, row0(get).bibleMode)
+        // The menu must not have opened by itself.
+        translationRow(0).assertDoesNotExist()
+
+        // ...and it still opens on demand.
+        openPicker()
+        translationMaster().assertIsOn()
+    }
+
+    @Test
+    fun `ticking a translation while the output is off switches it back on alone`() = projectionTab(
+        initial = threeTranslations(
+            ProjectionSettings(screenAssignments = listOf(ScreenAssignment(bibleMode = Constants.SONG_LANG_OFF))),
+        ),
+    ) { get ->
+        openContentOutputs()
+        openPicker()
+
+        toggleTranslation(1)
+
+        // Both halves in one event — two back-to-back callbacks would each read the same pre-click
+        // assignment and the second would overwrite the first.
+        assertEquals(Constants.SONG_LANG_BOTH, row0(get).bibleMode)
+        assertEquals(listOf(1), row0(get).bibleTranslations, "only the one just ticked")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabTranslationPickerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabTranslationPickerTest.kt
@@ -2,7 +2,11 @@
 
 package org.churchpresenter.app.churchpresenter.dialogs.tabs
 
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.onNodeWithText
@@ -20,23 +24,29 @@ import kotlin.test.assertEquals
  *
  * Which translations an output shows is stored as [ScreenAssignment.bibleTranslations], a list of
  * positions in the configured stack, where **empty means all of them** — so that a translation added
- * later appears on every output rather than having to be ticked on each one. That normalisation is
- * what these two tests are about: it makes "none selected" unrepresentable as a selection, so
- * showing none of them has to be stored as `bibleMode = SONG_LANG_OFF` instead, which is the same
- * statement about the output. Before that, unticking the last box wrote an empty list that read
- * straight back as *all* and every box silently re-ticked.
+ * later appears on every output rather than having to be ticked on each one. Most of what is tested
+ * here follows from that one normalisation:
+ *
+ *  * it makes "none selected" unrepresentable as a selection, so showing none of them has to be
+ *    stored as `bibleMode = SONG_LANG_OFF` instead, which is the same statement about the output.
+ *    Before that, unticking the last box wrote an empty list that read straight back as *all* and
+ *    every box silently re-ticked;
+ *  * and it means a **position** is only meaningful against the stack it was stored for. One past the
+ *    end of the current stack is ignored rather than counted, and a selection left with none of its
+ *    positions surviving shows nothing rather than reading as the empty "all of them".
  *
  * Because clearing switches scripture off, both the trigger and the menu are mounted regardless of
  * whether scripture is on. Gate them on it — `expanded = dropdownOpen && showing` is all it takes —
  * and both halves of the second bug come back at once: Clear shuts the menu under the hand that just
  * pressed it, and because nothing cleared the flag that opened it, switching scripture back on later
- * pops the menu open again unprompted. That mutation is what the second test below was checked
- * against; it fails on the first assertion, the one saying Clear left the menu standing.
+ * pops the menu open again unprompted. That mutation is what `the menu does not reopen by itself after
+ * Clear` was checked against; it fails on the first assertion, the one saying Clear left the menu
+ * standing.
  *
  * This picker was rewritten (`567242f8`) after those fixes landed, which deleted the suite that
- * guarded them. These are the two cases worth having back, restated for the current UI: the captions
- * and row structure are all different, and the on/off control now lives inside the menu rather than
- * beside the trigger.
+ * guarded them. These are the cases worth having back, restated for the current UI: the captions and
+ * row structure are all different, and the on/off control now lives inside the menu rather than beside
+ * the trigger.
  *
  * The picker's controls are addressed by test tag, not caption: see [TranslationPickerTags]. The
  * cleared trigger reads "None", which is also what an unassigned target-display dropdown reads, so
@@ -129,6 +139,41 @@ class ProjectionSettingsTabTranslationPickerTest {
         // ...and it still opens on demand.
         openPicker()
         translationMaster().assertIsOn()
+    }
+
+    @Test
+    fun `a position left behind by a removed translation is not counted`() = projectionTab(
+        // Position 7 names a translation that is not in this three-deep stack. Stack edits remap
+        // selections now, so this is what reaches the picker from a settings file written before they
+        // did, or a hand-edited one.
+        initial = threeTranslations(
+            ProjectionSettings(screenAssignments = listOf(ScreenAssignment(bibleTranslations = listOf(0, 7)))),
+        ),
+    ) { _ ->
+        openContentOutputs()
+        openPicker()
+
+        // One position survives, so one translation is enabled — the count used to say two, while the
+        // preview chip on the row behind it named only the one.
+        onNodeWithText("1 of 3 translations enabled").assertExists()
+        // And one of three reads as a partial selection, not as all of them.
+        translationMaster().assert(
+            SemanticsMatcher.expectValue(SemanticsProperties.ToggleableState, ToggleableState.Indeterminate),
+        )
+    }
+
+    @Test
+    fun `a selection of nothing but removed translations shows none, not all`() = projectionTab(
+        initial = threeTranslations(
+            ProjectionSettings(screenAssignments = listOf(ScreenAssignment(bibleTranslations = listOf(7, 8)))),
+        ),
+    ) { _ ->
+        openContentOutputs()
+        openPicker()
+
+        // Naming translations that have gone is not the same statement as the empty "all of them", so
+        // it must not read as all: that would put three languages on an output narrowed to one.
+        onNodeWithText("0 of 3 translations enabled").assertExists()
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BibleFitScaleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BibleFitScaleTest.kt
@@ -8,13 +8,23 @@ import kotlin.test.assertTrue
  * Shrinking a verse until it fits the screen.
  *
  * A long passage in a large font does not fit, and the presenter cannot ask "what scale would fit?"
- * — it can only lay text out at a given scale and ask whether the result overflowed. So it
- * bisects: eight probes between a floor and full size, keeping the largest scale that still fit.
+ * — it can only lay text out at a given scale and ask whether the result overflowed. So it bisects,
+ * keeping the largest scale that still fit.
  *
- * Two properties matter and neither is visible from the call site. The answer must always be one
- * that FITS — returning a scale that overflows puts a verse on screen with its last line cut off,
- * which is exactly what auto-fit exists to prevent — and the probe count must stay fixed, because
- * each probe is a full text layout of the whole passage and this runs on every verse change.
+ * The property that matters, and is invisible from the call site: **the answer must always be one
+ * that FITS**. A scale that overflows puts a verse on screen with its last line cut off, which is
+ * exactly what auto-fit exists to prevent.
+ *
+ * That used to be only half true. The search took a floor, and when nothing at or above the floor
+ * fitted it returned the floor anyway, unprobed — so the caller could not tell a fit from a failure
+ * and drew the overflow. This suite asserted that behaviour as `text that fits nowhere still returns
+ * the floor`, which contradicted its own opening paragraph. The floor is now a *starting point*: when
+ * it does not fit, the search halves below it until something does.
+ *
+ * The cost of that is bounded but no longer identical for every passage — halving is what makes it
+ * text-dependent — so `the number of layout probes stays bounded` replaces the old fixed-count
+ * assertion. Each probe is a full layout of the whole passage and this runs on every verse change,
+ * so the ceiling is the thing worth holding.
  *
  * The search is private to `BiblePresenter`, so it is reached by reflection on the file class.
  */
@@ -65,20 +75,24 @@ class BibleFitScaleTest {
     }
 
     @Test
-    fun `text that fits nowhere still returns the floor rather than nothing`() {
-        val scale = fitScale(fitsUpTo = 0f)
+    fun `text that fits nowhere is shrunk further rather than drawn overflowing`() {
+        // fitsUpTo = 0.02 is far below the 0.15 the search starts from: nothing in its original range
+        // fits, which used to be answered with the floor and an overflowing screen.
+        val scale = fitScale(fitsUpTo = 0.02f)
 
-        assertEquals(
-            0.15f,
-            scale,
-            "an unreadably long passage is shown small; showing nothing at all would be worse",
-        )
+        assertTrue(scale <= 0.02f, "the answer must fit, not sit at the floor overflowing: $scale")
+        assertTrue(scale > 0f, "and it must still be a usable scale, not nothing")
     }
 
     @Test
-    fun `the answer never drops below the floor it was given`() {
-        listOf(0.15f, 0.3f, 0.5f).forEach { floor ->
-            assertTrue(fitScale(fitsUpTo = 0f, minScale = floor) >= floor, "the floor is a legibility limit")
+    fun `the starting scale is a starting point, not a limit`() {
+        listOf(0.15f, 0.3f, 0.5f).forEach { start ->
+            val scale = fitScale(fitsUpTo = 0.05f, minScale = start)
+
+            assertTrue(
+                scale <= 0.05f,
+                "starting at $start, the search must go below it to find a scale that fits: $scale",
+            )
         }
     }
 
@@ -114,36 +128,41 @@ class BibleFitScaleTest {
     // ── It costs a fixed amount ─────────────────────────────────────────────────
 
     @Test
-    fun `the number of layout probes is fixed rather than driven by the text`() {
+    fun `the number of layout probes stays bounded however badly the text overflows`() {
         fitScale(fitsUpTo = 0.62f)
         val forAMediumVerse = probed.size
         probed.clear()
 
-        fitScale(fitsUpTo = 0.01f)
+        // The worst case this can be handed: nothing fits at any scale, so the halving runs its full
+        // course before the bisection.
+        fitScale(fitsUpTo = 0f)
+        val forAHopelessOne = probed.size
 
-        assertEquals(
-            forAMediumVerse,
-            probed.size,
-            "each probe lays the whole passage out again — a passage-dependent count would stall on long ones",
+        assertTrue(
+            forAMediumVerse <= 12,
+            "the ordinary case must stay close to the bisection budget: $forAMediumVerse probes",
         )
-        assertEquals(8, forAMediumVerse, "eight is the budget this runs on for every verse change")
+        assertTrue(
+            forAHopelessOne <= 24,
+            "each probe lays the whole passage out again, so even the hopeless case needs a ceiling: " +
+                "$forAHopelessOne probes",
+        )
     }
 
     @Test
-    fun `no probe falls outside the range it was given`() {
+    fun `no probe is wasted on a scale larger than full size`() {
         fitScale(fitsUpTo = 0.62f, minScale = 0.2f)
 
         assertTrue(
-            probed.all { it in 0.2f..1f },
-            "laying text out at a scale outside the range wastes a probe on an answer that cannot be used: $probed",
+            probed.all { it <= 1f },
+            "laying text out above full size wastes a probe on an answer that cannot be used: \$probed",
         )
     }
 
     @Test
-    fun `zero probes returns the floor untouched`() {
-        val scale = fitScale(fitsUpTo = 1f, iterations = 0)
+    fun `with no bisection budget the starting scale is still made to fit`() {
+        val scale = fitScale(fitsUpTo = 0.05f, iterations = 0)
 
-        assertEquals(0.15f, scale)
-        assertTrue(probed.isEmpty(), "no probes means no layout work at all")
+        assertTrue(scale <= 0.05f, "iterations only fund the bisection; fitting is not optional: \$scale")
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenterFitScaleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenterFitScaleTest.kt
@@ -1,0 +1,76 @@
+package org.churchpresenter.app.churchpresenter.presenter
+
+import org.churchpresenter.app.churchpresenter.utils.MIN_AUTO_FIT_FONT_SIZE
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * How far the parallel translation stack is allowed to shrink to fit (issue #97).
+ *
+ * The stack shares one fit scale across every translation on it, so the more translations an output
+ * shows the smaller that scale has to go. It used to be allowed down to 3% — which fits eight
+ * translations on a screen at around 2sp, a size nobody in the room can read. The floor now says what
+ * it actually means: no line under [MIN_AUTO_FIT_FONT_SIZE].
+ *
+ * Not covered here: the `clipToBounds` that keeps a stack too tall even at the floor inside the
+ * configured margins. It is a draw-time modifier on the layout with no observable state, so there is
+ * nothing to assert against short of rasterising an output window.
+ */
+class BiblePresenterFitScaleTest {
+
+    /** What a line configured at [fontSize] actually renders at once both scalings are applied. */
+    private fun renderedSize(fontSize: Int, scaleFactor: Float): Float =
+        fontSize * scaleFactor * multiTranslationMinFitScale(fontSize, scaleFactor)
+
+    @Test
+    fun `the floor keeps the smallest line at the minimum readable size`() {
+        listOf(70 to 1f, 70 to 3f, 70 to 0.5f, 24 to 1f, 300 to 2f).forEach { (fontSize, scaleFactor) ->
+            assertEquals(
+                MIN_AUTO_FIT_FONT_SIZE.toFloat(),
+                renderedSize(fontSize, scaleFactor),
+                absoluteTolerance = 0.01f,
+                "$fontSize at scaleFactor $scaleFactor",
+            )
+        }
+    }
+
+    @Test
+    fun `the smallest configured size in the stack is what sets the floor`() {
+        // A stack of eight at the default 70 is the case from the issue: the old 3% floor let it down
+        // to ~2sp. The floor is now over five times that, whatever the stack length.
+        val floor = multiTranslationMinFitScale(smallestFontSize = 70, scaleFactor = 1f)
+        assertTrue(floor > 0.1f, "expected a floor well above the old 0.03, was $floor")
+        // A reference line configured smaller than the verse text hits the limit first, so it is the
+        // one the floor has to be computed from.
+        assertTrue(
+            multiTranslationMinFitScale(24, 1f) > floor,
+            "a smaller configured size must yield a higher floor",
+        )
+    }
+
+    @Test
+    fun `a stack already configured at or below the minimum is never scaled up`() {
+        assertEquals(1f, multiTranslationMinFitScale(MIN_AUTO_FIT_FONT_SIZE, 1f))
+        assertEquals(1f, multiTranslationMinFitScale(4, 1f))
+        // Nor is a nonsense size allowed to divide by zero or invert the scale.
+        assertEquals(1f, multiTranslationMinFitScale(0, 1f))
+        assertEquals(1f, multiTranslationMinFitScale(-5, 1f))
+    }
+
+    @Test
+    fun `the fit search never returns a scale under its floor`() {
+        val floor = multiTranslationMinFitScale(smallestFontSize = 70, scaleFactor = 1f)
+        // Nothing fits, however far it shrinks — the case that used to bottom out at 2sp.
+        val scale = binarySearchFitScale(minScale = floor, iterations = 10) { false }
+        assertEquals(floor, scale, "a stack that cannot fit must stop at the floor, not below it")
+    }
+
+    @Test
+    fun `the fit search still finds the largest scale that fits`() {
+        val floor = multiTranslationMinFitScale(smallestFontSize = 70, scaleFactor = 1f)
+        val scale = binarySearchFitScale(minScale = floor, iterations = 12) { it <= 0.5f }
+        assertTrue(scale <= 0.5f, "must not return a scale that does not fit, was $scale")
+        assertTrue(scale > 0.49f, "must get close to the largest fitting scale, was $scale")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenterFitScaleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenterFitScaleTest.kt
@@ -1,76 +1,89 @@
 package org.churchpresenter.app.churchpresenter.presenter
 
-import org.churchpresenter.app.churchpresenter.utils.MIN_AUTO_FIT_FONT_SIZE
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * How far the parallel translation stack is allowed to shrink to fit (issue #97).
+ * The fit search behind every Bible layout: it must always come back with a scale that fits.
  *
- * The stack shares one fit scale across every translation on it, so the more translations an output
- * shows the smaller that scale has to go. It used to be allowed down to 3% — which fits eight
- * translations on a screen at around 2sp, a size nobody in the room can read. The floor now says what
- * it actually means: no line under [MIN_AUTO_FIT_FONT_SIZE].
+ * Verse text shrinks to stay whole. It is never cut off to hold a size — not with eight translations
+ * stacked, not with the longest verse in the Bible, not in a lower-third band. That is the whole
+ * contract, and it is what the search did not previously offer: it started at a fixed 15% floor and
+ * returned that floor **without ever testing it**, so "the largest scale that fits" and "nothing in
+ * range fits" came back indistinguishable and the second silently overflowed (issue #97).
  *
- * Not covered here: the `clipToBounds` that keeps a stack too tall even at the floor inside the
- * configured margins. It is a draw-time modifier on the layout with no observable state, so there is
- * nothing to assert against short of rasterising an output window.
+ * The first fix attempt made it worse by raising the floor to a readable 8sp, which turned
+ * unreadably-small into cut-off. Both are wrong; fitting wins.
+ *
+ * The `fits` predicates below stand in for the real measurement. That is the whole of the decision
+ * being tested — the real ones differ only in calling `TextMeasurer`, which needs a composition and
+ * would test Compose's text metrics rather than this search.
  */
 class BiblePresenterFitScaleTest {
 
-    /** What a line configured at [fontSize] actually renders at once both scalings are applied. */
-    private fun renderedSize(fontSize: Int, scaleFactor: Float): Float =
-        fontSize * scaleFactor * multiTranslationMinFitScale(fontSize, scaleFactor)
+    /** A predicate shaped like the real ones: content of [contentAtFullScale] into [available]. */
+    private fun fitsWithin(available: Float, contentAtFullScale: Float): (Float) -> Boolean =
+        { scale -> contentAtFullScale * scale <= available }
 
     @Test
-    fun `the floor keeps the smallest line at the minimum readable size`() {
-        listOf(70 to 1f, 70 to 3f, 70 to 0.5f, 24 to 1f, 300 to 2f).forEach { (fontSize, scaleFactor) ->
-            assertEquals(
-                MIN_AUTO_FIT_FONT_SIZE.toFloat(),
-                renderedSize(fontSize, scaleFactor),
-                absoluteTolerance = 0.01f,
-                "$fontSize at scaleFactor $scaleFactor",
-            )
+    fun `content far too big for its frame still gets a scale that fits`() {
+        // 40x over: no scale at or above the old 15% floor fits, which is exactly the case that used
+        // to be returned as the floor itself and drawn overflowing.
+        val fits = fitsWithin(available = 100f, contentAtFullScale = 4000f)
+        val scale = binarySearchFitScale(fits = fits)
+
+        assertTrue(fits(scale), "the returned scale must fit; was $scale")
+    }
+
+    @Test
+    fun `a scale that fits is returned at every realistic degree of overflow`() {
+        // Eight translations of a long passage crammed into a lower-third band is the worst real case
+        // and overflows by tens of times. The range here runs to 1000x, well past it.
+        listOf(2f, 10f, 100f, 1_000f).forEach { overflowFactor ->
+            val fits = fitsWithin(available = 100f, contentAtFullScale = 100f * overflowFactor)
+            val scale = binarySearchFitScale(fits = fits)
+
+            assertTrue(fits(scale), "overflowing ${overflowFactor}x returned $scale, which does not fit")
+            assertTrue(scale > 0f, "the scale must stay positive; was $scale")
         }
     }
 
     @Test
-    fun `the smallest configured size in the stack is what sets the floor`() {
-        // A stack of eight at the default 70 is the case from the issue: the old 3% floor let it down
-        // to ~2sp. The floor is now over five times that, whatever the stack length.
-        val floor = multiTranslationMinFitScale(smallestFontSize = 70, scaleFactor = 1f)
-        assertTrue(floor > 0.1f, "expected a floor well above the old 0.03, was $floor")
-        // A reference line configured smaller than the verse text hits the limit first, so it is the
-        // one the floor has to be computed from.
-        assertTrue(
-            multiTranslationMinFitScale(24, 1f) > floor,
-            "a smaller configured size must yield a higher floor",
-        )
+    fun `the largest fitting scale is found, not merely a fitting one`() {
+        // Half-size fits exactly. Shrinking further than needed would waste the frame.
+        val scale = binarySearchFitScale(iterations = 14, fits = fitsWithin(100f, 200f))
+
+        assertTrue(scale <= 0.5f, "must not exceed what fits; was $scale")
+        assertTrue(scale > 0.49f, "must converge on the largest fitting scale; was $scale")
     }
 
     @Test
-    fun `a stack already configured at or below the minimum is never scaled up`() {
-        assertEquals(1f, multiTranslationMinFitScale(MIN_AUTO_FIT_FONT_SIZE, 1f))
-        assertEquals(1f, multiTranslationMinFitScale(4, 1f))
-        // Nor is a nonsense size allowed to divide by zero or invert the scale.
-        assertEquals(1f, multiTranslationMinFitScale(0, 1f))
-        assertEquals(1f, multiTranslationMinFitScale(-5, 1f))
+    fun `content that already fits is left at full size`() {
+        assertEquals(1f, binarySearchFitScale(fits = { true }))
     }
 
     @Test
-    fun `the fit search never returns a scale under its floor`() {
-        val floor = multiTranslationMinFitScale(smallestFontSize = 70, scaleFactor = 1f)
-        // Nothing fits, however far it shrinks — the case that used to bottom out at 2sp.
-        val scale = binarySearchFitScale(minScale = floor, iterations = 10) { false }
-        assertEquals(floor, scale, "a stack that cannot fit must stop at the floor, not below it")
+    fun `a starting scale that already fits is not lowered first`() {
+        // The halving is only for when the start does not fit; from a start that does, the search
+        // bisects upward as before.
+        val scale = binarySearchFitScale(startScale = 0.15f, iterations = 14, fits = fitsWithin(100f, 125f))
+
+        assertTrue(scale > 0.79f && scale <= 0.8f, "expected to climb to ~0.8; was $scale")
     }
 
     @Test
-    fun `the fit search still finds the largest scale that fits`() {
-        val floor = multiTranslationMinFitScale(smallestFontSize = 70, scaleFactor = 1f)
-        val scale = binarySearchFitScale(minScale = floor, iterations = 12) { it <= 0.5f }
-        assertTrue(scale <= 0.5f, "must not return a scale that does not fit, was $scale")
-        assertTrue(scale > 0.49f, "must get close to the largest fitting scale, was $scale")
+    fun `a predicate nothing can satisfy terminates instead of hanging`() {
+        // The shape of a layout holding part of its height fixed — a reference line measured once at
+        // full size — which no scale can rescue. It must bottom out rather than loop.
+        val scale = binarySearchFitScale(fits = { false })
+
+        assertTrue(scale > 0f, "must return a usable scale rather than zero; was $scale")
+        assertTrue(scale < 0.01f, "must have gone all the way down; was $scale")
+    }
+
+    @Test
+    fun `a start above one is not allowed to enlarge the text`() {
+        assertTrue(binarySearchFitScale(startScale = 5f, fits = { true }) <= 1f)
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenterLayoutRenderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BiblePresenterLayoutRenderTest.kt
@@ -3,7 +3,9 @@ package org.churchpresenter.app.churchpresenter.presenter
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.onNodeWithText
@@ -219,6 +221,34 @@ class BiblePresenterLayoutRenderTest {
         onNodeWithText("Denn also hat Gott die Welt geliebt", substring = true).assertExists()
     }
 
+    // ── The full-screen stack divides the output, it does not hug one edge of it ─────────────────
+    //
+    // Each translation gets an equal band of the height and is aligned inside it by the global
+    // verticalAlignment — what the 50/50 split this replaced did for two, generalised to any number.
+    // The stack that landed with #91 wrapped its content instead, so with the default bottom
+    // alignment two short verses bunched against the bottom edge and left the whole top half of the
+    // output empty: a blank band an operator reads as a section of its own.
+
+    /** A settings stack of [count] translations, matching the file names [stackVerses] hands out. */
+    private fun stackOf(count: Int): AppSettings = AppSettings(
+        bibleSettings = BibleSettings().withTranslations(
+            (0 until count).map { BibleTranslationSettings(fileName = "bible$it.spb") },
+        ),
+    )
+
+    private fun stackVerses(vararg markers: String) = markers.mapIndexed { index, marker ->
+        verse(marker, 16, fileName = "bible$index.spb")
+    }
+
+    /**
+     * The height the presenter actually drew into.
+     *
+     * Not [screen]'s 1080: the test harness roots these at its own window size and clips to it, so a
+     * band worked out from the requested size lands in the wrong place. Read it back instead.
+     */
+    private fun ComposeUiTest.outputHeight(): Float =
+        onRoot().fetchSemanticsNode().size.height.toFloat()
+
     @Test
     fun `four long translations stay inside the output bounds`() = runComposeUiTest {
         val files = listOf("one.spb", "two.spb", "three.spb", "four.spb")
@@ -248,6 +278,88 @@ class BiblePresenterLayoutRenderTest {
             assertTrue(bounds.top >= 0f, "$marker starts above the output: $bounds")
             assertTrue(bounds.bottom <= 1080f, "$marker is clipped below the output: $bounds")
         }
+    }
+
+    @Test
+    fun `two short translations leave no empty band above the stack`() = runComposeUiTest {
+        setContent {
+            Box(screen) {
+                BiblePresenter(
+                    selectedVerses = stackVerses("FIRST TEXT", "SECOND TEXT"),
+                    appSettings = stackOf(2),
+                )
+            }
+        }
+
+        // The regression: wrapped and bottom-aligned, both blocks sat below the halfway line and left
+        // the whole top half of the output blank.
+        val half = outputHeight() / 2f
+        val firstTop = onNodeWithText("FIRST TEXT").fetchSemanticsNode().boundsInRoot.top
+        assertTrue(
+            firstTop < half,
+            "the first translation must use the top half of the output, not bunch at the bottom: $firstTop",
+        )
+    }
+
+    @Test
+    fun `each translation is drawn inside its own band`() = runComposeUiTest {
+        val markers = listOf("FIRST TEXT", "SECOND TEXT", "THIRD TEXT")
+        setContent {
+            Box(screen) {
+                BiblePresenter(
+                    selectedVerses = stackVerses(*markers.toTypedArray()),
+                    appSettings = stackOf(markers.size),
+                )
+            }
+        }
+
+        // Bands, not pixel positions: font metrics differ across the three target platforms, but the
+        // verse belonging to band i must have its centre inside band i whatever they measure.
+        val bandHeight = outputHeight() / markers.size
+        markers.forEachIndexed { index, marker ->
+            val bounds = onNodeWithText(marker).fetchSemanticsNode().boundsInRoot
+            val centre = (bounds.top + bounds.bottom) / 2f
+            assertTrue(
+                centre > index * bandHeight && centre < (index + 1) * bandHeight,
+                "$marker must sit in band $index (${index * bandHeight}..${(index + 1) * bandHeight}), was at $centre",
+            )
+        }
+    }
+
+    @Test
+    fun `a long verse beside a short one still fits its own band`() = runComposeUiTest {
+        val settings = AppSettings(
+            bibleSettings = BibleSettings().withTranslations(
+                listOf("bible0.spb", "bible1.spb").map {
+                    BibleTranslationSettings(fileName = it, textFontSize = 90)
+                },
+            ),
+        )
+        setContent {
+            Box(screen) {
+                BiblePresenter(
+                    selectedVerses = listOf(
+                        verse("LONG ${"and it came to pass ".repeat(60)}", 16, fileName = "bible0.spb"),
+                        verse("SHORT", 16, fileName = "bible1.spb"),
+                    ),
+                    appSettings = settings,
+                )
+            }
+        }
+
+        // The long one can no longer borrow the short one's slack, so the shared scale shrinks until
+        // it fits its own band — and neither translation may leave the output.
+        val height = outputHeight()
+        listOf("LONG", "SHORT").forEach { marker ->
+            val bounds = onNodeWithText(marker, substring = true).fetchSemanticsNode().boundsInRoot
+            assertTrue(bounds.top >= 0f, "$marker starts above the output: $bounds")
+            assertTrue(bounds.bottom <= height, "$marker is clipped below the output: $bounds")
+        }
+        val shortTop = onNodeWithText("SHORT").fetchSemanticsNode().boundsInRoot.top
+        assertTrue(
+            shortTop >= height / 2f,
+            "the second translation belongs in the lower band, was at $shortTop",
+        )
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/ThemeSurfaceRampTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/ThemeSurfaceRampTest.kt
@@ -1,0 +1,143 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.ui.theme
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * That every theme's settings screens stay readable as three distinct layers (issue #95).
+ *
+ * A settings tab paints its page with `surfaceVariant`, puts `SettingsSection` cards on it in
+ * `surfaceContainer`, and puts `SettingsTextField` inputs on those cards in `surfaceContainerHigh`.
+ * If two of the three land on the same tone, the layer between them stops reading as a layer: a card
+ * becomes a flat region of page, or a field becomes a hole in a card with only a 1dp border to say
+ * otherwise — and in several themes `outlineVariant` equals `surfaceVariant`, so even the border can
+ * disappear.
+ *
+ * That is what went wrong before: no scheme declared the container roles, so both came from the M3
+ * baseline rather than the theme, and in the Studio theme the card came out at exactly the luminance
+ * of its own page. Since the tones are now chosen per theme, they need something holding them apart —
+ * every theme, not just the two anyone happens to open.
+ *
+ * The bar is deliberately low. These are adjacent tones on one ramp, not text on a background, so
+ * WCAG's 4.5:1 does not apply; what matters is that the step is present and above the ~1.1:1 where an
+ * edge stops being visible on a projector-lit booth monitor. Body text against the field is held to
+ * the real contrast bar separately below.
+ */
+class ThemeSurfaceRampTest {
+
+    /** Relative luminance, WCAG 2.1. */
+    private fun luminance(color: Color): Double {
+        fun channel(v: Float): Double =
+            if (v <= 0.03928f) v / 12.92 else Math.pow((v + 0.055) / 1.055, 2.4)
+        return 0.2126 * channel(color.red) + 0.7152 * channel(color.green) + 0.0722 * channel(color.blue)
+    }
+
+    private fun contrast(a: Color, b: Color): Double {
+        val (hi, lo) = luminance(a).let { la -> luminance(b).let { lb -> maxOf(la, lb) to minOf(la, lb) } }
+        return (hi + 0.05) / (lo + 0.05)
+    }
+
+    private fun hex(c: Color): String =
+        "#%02X%02X%02X".format((c.red * 255).toInt(), (c.green * 255).toInt(), (c.blue * 255).toInt())
+
+    /** Runs [check] against every theme the app ships, reporting all failures at once. */
+    private fun everyTheme(check: (ColorScheme) -> String?) {
+        val failures = mutableListOf<String>()
+        runComposeUiTest {
+            setContent {
+                ThemeMode.entries.forEach { mode ->
+                    ChurchPresenterTheme(themeMode = mode) {
+                        check(MaterialTheme.colorScheme)?.let { failures.add("${mode.name}: $it") }
+                    }
+                }
+            }
+        }
+        if (failures.isNotEmpty()) fail(failures.joinToString("\n", prefix = "\n"))
+    }
+
+    private val minStep = 1.10
+
+    @Test
+    fun `a settings card is distinguishable from the page it sits on`() {
+        everyTheme { s ->
+            val ratio = contrast(s.surfaceContainer, s.surfaceVariant)
+            if (ratio >= minStep) null
+            else "card ${hex(s.surfaceContainer)} on page ${hex(s.surfaceVariant)} is only %.3f:1".format(ratio)
+        }
+    }
+
+    @Test
+    fun `an input field is distinguishable from the card it sits on`() {
+        everyTheme { s ->
+            val ratio = contrast(s.surfaceContainerHigh, s.surfaceContainer)
+            if (ratio >= minStep) null
+            else "field ${hex(s.surfaceContainerHigh)} on card ${hex(s.surfaceContainer)} is only %.3f:1".format(ratio)
+        }
+    }
+
+    @Test
+    fun `a field is not the same tone as the page two layers behind it`() {
+        // The change originally proposed for #95 — pointing the field at surfaceVariant — is exactly
+        // this: the field would have been painted the page's own colour.
+        everyTheme { s ->
+            val ratio = contrast(s.surfaceContainerHigh, s.surfaceVariant)
+            if (ratio >= minStep) null
+            else "field ${hex(s.surfaceContainerHigh)} matches the page ${hex(s.surfaceVariant)} (%.3f:1)".format(ratio)
+        }
+    }
+
+    @Test
+    fun `a field's border reads against the field`() {
+        // In several themes outlineVariant is the same value as surfaceVariant, so a field painted
+        // the page colour loses its border as well as its fill. This is what keeps the two apart.
+        everyTheme { s ->
+            val ratio = contrast(s.outlineVariant, s.surfaceContainerHigh)
+            if (ratio >= minStep) null
+            else "border ${hex(s.outlineVariant)} on field ${hex(s.surfaceContainerHigh)} is only %.3f:1".format(ratio)
+        }
+    }
+
+    @Test
+    fun `body text on a field clears the real contrast bar`() {
+        // Text, unlike the ramp above, is held to WCAG AA for normal text.
+        everyTheme { s ->
+            val ratio = contrast(s.onSurface, s.surfaceContainerHigh)
+            if (ratio >= 4.5) null
+            else "text ${hex(s.onSurface)} on field ${hex(s.surfaceContainerHigh)} is only %.2f:1".format(ratio)
+        }
+    }
+
+    @Test
+    fun `every theme declares the container roles rather than inheriting the baseline`() {
+        // The M3 baseline values, which is what a scheme that omits them silently gets. They are a
+        // lavender tint that belongs to none of these palettes.
+        val baseline = setOf(Color(0xFFF3EDF7), Color(0xFFECE6F0), Color(0xFF211F26), Color(0xFF2B2930))
+        everyTheme { s ->
+            when {
+                s.surfaceContainer in baseline -> "surfaceContainer is still the M3 baseline ${hex(s.surfaceContainer)}"
+                s.surfaceContainerHigh in baseline ->
+                    "surfaceContainerHigh is still the M3 baseline ${hex(s.surfaceContainerHigh)}"
+                else -> null
+            }
+        }
+    }
+
+    @Test
+    fun `the ramp check would have caught what shipped before`() {
+        // Guards the assertions above against passing vacuously: fed the old baseline pair against
+        // the Studio page, the card/page step is the 1.000 that was actually shipping.
+        val studioPage = Color(0xFF182030)
+        val baselineCard = Color(0xFF211F26)
+        assertTrue(
+            contrast(baselineCard, studioPage) < minStep,
+            "the old baseline card must fail the bar this test sets",
+        )
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelTranslationOrderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelTranslationOrderTest.kt
@@ -1,0 +1,158 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import kotlinx.coroutines.Dispatchers
+import org.churchpresenter.app.churchpresenter.data.SpbFixture
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleTranslationSettings
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What a change to the translation stack costs (issue #96).
+ *
+ * Rearranging the stack used to go through the same full reload as adding or swapping a translation:
+ * every .spb parsed again from disk, and — because the load republishes a books-only bible partway
+ * through — the verse list emptied out under whatever was live until the parse finished. None of that
+ * work is needed to put the same modules in a different order.
+ *
+ * Both view models here run on `Dispatchers.Unconfined`, so a reload would finish inside the
+ * `updateSettings` call rather than after it. That is what makes the assertions below decide
+ * anything: they are read immediately afterwards, when a reload would already have happened.
+ */
+class BibleViewModelTranslationOrderTest {
+
+    private lateinit var dir: File
+
+    @BeforeTest
+    fun createDir() {
+        dir = Files.createTempDirectory("cp-bible-order-test").toFile()
+    }
+
+    @AfterTest
+    fun deleteDir() {
+        dir.deleteRecursively()
+    }
+
+    /** Three one-verse modules, each with its own wording so the stack order is readable. */
+    private fun threeModules(): BibleSettings {
+        listOf("p.spb" to "English", "s.spb" to "Русский", "t.spb" to "Deutsch").forEach { (file, text) ->
+            SpbFixture.spbFile(
+                dir, name = file,
+                content = SpbFixture.buildContent(
+                    title = file,
+                    books = listOf(SpbFixture.Book(43, "John", 1)),
+                    verses = listOf(SpbFixture.Verse(43, 1, 1, text)),
+                ),
+            )
+        }
+        return BibleSettings(storageDirectory = dir.absolutePath).withTranslations(
+            listOf("p.spb", "s.spb", "t.spb").map { BibleTranslationSettings(fileName = it) },
+        )
+    }
+
+    private fun viewModel(settings: BibleSettings) = BibleViewModel(
+        AppSettings(bibleSettings = settings),
+        dispatcher = Dispatchers.Unconfined,
+        ioDispatcher = Dispatchers.Unconfined,
+    )
+
+    @Test
+    fun `reordering behind the navigation bible neither re-reads the files nor blanks the verses`() {
+        val settings = threeModules()
+        val model = viewModel(settings)
+        assertEquals(listOf("p.spb", "s.spb", "t.spb"), model.loadedTranslations.value.map { it.fileName })
+        val versesBefore = model.verses.value
+        assertTrue(versesBefore.isNotEmpty(), "fixture error: the initial load produced no verses")
+        val tokenBefore = model.verseSelectionToken.value
+
+        // The modules are already parsed and in memory, so putting them in a different order must not
+        // depend on the files at all. Deleting them is how that is held to.
+        dir.listFiles().orEmpty().forEach { assertTrue(it.delete(), "could not delete ${it.name}") }
+
+        model.updateSettings(AppSettings(bibleSettings = settings.moveTranslation(2, -1)))
+
+        assertEquals(
+            listOf("p.spb", "t.spb", "s.spb"),
+            model.loadedTranslations.value.map { it.fileName },
+            "the new order must be applied to what is already loaded",
+        )
+        assertEquals(
+            listOf("p.spb", "t.spb", "s.spb"),
+            model.loadedBibles.value.map { it.getBibleTitle() },
+            "the bible list the presenter stacks from must be reordered with it",
+        )
+        assertEquals(versesBefore, model.verses.value, "the verse list must be left alone")
+        assertTrue(model.isFullyLoaded, "nothing was reloaded, so nothing is mid-load")
+        assertEquals(
+            listOf("English", "Deutsch", "Русский"),
+            model.getSelectedVerses().map { it.verseText },
+            "the live selection must restack in the new order",
+        )
+        assertTrue(
+            model.verseSelectionToken.value != tokenBefore,
+            "the selection must be re-emitted so the screen restacks too",
+        )
+    }
+
+    @Test
+    fun `a stack whose order is unchanged is left completely alone`() {
+        val settings = threeModules()
+        val model = viewModel(settings)
+        val tokenBefore = model.verseSelectionToken.value
+
+        // Same stack, a styling change elsewhere in the same settings object.
+        model.updateSettings(AppSettings(bibleSettings = settings.copy(splitBrowseMode = true)))
+
+        assertEquals(listOf("p.spb", "s.spb", "t.spb"), model.loadedTranslations.value.map { it.fileName })
+        assertEquals(
+            tokenBefore, model.verseSelectionToken.value,
+            "nothing moved, so the live verse must not be re-emitted",
+        )
+    }
+
+    // ── The reload decision on its own ──────────────────────────────────────────────────────────
+
+    private fun stack(vararg names: String, storage: String = "/bibles"): BibleSettings =
+        BibleSettings(storageDirectory = storage)
+            .withTranslations(names.map { BibleTranslationSettings(fileName = it) })
+
+    private fun reloadRequired(previous: BibleSettings, next: BibleSettings): Boolean =
+        viewModel(threeModules()).translationReloadRequired(previous, next)
+
+    @Test
+    fun `rearranging the stack behind the navigation bible needs no reload`() {
+        assertFalse(reloadRequired(stack("a.spb", "b.spb", "c.spb"), stack("a.spb", "c.spb", "b.spb")))
+    }
+
+    @Test
+    fun `a different navigation bible needs a reload`() {
+        // The first of the stack supplies the book, chapter and verse lists, and the canonical code
+        // every other translation's verse is looked up by — so this one is not a rearrangement.
+        assertTrue(reloadRequired(stack("a.spb", "b.spb", "c.spb"), stack("b.spb", "a.spb", "c.spb")))
+    }
+
+    @Test
+    fun `adding or removing a translation needs a reload`() {
+        assertTrue(reloadRequired(stack("a.spb", "b.spb"), stack("a.spb", "b.spb", "c.spb")))
+        assertTrue(reloadRequired(stack("a.spb", "b.spb", "c.spb"), stack("a.spb", "b.spb")))
+        assertTrue(reloadRequired(stack("a.spb", "b.spb"), stack("a.spb", "c.spb")))
+    }
+
+    @Test
+    fun `a different bible folder needs a reload`() {
+        // Same file names, different files.
+        assertTrue(
+            reloadRequired(
+                stack("a.spb", "b.spb", storage = "/bibles"),
+                stack("a.spb", "b.spb", storage = "/other"),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Picks up the four open issues left behind by #91/#94, plus the regression cover the picker rewrite deleted, plus a full-screen layout regression reported against this branch, plus four things found while doing that. Each fix was checked by mutating it and confirming the test fails; where a mutation is worth knowing about, it is named in the test's own doc comment.

Three things came out differently from how the issues describe them — see #97, #95 and #98.

## Regression cover back on the per-output translation picker

`ContentTranslationCell` was rewritten in 567242f8, which took its 17-case suite with it. I checked the new picker against the two fixes that suite existed for and it still handles both, so these are the old cases restated rather than new fixes:

- unticking the last translation switches the output off, because an empty selection means *all of them* everywhere else in the cell and used to read straight back as every box re-ticking itself;
- the menu and its trigger stay mounted whether or not scripture is on, so Clear cannot shut the menu under the hand that pressed it, and cannot leave the flag that opened it standing for the next time scripture goes on.

The captions, row structure and callback shape all changed, so the controls are now addressed by test tag (`TranslationPickerTags`) — every caption in that cell is either derived from the current selection or read out of the .spb file, and the cleared trigger reads "None", which is also what an unassigned target-display dropdown reads.

Worth knowing for anyone else testing this dialog: Escape does not dismiss that popup under the test harness. A click aimed outside it does, and is consumed by the dismissal, so reaching a control underneath takes a second click.

## #97 — fitting is now a guarantee, not a floor

**This does the opposite of what the issue asks for.** #97 called for a readable floor (8sp) plus clipping. Built that way first, then reverted: capping the shrink converts an unreadably small verse into a *cut-off* one, and being cut off is the failure auto-fit exists to prevent. Text shrinks to stay whole — however many translations are stacked, however long the passage, band or full screen.

Two things stood between the search and that:

- **It never tested its own floor.** `binarySearchFitScale` set `lo = minScale` and returned it after bisecting, so when nothing at or above the floor fitted, the caller got a scale that overflows and could not tell it apart from one that fits. It now halves below the starting scale until the content fits. Even a 10x overflow — entirely ordinary — was silently returning a non-fitting scale before.
- **Two layouts held their reference lines outside the search**, measured once at full size while only the verse scaled: the single-column path, which is what the lower third uses, and the fullscreen 50/50 split. Those references were a floor no scale could get under — a band whose reference alone overfilled it had *no* fitting scale to find, so text ran off the bottom however far the verse shrank. They scale with the verse now, as the multi-translation stack's already did.

`BibleFitScaleTest` (which I had not seen when I wrote the first version) asserted the old behaviour as `text that fits nowhere still returns the floor` — contradicting its own opening paragraph, that the answer must always be one that fits. Its stated intent is what holds now.

The cost is bounded but no longer identical per passage: the halving adds up to about a dozen extra text layouts in the pathological case, so the old fixed-probe-count assertion becomes a ceiling. `clipToBounds` stays as the guard against text leaving the frame; with the fit guaranteed it should never come into play.

Full-screen behaviour confirmed by hand. Note the visible consequence: a long passage now shows a *smaller* reference line than before, because the reference shrinks with it.

## #96 — reordering translations no longer re-parses every .spb

`updateSettings` now decides whether a settings change needs the disk. A reload is only for a different set of files, a different navigation bible (the first of the stack, which supplies the book/chapter/verse lists and the canonical code the others are looked up by), or a different bible folder. Anything else is applied by permuting what is already loaded, and re-emits the live selection so the screen restacks.

The test deletes the .spb files before reordering, so nothing but an in-memory rearrange can pass it.

## #98 — one `##Title:` reader, and none of them on the composition thread

Four places had their own scan with their own copy of the fallback rules. They now share `readTranslationTitle`, which goes through `Bible.readTranslationSummary`.

Two things the issue does not mention but that had to be preserved:

- **The read has to be bounded.** An existing test pins a 10-line cap, and rightly: these callers scan whole folders, and a module with no `-----` line would otherwise be read to its end. The bound is now a parameter on `readTranslationSummary` rather than an implicit line count, so the projection tab can still reach the book list behind it.
- **The separator is not fixed.** A tab from the converter, a space from many hand-made modules, sometimes nothing. And a present-but-empty header stays empty while an absent one falls back to the file stem — the distinction the full loader already makes.

The issue named the Bible tab as reading headers during composition; it was three places. All now go through `produceState` on `Dispatchers.IO`, following `PresentationTab`'s thumbnail load:

- the **Bible tab**, which was also constructing a whole `BibleSettingsViewModel` inside a `remember` to reach the helper;
- the **projection tab**, one header per configured translation. Its read list is held at `null` across a stack change, so a list read for the previous stack is never shown against the current one — that would put the wrong number of rows in the picker and misalign the positions a selection is stored as;
- the **canvas source panel**, which listed the entire bible folder *and* read a header from every module in it, on a panel that rebuilds on each canvas selection and property edit.

That last one made the version picker a second asynchronous thing on that panel: `awaitBibleLoaded` waited only for the module load, so every assertion about the version picker was racing the folder read. It waits for both now.

One correction to the issue: the projection tab already shows real translation titles, not file stems.

## #95 — not the change proposed; the cause underneath it

**The two-line change is not applied.** Measured across the nine themes it makes things worse in four. `surfaceVariant` is the colour a settings tab paints its *page*, so a field pointed at it is painted the backdrop two layers behind it — and in Dark, Midnight, Forest and Mocha `outlineVariant` holds that same value, so the border would disappear along with the fill. In Studio the result lands at exactly the luminance of its own card.

The reason the fields looked wrong enough to want changing is upstream: **not one of the nine schemes declared `surfaceContainer` or `surfaceContainerHigh`**, so both fell back to Material's baseline — one lavender-tinted card and field for every palette, navy and green included, with whatever contrast that happened to give. In the Studio theme it gave a card at exactly the luminance of its own page, so those cards were already invisible before any of this came up.

Each scheme now sets both, derived from its own `surface` and stepped until page, card and field are three distinguishable layers. `ThemeSurfaceRampTest` holds all nine to that, plus body text on a field to WCAG AA; fed the old baseline it reports the 1.000:1 that was shipping.

The unused `leadingIcon` parameter the reverted commit also carried is not reintroduced.

**These nine pairs of colour values are the one thing here that is a judgement call rather than a measurement, so they want a reviewer's eye.** Before/after of all nine drawn at their real colours, with the measured step at each layer: https://claude.ai/code/artifact/6e80f40a-0fe6-4de3-bcbb-dd570f3623dd

## The full-screen stack left an empty band above itself

**Reported against this branch, not one of the issues.** The ordered stack that replaced the bilingual layout in #91 wrapped its content, so every translation bunched against the configured vertical alignment and the whole remainder of the frame collected into one empty strip. With two bibles and the default bottom alignment that is an empty top half, which an operator reads as a third section rather than as slack.

The 50/50 split it replaced did not have this — each translation held half the height and was aligned inside its own half — and that generalises: N translations, N equal bands. The stack fills the frame again for any number of them, not just two.

Fitting is now measured **per band** rather than against the total. A long verse can no longer borrow the slack of a short one beside it, so mixed-length passages settle on a smaller shared scale; that is the cost of the long one staying inside its own band instead of running through the one below. Everything in the predicate still scales with the argument, so the guarantee established above holds and a fitting scale always exists.

This also removes the full-screen 50/50 branch itself, unreachable since #91: the stack returns before it for every `!isLowerThird` case, whatever the stack holds. The single-column branch below it is the lower third's and stays.

The band assertions are positional, not pixel-exact — a verse belonging to band *i* must have its centre inside band *i* — since font metrics differ across the three target platforms. They read the output height back from the harness rather than trusting the requested size; the test window is smaller than the 1920×1080 the `Modifier.size` asks for, and a band worked out from the requested size lands in the wrong place.

## A cap of six translations

Six bands is already past what an output renders legibly, and since the fit floor came off above, a deeper stack no longer clips — it just goes on getting smaller, with nothing to tell an operator they have gone too far.

Capped in `withTranslations`, the choke point every edit funnels through, so a hand-edited settings file is bounded by the same rule the UI is. `addTranslation` refuses at the cap rather than adding and truncating: dropping the entry the operator just picked while the picker reports success is the one outcome worse than not offering the add. The picker is withdrawn at the cap too, so it cannot offer what would be refused.

The reorder buttons in that list also needed a gap standing in for the one each end row is missing — no "up" on the first, no "down" on the last — or the delete buttons stepped in and out along the column. From three rows up only: one or two rows are short of the same single button, so they line up as they are and a placeholder would open a gap nothing can fill. Alignment alone cannot see that placeholder (padding every row keeps them aligned, just wider), so the two-row test measures the run from the row's reorder button to its delete instead.

The lower third is untouched by both, and still draws at most two translations — see the note at the end.

## Found while doing the above

- **Nothing showed which settings field had focus.** `SettingsTextField` built a `MutableInteractionSource`, handed it to `BasicTextField` and never read it; the border branched on `isError` alone, so across roughly two dozen settings screens a focused field was pixel-identical to an unfocused one. The border now carries focus in the accent colour, with the error state still outranking it. The ATEM slot tests read that same border as their error signal and were comparing an unfocused baseline against a post-typing reading — three of them were passing on the focus change alone; all now take a focused baseline.
- **The picker counted translation positions that are not in the stack**, while the preview chip beside it filtered them, so the two disagreed ("2 of 3 translations enabled" over one ticked row). Everything in the cell now derives from one filtered list, and a selection left with none of its positions surviving shows nothing rather than reading as the empty "all of them". Narrow in practice, since `TranslationStackEdits` remaps selections on every edit — this is what reaches the picker from a settings file written before that landed.

**Checked and found already correct**, recorded so nobody re-investigates: per-output selections *are* remapped when the stack is reordered or a translation removed — `TranslationStackEdits.kt` covers screens and browser sources, and switches scripture off when a remap empties an output. I suspected a bug here and was wrong.

**Deliberately not touched:** the Dark theme's `surfaceVariant` (`#49454F`) is Material's baseline purple-grey, lighter than its own `surface` (`#1E1E1E`), making it the only dark theme whose page is lighter than the cards on it. Changing a page colour is a redesign, not a contrast fix. Also `BibleTranslationSettings.lowerThirdEnabled` gates the second language in the band but is set by nothing in the UI.

## Checks

`./gradlew :composeApp:check` green (5865 tests); each touched suite run three times with `--rerun-tasks` for flakes; `cleanup_check.sh` unchanged except for the `@file:OptIn(androidx.compose.ui.test…)` file annotation the existing suites already use. Full-screen verse fitting, the banded stack at one, two and three translations, and the capped translation list all confirmed by hand in the running app.

Not covered: `clipToBounds` is a draw-time modifier with no observable state, so there is nothing to assert against short of rasterising an output window. Moving a read off the composition thread is structural and has no test that would catch a regression back to `remember`. Both noted at their sites.

The lower third still draws at most two translations. That is the pre-existing documented cap from `02e00759`, untouched here — though its rationale ("a narrow band cannot usefully hold more than a couple of languages") is a readability argument, and with fitting now guaranteed the band would shrink a deeper stack rather than overflow. Lifting it is a policy call for a separate change.
