### PR TITLE
Put the CI push trigger back on main only — a cancelled duplicate run blocks every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,23 @@ name: Tests
 
 # The three build workflows are all workflow_dispatch-only, so until this existed nothing ran
 # automatically on a push or a pull request -- including the submodule test suites, which were
-# green but unenforced. This runs the whole suite on every push and PR.
-# Every branch, not just main: a branch whose PR has already merged stops matching `pull_request`,
-# so work pushed to it afterwards ran nothing at all until this was widened.
+# green but unenforced. This runs the whole suite on every PR, and on main after a merge.
+#
+# `push` is main-only again, and that is deliberate. Widening it to every branch meant a PR commit
+# matched BOTH events, and the two runs then had to be reconciled somehow -- neither way works here:
+#
+#   * let both run: two 15-minute runs of the same commit, for nothing;
+#   * dedupe them with a shared concurrency group: whichever is cancelled still posts a check named
+#     `test`, and `test` is the required context on main (strict). A cancelled required check is not
+#     a passing one, so EVERY pull request sat at BLOCKED with a green run beside a cancelled one.
+#     #106, #107 and #108 all hit this.
+#
+# What the widening was for -- commits pushed to a branch whose PR had already merged running
+# nothing -- is real but much smaller, and it only happens by pushing to a merged PR's branch, which
+# is a mistake worth catching with `gh pr view` rather than with a second CI run per commit.
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -17,14 +29,13 @@ permissions:
   contents: read
 
 concurrency:
-  # A newer push to the same branch makes an in-flight run redundant. Keyed on the bare branch name
-  # so a branch's own push run and its PR run share one group instead of both building the same
-  # commit -- now that every branch push triggers this.
+  # A newer push to the same branch makes an in-flight run redundant. With `push` back to main only,
+  # a commit matches one event, so this no longer has two runs to reconcile -- it just keeps the
+  # newest run per branch.
   #
-  # ref_name, not ref: the two events spell the same branch differently. On push, head_ref is empty
-  # and ref is `refs/heads/<branch>`; on pull_request, head_ref is `<branch>`. Those are different
-  # strings, so `head_ref || ref` put the two events in different groups and ran both -- 15 minutes
-  # of runner per commit, twice. ref_name drops the prefix, so both spell it `<branch>`.
+  # Still keyed on the bare branch name rather than `ref`: the two events spell the same branch
+  # differently (on push `ref` is `refs/heads/<branch>`, on pull_request `head_ref` is `<branch>`),
+  # so anything that has to hold for both wants `ref_name`.
   group: tests-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 


### PR DESCRIPTION
**#106, #107 and #108 are all blocked right now by this, with a green test run sitting next to a cancelled one.** This unblocks them.

## What happened

#105 widened `push:` to every branch, so a PR commit matches **both** `push` and `pull_request`. That leaves two runs of the same commit to reconcile, and neither way works here:

- **Let both run** — two 15-minute runs per commit, for nothing.
- **Dedupe with a shared concurrency group** (what shipped, `2891c208`) — one of them is cancelled, and *a cancelled run still posts a check named `test`*. `test` is the required context on `main` (`strict: true`), and cancelled is not passing, so the PR sits at `BLOCKED`:

```
test  COMPLETED/CANCELLED   (push run)
test  COMPLETED/SUCCESS     (pull_request run)
→ mergeStateStatus: BLOCKED
```

Which of the two gets cancelled is not controllable either, so this is not fixable by choosing a different key.

## The fix

`push: branches: [main]`, as it was before #105. One event per commit, one `test` check, nothing to cancel. The concurrency key keeps `ref_name` — it costs nothing and is the correct spelling if the trigger is ever widened again.

## What we give up, and why it's the right trade

The widening was for a real gap: commits pushed to a branch whose PR has **already merged** match no trigger and run nothing — eight commits went untested that way after #102. But that only happens by pushing to a merged PR's branch, which is a workflow mistake `gh pr view` catches for free, and it is already written down as one. A second full CI run on every commit is a steep price for it — and this version of it blocked merges outright.

I noticed it while reviewing #106/#107/#108, all of which were `BLOCKED` on a passing suite.