### PR TITLE
Cover BibleTab's translation-order panel and narrow search layout

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabNarrowSearchTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabNarrowSearchTest.kt
@@ -1,0 +1,145 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The search row's narrow layout — what the tab shows when the Bible panel is dragged in.
+ *
+ * `BoxWithConstraints` picks between two arrangements at 440dp: above it the search field, the scope
+ * and mode dropdowns and the search button sit in one row; below it the field takes a line of its own
+ * and the three controls stack underneath. They are separate call sites, not one row that wraps, so
+ * the narrow one is its own set of controls that no test reached while every suite composed the tab
+ * at full width.
+ *
+ * That matters because the panel is resizable by a drag handle and an operator working on a laptop
+ * runs it narrow — if the narrow branch lost its search button, search would be unreachable for them
+ * and every wide-layout test would still pass.
+ *
+ * Each test asserts the control *works*, not merely that it rendered: a layout branch that draws the
+ * right things but wires them to nothing is the failure worth catching.
+ *
+ * See `BibleTabTestSupport.kt` for the harness; `width` is what selects the branch.
+ */
+class BibleTabNarrowSearchTest {
+
+    /** Comfortably under the 440dp threshold, and a plausible real panel width. */
+    private val narrow = 360.dp
+
+    /** Comfortably over it, for the comparisons that need both branches. */
+    private val wide = 900.dp
+
+    private fun ComposeUiTest.searchField() = onAllNodes(hasSetTextAction())[0]
+
+    // ── The branch itself ───────────────────────────────────────────────────────
+
+    @Test
+    fun `the narrow layout still offers every search control`() =
+        bibleTab(width = narrow) { _, _ ->
+            // The field, both dropdowns and the button all have to survive the stack; losing any of
+            // them would leave a narrow panel unable to search at all.
+            assertTrue(
+                onAllNodes(hasSetTextAction()).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty(),
+                "the search field must be present",
+            )
+            onNodeWithText("SCOPE").assertExists("the scope selector must survive the narrow layout")
+            onNodeWithText("MODE").assertExists("as must the mode selector")
+            onNodeWithContentDescription("Search").assertExists("and the search button")
+        }
+
+    @Test
+    fun `the narrow layout stacks the controls below the field rather than beside it`() =
+        bibleTab(width = narrow) { _, _ ->
+            val field = onAllNodes(hasSetTextAction())[0].fetchSemanticsNode().boundsInRoot
+            val scope = onNodeWithText("SCOPE").fetchSemanticsNode().boundsInRoot
+
+            // The distinguishing property of this branch, asserted as a relationship rather than a
+            // coordinate: stacked means the scope selector starts below the field's bottom edge.
+            assertTrue(
+                scope.top >= field.bottom,
+                "scope (top=${scope.top}) must sit below the field (bottom=${field.bottom})",
+            )
+        }
+
+    @Test
+    fun `the wide layout keeps them on one line`() =
+        bibleTab(width = wide) { _, _ ->
+            val field = onAllNodes(hasSetTextAction())[0].fetchSemanticsNode().boundsInRoot
+            val scope = onNodeWithText("SCOPE").fetchSemanticsNode().boundsInRoot
+
+            // The mirror of the assertion above — together they prove the threshold does something,
+            // rather than the narrow test passing because both branches happen to look alike.
+            assertTrue(
+                scope.top < field.bottom,
+                "scope (top=${scope.top}) must sit beside the field (bottom=${field.bottom})",
+            )
+        }
+
+    // ── The controls, driven ────────────────────────────────────────────────────
+
+    @Test
+    fun `the narrow layout's search button runs the query`() =
+        bibleTab(width = narrow) { vm, _ ->
+            searchField().performTextReplacement("God")
+            waitForIdle()
+
+            onNodeWithContentDescription("Search").performClick()
+            waitForIdle()
+
+            // Submitting is what turns typed text into results; the button is the only way to do it
+            // in this layout other than the enter key.
+            assertTrue(vm.searchQuery.value.isNotEmpty(), "the query must have reached the view model")
+        }
+
+    @Test
+    fun `the narrow layout's search field accepts and reports typing`() =
+        bibleTab(width = narrow) { vm, _ ->
+            searchField().performTextReplacement("John 3:16")
+            waitForIdle()
+
+            assertTrue(
+                vm.searchQuery.value.contains("John", ignoreCase = true),
+                "the narrow field must be wired to the same smart-query handler, was '${vm.searchQuery.value}'",
+            )
+        }
+
+    @Test
+    fun `the narrow layout's scope selector changes the scope`() =
+        bibleTab(width = narrow) { vm, _ ->
+            assertEquals(0, vm.selectedScopeIndex.value, "the tab starts searching the whole Bible")
+
+            onNodeWithText("SCOPE").performClick()
+            waitForIdle()
+            // The menu opens over the stacked layout rather than being clipped out of it, which is
+            // the thing that could plausibly break in the narrow branch.
+            onNodeWithText("Current Book").performClick()
+            waitForIdle()
+
+            // Asserted through the view model, not by reading the label back: a DropdownMenu keeps
+            // showing whatever was clicked whether or not anything was stored.
+            assertEquals(1, vm.selectedScopeIndex.value, "picking Current Book must narrow the search")
+        }
+
+    @Test
+    fun `the narrow layout's mode selector changes the mode`() =
+        bibleTab(width = narrow) { vm, _ ->
+            assertEquals(0, vm.selectedModeIndex.value)
+
+            onNodeWithText("MODE").performClick()
+            waitForIdle()
+            onNodeWithText("Exact Match").performClick()
+            waitForIdle()
+
+            assertEquals(1, vm.selectedModeIndex.value, "picking Exact Match must change how it matches")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabTestSupport.kt
@@ -2,7 +2,10 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeUiTest
@@ -16,6 +19,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Dp
 import kotlinx.coroutines.Dispatchers
 import org.churchpresenter.app.churchpresenter.data.SpbFixture
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
@@ -134,6 +138,14 @@ internal fun bibleTab(
     /** Instance Link Controller mode: non-null makes the tab mirror every go-live to the primary. */
     onInstanceLinkSendVerse: ((SelectedVerse) -> Unit)? = null,
     onInstanceLinkSendBibleHold: ((Boolean) -> Unit)? = null,
+    /**
+     * Constrains the tab's width.
+     *
+     * The search row lays itself out from `BoxWithConstraints`, stacking into a column below 440dp
+     * and sitting in one row above it, so which of the two branches a test sees is decided here.
+     * Left null everywhere else, which gives the tab the whole test window — the wide branch.
+     */
+    width: Dp? = null,
     block: ComposeUiTest.(vm: BibleViewModel, reports: BibleReports) -> Unit,
 ) {
     val dir = Files.createTempDirectory("cp-bible-tab").toFile()
@@ -156,6 +168,7 @@ internal fun bibleTab(
         runComposeUiTest {
             setContent {
                 MaterialTheme {
+                    Box(modifier = width?.let { Modifier.width(it) } ?: Modifier) {
                     BibleTab(
                         viewModel = vm,
                         appSettings = appSettings,
@@ -186,6 +199,7 @@ internal fun bibleTab(
                         },
                         onInstanceLinkSendBibleHold = onInstanceLinkSendBibleHold,
                     )
+                    }
                 }
             }
             block(vm, reports)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabTranslationOrderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabTranslationOrderTest.kt
@@ -1,0 +1,277 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleTranslationSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The multi-translation display-order panel — the dropdown behind the translation chip, which is the
+ * only place the stacking order of three or more translations can be changed.
+ *
+ * The order is not cosmetic: the first translation is the *navigation* bible (the one whose book and
+ * chapter list drives the tab) and the rest stack down the audience screen beneath it. Reordering
+ * with the wrong index or a wrong offset silently repoints the whole tab at a different translation.
+ *
+ * Every row offers two ways to move: the up/down arrows, and dragging the row by its grip. Both end
+ * at the same `moveBibleTranslation`, and both are covered here — the drag because it is the one an
+ * operator reaches for, the arrows because they are the accessible route and because their disabled
+ * state at the ends of the list is its own branch.
+ *
+ * The panel lives inside a `DropdownMenu`, so every test opens the chip first. Note that clicking a
+ * row inside the menu does **not** close it, so an assertion after a click is still looking at the
+ * open panel.
+ *
+ * See `BibleTabTestSupport.kt` for the harness.
+ */
+class BibleTabTranslationOrderTest {
+
+    /** Three translations: the minimum that turns the one-tap swap into an ordered list. */
+    private fun stack(vararg fileNames: String): (AppSettings) -> AppSettings =
+        { app ->
+            app.copy(
+                bibleSettings = app.bibleSettings.copy(
+                    translations = fileNames.map { BibleTranslationSettings(fileName = it) },
+                )
+            )
+        }
+
+    private val three = stack("test.spb", "second.spb", "third.spb")
+
+    /**
+     * Opens the chip's dropdown, which is where the whole panel lives.
+     *
+     * Addressed by the chip's own caption rather than by the translation it names: the name shown
+     * is the display name read out of the `.spb`, not the file name, so keying on it would tie the
+     * test to the fixture's metadata.
+     */
+    private fun ComposeUiTest.openOrderPanel() {
+        onNodeWithText("TRANSLATION ORDER").performClick()
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.panelIsOpen(): Boolean =
+        onAllNodesWithContentDescription("Drag to reorder")
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .isNotEmpty()
+
+    /** The resulting translation order after the tab's most recent settings change. */
+    private fun BibleReports.orderAfterChange(): List<String>? =
+        settingsAfterChange?.bibleSettings?.translations?.map { it.fileName }
+
+    // ── The panel's contents ────────────────────────────────────────────────────
+
+    @Test
+    fun `the chip opens a panel listing every translation in order`() =
+        bibleTab(settings = three) { _, _ ->
+            openOrderPanel()
+
+            assertTrue(panelIsOpen(), "the chip must open the order panel")
+            onNodeWithText("Display order").assertExists("the panel must say what it orders")
+            onNodeWithText("Verses stack top to bottom on screen").assertExists()
+            // Each translation is listed by the file it comes from, which is what makes two
+            // translations with the same display name tellable apart.
+            onNodeWithText("test.spb").assertExists()
+            onNodeWithText("second.spb").assertExists()
+            onNodeWithText("third.spb").assertExists()
+        }
+
+    @Test
+    fun `every row has a drag grip and a pair of arrows`() =
+        bibleTab(settings = three) { _, _ ->
+            openOrderPanel()
+
+            assertEquals(3, countByDescription("Drag to reorder"), "one grip per translation")
+            assertEquals(3, countByDescription("Move translation up"))
+            assertEquals(3, countByDescription("Move translation down"))
+        }
+
+    @Test
+    fun `only the first translation is badged as primary`() =
+        bibleTab(settings = three) { _, _ ->
+            openOrderPanel()
+
+            // The badge is what tells the operator which one drives the book and chapter list.
+            assertEquals(
+                1,
+                renderedText().count { it.equals("PRIMARY", ignoreCase = true) },
+                "exactly one row is the navigation bible: ${renderedText()}",
+            )
+        }
+
+    @Test
+    fun `the panel explains both ways to reorder`() =
+        bibleTab(settings = three) { _, _ ->
+            openOrderPanel()
+
+            onNodeWithText("Drag a row or use the arrows to reorder.").assertExists()
+        }
+
+    // ── The arrows ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the down arrow on the first row moves it below the second`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+
+            onAllNodesWithContentDescription("Move translation down")[0].performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("second.spb", "test.spb", "third.spb"),
+                reports.orderAfterChange(),
+                "the navigation bible must hand over to the one it swapped with",
+            )
+        }
+
+    @Test
+    fun `the up arrow on the last row moves it above the second`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+
+            onAllNodesWithContentDescription("Move translation up")[2].performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("test.spb", "third.spb", "second.spb"),
+                reports.orderAfterChange(),
+            )
+        }
+
+    @Test
+    fun `the up arrow on the first row does nothing`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+            // The grips prove the panel is open, so a later "nothing happened" is about the arrow
+            // and not about the panel having failed to render.
+            assertTrue(panelIsOpen())
+
+            onAllNodesWithContentDescription("Move translation up")[0].performClick()
+            waitForIdle()
+
+            // Disabled here omits the clickable modifier entirely rather than reporting itself
+            // disabled, so "cannot be pressed" is the absence of any effect.
+            assertEquals(0, reports.settingsChanges, "there is nothing above the first row")
+        }
+
+    @Test
+    fun `the down arrow on the last row does nothing`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+            assertTrue(panelIsOpen())
+
+            onAllNodesWithContentDescription("Move translation down")[2].performClick()
+            waitForIdle()
+
+            assertEquals(0, reports.settingsChanges, "there is nothing below the last row")
+        }
+
+    @Test
+    fun `the arrows in the middle row move it either way`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+
+            onAllNodesWithContentDescription("Move translation up")[1].performClick()
+            waitForIdle()
+            assertEquals(listOf("second.spb", "test.spb", "third.spb"), reports.orderAfterChange())
+
+            onAllNodesWithContentDescription("Move translation down")[1].performClick()
+            waitForIdle()
+            // The tab does not hold settings, so the second click starts from the original order
+            // again — what is asserted is the transform each click produces, not an accumulation.
+            assertEquals(listOf("test.spb", "third.spb", "second.spb"), reports.orderAfterChange())
+        }
+
+    // ── The drag grip ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `dragging a row down past the next one reorders it`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+
+            // The reorder commits once on drop, by whole row heights travelled — dragging a full
+            // row's height down moves it exactly one place.
+            dragGrip(row = 0, dy = ROW_HEIGHT_PX)
+
+            assertEquals(
+                listOf("second.spb", "test.spb", "third.spb"),
+                reports.orderAfterChange(),
+                "a one-row drag moves one place",
+            )
+        }
+
+    @Test
+    fun `dragging a row up past the previous one reorders it`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+
+            dragGrip(row = 2, dy = -ROW_HEIGHT_PX)
+
+            assertEquals(listOf("test.spb", "third.spb", "second.spb"), reports.orderAfterChange())
+        }
+
+    @Test
+    fun `a drag too short to cross a row leaves the order alone`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+
+            // Under half a row rounds to zero steps: a nudge while reading the list must not
+            // silently repoint the navigation bible.
+            dragGrip(row = 0, dy = ROW_HEIGHT_PX / 4f)
+
+            assertEquals(0, reports.settingsChanges, "a nudge is not a reorder")
+        }
+
+    @Test
+    fun `dragging far past the end stops at the last position`() =
+        bibleTab(settings = three) { _, reports ->
+            openOrderPanel()
+
+            dragGrip(row = 0, dy = ROW_HEIGHT_PX * 10f)
+
+            // Clamped to the list rather than throwing or dropping the translation.
+            assertEquals(
+                listOf("second.spb", "third.spb", "test.spb"),
+                reports.orderAfterChange(),
+                "the row lands at the bottom, not off the end",
+            )
+        }
+
+    private companion object {
+        /** `TRANSLATION_ORDER_ROW_HEIGHT` in pixels at the tests' density of 1. */
+        const val ROW_HEIGHT_PX = 46f
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private fun ComposeUiTest.countByDescription(description: String): Int =
+        onAllNodesWithContentDescription(description)
+            .fetchSemanticsNodes(atLeastOneRootRequired = false)
+            .size
+
+    /**
+     * Drags the [row]th grip vertically by [dy] pixels and drops it.
+     *
+     * The press is nudged before the real move for the same reason as the scene canvas's drag
+     * helper: `detectDragGestures` only reports movement once touch slop is passed.
+     */
+    private fun ComposeUiTest.dragGrip(row: Int, dy: Float) {
+        onAllNodesWithContentDescription("Drag to reorder")[row].performMouseInput {
+            moveTo(Offset(2f, 8f))
+            press()
+            moveTo(Offset(2f, 8f + dy / 2f))
+            moveTo(Offset(2f, 8f + dy))
+            release()
+        }
+        waitForIdle()
+    }
+}


### PR DESCRIPTION
`BibleTab` **73.7% → 85.0%** (462 missed lines → 263). Test-only apart from one optional parameter on
the existing test harness.

## The translation-order panel

About 180 of those lines were one region: the dropdown behind the translation chip, which is the only
place the stacking order of three or more translations can be changed. Existing tests reached the
chip but never opened it, so the entire panel was unexercised.

The order is not cosmetic — the **first** translation is the *navigation* bible, whose book and
chapter list drives the whole tab, and the rest stack down the audience screen beneath it. Reordering
with a wrong index or offset silently repoints the tab at a different translation.

Both routes are driven: the up/down arrows, and dragging a row by its grip. Plus:

- the **disabled arrows** at each end of the list — disabled here omits the `clickable` modifier
  entirely rather than reporting itself disabled, so it is tested as the absence of an effect, with
  the panel's grips asserted first so "nothing happened" cannot pass because the panel failed to open;
- a **drag too short to cross a row** (rounds to zero steps — a nudge while reading the list must not
  repoint the navigation bible);
- a **drag far past the end**, which clamps to the last position rather than dropping the row.

The chip is addressed by its own caption rather than by the translation it names: the name shown is
the display name read out of the `.spb`, so keying on it would tie the test to fixture metadata.

## The narrow search layout

`BoxWithConstraints` picks between two arrangements at 440dp — above it the search field, both
dropdowns and the search button sit in one row; below it they stack. They are **separate call sites**,
not one row that wraps, and every existing suite composes the tab at full width, so the narrow branch
had never been rendered. If it lost its search button, search would be unreachable for anyone running
the panel narrow on a laptop and the whole suite would still be green.

Each control is driven rather than merely asserted present: the button submits, the field reaches the
smart-query handler, and each dropdown picks an option with the result read back **from the view
model** — a `DropdownMenu` goes on showing whatever was clicked whether or not anything was stored.

The two layout tests assert a *relationship* (the scope selector sits below the field, versus beside
it) rather than coordinates, and they assert opposite things at the two widths, so neither can pass
by the threshold doing nothing.

## The one harness change

`bibleTab(...)` takes an optional `width`, which is what selects the branch. Null everywhere else, so
every existing test is unaffected.

## Verification

`./gradlew :composeApp:check` green including the 75% coverage gate; overall 71.6% → 71.9%. Both new
suites ran 3× with `--rerun-tasks`, all green, and the whole `*BibleTab*` set passes on this branch on
its own.

Stacks alongside #106 (scene canvas) — different files, no overlap, and neither touches PR #9's.
