### PR TITLE
Stop the legacy Bible fields drifting from the translation stack

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -192,6 +192,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleTranslationSettings
 import org.churchpresenter.app.churchpresenter.models.SceneSource
 import org.churchpresenter.app.churchpresenter.models.SourceTransform
 import org.churchpresenter.app.churchpresenter.utils.Utils
@@ -1870,12 +1871,22 @@ private fun BibleProperties(
     }
 
     // Selected bible version
-    var selectedBibleFile by remember { mutableStateOf(appSettings?.bibleSettings?.primaryBible ?: "") }
+    var selectedBibleFile by remember {
+        mutableStateOf(appSettings?.bibleSettings?.translationList()?.firstOrNull()?.fileName ?: "")
+    }
 
-    // Bible data loading — keyed on the selected bible file
+    // Bible data loading — keyed on the selected bible file. The picked version is handed over as a
+    // one-entry stack, not as the legacy `primaryBible` field: BibleViewModel loads whatever
+    // `translationList()` returns, and that ignores the legacy field entirely once the stack is
+    // populated. Written the old way this dropdown moved nothing at all on a configured machine --
+    // it only appeared to work on a settings file still falling back to the legacy pair.
     val bibleVm = remember(appSettings, selectedBibleFile) {
         appSettings?.let {
-            val settings = it.copy(bibleSettings = it.bibleSettings.copy(primaryBible = selectedBibleFile))
+            val settings = it.copy(
+                bibleSettings = it.bibleSettings.withTranslations(
+                    listOf(BibleTranslationSettings(fileName = selectedBibleFile)),
+                ),
+            )
             BibleViewModel(settings)
         }
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManager.kt
@@ -116,11 +116,11 @@ class SettingsManager {
             // keeps its higher number: the newer build's own migrations have already run against
             // this data and must not run a second time when it is loaded there again.
             backupSource?.let { backupBeforeRewrite(it, fromVersion) }
-            return jsonFormat.decodeFromString<AppSettings>(raw)
+            return jsonFormat.decodeFromString<AppSettings>(raw).repaired()
         }
 
         if (fromVersion == CURRENT_SETTINGS_VERSION) {
-            return jsonFormat.decodeFromString<AppSettings>(raw)
+            return jsonFormat.decodeFromString<AppSettings>(raw).repaired()
         }
 
         backupSource?.let { backupBeforeRewrite(it, fromVersion) }
@@ -135,8 +135,10 @@ class SettingsManager {
             // than raw, because the conversion is a field-by-field restructure the data class
             // already knows how to do. The old fields are left in the document on purpose so a
             // downgrade still finds a configured bible.
+            //
+            // Only the *output* half of that conversion belongs behind this version gate. The stack
+            // itself is repaired by `repaired()` on every load, whatever the version says.
             settings = settings.copy(
-                bibleSettings = settings.bibleSettings.migrateTranslations(),
                 projectionSettings = settings.projectionSettings.copy(
                     screenAssignments = settings.projectionSettings.screenAssignments
                         .map(::migrateOutputTranslations),
@@ -149,8 +151,27 @@ class SettingsManager {
                 ),
             )
         }
-        return settings.copy(settingsVersion = CURRENT_SETTINGS_VERSION)
+        return settings.copy(settingsVersion = CURRENT_SETTINGS_VERSION).repaired()
     }
+
+    /**
+     * Puts the translation stack back in step with the legacy bible pair it mirrors.
+     *
+     * An invariant, not a migration, which is why it runs on every load and not behind a version
+     * gate. `primaryBible`/`secondaryBible` are only kept so an older build can still read the file;
+     * anything that sets one of them without going through [BibleSettings.withTranslations] leaves a
+     * current-version document with a configured pair and an empty stack. That document is never
+     * migrated — it is already at the current version — so before this it stayed broken for good.
+     * Nothing shows it either: [BibleSettings.translationList] falls back to the pair, so the app
+     * presents correctly right up until the first stack edit rewrites the pair from a list that
+     * never held those bibles, and the operator's translations disappear.
+     *
+     * Safe on a stack that is empty on purpose: emptying it through `withTranslations` clears the
+     * legacy pair too, so there is nothing to put back. Idempotent, by
+     * [BibleSettings.migrateTranslations]'s own guard.
+     */
+    private fun AppSettings.repaired(): AppSettings =
+        copy(bibleSettings = bibleSettings.migrateTranslations())
 
     /**
      * An output used to name which of two bibles it showed. With a stack of any length it names

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/BibleSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/BibleSettings.kt
@@ -230,7 +230,11 @@ data class BibleSettings(
     fun translationSelectionKey(): List<String> = translationList().map { it.fileName }
 
     /**
-     * Moves a pre-list settings file onto [translations], once, at load.
+     * Fills [translations] from the legacy primary/secondary pair when it is empty.
+     *
+     * Both the one-time conversion of a pre-list settings file and, since it is idempotent, the
+     * repair the load path applies on every read to keep the two in step — see
+     * `SettingsManager.repaired`.
      *
      * The old primary/secondary fields are deliberately left in place rather than cleared: they are
      * what an older build reads, so a user who rolls back keeps their setup instead of opening a

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/TranslationStackEdits.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/TranslationStackEdits.kt
@@ -56,6 +56,34 @@ fun AppSettings.moveBibleTranslation(index: Int, offset: Int): AppSettings {
 fun AppSettings.swapBibleTranslations(): AppSettings = moveBibleTranslation(0, 1)
 
 /**
+ * First run: points the app at [directory] and puts the bundled [fileName] in the stack.
+ *
+ * Separate from its one caller in `main()` so it can be tested, and going through
+ * [BibleSettings.addTranslation] rather than setting `primaryBible`: written straight to the legacy
+ * field, the very first settings file the app ever saves is one whose stack is empty and whose
+ * legacy pair is not — the drift `SettingsManager.repaired` now has to undo on every subsequent load.
+ */
+fun AppSettings.withBundledBible(directory: String, fileName: String): AppSettings =
+    copy(bibleSettings = bibleSettings.copy(storageDirectory = directory).addTranslation(fileName))
+
+/**
+ * A bible just installed from the catalogue, presented if nothing else is.
+ *
+ * Deliberately not an unconditional add. The rule it replaces was "become the primary bible if there
+ * isn't one", which — once the stack existed — could no longer be honoured: the legacy field it
+ * tested is mirrored from the stack, so it was never empty and a downloaded module simply never
+ * appeared anywhere. Restoring the intent means asking the stack instead. An unconditional add would
+ * be a different rule altogether: browse the catalogue for an afternoon and every module you tried
+ * is stacked on the output.
+ */
+fun AppSettings.withInstalledBible(fileName: String): AppSettings =
+    if (bibleSettings.translationList().isEmpty()) {
+        copy(bibleSettings = bibleSettings.addTranslation(fileName))
+    } else {
+        this
+    }
+
+/**
  * Rewrites every output's stored positions through [newPositionOf]; null means that translation is
  * gone. Covers browser sources as well as screens — the same shape, driven by the same UI.
  */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SystemSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SystemSettingsTab.kt
@@ -95,6 +95,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.withInstalledBible
 import org.churchpresenter.app.churchpresenter.data.SettingsManager
 import org.churchpresenter.app.churchpresenter.BuildConfig
 import org.churchpresenter.app.churchpresenter.data.SpsConverter
@@ -216,13 +217,7 @@ fun SystemSettingsTab(
                     storageDirectory = bibleDir,
                     onDismiss = { showBibleCatalog = false },
                     onBibleInstalled = { fileName ->
-                        onSettingsChange { s ->
-                            s.copy(
-                                bibleSettings = s.bibleSettings.copy(
-                                    primaryBible = s.bibleSettings.primaryBible.ifEmpty { fileName }
-                                )
-                            )
-                        }
+                        onSettingsChange { s -> s.withInstalledBible(fileName) }
                         bibleFiles = bibleFiles + fileName
                     }
                 )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -85,6 +85,7 @@ import org.churchpresenter.app.churchpresenter.data.settings.BibleSyncMode
 import org.churchpresenter.app.churchpresenter.data.settings.CompanionSatelliteSettings
 import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkRole
 import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
+import org.churchpresenter.app.churchpresenter.data.settings.withBundledBible
 import org.churchpresenter.app.churchpresenter.data.Language
 import org.churchpresenter.app.churchpresenter.data.RemoteClientManager
 import org.churchpresenter.app.churchpresenter.data.SettingsManager
@@ -236,12 +237,7 @@ fun main() {
                 targetFile.writeBytes(runBlocking { Res.readBytes("files/bible_samples/kjv1769.spb") })
             }
             SettingsManager().saveSettings(
-                startupSettings.copy(
-                    bibleSettings = startupSettings.bibleSettings.copy(
-                        storageDirectory = defaultBibleDir.absolutePath,
-                        primaryBible = "kjv1769.spb"
-                    )
-                )
+                startupSettings.withBundledBible(defaultBibleDir.absolutePath, "kjv1769.spb")
             )
         } catch (e: Exception) {
             CrashReporter.reportException(e, "Bundling default KJV Bible")

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PlanningCenterImportViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PlanningCenterImportViewModel.kt
@@ -86,7 +86,9 @@ class PlanningCenterImportViewModel(
         triedLoadingPrimaryBible = true
         try {
             val bibleSettings = SettingsManager().loadSettings().bibleSettings
-            val fileName = bibleSettings.primaryBible
+            // The navigation bible, read from the stack rather than from the legacy field it
+            // mirrors -- the same thing today, but the stack is what is actually maintained.
+            val fileName = bibleSettings.translationList().firstOrNull()?.fileName.orEmpty()
             val storageDir = bibleSettings.storageDirectory
             if (fileName.isBlank() || storageDir.isBlank()) return@withContext null
             val path = File(storageDir, fileName).absolutePath

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesBibleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesBibleTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.test.performScrollTo
 import org.churchpresenter.app.churchpresenter.data.SpbFixture
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.BibleSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleTranslationSettings
 import org.churchpresenter.app.churchpresenter.dialogs.tabs.recolor
 import org.churchpresenter.app.churchpresenter.models.SceneSource
 import java.io.File
@@ -376,6 +377,50 @@ class SourcePropertiesBibleTest {
             onNodeWithText("BOOK").assertExists()
             onNodeWithText("CHAPTER").assertExists()
             assertEquals(0, countOf("No Primary Bible Configured"), "and the notice is gone")
+        }
+    }
+
+    /**
+     * Two modules with no book in common, and a settings file whose stack is real.
+     *
+     * [settingsWithBible] deliberately builds the legacy shape — `primaryBible` with an empty
+     * `translations` — which is the one configuration where the version picker used to appear to
+     * work. `BibleViewModel` reads `translationList()`, and that only falls back to the legacy field
+     * while the stack is empty, so a panel that hands its choice over as `primaryBible` moves nothing
+     * at all on a machine that has been through the Bible settings tab. This fixture is that machine.
+     */
+    private fun settingsWithTwoBibles(): AppSettings {
+        val dir = storage ?: Files.createTempDirectory("cp-canvas-bible").toFile().also { storage = it }
+        SpbFixture.spbFile(dir, name = "kjv.spb", content = SpbFixture.sampleContent(title = "King James"))
+        SpbFixture.spbFile(
+            dir,
+            name = "rst.spb",
+            content = SpbFixture.buildContent(
+                title = "Synodal",
+                books = listOf(SpbFixture.Book(40, "Matthew", 1)),
+                verses = listOf(SpbFixture.Verse(40, 1, 1, "The book of the generation of Jesus Christ.")),
+            ),
+        )
+        return AppSettings(
+            bibleSettings = BibleSettings(storageDirectory = dir.absolutePath).withTranslations(
+                listOf(BibleTranslationSettings(fileName = "kjv.spb")),
+            ),
+        )
+    }
+
+    @Test
+    fun `choosing another version loads that module`() {
+        sourcePanel(Fixture.bible(), appSettings = settingsWithTwoBibles()) { _ ->
+            awaitBibleLoaded()
+            onNodeWithText("Genesis").assertExists("the stack's own bible is what loads first")
+
+            chooseFromDropdown(showing = "King James", option = "Synodal")
+
+            // Matthew belongs only to the second module, Psalms only to the first, so this cannot
+            // pass on the first module still being loaded.
+            waitUntil("the picked module's books must replace the previous module's", timeoutMillis = 5_000) {
+                countOf("Matthew") >= 1 && countOf("Psalms") == 0 && countOf("Genesis") == 0
+            }
         }
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManagerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManagerTest.kt
@@ -369,6 +369,62 @@ class SettingsManagerTest {
         assertTrue(!outputs[3].showBible, "and an output that was off stays off")
     }
 
+    // ── The stack is repaired on every load, not only on the version-6 upgrade ──
+    //
+    // `primaryBible`/`secondaryBible` are legacy mirrors of the first two of the stack. Anything that
+    // writes one of them without going through `withTranslations` leaves a document at the *current*
+    // version whose stack is empty and whose pair is not — and a current-version document takes the
+    // early return above, so before this it was never repaired and never would be. Nothing surfaces
+    // it either: `translationList()` falls back to the pair, so the app presents correctly until the
+    // first stack edit rewrites the pair from a list that never held those bibles.
+
+    @Test
+    fun `a current-version file whose stack never got filled is repaired on load`() {
+        val current = AppSettings.CURRENT_SETTINGS_VERSION
+        val loaded = SettingsManager().migrateAndDecode(
+            """{"settingsVersion":$current,"bibleSettings":{"primaryBible":"kjv.spb","secondaryBible":"rst.spb","translations":[]}}""",
+        )
+
+        assertEquals(
+            listOf("kjv.spb", "rst.spb"),
+            loaded.bibleSettings.translations.map { it.fileName },
+            "the pair has to reach the stack, in order, or the first stack edit erases both bibles",
+        )
+    }
+
+    @Test
+    fun `a stack emptied on purpose is not refilled`() {
+        // The other half of the repair, and what stops it being wrong: clearing the last translation
+        // goes through `withTranslations`, which clears the legacy pair with it. An empty stack
+        // beside an empty pair is a deliberate state, not drift, and must survive a reload.
+        val current = AppSettings.CURRENT_SETTINGS_VERSION
+        val loaded = SettingsManager().migrateAndDecode(
+            """{"settingsVersion":$current,"bibleSettings":{"primaryBible":"","secondaryBible":"","translations":[]}}""",
+        )
+
+        assertTrue(
+            loaded.bibleSettings.translations.isEmpty(),
+            "nothing to put back, so nothing may be invented",
+        )
+    }
+
+    @Test
+    fun `a repaired load leaves a configured stack exactly as it was`() {
+        val current = AppSettings.CURRENT_SETTINGS_VERSION
+        val loaded = SettingsManager().migrateAndDecode(
+            """{"settingsVersion":$current,"bibleSettings":{"primaryBible":"kjv.spb","secondaryBible":"rst.spb",
+                "translations":[{"fileName":"rst.spb","textColor":"#ABCDEF"},{"fileName":"kjv.spb"}]}}"""
+                .trimIndent().replace("\n", ""),
+        )
+
+        assertEquals(
+            listOf("rst.spb", "kjv.spb"),
+            loaded.bibleSettings.translations.map { it.fileName },
+            "the stack is the source of truth; the repair must not reorder it to match the mirror",
+        )
+        assertEquals("#ABCDEF", loaded.bibleSettings.translations[0].textColor)
+    }
+
     // ── Import path ─────────────────────────────────────────────────────────────
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/settings/TranslationStackEditsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/settings/TranslationStackEditsTest.kt
@@ -149,4 +149,41 @@ class TranslationStackEditsTest {
 
         assertEquals(before, before.swapBibleTranslations().swapBibleTranslations())
     }
+
+    // ── Bibles arriving from outside the Bible settings tab ─────────────────────
+    //
+    // Both of these used to write `primaryBible` directly. That field is a mirror of the stack kept
+    // for older builds to read, so writing it alone produces a settings file with a configured bible
+    // and an empty stack — which the Bible settings tab, and every stack edit, then work against.
+
+    @Test
+    fun `the bundled bible goes into the stack, not just the legacy field`() {
+        val first = AppSettings().withBundledBible("/bibles", "kjv1769.spb")
+
+        assertEquals(listOf("kjv1769.spb"), first.stack())
+        assertEquals("/bibles", first.bibleSettings.storageDirectory)
+        assertEquals(
+            listOf("kjv1769.spb"), first.bibleSettings.translations.map { it.fileName },
+            "the stack itself has to hold it -- translationList() would report it either way, " +
+                "because it falls back to the legacy pair",
+        )
+    }
+
+    @Test
+    fun `a bible installed with nothing configured becomes the one that presents`() {
+        val after = AppSettings().withInstalledBible("downloaded.spb")
+
+        assertEquals(listOf("downloaded.spb"), after.stack())
+    }
+
+    @Test
+    fun `a bible installed alongside a configured stack does not join it`() {
+        // The rule this restores is "become the presented bible if there isn't one". It had stopped
+        // working in both directions: with a stack configured the old test was against a mirrored
+        // field that is never empty, so the download vanished; with none, it created the drift.
+        val before = settings()
+        val after = before.withInstalledBible("downloaded.spb")
+
+        assertEquals(before, after, "a stack the operator has set up is not to be added to behind them")
+    }
 }


### PR DESCRIPTION
`BibleSettings.translations` is the source of truth for the Bible stack. `primaryBible`/`secondaryBible` are mirrors of its first two entries, kept only so an older build can still read the file, and `withTranslations` is what holds the two together. Three places still wrote the mirror directly, and nothing put the two back in step afterwards.

The visible symptom is a settings file with a configured bible pair and an empty stack. That state is invisible until it isn't: `translationList()` falls back to the pair, so the app presents correctly right up until the first edit in the Bible settings tab, at which point `withTranslations` rewrites the pair from a list that never held those bibles and the operator's translations disappear. Found on a real machine in exactly that state.

## The repair is an invariant, not a migration

`migrateTranslations` ran only behind `fromVersion < 6`, and `migrateAndDecode` returns early for a document already at the current version — before any migration step. So a file that acquired the drift *after* upgrading was never repaired and never would be.

It now runs on every decode path. It is idempotent by its own guard, and safe on a stack emptied on purpose: emptying one through `withTranslations` clears the legacy pair with it, so there is nothing left to put back — the test for that is the one holding this honest, since a repair that resurrects a deliberately cleared stack is worse than no repair. Only the output-assignment half of the version-6 conversion stays version-gated; that one really is a one-shot format change.

## The three writers

- **First run** wrote the bundled KJV to the legacy field and saved it, so the first settings file the app ever produces is a drifted one, on every fresh install.
- **Installing from the Bible catalogue** applied "become the primary bible if there isn't one" to a field that is mirrored from the stack and so is never empty once anything is configured. The downloaded module joined nothing and appeared nowhere; with nothing configured it made the drift instead. The rule is restored by asking the stack. **Deliberately not an unconditional add** — browse the catalogue for an afternoon and every module you tried would be stacked on the output.
- **The canvas Bible source's version dropdown did nothing at all.** It handed the picked module over as `primaryBible`, and `BibleViewModel` loads from `translationList()`, which ignores that field whenever the stack is populated. The dropdown moved the panel only on a settings file still in the legacy-fallback state — and that is exactly what its existing test fixture is, which is why this was never caught. The new test builds a real stack plus two modules with no book in common, so it cannot pass on the first module simply staying loaded.

The two persisting transforms are named functions in `TranslationStackEdits` rather than inline at their call sites, so they can be tested at all: one lives in `main()`, the other in a lambda handed to a dialog that downloads over the network.

Also switches `PlanningCenterImportViewModel` to read the navigation bible from the stack rather than the mirrored field. Same answer today; the stack is what is actually maintained.

## Checks

`./gradlew :composeApp:check` green; the three touched suites run three times with `--rerun-tasks`. The two tests that could plausibly pass for the wrong reason were mutation-checked: reverting the canvas panel to `copy(primaryBible = …)` makes the dropdown test time out waiting for the second module's books, and the load repair is pinned in both directions by the pair of tests described above.

Confirmed end to end as well, against a throwaway `user.home` holding a hand-written drifted document: the app starts, and the file on disk comes back with the pair promoted into a two-entry stack.

Not covered: the catalogue path itself still cannot be driven from a test — `onBibleInstalled` fires from a dialog that downloads over the network — so the extracted transform is tested and the one-line wiring to it is not. Noted at the site.
