### PR TITLE
Cover the scene canvas: drawing, selection, and the resize handles

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneCanvas.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneCanvas.kt
@@ -448,6 +448,66 @@ internal fun computeSnap(
 
 // --- Resize Handles ---
 
+/**
+ * One of the eight resize grips around a selected source: where it sits on the source's box, the
+ * cursor it shows, and what a drag of it does to the transform.
+ */
+internal data class ResizeHandleDef(
+    /** 0, 0.5 or 1 along the source's width — 0 is its left edge. */
+    val anchorX: Float,
+    /** 0, 0.5 or 1 along the source's height — 0 is its top edge. */
+    val anchorY: Float,
+    val cursor: Int,
+    val onDrag: (SourceTransform, Offset) -> SourceTransform
+)
+
+/**
+ * The eight resize handles, in the order they are drawn: NW, N, NE, W, E, SW, S, SE.
+ *
+ * Each `onDrag` takes a pixel drag and returns the new transform in normalised 0..1 coordinates,
+ * which is why it needs the canvas size. Which edges move and which stay anchored differs per
+ * handle: dragging the west edge moves `x` *and* shrinks `width`, while dragging the east edge only
+ * grows `width`. Getting that backwards makes a source jump across the screen as it is resized.
+ *
+ * Declared here rather than inside the composable so the arithmetic can be exercised directly —
+ * driving it through the grips themselves would mean a test reproducing the handle-placement maths
+ * to find out where each 8dp box landed, which asserts the test's own arithmetic rather than this.
+ */
+internal fun resizeHandles(canvasWidth: Float, canvasHeight: Float): List<ResizeHandleDef> = listOf(
+    ResizeHandleDef(0f, 0f, Cursor.NW_RESIZE_CURSOR) { t, d ->
+        val dx = d.x / canvasWidth; val dy = d.y / canvasHeight
+        t.copy(x = t.x + dx, y = t.y + dy, width = t.width - dx, height = t.height - dy)
+    },
+    ResizeHandleDef(0.5f, 0f, Cursor.N_RESIZE_CURSOR) { t, d ->
+        val dy = d.y / canvasHeight
+        t.copy(y = t.y + dy, height = t.height - dy)
+    },
+    ResizeHandleDef(1f, 0f, Cursor.NE_RESIZE_CURSOR) { t, d ->
+        val dx = d.x / canvasWidth; val dy = d.y / canvasHeight
+        t.copy(y = t.y + dy, width = t.width + dx, height = t.height - dy)
+    },
+    ResizeHandleDef(0f, 0.5f, Cursor.W_RESIZE_CURSOR) { t, d ->
+        val dx = d.x / canvasWidth
+        t.copy(x = t.x + dx, width = t.width - dx)
+    },
+    ResizeHandleDef(1f, 0.5f, Cursor.E_RESIZE_CURSOR) { t, d ->
+        val dx = d.x / canvasWidth
+        t.copy(width = t.width + dx)
+    },
+    ResizeHandleDef(0f, 1f, Cursor.SW_RESIZE_CURSOR) { t, d ->
+        val dx = d.x / canvasWidth; val dy = d.y / canvasHeight
+        t.copy(x = t.x + dx, width = t.width - dx, height = t.height + dy)
+    },
+    ResizeHandleDef(0.5f, 1f, Cursor.S_RESIZE_CURSOR) { t, d ->
+        val dy = d.y / canvasHeight
+        t.copy(height = t.height + dy)
+    },
+    ResizeHandleDef(1f, 1f, Cursor.SE_RESIZE_CURSOR) { t, d ->
+        val dx = d.x / canvasWidth; val dy = d.y / canvasHeight
+        t.copy(width = t.width + dx, height = t.height + dy)
+    }
+)
+
 @Composable
 private fun ResizeHandles(
     transform: SourceTransform,
@@ -460,47 +520,7 @@ private fun ResizeHandles(
     val scale = density.density
     val currentTransform by rememberUpdatedState(transform)
 
-    data class HandleDef(
-        val anchorX: Float,
-        val anchorY: Float,
-        val cursor: Int,
-        val onDrag: (SourceTransform, Offset) -> SourceTransform
-    )
-
-    val handles = listOf(
-        HandleDef(0f, 0f, Cursor.NW_RESIZE_CURSOR) { t, d ->
-            val dx = d.x / canvasWidth; val dy = d.y / canvasHeight
-            t.copy(x = t.x + dx, y = t.y + dy, width = t.width - dx, height = t.height - dy)
-        },
-        HandleDef(0.5f, 0f, Cursor.N_RESIZE_CURSOR) { t, d ->
-            val dy = d.y / canvasHeight
-            t.copy(y = t.y + dy, height = t.height - dy)
-        },
-        HandleDef(1f, 0f, Cursor.NE_RESIZE_CURSOR) { t, d ->
-            val dx = d.x / canvasWidth; val dy = d.y / canvasHeight
-            t.copy(y = t.y + dy, width = t.width + dx, height = t.height - dy)
-        },
-        HandleDef(0f, 0.5f, Cursor.W_RESIZE_CURSOR) { t, d ->
-            val dx = d.x / canvasWidth
-            t.copy(x = t.x + dx, width = t.width - dx)
-        },
-        HandleDef(1f, 0.5f, Cursor.E_RESIZE_CURSOR) { t, d ->
-            val dx = d.x / canvasWidth
-            t.copy(width = t.width + dx)
-        },
-        HandleDef(0f, 1f, Cursor.SW_RESIZE_CURSOR) { t, d ->
-            val dx = d.x / canvasWidth; val dy = d.y / canvasHeight
-            t.copy(x = t.x + dx, width = t.width - dx, height = t.height + dy)
-        },
-        HandleDef(0.5f, 1f, Cursor.S_RESIZE_CURSOR) { t, d ->
-            val dy = d.y / canvasHeight
-            t.copy(height = t.height + dy)
-        },
-        HandleDef(1f, 1f, Cursor.SE_RESIZE_CURSOR) { t, d ->
-            val dx = d.x / canvasWidth; val dy = d.y / canvasHeight
-            t.copy(width = t.width + dx, height = t.height + dy)
-        }
-    )
+    val handles = resizeHandles(canvasWidth, canvasHeight)
 
     val centerPx = Offset(
         (transform.x + transform.width / 2f) * canvasWidth,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneCanvasDrawingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneCanvasDrawingTest.kt
@@ -1,0 +1,332 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.churchpresenter.app.churchpresenter.models.Scene
+import org.churchpresenter.app.churchpresenter.models.SceneSource
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Drawing a shape onto the canvas by dragging, which is how every shape in a scene is created.
+ *
+ * The gesture turns a drag in screen pixels into a `ShapeSource` in normalised 0..1 canvas
+ * coordinates, and the arithmetic differs per tool: a rectangle or ellipse takes the drag's bounding
+ * box, a line or arrow additionally stores its two endpoints *relative to* that box, and freehand
+ * stores every sampled point the same way. A shape whose transform or points are wrong lands in the
+ * wrong place on the audience screen, or collapses to nothing.
+ *
+ * Everything here is asserted as an invariant rather than an exact pixel: the drag positions are
+ * fixed but the canvas measures to whatever the layout gives it, and the normalisation divides by
+ * that. What is pinned is the shape's identity, the ordering and containment of its bounds, and the
+ * relationships between its points — all of which hold at any canvas size.
+ *
+ * A backwards drag (right-to-left, bottom-to-top) is covered deliberately: the code takes `minOf`
+ * and `abs` throughout precisely so a shape dragged in any direction still has a positive extent,
+ * and that is easy to regress.
+ */
+class SceneCanvasDrawingTest {
+
+    private val canvasTag = "scene-canvas"
+
+    /** How far a drag is nudged to get past touch slop before its real move — see [dragOnCanvas]. */
+    private val ARM_PX = 8f
+
+    /** Slack for assertions comparing two drags: the arming nudge on each, over the 400dp canvas. */
+    private val ARM_TOLERANCE = 2f * ARM_PX / 400f
+
+    /** A 16:9 scene with nothing on it, so the only pointer target is the drawing surface. */
+    private fun emptyScene() = Scene(
+        id = "scene-1",
+        name = "Scene",
+        canvasWidth = 1920,
+        canvasHeight = 1080,
+        sources = emptyList(),
+    )
+
+    /**
+     * Composes the canvas with [tool] active and runs [block], returning whatever shapes the drag
+     * reported. The width is fixed so the canvas is laid out; its height follows the aspect ratio.
+     */
+    private fun draw(
+        tool: String,
+        strokeColor: String = "#FFFFFF",
+        fillColor: String = "#00000000",
+        strokeWidth: Float = 3f,
+        block: ComposeUiTest.() -> Unit,
+    ): List<SceneSource.ShapeSource> {
+        val drawn = mutableListOf<SceneSource.ShapeSource>()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    Box(Modifier.width(400.dp)) {
+                        SceneCanvas(
+                            modifier = Modifier.testTag(canvasTag),
+                            scene = emptyScene(),
+                            selectedSourceId = null,
+                            onSourceSelected = { },
+                            onTransformChanged = { _, _ -> },
+                            activeTool = tool,
+                            drawingStrokeColor = strokeColor,
+                            drawingFillColor = fillColor,
+                            drawingStrokeWidth = strokeWidth,
+                            onShapeDrawn = { drawn += it },
+                        )
+                    }
+                }
+            }
+            block()
+        }
+        return drawn
+    }
+
+    /**
+     * Drags from [from] to [to].
+     *
+     * The small step away from [from] before the real move is load-bearing. `detectDragGestures`
+     * reports `onDragStart` at the position where touch slop was first exceeded, **not** at the
+     * press — so whatever point the drag is armed at becomes the shape's recorded origin. Arming a
+     * few pixels from [from] keeps that origin next to the press; moving straight to a far-away
+     * point instead would record the drag as starting there.
+     */
+    private fun ComposeUiTest.dragOnCanvas(from: Offset, to: Offset) {
+        val arm = Offset(
+            from.x + ARM_PX * (if (to.x >= from.x) 1f else -1f),
+            from.y + ARM_PX * (if (to.y >= from.y) 1f else -1f),
+        )
+        onNodeWithTag(canvasTag).performMouseInput {
+            // press() takes a button, not a position: the pointer is moved first, then pressed.
+            moveTo(from)
+            press()
+            moveTo(arm)
+            moveTo(to)
+            release()
+        }
+        waitForIdle()
+    }
+
+    private fun assertNormalised(shape: SceneSource.ShapeSource) {
+        val t = shape.transform
+        assertTrue(t.x >= 0f && t.x <= 1f, "x must be normalised, was ${t.x}")
+        assertTrue(t.y >= 0f && t.y <= 1f, "y must be normalised, was ${t.y}")
+        assertTrue(t.width > 0f, "a drawn shape must have a positive width, was ${t.width}")
+        assertTrue(t.height > 0f, "a drawn shape must have a positive height, was ${t.height}")
+    }
+
+    // ── Rectangle and ellipse: the bounding-box branch ──────────────────────────
+
+    @Test
+    fun `dragging with the rectangle tool reports one rectangle covering the drag`() {
+        val drawn = draw("rectangle") {
+            dragOnCanvas(Offset(40f, 30f), Offset(160f, 120f))
+        }
+
+        val shape = drawn.singleOrNull()
+        assertNotNull(shape, "one drag must produce exactly one shape, got ${drawn.size}")
+        assertEquals("rectangle", shape.shapeType)
+        assertNormalised(shape)
+        // The bounding-box branch keeps no explicit points; the transform is the whole description.
+        assertTrue(shape.points.isEmpty(), "a rectangle needs no path points")
+    }
+
+    @Test
+    fun `the ellipse tool reports its own type rather than a rectangle`() {
+        val drawn = draw("ellipse") {
+            dragOnCanvas(Offset(40f, 30f), Offset(160f, 120f))
+        }
+
+        assertEquals("ellipse", drawn.single().shapeType, "the active tool must name the shape")
+    }
+
+    @Test
+    fun `a shape is named after the tool that drew it, capitalised`() {
+        val drawn = draw("rectangle") {
+            dragOnCanvas(Offset(40f, 30f), Offset(160f, 120f))
+        }
+
+        // The name is what the operator sees in the source list, so it must be legible.
+        assertEquals("Rectangle", drawn.single().name)
+    }
+
+    @Test
+    fun `the drawing colours and stroke width are carried onto the shape`() {
+        val drawn = draw("rectangle", strokeColor = "#FF0000", fillColor = "#8000FF00", strokeWidth = 7.5f) {
+            dragOnCanvas(Offset(40f, 30f), Offset(160f, 120f))
+        }
+
+        val shape = drawn.single()
+        assertEquals("#FF0000", shape.strokeColor)
+        assertEquals("#8000FF00", shape.fillColor)
+        assertEquals(7.5f, shape.strokeWidth)
+    }
+
+    @Test
+    fun `dragging backwards still produces a positive-sized shape`() {
+        val forwards = draw("rectangle") { dragOnCanvas(Offset(40f, 30f), Offset(160f, 120f)) }.single()
+        val backwards = draw("rectangle") { dragOnCanvas(Offset(160f, 120f), Offset(40f, 30f)) }.single()
+
+        assertNormalised(backwards)
+        // Both drags describe the same rectangle, so they must agree on it.
+        assertTrue(
+            abs(forwards.transform.x - backwards.transform.x) <= ARM_TOLERANCE,
+            "same left edge: ${forwards.transform.x} vs ${backwards.transform.x}",
+        )
+        assertTrue(
+            abs(forwards.transform.y - backwards.transform.y) <= ARM_TOLERANCE,
+            "same top edge: ${forwards.transform.y} vs ${backwards.transform.y}",
+        )
+        assertTrue(
+            abs(forwards.transform.width - backwards.transform.width) <= ARM_TOLERANCE,
+            "same width: ${forwards.transform.width} vs ${backwards.transform.width}",
+        )
+        assertTrue(
+            abs(forwards.transform.height - backwards.transform.height) <= ARM_TOLERANCE,
+            "same height: ${forwards.transform.height} vs ${backwards.transform.height}",
+        )
+    }
+
+    @Test
+    fun `a drag that barely moves still has a usable minimum size`() {
+        val drawn = draw("rectangle") {
+            dragOnCanvas(Offset(80f, 80f), Offset(81f, 81f))
+        }
+
+        val t = drawn.single().transform
+        // Without the 0.01 floor a mis-click would create a shape too small to select or resize.
+        assertTrue(t.width >= 0.01f, "width must not collapse, was ${t.width}")
+        assertTrue(t.height >= 0.01f, "height must not collapse, was ${t.height}")
+    }
+
+    // ── Line and arrow: endpoints stored relative to the bounding box ───────────
+
+    @Test
+    fun `a line stores its two endpoints inside its own bounding box`() {
+        val drawn = draw("line") {
+            dragOnCanvas(Offset(40f, 30f), Offset(160f, 120f))
+        }
+
+        val shape = drawn.single()
+        assertEquals("line", shape.shapeType)
+        assertNormalised(shape)
+        assertEquals(2, shape.points.size, "a line is exactly its two ends")
+        // Points are relative to the bounding box the transform describes, so they span it corner
+        // to corner: this drag went down-right, so it runs (0,0) -> (1,1).
+        shape.points.forEach { p ->
+            assertTrue(p.x in -0.001f..1.001f, "point x must sit inside the box, was ${p.x}")
+            assertTrue(p.y in -0.001f..1.001f, "point y must sit inside the box, was ${p.y}")
+        }
+        assertTrue(abs(shape.points[0].x - 0f) < 0.05f && abs(shape.points[0].y - 0f) < 0.05f)
+        assertTrue(abs(shape.points[1].x - 1f) < 0.05f && abs(shape.points[1].y - 1f) < 0.05f)
+    }
+
+    @Test
+    fun `a line drawn up-right keeps its direction rather than its bounding box`() {
+        val drawn = draw("line") {
+            dragOnCanvas(Offset(40f, 120f), Offset(160f, 30f))
+        }
+
+        val shape = drawn.single()
+        // The box is the same either way; only the points say which way the line actually runs.
+        // Bottom-left to top-right means the first point is low and the second is high.
+        assertTrue(shape.points[0].y > shape.points[1].y, "the line must still run upwards")
+        assertTrue(shape.points[0].x < shape.points[1].x, "and rightwards")
+    }
+
+    @Test
+    fun `an arrow is stored the same way as a line but keeps its own type`() {
+        val drawn = draw("arrow") {
+            dragOnCanvas(Offset(40f, 30f), Offset(160f, 120f))
+        }
+
+        val shape = drawn.single()
+        assertEquals("arrow", shape.shapeType, "an arrow head is drawn from the type, not the points")
+        assertEquals(2, shape.points.size)
+    }
+
+    // ── Freehand: every sampled point ──────────────────────────────────────────
+
+    @Test
+    fun `freehand keeps the whole stroke, normalised into its bounding box`() {
+        val drawn = draw("freehand") {
+            onNodeWithTag(canvasTag).performMouseInput {
+                moveTo(Offset(40f, 40f))
+                press()
+                moveTo(Offset(80f, 60f))
+                moveTo(Offset(120f, 40f))
+                moveTo(Offset(160f, 100f))
+                release()
+            }
+            waitForIdle()
+        }
+
+        val shape = drawn.single()
+        assertEquals("freehand", shape.shapeType)
+        assertNormalised(shape)
+        assertTrue(shape.points.size >= 4, "every sampled point must be kept, got ${shape.points.size}")
+        shape.points.forEach { p ->
+            assertTrue(p.x in -0.001f..1.001f, "point x must be normalised into the box, was ${p.x}")
+            assertTrue(p.y in -0.001f..1.001f, "point y must be normalised into the box, was ${p.y}")
+        }
+        // Normalisation is relative to the stroke's own extent, so it must touch both edges.
+        assertTrue(shape.points.any { it.x < 0.02f } && shape.points.any { it.x > 0.98f })
+    }
+
+    @Test
+    fun `a second freehand stroke does not inherit the first one's points`() {
+        val drawn = draw("freehand") {
+            onNodeWithTag(canvasTag).performMouseInput {
+                moveTo(Offset(40f, 40f)); press(); moveTo(Offset(60f, 60f)); moveTo(Offset(80f, 80f)); release()
+            }
+            waitForIdle()
+            onNodeWithTag(canvasTag).performMouseInput {
+                moveTo(Offset(200f, 40f)); press(); moveTo(Offset(220f, 60f)); release()
+            }
+            waitForIdle()
+        }
+
+        assertEquals(2, drawn.size, "each stroke is its own shape")
+        // The buffer is cleared on drag end; if it were not, the second stroke would carry the
+        // first one's points and its bounding box would stretch back across the canvas.
+        assertTrue(
+            drawn[1].points.size < drawn[0].points.size + 3,
+            "the second stroke kept ${drawn[1].points.size} points against the first's ${drawn[0].points.size}",
+        )
+    }
+
+    // ── When drawing is off ────────────────────────────────────────────────────
+
+    @Test
+    fun `the select tool draws nothing`() {
+        val drawn = draw("select") {
+            dragOnCanvas(Offset(40f, 30f), Offset(160f, 120f))
+        }
+
+        assertTrue(drawn.isEmpty(), "dragging in select mode must not create a shape")
+    }
+
+    @Test
+    fun `a tap without a drag draws nothing`() {
+        val drawn = draw("rectangle") {
+            onNodeWithTag(canvasTag).performMouseInput { moveTo(Offset(80f, 80f)); press(); release() }
+            waitForIdle()
+        }
+
+        // A click with no movement never starts the gesture, so a mis-click leaves no stray shape.
+        assertNull(drawn.firstOrNull(), "a bare click must not create a shape")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneCanvasSelectionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneCanvasSelectionTest.kt
@@ -1,0 +1,238 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.churchpresenter.app.churchpresenter.models.Scene
+import org.churchpresenter.app.churchpresenter.models.SceneSource
+import org.churchpresenter.app.churchpresenter.models.SourceTransform
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Selecting and moving a source on the canvas with the select tool.
+ *
+ * These are the two gestures the canvas exists for. Which source a click selects decides what every
+ * control in the properties panel then edits, and a drag has to move the source the operator grabbed
+ * — by the distance they dragged — while the snap logic pulls it onto the guides. A source that is
+ * locked, or invisible, must ignore both.
+ *
+ * The canvas is 400dp wide at 16:9, so it lays out 400 x 225 and a normalised coordinate maps to
+ * pixels by multiplying by those — confirmed by `SceneCanvasDrawingTest`, which reads the same
+ * mapping back out of a drag. Sources publish no test tag, so they are addressed by pressing at a
+ * position inside their bounds: they are descendants of the canvas node and hit-testing routes the
+ * event to the topmost one, which is exactly what a real click does.
+ *
+ * **Not covered: the rotation handle.** It is drawn at a `.offset(...)` outside the source's own
+ * bounds and sized 12dp, so addressing it means reproducing the handle-placement arithmetic in the
+ * test to find out where it landed — an assertion about the test's own maths rather than the
+ * production code's. Its angle computation is worth covering through a seam if one is ever extracted.
+ */
+class SceneCanvasSelectionTest {
+
+    private val canvasTag = "scene-canvas"
+
+    /** What the canvas reported back. */
+    private class Reports {
+        val selected = mutableListOf<String?>()
+        val transforms = mutableListOf<Pair<String, SourceTransform>>()
+    }
+
+    /** A shape occupying the normalised box 0.1..0.4 on both axes — pixels 40..160 by 22.5..90. */
+    private fun shape(
+        id: String = "shape-1",
+        x: Float = 0.1f,
+        y: Float = 0.1f,
+        locked: Boolean = false,
+        visible: Boolean = true,
+    ) = SceneSource.ShapeSource(
+        id = id,
+        name = id,
+        transform = SourceTransform(x = x, y = y, width = 0.3f, height = 0.3f),
+        shapeType = "rectangle",
+        strokeColor = "#FFFFFF",
+        fillColor = "#FF808080",
+        strokeWidth = 2f,
+        locked = locked,
+        visible = visible,
+    )
+
+    private fun canvas(
+        sources: List<SceneSource>,
+        selectedId: String? = null,
+        block: ComposeUiTest.(Reports) -> Unit,
+    ) {
+        val reports = Reports()
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    Box(Modifier.width(400.dp)) {
+                        SceneCanvas(
+                            modifier = Modifier.testTag(canvasTag),
+                            scene = Scene(
+                                id = "scene-1",
+                                name = "Scene",
+                                canvasWidth = 1920,
+                                canvasHeight = 1080,
+                                sources = sources,
+                            ),
+                            selectedSourceId = selectedId,
+                            onSourceSelected = { reports.selected += it },
+                            onTransformChanged = { id, t -> reports.transforms += id to t },
+                            activeTool = "select",
+                        )
+                    }
+                }
+            }
+            block(reports)
+        }
+    }
+
+    private fun ComposeUiTest.clickAt(x: Float, y: Float) {
+        onNodeWithTag(canvasTag).performMouseInput {
+            moveTo(Offset(x, y))
+            press()
+            release()
+        }
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.dragBy(fromX: Float, fromY: Float, dx: Float, dy: Float) {
+        onNodeWithTag(canvasTag).performMouseInput {
+            moveTo(Offset(fromX, fromY))
+            press()
+            // Stepped rather than jumped: the move handler accumulates dragAmount per event, so a
+            // single leap would exercise one large delta instead of the accumulation itself.
+            moveTo(Offset(fromX + dx / 2f, fromY + dy / 2f))
+            moveTo(Offset(fromX + dx, fromY + dy))
+            release()
+        }
+        waitForIdle()
+    }
+
+    // ── Selecting ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clicking a source selects it`() = canvas(listOf(shape())) { reports ->
+        clickAt(100f, 56f) // inside the shape
+
+        assertEquals(listOf<String?>("shape-1"), reports.selected)
+    }
+
+    @Test
+    fun `clicking empty canvas clears the selection`() = canvas(listOf(shape())) { reports ->
+        clickAt(350f, 200f) // outside the shape
+
+        // Clearing is what lets the properties panel fall back to the scene itself.
+        assertEquals(listOf<String?>(null), reports.selected)
+    }
+
+    @Test
+    fun `clicking the top source selects it rather than the one beneath`() {
+        val back = shape(id = "back")
+        val front = shape(id = "front")
+        // Later in the list = drawn in front, so a click in the overlap belongs to the front one.
+        canvas(listOf(back, front)) { reports ->
+            clickAt(100f, 56f)
+
+            assertEquals(listOf<String?>("front"), reports.selected)
+        }
+    }
+
+    @Test
+    fun `a locked source can still be selected`() = canvas(listOf(shape(locked = true))) { reports ->
+        clickAt(100f, 56f)
+
+        // Locking prevents moving, not selecting — otherwise it could never be unlocked again.
+        assertEquals(listOf<String?>("shape-1"), reports.selected)
+    }
+
+    @Test
+    fun `an invisible source is not clickable`() = canvas(listOf(shape(visible = false))) { reports ->
+        clickAt(100f, 56f)
+
+        // A hidden source is skipped entirely, so the click falls through to the canvas.
+        assertEquals(listOf<String?>(null), reports.selected)
+    }
+
+    // ── Moving ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `dragging the selected source moves it by the drag distance`() =
+        canvas(listOf(shape()), selectedId = "shape-1") { reports ->
+            dragBy(fromX = 100f, fromY = 56f, dx = 80f, dy = 40f)
+
+            assertTrue(reports.transforms.isNotEmpty(), "a drag must report a transform")
+            val (id, moved) = reports.transforms.last()
+            assertEquals("shape-1", id, "the dragged source must be the one that moves")
+            // 80px right on a 400px canvas is +0.2; 40px down on 225px is about +0.178. The drag is
+            // armed after slop so a little is lost, hence a tolerance rather than an equality.
+            assertTrue(moved.x > 0.1f, "it must have moved right, x was ${moved.x}")
+            assertTrue(moved.y > 0.1f, "and downwards, y was ${moved.y}")
+            assertTrue(moved.x <= 0.1f + 0.2f + 0.01f, "but no further than dragged, x was ${moved.x}")
+        }
+
+    @Test
+    fun `dragging leaves the source's size and rotation alone`() =
+        canvas(listOf(shape()), selectedId = "shape-1") { reports ->
+            dragBy(fromX = 100f, fromY = 56f, dx = 60f, dy = 30f)
+
+            val moved = reports.transforms.last().second
+            assertEquals(0.3f, moved.width, "a move must not resize")
+            assertEquals(0.3f, moved.height, "a move must not resize")
+            assertEquals(0f, moved.rotation, "nor rotate")
+        }
+
+    @Test
+    fun `a locked source does not move when dragged`() =
+        canvas(listOf(shape(locked = true)), selectedId = "shape-1") { reports ->
+            // First prove these coordinates really do land on the source: without this the test
+            // would pass just as well if the drag were missing it entirely.
+            clickAt(100f, 56f)
+            assertEquals(listOf<String?>("shape-1"), reports.selected, "the press must hit the source")
+
+            dragBy(fromX = 100f, fromY = 56f, dx = 80f, dy = 40f)
+
+            // The whole point of the lock: a background someone has positioned stays put even if
+            // they grab it by accident mid-service.
+            assertTrue(
+                reports.transforms.isEmpty(),
+                "a locked source must report no transform, got ${reports.transforms}",
+            )
+        }
+
+    @Test
+    fun `an unselected source does not move when dragged`() =
+        canvas(listOf(shape()), selectedId = null) { reports ->
+            // Same guard as above — the click proves the coordinates are on the source, so the
+            // absence of a transform afterwards is about the branch and not about a missed press.
+            clickAt(100f, 56f)
+            assertEquals(listOf<String?>("shape-1"), reports.selected, "the press must hit the source")
+
+            dragBy(fromX = 100f, fromY = 56f, dx = 80f, dy = 40f)
+
+            // Only the selected source takes the drag modifier; the rest are tap-to-select only.
+            assertTrue(reports.transforms.isEmpty(), "got ${reports.transforms}")
+        }
+
+    @Test
+    fun `dragging a source towards the canvas edge snaps it flush`() =
+        canvas(listOf(shape(x = 0.1f, y = 0.1f)), selectedId = "shape-1") { reports ->
+            // Aim just past the left edge: the snap threshold pulls the left edge onto 0 exactly.
+            dragBy(fromX = 100f, fromY = 56f, dx = -39f, dy = 0f)
+
+            val moved = reports.transforms.last().second
+            assertEquals(0f, moved.x, "the left edge must snap flush to the canvas edge")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneResizeHandleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneResizeHandleTest.kt
@@ -1,0 +1,205 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.ui.geometry.Offset
+import org.churchpresenter.app.churchpresenter.models.SourceTransform
+import java.awt.Cursor
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The eight resize grips' arithmetic — what a drag of each one does to a source's transform.
+ *
+ * Which edges move and which stay put differs per handle, and the two halves are not symmetric:
+ * dragging the **west** edge right moves `x` *and* shrinks `width`, while dragging the **east** edge
+ * right only grows `width`. Swap those and a source leaps across the screen as it is resized, in
+ * front of a congregation. The same asymmetry applies on the vertical axis, and the corners combine
+ * both.
+ *
+ * Driven directly rather than through the grips: each is an 8dp box placed at a rotated offset
+ * outside the source's own bounds, so a positional test would have to reproduce the placement maths
+ * to find out where it landed and would then be asserting its own arithmetic. The gesture that calls
+ * these — one `detectDragGestures` with a `coerceAtLeast` floor — stays uncovered; everything it
+ * decides is here.
+ *
+ * A drag is in pixels and a transform in normalised 0..1, so every expectation below is the pixel
+ * delta divided by the canvas dimension: on a 1000 x 500 canvas, 100px right is +0.1 and 50px down
+ * is +0.1.
+ */
+class SceneResizeHandleTest {
+
+    private val w = 1000f
+    private val h = 500f
+
+    /** A source occupying the middle of the canvas, so every edge has room to move either way. */
+    private val source = SourceTransform(x = 0.2f, y = 0.2f, width = 0.4f, height = 0.4f)
+
+    private val handles = resizeHandles(w, h)
+
+    private fun handleAt(anchorX: Float, anchorY: Float): ResizeHandleDef =
+        handles.single { it.anchorX == anchorX && it.anchorY == anchorY }
+
+    private fun drag(anchorX: Float, anchorY: Float, dxPx: Float, dyPx: Float): SourceTransform =
+        handleAt(anchorX, anchorY).onDrag(source, Offset(dxPx, dyPx))
+
+    private fun assertClose(expected: Float, actual: Float, what: String = "value") =
+        assertTrue(abs(expected - actual) < 0.0001f, "$what: expected $expected, was $actual")
+
+    // ── The set itself ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `there are eight handles, one per edge and corner`() {
+        assertEquals(8, handles.size)
+        assertEquals(
+            listOf(
+                0f to 0f, 0.5f to 0f, 1f to 0f,
+                0f to 0.5f, 1f to 0.5f,
+                0f to 1f, 0.5f to 1f, 1f to 1f,
+            ),
+            handles.map { it.anchorX to it.anchorY },
+            "the drawing order is NW, N, NE, W, E, SW, S, SE",
+        )
+    }
+
+    @Test
+    fun `each handle offers the resize cursor for the direction it drags`() {
+        // The cursor is the only thing telling the operator what a grip will do before they use it.
+        assertEquals(Cursor.NW_RESIZE_CURSOR, handleAt(0f, 0f).cursor)
+        assertEquals(Cursor.N_RESIZE_CURSOR, handleAt(0.5f, 0f).cursor)
+        assertEquals(Cursor.NE_RESIZE_CURSOR, handleAt(1f, 0f).cursor)
+        assertEquals(Cursor.W_RESIZE_CURSOR, handleAt(0f, 0.5f).cursor)
+        assertEquals(Cursor.E_RESIZE_CURSOR, handleAt(1f, 0.5f).cursor)
+        assertEquals(Cursor.SW_RESIZE_CURSOR, handleAt(0f, 1f).cursor)
+        assertEquals(Cursor.S_RESIZE_CURSOR, handleAt(0.5f, 1f).cursor)
+        assertEquals(Cursor.SE_RESIZE_CURSOR, handleAt(1f, 1f).cursor)
+    }
+
+    // ── The four edges ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `dragging the west edge right moves the left edge in and narrows the source`() {
+        val t = drag(0f, 0.5f, dxPx = 100f, dyPx = 0f)
+
+        assertClose(0.3f, t.x, "x follows the dragged edge")
+        assertClose(0.3f, t.width, "and the width shrinks by the same amount")
+        assertClose(0.2f, t.y, "the vertical axis is untouched")
+        assertClose(0.4f, t.height, "the vertical axis is untouched")
+    }
+
+    @Test
+    fun `dragging the east edge right widens the source without moving it`() {
+        val t = drag(1f, 0.5f, dxPx = 100f, dyPx = 0f)
+
+        // The asymmetry with the west edge is the whole point: x must not move here.
+        assertClose(0.2f, t.x, "the left edge stays anchored")
+        assertClose(0.5f, t.width, "only the width grows")
+    }
+
+    @Test
+    fun `dragging the north edge down moves the top edge in and shortens the source`() {
+        val t = drag(0.5f, 0f, dxPx = 0f, dyPx = 50f)
+
+        assertClose(0.3f, t.y)
+        assertClose(0.3f, t.height)
+        assertClose(0.2f, t.x, "the horizontal axis is untouched")
+        assertClose(0.4f, t.width, "the horizontal axis is untouched")
+    }
+
+    @Test
+    fun `dragging the south edge down lengthens the source without moving it`() {
+        val t = drag(0.5f, 1f, dxPx = 0f, dyPx = 50f)
+
+        assertClose(0.2f, t.y, "the top edge stays anchored")
+        assertClose(0.5f, t.height, "only the height grows")
+    }
+
+    // ── The four corners ────────────────────────────────────────────────────────
+
+    @Test
+    fun `the north-west corner moves both edges in and shrinks both dimensions`() {
+        val t = drag(0f, 0f, dxPx = 100f, dyPx = 50f)
+
+        assertClose(0.3f, t.x)
+        assertClose(0.3f, t.y)
+        assertClose(0.3f, t.width)
+        assertClose(0.3f, t.height)
+    }
+
+    @Test
+    fun `the north-east corner moves only the top edge`() {
+        val t = drag(1f, 0f, dxPx = 100f, dyPx = 50f)
+
+        assertClose(0.2f, t.x, "the left edge is not the one being dragged")
+        assertClose(0.3f, t.y, "but the top edge is")
+        assertClose(0.5f, t.width, "so the width grows")
+        assertClose(0.3f, t.height, "and the height shrinks")
+    }
+
+    @Test
+    fun `the south-west corner moves only the left edge`() {
+        val t = drag(0f, 1f, dxPx = 100f, dyPx = 50f)
+
+        assertClose(0.3f, t.x)
+        assertClose(0.2f, t.y, "the top edge stays put")
+        assertClose(0.3f, t.width)
+        assertClose(0.5f, t.height)
+    }
+
+    @Test
+    fun `the south-east corner moves neither edge and grows both dimensions`() {
+        val t = drag(1f, 1f, dxPx = 100f, dyPx = 50f)
+
+        assertClose(0.2f, t.x)
+        assertClose(0.2f, t.y)
+        assertClose(0.5f, t.width)
+        assertClose(0.5f, t.height)
+    }
+
+    // ── Properties that hold across the set ─────────────────────────────────────
+
+    @Test
+    fun `a zero drag leaves every handle's transform untouched`() {
+        handles.forEach { handle ->
+            assertEquals(
+                source,
+                handle.onDrag(source, Offset.Zero),
+                "a handle pressed but not moved must change nothing",
+            )
+        }
+    }
+
+    @Test
+    fun `no handle alters rotation or opacity`() {
+        val rotated = source.copy(rotation = 30f, opacity = 0.5f)
+        handles.forEach { handle ->
+            val t = handle.onDrag(rotated, Offset(40f, 20f))
+            assertEquals(30f, t.rotation, "resizing must not rotate")
+            assertEquals(0.5f, t.opacity, "resizing must not change opacity")
+        }
+    }
+
+    @Test
+    fun `dragging an edge out and back returns the source to where it started`() {
+        // Each handle's inverse is its own negated drag, which is what makes a resize feel
+        // predictable when the operator overshoots and comes back.
+        handles.forEach { handle ->
+            val out = handle.onDrag(source, Offset(60f, 30f))
+            val back = handle.onDrag(out, Offset(-60f, -30f))
+            assertClose(source.x, back.x, "x after there-and-back")
+            assertClose(source.y, back.y, "y after there-and-back")
+            assertClose(source.width, back.width, "width after there-and-back")
+            assertClose(source.height, back.height, "height after there-and-back")
+        }
+    }
+
+    @Test
+    fun `the canvas size is what converts a pixel drag into the transform`() {
+        // The same drag on a canvas twice as wide moves half as far in normalised terms — this is
+        // why the handles are built per canvas rather than once.
+        val wide = resizeHandles(canvasWidth = 2000f, canvasHeight = h)
+        val t = wide.single { it.anchorX == 1f && it.anchorY == 0.5f }.onDrag(source, Offset(100f, 0f))
+
+        assertClose(0.45f, t.width, "100px of 2000 is +0.05, not +0.1")
+    }
+}


### PR DESCRIPTION
`SceneCanvas` **46.7% → 86.7%** (223 missed lines → 56). It was the best remaining coverage target
once the tabs work landed.

## What is covered

**Drawing** (`SceneCanvasDrawingTest`) — turning a drag into a `ShapeSource`. The arithmetic differs
per tool: a rectangle or ellipse takes the drag's bounding box, a line or arrow additionally stores
its two endpoints *relative to* that box, and freehand stores every sampled point the same way. Also
the minimum-size floor, a backwards drag, and that select mode and a bare click create nothing.

**Selection and movement** (`SceneCanvasSelectionTest`) — click-to-select including z-order, that a
locked source still selects but does not move, that an invisible one is skipped entirely,
drag-to-move, and that a drag near an edge snaps flush to it.

**The eight resize grips** (`SceneResizeHandleTest`) — see the production change below.

Unlike `PicturesTab`'s thumbnail reorder, none of these gestures reads `keyboardModifiers`, so they
can be driven for real rather than worked around.

## The one production change

The resize grips' `onDrag` lambdas — pure `(SourceTransform, Offset) -> SourceTransform` — were
declared inside a private `@Composable`, so nothing could reach them. Driving them through the grips
is not the answer either: each is an 8dp box placed at a *rotated offset outside* the source's own
bounds, so a positional test would have to reproduce the placement maths to find out where each one
landed, and would then be asserting its own arithmetic rather than this code's.

They move to an `internal resizeHandles(canvasWidth, canvasHeight)` — the split `AGENT.md`
prescribes: the decisions become directly testable and only the single `detectDragGestures` call is
left uncovered. Nothing else changes; the composable calls the new function in place of its inline
list.

What those tests pin is the asymmetry that makes the code worth testing at all: dragging the **west**
edge right moves `x` *and* shrinks `width`, while dragging the **east** edge right only grows
`width`. Swap them and a source leaps across the screen mid-resize, in front of a congregation.

`SceneCanvas.kt` is not among PR #9's 17 files, so this does not collide with it.

## Left uncovered deliberately

The **rotation handle** (37 lines), for the same placement-arithmetic reason as the resize grips —
its angle computation would be worth a seam if it is ever touched, and that is noted in the class
docs rather than papered over with a fragile positional test.

## A gotcha worth knowing

`detectDragGestures` reports `onDragStart` at the position where touch slop was first exceeded, not
at the press. My first backwards-drag test asserted that dragging a rectangle in either direction
describes the same box; it failed, and the cause was the test — the intermediate `moveTo` was
becoming the shape's recorded origin. The drag helper now arms itself a few pixels from the press,
which is documented at the helper.

## Verification

`./gradlew :composeApp:check` green including the 75% gate; overall coverage 71.3% → 71.6%. The new
suites ran 3× with `--rerun-tasks`, all green. Timings: 0.90s / 0.22s / 0.00s.
