### PR TITLE
Cover SongsTab's back-to-live button and column drag gestures

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabBackToLiveTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabBackToLiveTest.kt
@@ -1,0 +1,152 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The "Back to Live" button — the way back to whatever is on the screen after searching away from it.
+ *
+ * Mid-service the operator searches for the *next* song while the current one is still projected.
+ * That leaves the tab showing one song and the audience seeing another, and the lyric pane following
+ * the selection rather than the output. This button is the only route back: it reselects the live
+ * song and restores the exact section and line that are live, not merely the song.
+ *
+ * It appears only when all three hold — the tab is presenting, something is live, and the row the
+ * selection now points at is a *different* song. Each of those is its own reason to hide it, and the
+ * button appearing when nothing is live would be an invitation to jump somewhere arbitrary.
+ *
+ * The live song is put out of view with a **search**, which is what the production comment names as
+ * the case: `liveSongId` is re-stamped on every push, so a plain selection change cannot separate the
+ * two — filtering the list underneath the selection is what does.
+ *
+ * See `SongsTabTestSupport.kt` for the harness.
+ */
+class SongsTabBackToLiveTest {
+
+    private val backToLive = "Back to Live"
+
+    private fun ComposeUiTest.hasBackToLive(): Boolean =
+        onAllNodes(hasText(backToLive)).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
+
+    /** Puts [title] live, which is what stamps it as the live song. */
+    private fun ComposeUiTest.goLiveWith(title: String) {
+        onAllNodes(hasText(title))[0].performClick()
+        waitForIdle()
+        onAllNodes(hasContentDescription("Go Live"))[0].performClick()
+        waitForIdle()
+    }
+
+    // ── When it is offered ──────────────────────────────────────────────────────
+
+    @Test
+    fun `nothing live means no way back`() = songsTab(isPresenting = true) { _, _ ->
+        // Presenting but with nothing pushed yet: there is no "live" to return to.
+        assertTrue(!hasBackToLive(), "the button must not offer a jump to nothing")
+    }
+
+    @Test
+    fun `while the live song is the selected one there is nothing to go back to`() =
+        songsTab(isPresenting = true) { _, _ ->
+            goLiveWith("Amazing Grace")
+
+            assertTrue(!hasBackToLive(), "the selection already is the live song")
+        }
+
+    @Test
+    fun `searching the live song out of view offers the way back`() =
+        songsTab(isPresenting = true) { _, _ ->
+            goLiveWith("Amazing Grace")
+
+            // "Be Thou" matches only the other song, so the selection now points at a row that is
+            // not what the congregation is looking at.
+            search("Be Thou")
+
+            assertTrue(hasBackToLive(), "the operator must be able to get back to what is live")
+        }
+
+    @Test
+    fun `the button goes away once it has been used`() =
+        songsTab(isPresenting = true) { _, _ ->
+            goLiveWith("Amazing Grace")
+            search("Be Thou")
+            assertTrue(hasBackToLive())
+
+            onNodeWithText(backToLive).performClick()
+            waitForIdle()
+
+            assertTrue(!hasBackToLive(), "with the live song selected again there is nowhere to go")
+        }
+
+    @Test
+    fun `clearing the search does not by itself put the selection back`() =
+        songsTab(isPresenting = true) { _, _ ->
+            goLiveWith("Amazing Grace")
+            search("Be Thou")
+
+            search("")
+
+            // Worth pinning because it is the opposite of what one might assume: restoring the full
+            // list does not move the selection back onto the live song, so the offer to return
+            // stands until the operator takes it. The alternative — silently reselecting on every
+            // search clear — would yank the tab away from a song they were deliberately queueing up.
+            assertTrue(hasBackToLive(), "the way back must stay offered until it is taken")
+        }
+
+    @Test
+    fun `not presenting means the button stays away even with the live song out of view`() =
+        songsTab(isPresenting = false) { _, _ ->
+            goLiveWith("Amazing Grace")
+            search("Be Thou")
+
+            // Nothing is on the screen, so there is nothing to be "back" to — the lyric pane
+            // following the selection is simply what the operator asked for.
+            assertTrue(!hasBackToLive(), "the button belongs to presenting, not to browsing")
+        }
+
+    // ── What it does ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `pressing it reselects the live song`() = songsTab(isPresenting = true) { vm, _ ->
+        goLiveWith("Amazing Grace")
+        val liveId = vm.filteredSongItems.value[vm.selectedSongIndex.value].songId
+
+        search("Be Thou")
+        onNodeWithText(backToLive).performClick()
+        waitForIdle()
+
+        assertEquals(
+            liveId,
+            vm.filteredSongItems.value.getOrNull(vm.selectedSongIndex.value)?.songId,
+            "the selection must land back on the song that is live",
+        )
+    }
+
+    @Test
+    fun `pressing it restores the live section and line, not just the song`() =
+        songsTab(isPresenting = true) { vm, _ ->
+            goLiveWith("Amazing Grace")
+            // Step within the live song so the live position is not the song's first line — that is
+            // the whole point of restoring position rather than just reselecting.
+            vm.selectSection(0)
+            vm.setLineIndex(0)
+            waitForIdle()
+            val liveSection = vm.selectedSectionIndex.value
+            val liveLine = vm.selectedLineIndex.value
+
+            search("Be Thou")
+            waitForIdle()
+            onNodeWithText(backToLive).performClick()
+            waitForIdle()
+
+            assertEquals(liveSection, vm.selectedSectionIndex.value, "the live section must come back")
+            assertEquals(liveLine, vm.selectedLineIndex.value, "and the live line with it")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabColumnLayoutTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabColumnLayoutTest.kt
@@ -1,0 +1,152 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performMouseInput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Rearranging the song table's columns by dragging its headers — reordering by dragging a header
+ * sideways, and resizing by dragging the divider between two of them.
+ *
+ * Both persist through `onSettingsChange`, and that is the point: an operator sets the table up once
+ * to suit their screen and expects it back next Sunday. Neither is reachable from a menu, so
+ * dragging is the only way either happens.
+ *
+ * `SongColumnsTest` covers `moveColumn` and `computeNewIdx` as arithmetic; this covers the gesture
+ * that feeds them and the settings write that follows, which is where a drag can be wired to the
+ * wrong column or drop its save.
+ *
+ * The header cells are addressed by their labels. The **resize divider is not addressable** — it is a
+ * bare 6dp `Box` with no semantics — so it is reached positionally, just past the right edge of the
+ * header it belongs to. That is stated rather than hidden: if the header layout changes, these two
+ * resize tests are the ones to re-check.
+ *
+ * See `SongsTabTestSupport.kt` for the harness.
+ */
+class SongsTabColumnLayoutTest {
+
+    /** No hidden columns, so every header is on screen and orderable. */
+    private val allShown = emptySet<String>()
+
+    private fun ComposeUiTest.header(label: String) = onAllNodes(hasText(label))[0]
+
+    /** Drags a header sideways by [dx] pixels, which is the reorder gesture. */
+    private fun ComposeUiTest.dragHeader(label: String, dx: Float) {
+        val bounds = header(label).fetchSemanticsNode().boundsInRoot
+        val y = bounds.center.y
+        val startX = bounds.center.x
+        onRoot().performMouseInput {
+            moveTo(Offset(startX, y))
+            press()
+            moveTo(Offset(startX + dx / 2f, y))
+            moveTo(Offset(startX + dx, y))
+            release()
+        }
+        waitForIdle()
+    }
+
+    /**
+     * Drags the divider on the right-hand edge of [label]'s header by [dx] pixels.
+     *
+     * The divider has no semantics of its own, so it is found by geometry: it is the 6dp strip
+     * immediately after the header cell, and the header's own label ends a little before it.
+     */
+    private fun ComposeUiTest.dragDivider(label: String, dx: Float) {
+        val bounds = header(label).fetchSemanticsNode().boundsInRoot
+        val y = bounds.center.y
+        val x = bounds.right + 3f
+        onRoot().performMouseInput {
+            moveTo(Offset(x, y))
+            press()
+            moveTo(Offset(x + dx / 2f, y))
+            moveTo(Offset(x + dx, y))
+            release()
+        }
+        waitForIdle()
+    }
+
+    // ── Reordering ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `dragging a header far enough sideways reorders the columns and saves it`() =
+        songsTab(hiddenCols = allShown) { _, reports ->
+            val before = header(Col.TITLE).fetchSemanticsNode().boundsInRoot
+
+            // Dragged *left*, past Number. The table's default order is number-then-title, so
+            // asserting that title ends up after number would have been true before the drag too —
+            // the direction is chosen so the assertion can only pass if something moved.
+            dragHeader(Col.TITLE, dx = -(before.width + 120f))
+
+            val order = reports.settingsAfterChange?.songColOrder
+            assertNotNull(order, "a reorder must be written to settings to survive a restart")
+            assertTrue(
+                order.indexOf("title") < order.indexOf("number"),
+                "title must have moved ahead of number, which it does not start as: $order",
+            )
+        }
+
+    @Test
+    fun `a small nudge does not reorder anything`() =
+        songsTab(hiddenCols = allShown) { _, reports ->
+            dragHeader(Col.TITLE, dx = 3f)
+
+            // Brushing a header while reaching for the sort must not rearrange the table.
+            assertEquals(null, reports.settingsAfterChange?.songColOrder, "a nudge is not a reorder")
+        }
+
+    @Test
+    fun `reordering leaves every column present`() =
+        songsTab(hiddenCols = allShown) { _, reports ->
+            val before = header(Col.TITLE).fetchSemanticsNode().boundsInRoot
+            dragHeader(Col.TITLE, dx = -(before.width + 120f))
+
+            val order = reports.settingsAfterChange?.songColOrder
+            assertNotNull(order)
+            // A reorder that dropped or duplicated a column would leave the table missing one.
+            assertEquals(order.size, order.distinct().size, "no column may be duplicated: $order")
+            assertTrue("title" in order && "number" in order, "nor lost: $order")
+        }
+
+    // ── Resizing ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `dragging the divider right widens the column and saves the width`() =
+        songsTab(hiddenCols = allShown) { _, reports ->
+            val before = header(Col.TITLE).fetchSemanticsNode().boundsInRoot.width
+
+            dragDivider(Col.TITLE, dx = 80f)
+
+            val saved = reports.settingsAfterChange?.songSettings?.colWidthTitle
+            assertNotNull(saved, "a resize must be written to settings on drop")
+            val after = header(Col.TITLE).fetchSemanticsNode().boundsInRoot.width
+            assertTrue(after > before, "the column must actually get wider ($before -> $after)")
+        }
+
+    @Test
+    fun `a column cannot be dragged narrower than its minimum`() =
+        songsTab(hiddenCols = allShown) { _, reports ->
+            // Far more than the column's width, so without a floor it would go to zero or negative
+            // and the header would vanish from the table entirely.
+            dragDivider(Col.TITLE, dx = -4000f)
+
+            val saved = reports.settingsAfterChange?.songSettings?.colWidthTitle
+            assertNotNull(saved)
+            assertTrue(saved >= 60, "title's floor is 60dp, was $saved")
+            assertTrue(
+                header(Col.TITLE).fetchSemanticsNode().boundsInRoot.width > 0f,
+                "the header must survive being squeezed",
+            )
+        }
+
+    private object Col {
+        const val TITLE = "Title"
+    }
+}


### PR DESCRIPTION
`SongsTab` **78.1% → 82.2%** (273 missed lines → 221). Test-only.

## Back to Live

The button that returns the operator to what the congregation is actually looking at. Mid-service
they search for the *next* song while the current one is still projected — that leaves the tab
showing one song and the output showing another, with the lyric pane following the selection rather
than the screen. This is the only route back, and it restores the live **section and line**, not just
the song.

Covered: each of the three conditions that hide it (not presenting, nothing live, the live song
already selected) and both of its effects.

Two behaviours the code corrected me on, and both are now pinned:

- The live song is separated from the selection by a **search**, not by a plain selection change —
  `liveSongId` is re-stamped on every push, so filtering the list underneath the selection is what
  splits them. That is exactly what the production comment says.
- **Clearing the search does not put the selection back**, so the offer to return stands until it is
  taken. I had assumed the opposite. The current behaviour is the better one: silently reselecting on
  every search clear would yank the tab away from a song being deliberately queued up.

## Column reorder and resize

Neither is reachable from a menu — dragging is the only way either happens — and both persist through
`onSettingsChange`, which is the point: an operator arranges the table once for their screen and
expects it back next Sunday. `SongColumnsTest` already covers `moveColumn`/`computeNewIdx` as
arithmetic; this covers the gesture that feeds them and the settings write that follows, which is
where a drag gets wired to the wrong column or drops its save.

Also covered: a nudge must not rearrange the table, a reorder must not drop or duplicate a column,
and a column dragged far narrower than its floor must survive rather than vanish.

**One assertion worth flagging.** My first version dragged Title right and asserted it ended up after
Number — but the default order *is* number-then-title, so that was true before the drag and would
have passed against a completely broken gesture. It now drags left and asserts Title precedes Number,
which can only pass if something moved.

The resize divider is a bare 6dp `Box` with no semantics, so those two tests reach it positionally,
just past the header's right edge. That is stated in the class doc rather than left as a silent
fragility — if the header layout changes, they are the ones to re-check.

## Verification

`./gradlew :composeApp:check` green including the 75% gate; overall 71.3% → 71.4% **measured on this
branch alone**, which does not include #106 or #107. Both new suites ran 3× with `--rerun-tasks`, all
green.

Third of three stacked coverage PRs (#106 scene canvas, #107 Bible tab) — separate branches off
`main`, different files, no overlap between them or with PR #9.
