### PR TITLE
Fix two live bugs found while auditing untestable code, and cover ScheduleTab/PicturesTab

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,15 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer push to the same branch makes an in-flight run redundant. Keyed on head_ref for a
-  # pull_request event so a branch's own push run and its PR run share one group instead of both
-  # running the same commit twice -- now that every branch push triggers this.
-  group: tests-${{ github.head_ref || github.ref }}
+  # A newer push to the same branch makes an in-flight run redundant. Keyed on the bare branch name
+  # so a branch's own push run and its PR run share one group instead of both building the same
+  # commit -- now that every branch push triggers this.
+  #
+  # ref_name, not ref: the two events spell the same branch differently. On push, head_ref is empty
+  # and ref is `refs/heads/<branch>`; on pull_request, head_ref is `<branch>`. Those are different
+  # strings, so `head_ref || ref` put the two events in different groups and ran both -- 15 minutes
+  # of runner per commit, twice. ref_name drops the prefix, so both spell it `<branch>`.
+  group: tests-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,10 @@ name: Tests
 # The three build workflows are all workflow_dispatch-only, so until this existed nothing ran
 # automatically on a push or a pull request -- including the submodule test suites, which were
 # green but unenforced. This runs the whole suite on every push and PR.
+# Every branch, not just main: a branch whose PR has already merged stops matching `pull_request`,
+# so work pushed to it afterwards ran nothing at all until this was widened.
 on:
   push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -16,8 +17,10 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer push to the same branch makes an in-flight run redundant.
-  group: tests-${{ github.ref }}
+  # A newer push to the same branch makes an in-flight run redundant. Keyed on head_ref for a
+  # pull_request event so a branch's own push run and its PR run share one group instead of both
+  # running the same commit twice -- now that every branch push triggers this.
+  group: tests-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -25,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     # The suite takes ~14 minutes. Without a timeout a test that hangs instead of failing holds
     # the runner until GitHub's 6-hour default kills it, so the deadline is the failure signal.
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,9 +51,32 @@ jobs:
 
       - name: App unit tests
         # Tighter than the job's own deadline so a hang here is attributed to this step and the
-        # submodule suites below (`if: always()`) and the report upload still get to run.
-        timeout-minutes: 25
+        # submodule suites below (`if: always()`) and the report upload still get to run. Runs land
+        # around 11-14 minutes; one run was killed at a 25-minute budget with no diagnosis that
+        # survived scrutiny, so the budget is set well clear of the observed band rather than
+        # doubling as an alarm on a suite that is still growing.
+        timeout-minutes: 40
         run: ./gradlew :composeApp:jvmTest
+
+      # So an outlier explains itself instead of needing a guess: the one killed run above was
+      # attributed to the wrong fixture precisely because nothing recorded where the time went.
+      - name: Slowest test classes
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import glob, re
+          rows = []
+          for path in glob.glob('composeApp/build/test-results/jvmTest/TEST-*.xml'):
+              head = open(path, errors='replace').read(4000)
+              m = re.search(r'<testsuite name="([^"]+)"[^>]*tests="(\d+)"[^>]*time="([\d.]+)"', head)
+              if m:
+                  rows.append((float(m.group(3)), int(m.group(2)), m.group(1)))
+          rows.sort(reverse=True)
+          print(f'{len(rows)} suites, {sum(r[0] for r in rows):.0f}s of test time')
+          print(f'{"time":>9}  {"tests":>5}  class')
+          for t, n, name in rows[:25]:
+              print(f'{t:>8.1f}s  {n:>5}  {name}')
+          PY
 
       # The 75% line-coverage floor, off the execution data the tests above just produced (so this
       # adds no test time). Its denominator excludes the app-entry wiring that only runs under a real

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/NumberSettingsTextField.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/NumberSettingsTextField.kt
@@ -67,7 +67,9 @@ fun NumberSettingsTextField(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(
-            modifier = Modifier.padding(start = 11.dp, top = 2.dp, bottom = 0.dp),
+            // Weighted so the arrow column below keeps its 20dp: the text field fills this column's
+            // width, which without a weight is the whole row's, collapsing the arrows to zero.
+            modifier = Modifier.weight(1f).padding(start = 11.dp, top = 2.dp, bottom = 0.dp),
             verticalArrangement = Arrangement.Center
         ) {
             if (label.isNotEmpty()) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -3380,6 +3381,14 @@ class CompanionServer {
                     // wait is released by the job ending too rather than hanging the handler; the
                     // fallback is exactly the old behaviour, a snapshot and no broadcasts.
                     broadcastJob.invokeOnCompletion { subscribed.complete(Unit) }
+                    // Tied to this session rather than only to the `finally` below, because the
+                    // snapshot sends between here and there are outside it: a client that vanishes
+                    // mid-snapshot throws out of the handler before that `try` is ever entered, and
+                    // the collector -- launched on the server-lifetime scope, not this session's --
+                    // would be left parked on snapshotSent.await() for as long as the server runs,
+                    // holding this session with it. One leaked coroutine per aborted connect, in
+                    // exactly the reconnect churn this whole change is about.
+                    coroutineContext.job.invokeOnCompletion { broadcastJob.cancel() }
                     subscribed.await()
 
                     val catalog = _catalog.value

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
@@ -37,6 +37,7 @@ import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import io.ktor.websocket.readText
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import java.security.MessageDigest
@@ -51,6 +52,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -3357,6 +3359,29 @@ class CompanionServer {
                         InstanceLinkLogger.log(InstanceLinkLogSide.PRIMARY, "follower_connected", mapOf("deviceId" to wsClientId))
                     }
 
+                    // Subscribed to the broadcast flow BEFORE the connect snapshot is written, and
+                    // released only once it has been: broadcastChannel has no replay, so a change
+                    // emitted while the snapshot was still being sent used to land on a flow this
+                    // session had not subscribed to yet and was lost outright -- the client then
+                    // showed stale content until its next reconnect. Broadcasts that arrive during
+                    // the snapshot queue in the flow's own buffer instead, so the whole snapshot
+                    // still reaches the client ahead of any of them.
+                    val snapshotSent = CompletableDeferred<Unit>()
+                    val subscribed = CompletableDeferred<Unit>()
+                    val broadcastJob = scope.launch {
+                        broadcastChannel
+                            .onSubscription { subscribed.complete(Unit) }
+                            .collect { message ->
+                                snapshotSent.await()
+                                send(Frame.Text(message))
+                            }
+                    }
+                    // A scope already cancelled (server stopping) never runs the block above, so the
+                    // wait is released by the job ending too rather than hanging the handler; the
+                    // fallback is exactly the old behaviour, a snapshot and no broadcasts.
+                    broadcastJob.invokeOnCompletion { subscribed.complete(Unit) }
+                    subscribed.await()
+
                     val catalog = _catalog.value
                     val schedule = _schedule.value
                     send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
@@ -3400,9 +3425,8 @@ class CompanionServer {
                                 json.encodeToString(LiveStateDto.serializer(), state)))))
                     }
 
-                    val broadcastJob = scope.launch {
-                        broadcastChannel.collect { message -> send(Frame.Text(message)) }
-                    }
+                    // The snapshot is complete; anything the collector queued during it now flows.
+                    snapshotSent.complete(Unit)
 
                     // Ack for commands that carried a commandId (InstanceLink controller mode) —
                     // no-op for clients that don't send one, so mobile behavior is unchanged.

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/NumberSettingsTextFieldTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/NumberSettingsTextFieldTest.kt
@@ -1,0 +1,192 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The numeric settings field used by every bounded setting in the app — font sizes, ports,
+ * opacities, margins, timer durations.
+ *
+ * Its two arrow buttons are the only place the `range` clamp is applied on the way up: they refuse
+ * a step that would leave the range, where the text field accepts any digits and simply declines to
+ * report an out-of-range value. Both paths are exercised here.
+ *
+ * The layout is asserted as well as the behaviour. The arrow column previously measured to a
+ * zero-size rect — the text column carries a `fillMaxWidth()` child and had no `weight`, so in the
+ * `Row` it was measured against the full available width and consumed all of it, leaving nothing for
+ * the 20dp arrow column. That made both arrows undeliverable, in a test and in the real UI alike, so
+ * `both arrows are laid out at a clickable size` is a regression guard, not a formality.
+ */
+@OptIn(ExperimentalTestApi::class)
+class NumberSettingsTextFieldTest {
+
+    /** What the field currently shows; its contents are `EditableText`, never `Text`. */
+    private fun ComposeUiTest.shownValue(): String? =
+        onAllNodes(hasSetTextAction())[0].fetchSemanticsNode()
+            .config.getOrNull(SemanticsProperties.EditableText)?.text
+
+    @Test
+    fun `both arrows are laid out at a clickable size`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                Box(Modifier.width(200.dp)) {
+                    NumberSettingsTextField(label = "Font size", initialText = 8, range = 1..40, onValueChange = { })
+                }
+            }
+        }
+
+        val up = onNodeWithContentDescription("Increment").fetchSemanticsNode().size
+        val down = onNodeWithContentDescription("Decrement").fetchSemanticsNode().size
+        assertTrue(up.width > 0 && up.height > 0, "the up arrow must occupy space to be clickable, was $up")
+        assertTrue(down.width > 0 && down.height > 0, "the down arrow must occupy space to be clickable, was $down")
+    }
+
+    @Test
+    fun `the up arrow steps the value and reports it`() = runComposeUiTest {
+        var reported: Int? = null
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(initialText = 8, range = 1..40, onValueChange = { reported = it })
+            }
+        }
+
+        onNodeWithContentDescription("Increment").performClick()
+
+        assertEquals(9, reported, "clicking up must report the stepped value to the caller")
+        assertEquals("9", shownValue(), "the field must show the stepped value")
+    }
+
+    @Test
+    fun `the down arrow steps the value and reports it`() = runComposeUiTest {
+        var reported: Int? = null
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(initialText = 8, range = 1..40, onValueChange = { reported = it })
+            }
+        }
+
+        onNodeWithContentDescription("Decrement").performClick()
+
+        assertEquals(7, reported, "clicking down must report the stepped value to the caller")
+        assertEquals("7", shownValue(), "the field must show the stepped value")
+    }
+
+    @Test
+    fun `the up arrow refuses to step past the top of the range`() = runComposeUiTest {
+        var reported: Int? = null
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(initialText = 40, range = 1..40, onValueChange = { reported = it })
+            }
+        }
+
+        onNodeWithContentDescription("Increment").performClick()
+
+        assertNull(reported, "a step out of the range must not reach the setting")
+        assertEquals("40", shownValue(), "a refused step must leave the shown value alone")
+    }
+
+    @Test
+    fun `the down arrow refuses to step below the bottom of the range`() = runComposeUiTest {
+        var reported: Int? = null
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(initialText = 1, range = 1..40, onValueChange = { reported = it })
+            }
+        }
+
+        onNodeWithContentDescription("Decrement").performClick()
+
+        assertNull(reported, "a step out of the range must not reach the setting")
+        assertEquals("1", shownValue(), "a refused step must leave the shown value alone")
+    }
+
+    @Test
+    fun `repeated steps accumulate`() = runComposeUiTest {
+        var reported: Int? = null
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(initialText = 8, range = 1..40, onValueChange = { reported = it })
+            }
+        }
+
+        repeat(3) { onNodeWithContentDescription("Increment").performClick() }
+        onNodeWithContentDescription("Decrement").performClick()
+
+        assertEquals(10, reported, "each click must step from the value the previous one left behind")
+        assertEquals("10", shownValue())
+    }
+
+    @Test
+    fun `a typed in-range number is reported`() = runComposeUiTest {
+        var reported: Int? = null
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(initialText = 8, range = 1..40, onValueChange = { reported = it })
+            }
+        }
+
+        onAllNodes(hasSetTextAction())[0].performTextReplacement("24")
+
+        assertEquals(24, reported, "a typed value inside the range must reach the setting")
+    }
+
+    @Test
+    fun `a typed out-of-range number is shown but not reported`() = runComposeUiTest {
+        var reported: Int? = null
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(initialText = 8, range = 1..40, onValueChange = { reported = it })
+            }
+        }
+
+        onAllNodes(hasSetTextAction())[0].performTextReplacement("99")
+
+        assertNull(reported, "a typed value outside the range must not reach the setting")
+        assertEquals("99", shownValue(), "the operator has to see what they typed in order to correct it")
+    }
+
+    @Test
+    fun `clearing the field falls back to zero rather than crashing`() = runComposeUiTest {
+        var reported: Int? = null
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(initialText = 8, range = 0..40, onValueChange = { reported = it })
+            }
+        }
+
+        onAllNodes(hasSetTextAction())[0].performTextReplacement("")
+
+        // `toIntOrNull() ?: 0` — with 0 inside the range it is a legitimate value and is reported.
+        assertEquals(0, reported, "an emptied field must resolve to 0, not throw")
+        assertEquals("0", shownValue())
+    }
+
+    @Test
+    fun `the label is shown uppercased above the value`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                NumberSettingsTextField(label = "Font size", initialText = 8, range = 1..40, onValueChange = { })
+            }
+        }
+
+        onNodeWithText("FONT SIZE").assertExists("the label names which setting the number belongs to")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SettingsFieldEdgeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SettingsFieldEdgeTest.kt
@@ -16,14 +16,8 @@ import kotlin.test.assertTrue
  * url, the website bar, the Q&A entry all rely on it — and it lives in a `decorationBox` that draws it
  * only while the value is empty, so it is its own branch rather than a property of the field.
  *
- * **Not covered: `NumberSettingsTextField`'s arrows.** Both `IconButton`s measure to a zero-size rect
- * in a headless composition — under the parameter's own default modifier
- * (`widthIn(min = 60.dp).width(IntrinsicSize.Max)`) and equally when the component is given a fixed
- * 200dp width — so no click can be delivered to either one and the range clamp behind them is
- * unreachable from a test. Worth a look in the real UI: if the arrow column really does collapse once
- * the text field takes the row's width, those arrows are undeliverable there too and the clamp they
- * guard never runs (every caller feeds the value straight into a setting). Flagged rather than
- * asserted around, since a test written against the collapsed layout would pin the bug in place.
+ * `NumberSettingsTextField` lives in `NumberSettingsTextFieldTest` — its arrows were undeliverable
+ * (a zero-width arrow column) until the layout was fixed, and that test now guards it.
  */
 class SettingsFieldEdgeTest {
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/DictionarySettingsTabStructureTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/DictionarySettingsTabStructureTest.kt
@@ -123,27 +123,17 @@ class DictionarySettingsTabStructureTest {
     // ── The stepper arrows ──────────────────────────────────────────────────────────────────────
 
     /**
-     * Every stepper field publishes increment/decrement arrows and every one of them lays out zero
-     * pixels wide, so they draw nothing and cannot be clicked. The cause is in
-     * `NumberSettingsTextField` itself — its `BasicTextField` takes `fillMaxWidth()`, leaving the
-     * arrow column no room — so it affects every numeric field in the app rather than this tab.
-     * Pinned as present-but-unusable rather than driven: a test that clicked them would be asserting
-     * a defect works.
+     * Every stepper field publishes increment/decrement arrows, and each is laid out at a size a
+     * click can reach.
+     *
+     * These arrows used to collapse to zero pixels wide on every tab in the app — a defect in the
+     * shared `NumberSettingsTextField`, which this test pinned as present-but-unusable while it
+     * stood. Now that it is fixed, the same test guards the fix.
      */
     @Test
-    fun `the stepper arrows are published but laid out unusably`() {
+    fun `the stepper arrows are laid out where they can be clicked`() {
         dictionaryTab(initial = dictionarySettings { copy(wordShadow = true, referenceShadow = true) }) { _ ->
-            for (description in listOf("Increment", "Decrement")) {
-                val widths = onAllNodesWithContentDescription(description)
-                    .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                    .map { it.boundsInRoot.width }
-                assertEquals(8, widths.size, "one $description arrow per number field")
-                assertEquals(
-                    true,
-                    widths.all { it == 0f },
-                    "every $description arrow is zero pixels wide, so none of them can be clicked",
-                )
-            }
+            assertStepperArrowsUsable(expected = 8)
         }
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/DictionarySettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/DictionarySettingsTabTestSupport.kt
@@ -48,9 +48,9 @@ import kotlin.test.assertTrue
  *
  * Known gaps — what these tests do not reach, and why:
  *
- *  * **The stepper arrows** on every `NumberSettingsTextField` lay out zero pixels wide and cannot
- *    be clicked. That is a defect in the shared control, not this tab, and is pinned as
- *    present-but-unusable rather than driven.
+ *  * **The stepper arrows** on every `NumberSettingsTextField` are asserted clickable but the fields
+ *    are driven by typing. What the arrows do with a value — the range clamp at either end — belongs
+ *    to the shared control and is covered by `NumberSettingsTextFieldTest`.
  *  * **`GraphicsEnvironment.availableFontFamilyNames`** is called at composition. Unlike
  *    `screenDevices` it works headless, so it needs no seam — but it means the font dropdowns offer
  *    whatever the running machine has installed, which is why [uniquelyNamedFont] is used rather

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabAudioAndLabelsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabAudioAndLabelsTest.kt
@@ -249,29 +249,15 @@ class ProjectionSettingsTabAudioAndLabelsTest {
     // ── Stepper arrows ──────────────────────────────────────────────────────────────────────────
 
     /**
-     * Every stepper field publishes increment/decrement arrows, and every one of them lays out zero
-     * pixels wide — so they draw nothing and cannot be clicked. The cause is in
-     * `NumberSettingsTextField` itself (its `BasicTextField` takes `fillMaxWidth()`, leaving the
-     * arrow column no room), so it affects every numeric field in the app rather than this tab.
-     * Pinned as present-but-unusable rather than driven: a test that clicked them would be asserting
-     * a defect works.
+     * Every stepper field publishes increment/decrement arrows — one per stepper field: lower-third
+     * height plus four window offsets — and each is laid out at a size a click can reach.
+     *
+     * These arrows used to collapse to zero pixels wide on every tab in the app — a defect in the
+     * shared `NumberSettingsTextField`, which this test pinned as present-but-unusable while it
+     * stood. Now that it is fixed, the same test guards the fix.
      */
     @Test
-    fun `the stepper arrows are published but laid out unusably`() = projectionTab { _ ->
-        for (description in listOf("Increment", "Decrement")) {
-            val widths = onAllNodesWithContentDescription(description)
-                .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                .map { it.boundsInRoot.width }
-            assertEquals(
-                5,
-                widths.size,
-                "one $description arrow per stepper field: lower-third height plus four window offsets",
-            )
-            assertEquals(
-                true,
-                widths.all { it == 0f },
-                "every $description arrow is zero pixels wide, so none of them can be clicked",
-            )
-        }
+    fun `the stepper arrows are laid out where they can be clicked`() = projectionTab { _ ->
+        assertStepperArrowsUsable(expected = 5)
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabTestSupport.kt
@@ -170,7 +170,7 @@ internal object Grid {
 
 /**
  * Every button on the tab that carries a label. Excludes the stepper arrows, which publish a content
- * description instead of text, and which lay out zero pixels wide in any case.
+ * description instead of text.
  */
 private val labelledButton =
     SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button) and

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTabTestSupport.kt
@@ -75,12 +75,11 @@ import kotlin.test.assertTrue
  *    condition already requires a non-blank line, so the guard cannot fire from the UI;
  *    `the auto-fit buttons leave the size alone when the live section is blank` asserts that.
  *  * `count == 1` in `segmentedItemShape`. Every segmented row on this tab has two or three items.
- *  * The increment/decrement arrows on every stepper field. They are laid out **zero pixels wide**,
- *    at every window size, so they cannot be clicked and nothing of them is drawn — the cause is in
- *    `NumberSettingsTextField` itself (its `BasicTextField` takes `fillMaxWidth()`, which leaves the
- *    20.dp arrow column no room), so it affects every numeric field in the app, not just this tab.
- *    The fields are driven by typing into them instead. Deliberately *not* pinned by a test: a test
- *    asserting the arrows are unclickable would lock the defect in.
+ *  * The increment/decrement arrows on every stepper field. The fields here are driven by typing
+ *    into them instead. (The arrows were once unclickable app-wide — the shared
+ *    `NumberSettingsTextField` gave its 20.dp arrow column no room — which is why these tests type.
+ *    That is fixed; `NumberSettingsTextFieldTest` covers the arrows and the range clamp behind them,
+ *    and the Projection, Dictionary and Stage Monitor suites assert they are clickable on a real tab.)
  *  * The `when`-on-String jump tables compile to a hash switch followed by an `equals` check; the
  *    "hash matched but the string differs" arms need a hash-colliding value to reach.
  */

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTabStructureTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTabStructureTest.kt
@@ -151,18 +151,14 @@ class StageMonitorSettingsTabStructureTest {
     // ── The stepper arrows ──────────────────────────────────────────────────────────────────────
 
     /**
-     * Every stepper arrow on the tab lays out zero pixels wide and so cannot be clicked — the same
-     * `NumberSettingsTextField` defect the Song, Projection and Dictionary tabs record. Pinned as
-     * present-but-unusable rather than driven: a test that clicked them would assert a defect works.
+     * Every stepper arrow on the tab is laid out at a size a click can reach.
+     *
+     * They used to collapse to zero pixels wide on every tab in the app — a defect in the shared
+     * `NumberSettingsTextField`, which this test pinned as present-but-unusable while it stood. Now
+     * that it is fixed, the same test guards the fix.
      */
     @Test
-    fun `the stepper arrows are published but laid out unusably`() = stageMonitorTab { _ ->
-        for (description in listOf("Increment", "Decrement")) {
-            val widths = onAllNodesWithContentDescription(description)
-                .fetchSemanticsNodes(atLeastOneRootRequired = false)
-                .map { it.boundsInRoot.width }
-            assertEquals(ZoneOrdinal.COUNT * 3, widths.size, "one $description arrow per number field")
-            assertEquals(true, widths.all { it == 0f }, "every $description arrow is zero pixels wide")
-        }
+    fun `the stepper arrows are laid out where they can be clicked`() = stageMonitorTab { _ ->
+        assertStepperArrowsUsable(expected = ZoneOrdinal.COUNT * 3)
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTabTestSupport.kt
@@ -55,8 +55,9 @@ import kotlin.test.assertEquals
  *
  * Known gaps — what these tests do not reach, and why:
  *
- *  * **The stepper arrows** on all 18 number fields lay out zero pixels wide and cannot be clicked;
- *    a defect in the shared `NumberSettingsTextField`, pinned rather than driven.
+ *  * **The stepper arrows** on all 18 number fields are asserted clickable but the fields are driven
+ *    by typing. What the arrows do with a value — the range clamp at either end — belongs to the
+ *    shared `NumberSettingsTextField` and is covered by `NumberSettingsTextFieldTest`.
  *  * **`MetronomeDot`** is not asserted at all. It is a bare `Box` with no semantics — nothing to
  *    locate — and its only visible property is an alpha driven by a `delay` loop, so the one way to
  *    see it is a pixel capture whose result depends on where that loop happens to be. Asserting on

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StepperArrows.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StepperArrows.kt
@@ -1,0 +1,86 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.dialogs.tabs
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.performClick
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The increment/decrement arrows every `NumberSettingsTextField` publishes, shared by the settings
+ * tab suites.
+ *
+ * These arrows used to lay out **zero pixels wide** on every tab — the component's text column held
+ * a `fillMaxWidth()` child and carried no `weight`, so it took the whole row and left the 20dp arrow
+ * column nothing. Three suites pinned that as present-but-unusable. The layout is fixed and they now
+ * assert the opposite: that the arrows occupy space and that clicking one moves a value. Left as a
+ * shared helper because the defect was in the shared control, so its regression guard belongs in one
+ * place too — `NumberSettingsTextFieldTest` covers the component itself.
+ */
+
+/** Every arrow of one direction, with the width it was laid out at. */
+internal fun ComposeUiTest.stepperArrowWidths(direction: String): List<Float> =
+    onAllNodesWithContentDescription(direction)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .map { it.boundsInRoot.width }
+
+/** What every number field on the tab currently shows, in tree order. */
+private fun ComposeUiTest.numberFieldValues(): List<String> =
+    numberFields()
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .map { it.config.getOrNull(SemanticsProperties.EditableText)?.text ?: "" }
+
+/** Whether each number field was actually laid out, in the same tree order as the arrows. */
+private fun ComposeUiTest.numberFieldIsDrawn(): List<Boolean> =
+    numberFields()
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .map { it.boundsInRoot.width > 0f }
+
+/**
+ * Asserts that [expected] arrows of each direction are published, that each one is laid out at a
+ * clickable size wherever its own field is drawn, and that clicking an increment arrow raises
+ * exactly one field's value by one.
+ *
+ * The "wherever its field is drawn" qualifier is load-bearing: these tabs compose sections that are
+ * measured to nothing (a zone whose panel is collapsed, an output row for hardware that is absent).
+ * Their fields measure `0x0` too, so an arrow of zero width there is the section being absent, not
+ * the arrow collapsing — the defect this guards against took the arrows to zero while the field
+ * beside them kept the whole row.
+ *
+ * Which field the click moves differs per tab and does not matter: what is asserted is that an arrow
+ * click reaches a value at all, which the collapsed layout made impossible. The range clamp the
+ * arrows enforce at either end is covered in `NumberSettingsTextFieldTest`.
+ */
+internal fun ComposeUiTest.assertStepperArrowsUsable(expected: Int) {
+    val drawn = numberFieldIsDrawn()
+    assertTrue(drawn.any { it }, "the tab must draw at least one number field to say anything about")
+
+    for (direction in listOf("Increment", "Decrement")) {
+        val widths = stepperArrowWidths(direction)
+        assertEquals(expected, widths.size, "one $direction arrow per number field")
+        assertEquals(
+            drawn,
+            widths.map { it > 0f },
+            "each $direction arrow must occupy space exactly where its field does, got $widths",
+        )
+    }
+
+    val first = drawn.indexOfFirst { it }
+    val before = numberFieldValues()
+    onAllNodesWithContentDescription("Increment")[first].performClick()
+    waitForIdle()
+    val after = numberFieldValues()
+
+    val moved = before.indices.filter { before[it] != after[it] }
+    assertEquals(1, moved.size, "one arrow click must move exactly one field: $before -> $after")
+    val i = moved.single()
+    assertEquals(
+        before[i].toInt() + 1,
+        after[i].toInt(),
+        "the increment arrow must step its field up by one",
+    )
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerTest.kt
@@ -32,6 +32,14 @@ import kotlin.test.assertTrue
  * Starting it on a free port and driving it over real HTTP/WebSocket tests the same pipeline a
  * phone or a follower instance actually talks to — including the connect snapshot, which is the
  * source of a whole class of "follower shows stale content" bugs.
+ *
+ * Not covered, deliberately: that a session which dies *during* its snapshot still releases its
+ * broadcast collector. The collector is launched before the snapshot so nothing emitted meanwhile is
+ * lost, which puts it outside the handler's own `try`/`finally` — it is cancelled from the session
+ * job's completion instead. Reaching that path means making a snapshot `send` fail, and the only
+ * lever a test has is closing the client early, which races the snapshot rather than landing inside
+ * it: sometimes the frames are already buffered and nothing throws. A test that only sometimes
+ * exercises what it claims to is worse than this note.
  */
 class CompanionServerTest {
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerTest.kt
@@ -232,7 +232,10 @@ class CompanionServerTest {
         withTimeoutOrNull(15_000) {
             client.webSocket(urlString = "ws://127.0.0.1:$port${Constants.ENDPOINT_WS}") {
                 // The first snapshot frame is the positive signal that this session is registered
-                // for broadcasts — pushing the change before that could race the registration.
+                // for broadcasts — pushing the change before that could race the registration. That
+                // holds because the server subscribes to its broadcast flow before writing any
+                // snapshot frame; it did not always, which is what made this test drop a broadcast
+                // on a loaded CI runner.
                 incoming.receive()
 
                 server.updateSchedule(

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabKeyboardTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabKeyboardTest.kt
@@ -1,0 +1,134 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Stepping through a slideshow from the keyboard.
+ *
+ * This is how the tab is actually driven during a service — nobody clicks thumbnails while the
+ * congregation is watching — so the arrow keys and the spacebar are the tab's real interface. The
+ * handler is an `onPreviewKeyEvent` on the tab's own focusable root, so presses go to the root
+ * rather than to any one control.
+ *
+ * Up and down move by a whole row, which means they depend on how many columns the grid laid out;
+ * these tests read that from the resulting selection rather than assuming a column count, since the
+ * grid is adaptive and the number differs with the window width.
+ *
+ * See `PicturesTabTestSupport.kt` for the harness.
+ */
+class PicturesTabKeyboardTest {
+
+    private fun ComposeUiTest.press(key: Key) {
+        onRoot().performKeyInput { pressKey(key) }
+        waitForIdle()
+    }
+
+    // ── Left and right ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `right steps to the next image`() = picturesTab { vm, _ ->
+        assertEquals(0, vm.selectedImageIndex)
+
+        press(Key.DirectionRight)
+
+        assertEquals(1, vm.selectedImageIndex)
+    }
+
+    @Test
+    fun `left steps back to the previous image`() = picturesTab { vm, _ ->
+        press(Key.DirectionRight)
+        press(Key.DirectionRight)
+        assertEquals(2, vm.selectedImageIndex)
+
+        press(Key.DirectionLeft)
+
+        assertEquals(1, vm.selectedImageIndex)
+    }
+
+    @Test
+    fun `right past the last image wraps to the first`() = picturesTab { vm, _ ->
+        repeat(vm.images.size - 1) { press(Key.DirectionRight) }
+        assertEquals(vm.images.lastIndex, vm.selectedImageIndex)
+
+        press(Key.DirectionRight)
+
+        // Wrapping matters live: running off the end mid-service must not stick or blank the screen.
+        assertEquals(0, vm.selectedImageIndex)
+    }
+
+    @Test
+    fun `left from the first image wraps to the last`() = picturesTab { vm, _ ->
+        press(Key.DirectionLeft)
+
+        assertEquals(vm.images.lastIndex, vm.selectedImageIndex)
+    }
+
+    // ── Up and down, which move by a row ────────────────────────────────────────
+
+    @Test
+    fun `down moves forward by a whole row and up comes back`() = picturesTab { vm, _ ->
+        press(Key.DirectionDown)
+        val afterDown = vm.selectedImageIndex
+
+        if (afterDown == 0) {
+            // Every image fitted on one row, so there is no row below to move to — the handler
+            // refuses rather than running off the end, which is the behaviour being pinned.
+            return@picturesTab
+        }
+        press(Key.DirectionUp)
+        assertEquals(0, vm.selectedImageIndex, "up must undo exactly what down did")
+    }
+
+    @Test
+    fun `up from the top row stays put`() = picturesTab { vm, _ ->
+        press(Key.DirectionUp)
+
+        // The target index is negative here; selecting it would throw or blank the output.
+        assertEquals(0, vm.selectedImageIndex)
+    }
+
+    @Test
+    fun `down from the last row stays put`() = picturesTab { vm, _ ->
+        press(Key.DirectionRight)
+        press(Key.DirectionRight)
+        val last = vm.selectedImageIndex
+
+        press(Key.DirectionDown)
+
+        assertEquals(last, vm.selectedImageIndex, "there is no row past the end to land on")
+    }
+
+    // ── Spacebar ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `space starts the slideshow and stops it again`() = picturesTab { vm, _ ->
+        press(Key.Spacebar)
+        assertEquals(true, vm.isPlaying, "space must start the auto-advance")
+
+        press(Key.Spacebar)
+        assertEquals(false, vm.isPlaying, "and the same key must stop it")
+    }
+
+    // ── With no folder loaded ───────────────────────────────────────────────────
+
+    @Test
+    fun `the arrow keys do nothing while no folder is loaded`() = picturesTab(folder = null) { vm, _ ->
+        press(Key.DirectionRight)
+        press(Key.DirectionLeft)
+        press(Key.DirectionDown)
+        press(Key.Spacebar)
+
+        // With an empty list and no Instance Link target the handler declines every key, leaving
+        // the presses to fall through rather than moving a selection that does not exist.
+        assertEquals(0, vm.selectedImageIndex)
+        assertEquals(false, vm.isPlaying)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabAutoRestoreTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabAutoRestoreTest.kt
@@ -1,0 +1,90 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The crash-recovery prompt: the first thing the operator sees after the app comes back up having
+ * died mid-service.
+ *
+ * Only one of its two buttons keeps the work — the other deletes the autosave outright — so which
+ * one is wired to which is not a detail. The prompt is also the last chance to recover: dismissing
+ * it and reopening the panel does not bring it back, by design.
+ *
+ * `ScheduleAutoSaveTest` covers what the view model does with the file; these tests cover the
+ * dialog in front of it. See `ScheduleTabTestSupport.kt` for the harness.
+ */
+class ScheduleTabAutoRestoreTest {
+
+    private val title = "Restore unsaved schedule?"
+
+    @Test
+    fun `no autosave means no prompt`() =
+        scheduleTab(seed = { seedService() }) { _, _ ->
+            onNodeWithText(title).assertDoesNotExist()
+        }
+
+    @Test
+    fun `an autosave from this session is offered on open`() =
+        scheduleTab(seed = { plantAutoSave("Amazing Grace") }) { _, _ ->
+            onNodeWithText(title).assertExists("a recovered service must be offered, not silently dropped")
+        }
+
+    @Test
+    fun `restoring loads the autosaved service and consumes the file`() =
+        scheduleTab(seed = { plantAutoSave("Amazing Grace", "Be Thou My Vision") }) { vm, _ ->
+            onNodeWithText("Restore").performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("1 - Amazing Grace", "2 - Be Thou My Vision"),
+                vm.scheduleItems.map { it.displayText },
+                "restore must put the recovered service back",
+            )
+            onNodeWithText(title).assertDoesNotExist()
+            assertFalse(autoSaveExists(), "a restored autosave is spent; leaving it would re-offer stale work")
+            assertEquals(
+                listOf("Amazing Grace", "Be Thou My Vision"),
+                orderOf("Amazing Grace", "Be Thou My Vision"),
+                "and the list must redraw with it",
+            )
+        }
+
+    @Test
+    fun `discarding throws the autosave away and leaves the schedule alone`() =
+        scheduleTab(
+            seed = {
+                seedService()
+                plantAutoSave("Amazing Grace")
+            },
+        ) { vm, _ ->
+            onNodeWithText("Discard").performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "42 - Amazing Grace", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+                "discarding must not touch what is already loaded",
+            )
+            onNodeWithText(title).assertDoesNotExist()
+            assertFalse(autoSaveExists(), "discard means the file is gone, not merely hidden")
+        }
+
+    @Test
+    fun `the prompt is offered once and not again on the next composition`() =
+        scheduleTab(seed = { plantAutoSave("Amazing Grace") }) { vm, _ ->
+            onNodeWithText("Discard").performClick()
+            waitForIdle()
+
+            // Collapsing and re-expanding the schedule panel remounts the tab against the same view
+            // model; re-prompting there would nag on every toggle.
+            assertFalse(vm.shouldPromptAutoRestore(), "the offer is made once per session")
+            assertTrue(vm.scheduleItems.isEmpty())
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabMenuActionsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabMenuActionsTest.kt
@@ -1,0 +1,316 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The action set the tab publishes to its parent through `onActionsReady`.
+ *
+ * Everything the app can do to a schedule from outside this tab goes through here: the File and
+ * Edit menus, the keyboard shortcuts, and the approved remote requests that arrive from a phone or
+ * a linked instance. None of them touches a button in the tab, so a lambda wired to the wrong view
+ * model call — `moveSelectedUp` bound to `moveItemToTop`, `removeById` reading the UI selection
+ * instead of the id it was handed — would look perfect on screen and still ruin a service order.
+ * Each action is invoked and the resulting schedule asserted.
+ *
+ * **Not covered: `openSchedule`, `saveSchedule` and `saveScheduleAs`.** All three open a native file
+ * chooser, which throws headless; the view-model half of each is covered by `ScheduleFileTest`.
+ *
+ * See `ScheduleTabTestSupport.kt` for the harness.
+ */
+class ScheduleTabMenuActionsTest {
+
+    @Test
+    fun `the tab publishes its actions to the parent`() =
+        scheduleTab(seed = { seedService() }) { _, reports ->
+            // MainDesktop's menus are dead until this arrives, so its absence is its own failure.
+            registeredActions(reports)
+        }
+
+    // ── Whole-schedule actions ──────────────────────────────────────────────────
+
+    @Test
+    fun `newSchedule empties the service`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            registeredActions(reports).newSchedule()
+            waitForIdle()
+
+            assertTrue(vm.scheduleItems.isEmpty(), "New Schedule must leave nothing behind")
+            assertEquals(emptyList(), orderOf("Welcome", "Amazing Grace", "John 3:16", "Notices"))
+        }
+
+    @Test
+    fun `clearSchedule empties the service`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            registeredActions(reports).clearSchedule()
+            waitForIdle()
+
+            assertTrue(vm.scheduleItems.isEmpty())
+        }
+
+    // ── Removal ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `removeSelected removes the row the operator has selected`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            val actions = registeredActions(reports)
+            vm.selectItem(vm.scheduleItems[1].id)
+            waitForIdle()
+
+            actions.removeSelected()
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+                "the selected song, and only it, must go",
+            )
+        }
+
+    @Test
+    fun `removeSelected does nothing while nothing is selected`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            val actions = registeredActions(reports)
+            vm.clearSelection()
+            waitForIdle()
+            val before = vm.scheduleItems.map { it.displayText }
+
+            actions.removeSelected()
+            waitForIdle()
+
+            assertEquals(before, vm.scheduleItems.map { it.displayText })
+        }
+
+    @Test
+    fun `removeById removes the item it names, not the selected one`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            val actions = registeredActions(reports)
+            val website = vm.scheduleItems.last().id
+            vm.selectItem(vm.scheduleItems.first().id)
+            waitForIdle()
+
+            // This is the approved-remote-request path: a phone asks for a specific item to go,
+            // and what the operator happens to have highlighted must not decide which one does.
+            actions.removeById(website)
+            waitForIdle()
+
+            assertEquals(
+                listOf("Welcome", "42 - Amazing Grace", "John 3:16"),
+                vm.scheduleItems.map { it.displayText },
+            )
+        }
+
+    // ── Reordering the selection ────────────────────────────────────────────────
+
+    @Test
+    fun `moveSelectedUp and moveSelectedDown step the selected row one place`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            val actions = registeredActions(reports)
+            vm.selectItem(vm.scheduleItems[1].id)
+            waitForIdle()
+
+            actions.moveSelectedUp()
+            waitForIdle()
+            assertEquals(
+                listOf("42 - Amazing Grace", "Welcome", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+            )
+
+            actions.moveSelectedDown()
+            waitForIdle()
+            assertEquals(
+                listOf("Welcome", "42 - Amazing Grace", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+                "and the two must be inverses of one another",
+            )
+        }
+
+    @Test
+    fun `moveSelectedToTop and moveSelectedToBottom send the selected row all the way`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            val actions = registeredActions(reports)
+            vm.selectItem(vm.scheduleItems[2].id)
+            waitForIdle()
+
+            actions.moveSelectedToTop()
+            waitForIdle()
+            assertEquals(
+                listOf("John 3:16", "Welcome", "42 - Amazing Grace", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+            )
+
+            actions.moveSelectedToBottom()
+            waitForIdle()
+            assertEquals(
+                listOf("Welcome", "42 - Amazing Grace", "Notices", "John 3:16"),
+                vm.scheduleItems.map { it.displayText },
+            )
+        }
+
+    @Test
+    fun `the move actions do nothing while nothing is selected`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            val actions = registeredActions(reports)
+            vm.clearSelection()
+            waitForIdle()
+            val before = vm.scheduleItems.map { it.displayText }
+
+            actions.moveSelectedUp()
+            actions.moveSelectedDown()
+            actions.moveSelectedToTop()
+            actions.moveSelectedToBottom()
+            waitForIdle()
+
+            assertEquals(before, vm.scheduleItems.map { it.displayText })
+        }
+
+    // ── Adding, one action per content type ─────────────────────────────────────
+
+    @Test
+    fun `every add action appends an item of its own type`() =
+        scheduleTab { vm, reports ->
+            val actions = registeredActions(reports)
+
+            actions.addLabel("Welcome", "#FFFFFF", "#203040")
+            actions.addSong(42, "Amazing Grace", "Hymnal", "Hymnal::42")
+            actions.addBibleVerse("John", 3, 16, "For God so loved the world.", "", 43)
+            actions.addPicture("/photos/advent", "Advent", 12)
+            actions.addPresentation("/decks/sermon.pptx", "sermon.pptx", 24, "pptx")
+            actions.addMedia("https://example.org/clip.mp4", "Clip", "video")
+            actions.addLowerThird("preset-1", "Speaker name", true, 1_500L)
+            actions.addWebsite("https://example.org", "Notices")
+            actions.addScene("scene-1", "Opening scene")
+            actions.addDictionary("G5485", "χάρις", "charis", "grace")
+            waitForIdle()
+
+            assertEquals(
+                listOf(
+                    ScheduleItem.LabelItem::class,
+                    ScheduleItem.SongItem::class,
+                    ScheduleItem.BibleVerseItem::class,
+                    ScheduleItem.PictureItem::class,
+                    ScheduleItem.PresentationItem::class,
+                    ScheduleItem.MediaItem::class,
+                    ScheduleItem.LowerThirdItem::class,
+                    ScheduleItem.WebsiteItem::class,
+                    ScheduleItem.SceneItem::class,
+                    ScheduleItem.DictionaryItem::class,
+                ),
+                vm.scheduleItems.map { it::class },
+                "each action must add its own type, in the order they were invoked",
+            )
+        }
+
+    @Test
+    fun `the add actions carry their arguments through to the item`() =
+        scheduleTab { vm, reports ->
+            val actions = registeredActions(reports)
+
+            actions.addSong(42, "Amazing Grace", "Hymnal", "Hymnal::42")
+            actions.addBibleVerse("John", 3, 16, "For God so loved the world.", "16-18", 43)
+            actions.addLowerThird("preset-1", "Speaker name", true, 1_500L)
+            waitForIdle()
+
+            val song = vm.scheduleItems[0] as ScheduleItem.SongItem
+            assertEquals(42, song.songNumber)
+            assertEquals("Amazing Grace", song.title)
+            assertEquals("Hymnal", song.songbook)
+            assertEquals("Hymnal::42", song.songId)
+
+            val verse = vm.scheduleItems[1] as ScheduleItem.BibleVerseItem
+            assertEquals("John", verse.bookName)
+            assertEquals(3, verse.chapter)
+            assertEquals(16, verse.verseNumber)
+            assertEquals("16-18", verse.verseRange)
+            assertEquals(43, verse.bookId)
+
+            val lowerThird = vm.scheduleItems[2] as ScheduleItem.LowerThirdItem
+            assertEquals("preset-1", lowerThird.presetId)
+            assertTrue(lowerThird.pauseAtFrame)
+            assertEquals(1_500L, lowerThird.pauseDurationMs)
+        }
+
+    @Test
+    fun `addAnnouncement carries its whole argument list through`() =
+        scheduleTab { vm, reports ->
+            // 28 parameters wide, and the ones that matter are deep in the middle of it: a shifted
+            // argument here is how a countdown ends up the wrong colour or counting to the wrong time.
+            registeredActions(reports).addAnnouncement(
+                "Service starts in", "#FFEEAA", "#101020", 64, "Georgia",
+                true, true, true, true, "#001122", 120, 55,
+                "left", "top", "FADE", 750, 3,
+                true, 1, 2, 3, "#00FF00", "We're starting!", "clock",
+                18, 30, 15, "hh:mm a",
+            )
+            waitForIdle()
+
+            val item = vm.scheduleItems.single() as ScheduleItem.AnnouncementItem
+            assertEquals("Service starts in", item.text)
+            assertEquals("#FFEEAA", item.textColor)
+            assertEquals("#101020", item.backgroundColor)
+            assertEquals(64, item.fontSize)
+            assertEquals("Georgia", item.fontType)
+            assertTrue(item.bold && item.italic && item.underline && item.shadow)
+            assertEquals("#001122", item.shadowColor)
+            assertEquals(120, item.shadowSize)
+            assertEquals(55, item.shadowOpacity)
+            assertEquals("left", item.horizontalAlignment)
+            assertEquals("top", item.position)
+            assertEquals("FADE", item.animationType)
+            assertEquals(750, item.animationDuration)
+            assertEquals(3, item.loopCount)
+            assertTrue(item.isTimer)
+            assertEquals(listOf(1, 2, 3), listOf(item.timerHours, item.timerMinutes, item.timerSeconds))
+            assertEquals("#00FF00", item.timerTextColor)
+            assertEquals("We're starting!", item.timerExpiredText)
+            assertEquals("clock", item.timerMode)
+            assertEquals(listOf(18, 30, 15), listOf(item.targetHour, item.targetMinute, item.targetSecond))
+            assertEquals("hh:mm a", item.liveClockFormat)
+        }
+
+    // ── Editing in place ────────────────────────────────────────────────────────
+
+    @Test
+    fun `updateLabel rewrites the label it names`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            val actions = registeredActions(reports)
+            val labelId = vm.scheduleItems.first().id
+
+            actions.updateLabel(labelId, "Announcements", "#000000", "#FFFFFF")
+            waitForIdle()
+
+            val label = vm.scheduleItems.first() as ScheduleItem.LabelItem
+            assertEquals("Announcements", label.text)
+            assertEquals("#000000", label.textColor)
+            assertEquals("#FFFFFF", label.backgroundColor)
+            assertTrue(
+                "Announcements" in orderOf("Announcements", "Welcome"),
+                "and the row must redraw with the new text",
+            )
+        }
+
+    @Test
+    fun `updateWebsiteTitle names a website that was added without one`() =
+        scheduleTab(seed = { addWebsite(url = "https://example.org/notices", title = "") }) { vm, reports ->
+            // Added from the address bar there is no title yet, so the row shows the raw URL; the
+            // page's own title arrives later, once it has loaded, and fills the row in.
+            registeredActions(reports).updateWebsiteTitle("https://example.org/notices", "Weekly notices")
+            waitForIdle()
+
+            assertEquals("Weekly notices", (vm.scheduleItems.single() as ScheduleItem.WebsiteItem).title)
+        }
+
+    @Test
+    fun `updateWebsiteTitle leaves a website the operator has already named alone`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            registeredActions(reports).updateWebsiteTitle("https://example.org", "Weekly notices")
+            waitForIdle()
+
+            // A page title arriving late must not overwrite the name someone chose deliberately.
+            assertEquals("Notices", (vm.scheduleItems.last() as ScheduleItem.WebsiteItem).title)
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabTestSupport.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.runComposeUiTest
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
 import org.churchpresenter.app.churchpresenter.TestSingletons
 import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
@@ -46,6 +48,12 @@ internal class ScheduleReports {
     var addLabelRequests = 0
     var addWebsiteRequests = 0
     val zoomChanges = mutableListOf<Int>()
+
+    /**
+     * The action set the tab hands its parent, so the menu and keyboard paths — which never touch a
+     * button in this tab — can be driven the way `MainDesktop` drives them.
+     */
+    var actions: ScheduleTabActions? = null
 }
 
 /**
@@ -81,6 +89,7 @@ internal fun scheduleTab(
                         onItemClick = { reports.clicked += it },
                         onEditLabel = { reports.editedLabels += it },
                         onSelectedItemChanged = { reports.selectionChanges += it },
+                        onActionsReady = { reports.actions = it },
                         onAddLabel = { reports.addLabelRequests++ },
                         onAddWebsite = { reports.addWebsiteRequests++ },
                         onPresentSong = { reports.presented += it },
@@ -102,7 +111,46 @@ internal fun scheduleTab(
     }
 }
 
+/**
+ * The registered [ScheduleTabActions], once the tab's `LaunchedEffect` has published them.
+ *
+ * Registration happens in an effect rather than during composition, so the wait is on the effect
+ * having run — `waitForIdle` returns on that positive signal, not on a duration.
+ */
+internal fun ComposeUiTest.registeredActions(reports: ScheduleReports): ScheduleTabActions {
+    waitForIdle()
+    return requireNotNull(reports.actions) { "the tab must publish its actions to the parent" }
+}
+
 // ── Fixtures ────────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Writes an autosave the tab will offer to restore, into the temp `user.home` the harness has
+ * already installed. Call from `seed`, which runs after the view model is built (so the path is
+ * fixed) and before the first frame (so the prompt is decided against a file that exists).
+ *
+ * Plain JSON rather than the encrypted form: the encryption helpers are on a private companion, and
+ * `restoreAutoSave` falls back to the raw text when decryption fails, which is the branch this
+ * takes. What the file contains is beside the point here — `ScheduleAutoSaveTest` covers the
+ * restore itself; these tests are about the dialog in front of it.
+ */
+internal fun plantAutoSave(vararg titles: String) {
+    val items = titles.mapIndexed { i, title ->
+        ScheduleItem.SongItem(id = "auto-$i", songNumber = i + 1, title = title, songbook = "Hymnal")
+    }
+    // Serialized through the real ScheduleItem serializer so the polymorphic discriminator is
+    // whatever the model actually declares, rather than a string this fixture guesses at.
+    val itemsJson = Json { encodeDefaults = true }
+        .encodeToString(ListSerializer(ScheduleItem.serializer()), items)
+    val file = File(System.getProperty("user.home"), ".churchpresenter/autosave_schedule.tmp")
+    file.parentFile.mkdirs()
+    file.writeText("""{"version":2,"items":$itemsJson,"notes":{}}""")
+}
+
+/** Whether the autosave the tab was offered is still on disk. */
+internal fun autoSaveExists(): Boolean =
+    File(System.getProperty("user.home"), ".churchpresenter/autosave_schedule.tmp").exists()
+
 
 /** A service order with one of each item type the row renderer draws differently. */
 internal fun ScheduleViewModel.seedService() {


### PR DESCRIPTION
Two bugs that had been recorded as test-environment artifacts turned out to be real. Both are fixed
here, with the tests that now guard them, plus CI follow-ups and coverage for two tabs.

## 1. `NumberSettingsTextField`'s arrows could never be clicked

The component's text `Column` holds a `fillMaxWidth()` child and carried no `weight`, so in the `Row`
it was measured against the full available width and consumed all of it — the 20dp arrow column
measured `0 × 16`. Both arrows were undeliverable in the app, not only in a test, and the `range`
clamp they are the only enforcer of therefore never ran. This affects **every numeric setting in the
app**: font sizes, ports, opacities, window offsets, timer values.

Fix is one `Modifier.weight(1f)`.

**Three suites had pinned the defect in place** — `the stepper arrows are published but laid out
unusably`, in the Dictionary, Projection and Stage Monitor settings tests. Their doc comments
diagnosed the cause correctly (*"its `BasicTextField` takes `fillMaxWidth()`, leaving the arrow column
no room"*) and then asserted the breakage. They failed as soon as the layout was fixed, which is how
they were found. All three now assert the arrows are clickable and that clicking one steps a value,
through one shared helper.

The assertion is deliberately **relative** — an arrow must occupy space *exactly where its own field
does*. These tabs legitimately compose sections that are measured to nothing (a collapsed stage
monitor zone, an output row for absent hardware), and their fields measure `0x0` too; an absolute
"every arrow is non-zero" assertion would fail on those and tell you nothing about the bug.

## 2. WebSocket broadcasts sent during a client's connect snapshot were lost

`CompanionServer`'s WS handler wrote the entire connect snapshot and *then* launched its
`broadcastChannel` collector. That flow has no replay, so anything emitted in the window between was
delivered to nobody for that session and was gone — the client went on showing stale content until
its next reconnect. A phone or a linked instance connecting at the moment the operator changes the
schedule is precisely the case.

It now subscribes via `onSubscription` **before** the snapshot and holds delivery on a
`CompletableDeferred` completed after it, so a broadcast raised meanwhile queues in the flow's own
buffer instead of being dropped, and the whole snapshot still precedes any of them. A cancelled scope
releases the wait through the job's completion, leaving the previous behaviour rather than hanging.

This is also the cause of `CompanionServerTest`'s rare CI failure. That test took "first frame
received" as proof the session was registered for broadcasts; it was not. It is now.

## 3. CI

- **`push:` no longer filters on `main`.** A branch whose PR has merged stops matching
  `pull_request`, so work pushed to it afterwards ran nothing at all — eight commits went untested
  this way after #102. Concurrency is keyed on `head_ref || ref` so a PR run and its branch push run
  share one group rather than both building the same commit.
- **A `Slowest test classes` step** prints per-suite times from the JUnit XML the test step already
  writes. A previous diagnosis of the 25-minute step kill was wrong and went unchallenged largely
  because nothing recorded where the time went.
- **Budget 25 → 40 minutes** (job 45 → 60). Runs land at 11–14 minutes.

Locally the suite is 224s of test time across 411 suites, slowest `CompanionServerTest` at 13.9s.
`CompanionServerLowerThirdTest` is nowhere near the top, so its `192.0.2.1` ATEM host is **not**
costing a UDP timeout per test as had been suspected. The 25-minute kill itself remains unexplained.

## 4. Coverage — `ScheduleTab` and `PicturesTab`

- **`ScheduleTabMenuActionsTest`** drives the `ScheduleTabActions` the tab publishes via
  `onActionsReady`. Every File/Edit menu item, keyboard shortcut and approved remote request runs
  through that set, none of it touches a button in the tab, and none of it had ever been invoked by a
  test — an action bound to the wrong view-model call would look perfect on screen and still wreck a
  service order. `openSchedule`/`saveSchedule`/`saveScheduleAs` stay uncovered: all three open a
  native file chooser, which throws headless.
- **`ScheduleTabAutoRestoreTest`** covers the crash-recovery prompt, where one button keeps the
  operator's unsaved service and the other deletes it.
- **`PicturesTabKeyboardTest`** covers the arrow keys and spacebar — how the tab is actually driven
  during a service. Up/down move by a row, so the tests read the column count out of the resulting
  selection rather than assuming one.

Still uncovered in `PicturesTab`, and blocked rather than skipped: the thumbnail reorder is a
*shift*-drag, and its gesture reads `keyboardModifiers`, which a test cannot set on an injected
pointer event. The recent-folders bar is reachable only through a `private object` that latches JSON
paths off `user.home` at class-init; seeding it would mean a process-wide singleton whose first touch
decides for the whole JVM whether it points at a temp home or the developer's real one.

## Verification

`./gradlew :composeApp:check` green, including the 75% coverage gate. New and changed suites ran 3×
with `--rerun-tasks`, all green. Every new suite is under 1.3s; the largest is the known one-off
Compose warm-up on the first test in a class.
