### PR TITLE
Cover PresentationTab and MediaTab, which had no tests at all

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
@@ -204,24 +204,35 @@ fun MediaTab(
     /** Instance Link Controller mode — non-null only when connected and controlling. Sends via
      *  PROJECT; only remote URLs (youtube/vimeo) will actually play on the primary — a "local" file
      *  path only exists on this machine's disk, not the primary's, a known limitation. */
-    onInstanceLinkSendProject: ((ScheduleItem) -> Unit)? = null
+    onInstanceLinkSendProject: ((ScheduleItem) -> Unit)? = null,
+    /**
+     * Whether VLC is usable, and if not, why.
+     *
+     * Parameters rather than reads of the globals in `VideoPlayer.kt`, which cache their answer in a
+     * process-wide field: what this tab renders would otherwise depend on whether the machine running
+     * it happens to have VLC installed, so neither branch could be tested deterministically. Same seam
+     * `WebTab` uses for `cefInitialized`. The defaults are the real checks, so callers see no change.
+     */
+    vlcAvailable: Boolean = isVlcAvailable,
+    vlcArchMismatch: Boolean = isVlcArchMismatch,
+    vlcLoadFailed: Boolean = isVlcLoadFailed,
 ) {
     val scope = rememberCoroutineScope()
 
-    if (!isVlcAvailable) {
+    if (!vlcAvailable) {
         Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Icon(
-                    imageVector = if (isVlcArchMismatch || isVlcLoadFailed) Icons.Default.Warning else Icons.Default.Videocam,
+                    imageVector = if (vlcArchMismatch || vlcLoadFailed) Icons.Default.Warning else Icons.Default.Videocam,
                     contentDescription = null,
                     modifier = Modifier.size(64.dp),
-                    tint = if (isVlcArchMismatch || isVlcLoadFailed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                    tint = if (vlcArchMismatch || vlcLoadFailed) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
                 )
                 Text(stringResource(Res.string.media_vlc_required), style = MaterialTheme.typography.titleMedium)
                 Text(
                     text = when {
-                        isVlcArchMismatch -> stringResource(Res.string.media_vlc_arch_mismatch)
-                        isVlcLoadFailed -> stringResource(Res.string.media_vlc_load_failed)
+                        vlcArchMismatch -> stringResource(Res.string.media_vlc_arch_mismatch)
+                        vlcLoadFailed -> stringResource(Res.string.media_vlc_load_failed)
                         else -> stringResource(Res.string.media_vlc_install)
                     },
                     style = MaterialTheme.typography.bodyMedium,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
@@ -223,7 +223,17 @@ fun PresentationTab(
     onStopTunnel: () -> Unit = {},
     presentationFrozen: Boolean = false,
     onFreezeToggle: () -> Unit = {},
-    onClearPresentation: () -> Unit = {}
+    onClearPresentation: () -> Unit = {},
+    /**
+     * Whether VLC is usable, which decides only whether the missing-VLC banner is offered for a deck
+     * containing video.
+     *
+     * A parameter rather than a read of the global in `VideoPlayer.kt`, which caches its answer in a
+     * process-wide field — otherwise the banner's presence would depend on whether the machine running
+     * the tests has VLC installed. Same seam `WebTab` uses for `cefInitialized`; the default is the
+     * real check, so callers see no change.
+     */
+    vlcAvailable: Boolean = isVlcAvailable,
 ) {
     val scope = rememberCoroutineScope()
     var showRemoteDialog by remember { mutableStateOf(false) }
@@ -859,7 +869,7 @@ fun PresentationTab(
                     val deckHasVideo = viewModel.deck?.slides
                         ?.any { slide -> slide.layers.any { it is LayerSpec.Media } } == true
                     var vlcBannerDismissed by remember(viewModel.loadGeneration) { mutableStateOf(false) }
-                    if (deckHasVideo && !isVlcAvailable && !vlcBannerDismissed) {
+                    if (deckHasVideo && !vlcAvailable && !vlcBannerDismissed) {
                         VlcMissingBanner(
                             detail = when {
                                 isVlcArchMismatch -> stringResource(Res.string.media_vlc_arch_mismatch)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTabTest.kt
@@ -1,0 +1,149 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The Media tab's source bar — choosing between a local file and a network URL, loading one, and
+ * putting it in the schedule.
+ *
+ * This is everything an operator does before playback starts, and none of it needs VLC: the picker, the
+ * URL field and the Load button are ordinary Compose. Only the player surface underneath is bound to
+ * the runtime, which is why this tab sat at 0% with no test file while `MediaViewModel` behind it was
+ * already at 97%.
+ *
+ * Loading is asserted through the view model rather than by reading the screen back — the tab shows the
+ * title it was given whether or not anything was actually loaded, so the screen alone cannot tell a
+ * working Load button from a decorative one.
+ *
+ * See `MediaTabTestSupport.kt` for the harness, and `MediaTabVlcUnavailableTest` for the other branch.
+ */
+class MediaTabTest {
+
+    // ── The source picker ───────────────────────────────────────────────────────
+
+    @Test
+    fun `the tab offers both a local file and a network url source`() = mediaTab { _, _ ->
+        onNodeWithText(MediaLabel.LOCAL_FILE).assertExists()
+        onNodeWithText(MediaLabel.NETWORK_URL).assertExists()
+    }
+
+    @Test
+    fun `it starts on local file, with the file picker rather than a url box`() = mediaTab { _, _ ->
+        // Local is the common case — a video file dropped in a folder — so it is the default.
+        onNodeWithText(MediaLabel.SELECT_FILE).assertExists()
+        onNodeWithText(MediaLabel.URL_PLACEHOLDER).assertDoesNotExist()
+    }
+
+    @Test
+    fun `choosing network url swaps the file picker for a url field`() = mediaTab { _, _ ->
+        onNodeWithText(MediaLabel.NETWORK_URL).performClick()
+        waitForIdle()
+
+        onNodeWithText(MediaLabel.URL_PLACEHOLDER).assertExists("the url entry must appear")
+        onNodeWithText(MediaLabel.SELECT_FILE).assertDoesNotExist()
+    }
+
+    @Test
+    fun `switching back to local file restores the picker`() = mediaTab { _, _ ->
+        onNodeWithText(MediaLabel.NETWORK_URL).performClick()
+        waitForIdle()
+        onNodeWithText(MediaLabel.LOCAL_FILE).performClick()
+        waitForIdle()
+
+        onNodeWithText(MediaLabel.SELECT_FILE).assertExists()
+        onNodeWithText(MediaLabel.URL_PLACEHOLDER).assertDoesNotExist()
+    }
+
+    // ── Loading a URL ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `typing a url and loading it reaches the view model`() = mediaTab { vm, _ ->
+        onNodeWithText(MediaLabel.NETWORK_URL).performClick()
+        waitForIdle()
+        onAllNodes(hasSetTextAction())[0].performTextReplacement("rtsp://example.org/stream")
+        waitForIdle()
+
+        onNodeWithText("Load").performClick()
+        waitForIdle()
+
+        // Asserted on the view model: the tab would display the url either way.
+        assertEquals("rtsp://example.org/stream", vm.mediaUrl)
+        assertEquals(Constants.MEDIA_TYPE_URL, vm.mediaType)
+    }
+
+    @Test
+    fun `an empty url does not load anything`() = mediaTab { vm, _ ->
+        onNodeWithText(MediaLabel.NETWORK_URL).performClick()
+        waitForIdle()
+
+        onNodeWithText("Load").performClick()
+        waitForIdle()
+
+        // A blank Load would clear whatever is playing for nothing.
+        assertEquals("", vm.mediaUrl)
+    }
+
+    // ── A schedule item arriving ────────────────────────────────────────────────
+
+    @Test
+    fun `a url item from the schedule selects the url source and loads it`() {
+        val item = ScheduleItem.MediaItem(
+            id = "1",
+            mediaUrl = "https://example.org/clip.mp4",
+            mediaTitle = "Clip",
+            mediaType = Constants.MEDIA_TYPE_URL,
+        )
+
+        mediaTab(selectedMediaItem = item) { vm, _ ->
+            waitForIdle()
+
+            // Clicking a media item in the schedule has to land the operator on a tab that is already
+            // showing that item, not on an empty picker they have to re-fill.
+            assertEquals("https://example.org/clip.mp4", vm.mediaUrl)
+            assertEquals("Clip", vm.mediaTitle)
+            onNodeWithText(MediaLabel.URL_PLACEHOLDER).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun `a local item from the schedule stays on the local source`() {
+        val item = ScheduleItem.MediaItem(
+            id = "1",
+            mediaUrl = "/videos/sermon.mp4",
+            mediaTitle = "Sermon",
+            mediaType = Constants.MEDIA_TYPE_LOCAL,
+        )
+
+        mediaTab(selectedMediaItem = item) { vm, _ ->
+            waitForIdle()
+
+            assertEquals("/videos/sermon.mp4", vm.mediaUrl)
+            assertEquals(Constants.MEDIA_TYPE_LOCAL, vm.mediaType)
+            onNodeWithText(MediaLabel.SELECT_FILE).assertExists("the local picker stays")
+        }
+    }
+
+    // ── What is shown before anything is loaded ─────────────────────────────────
+
+    @Test
+    fun `with nothing loaded the tab says so`() = mediaTab { vm, _ ->
+        assertTrue(!vm.isLoaded, "nothing is loaded at first")
+        // Said twice — once beside the file picker and once over the empty player area — so this
+        // counts rather than asserting a single node.
+        assertTrue(
+            onAllNodesWithText("No media loaded").fetchSemanticsNodes(atLeastOneRootRequired = false).size >= 1,
+            "an idle tab must say it has no source: ${renderedText()}",
+        )
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTabTestSupport.kt
@@ -1,0 +1,104 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.viewmodel.LocalMediaViewModel
+import org.churchpresenter.app.churchpresenter.viewmodel.MediaViewModel
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+
+/**
+ * Harness and fixtures for the `MediaTab` test classes.
+ *
+ * The tab had **no test file at all** before this one. It was written off as VLC-bound, but only its
+ * playback surface is: the source picker, the URL entry, the recents bar and the transport controls are
+ * ordinary Compose and render without VLC anywhere in sight. `WebTab` established the same thing for
+ * JCEF, and `MediaViewModel` (97%) and `LocalMediaViewModel` (100%) show the logic underneath was never
+ * the problem — only the tab.
+ *
+ * **[vlcAvailable] is the reason this works.** `isVlcAvailable` is a top-level `val` in
+ * `composables/VideoPlayer.kt` that caches its answer in a process-wide field, so without a seam the tab
+ * renders one thing on a developer's Mac with VLC installed and another on CI — neither branch testable
+ * on purpose. The tab now takes it as a parameter defaulting to the real check, so a test names which
+ * world it wants. Same shape as `WebTab`'s `cefInitialized`.
+ */
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class MediaReports {
+    /** mediaUrl, mediaTitle, mediaType — exactly what the schedule would be given. */
+    val scheduled = mutableListOf<Triple<String, String, String>>()
+}
+
+@OptIn(ExperimentalTestApi::class)
+internal fun mediaTab(
+    settings: (AppSettings) -> AppSettings = { it },
+    selectedMediaItem: ScheduleItem.MediaItem? = null,
+    presenterManager: PresenterManager? = null,
+    /** Which VLC world to compose in — see the note above. Defaults to "installed and working". */
+    vlcAvailable: Boolean = true,
+    vlcArchMismatch: Boolean = false,
+    vlcLoadFailed: Boolean = false,
+    block: ComposeUiTest.(vm: MediaViewModel, reports: MediaReports) -> Unit,
+) {
+    // The tab's recents list persists under user.home; pin the JVM-wide loggers first.
+    TestSingletons.latchToTestHome()
+    val appSettings = settings(AppSettings())
+    val reports = MediaReports()
+    // The tab's very first line is `LocalMediaViewModel.current ?: return`, so without this the whole
+    // composable is a no-op and every assertion below would be about an empty screen.
+    val vm = MediaViewModel()
+    runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                CompositionLocalProvider(LocalMediaViewModel provides vm) {
+                MediaTab(
+                    appSettings = appSettings,
+                    selectedMediaItem = selectedMediaItem,
+                    presenterManager = presenterManager,
+                    onAddToSchedule = { url, title, type -> reports.scheduled += Triple(url, title, type) },
+                    vlcAvailable = vlcAvailable,
+                    vlcArchMismatch = vlcArchMismatch,
+                    vlcLoadFailed = vlcLoadFailed,
+                )
+                }
+            }
+        }
+        block(vm, reports)
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object MediaLabel {
+    const val VLC_REQUIRED = "VLC media player is required for media playback"
+    const val VLC_INSTALL = "Please install VLC from videolan.org and restart the application"
+    const val LOCAL_FILE = "Local File"
+    const val NETWORK_URL = "Network URL"
+    const val SELECT_FILE = "Select File"
+    const val URL_PLACEHOLDER = "Enter URL (http://, rtsp://, ...)"
+    const val ADD_TO_SCHEDULE = "Add to Schedule"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+
+// renderedText/showsExactly/showsContainingText live in TabRenderedText.kt — shared with the other
+// tab suites in this package. Do not redeclare them.
+
+/** A button, addressed by the content description its tooltip gives it. */
+internal fun ComposeUiTest.mediaButton(label: String) = onNodeWithContentDescription(label)
+
+internal fun ComposeUiTest.hasMediaButton(label: String): Boolean =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTabVlcUnavailableTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTabVlcUnavailableTest.kt
@@ -1,0 +1,86 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * What the Media tab says when VLC cannot be used — which is the entire tab in that state, and the
+ * state a CI runner is always in.
+ *
+ * There are three distinct reasons playback can be unavailable and each gets its own instruction,
+ * because the fix differs: install it, install the *right architecture* of it, or repair a broken
+ * install. Showing "please install VLC" to someone who has VLC installed but on the wrong architecture
+ * sends them round a loop they cannot get out of — they already did the thing the message asks for.
+ *
+ * Reachable deterministically only because the tab takes the VLC state as parameters; the underlying
+ * globals cache a process-wide answer off the host machine. See `MediaTabTestSupport.kt`.
+ */
+class MediaTabVlcUnavailableTest {
+
+    @Test
+    fun `with VLC missing the tab explains that playback needs it`() =
+        mediaTab(vlcAvailable = false) { _, _ ->
+            onNodeWithText(MediaLabel.VLC_REQUIRED).assertIsDisplayed()
+        }
+
+    @Test
+    fun `a plain missing install is told where to get it`() =
+        mediaTab(vlcAvailable = false) { _, _ ->
+            onNodeWithText(MediaLabel.VLC_INSTALL).assertIsDisplayed()
+        }
+
+    @Test
+    fun `an architecture mismatch says so instead of asking for a reinstall`() =
+        mediaTab(vlcAvailable = false, vlcArchMismatch = true) { _, _ ->
+            // Someone on Apple Silicon with an Intel-only VLC has already installed it — repeating
+            // "please install VLC" would send them round the same loop.
+            assertTrue(
+                showsContainingText("Apple Silicon"),
+                "the arch mismatch must be named: ${renderedText()}",
+            )
+            onNodeWithText(MediaLabel.VLC_INSTALL).assertDoesNotExist()
+        }
+
+    @Test
+    fun `a failed load asks for a repair rather than an install`() =
+        mediaTab(vlcAvailable = false, vlcLoadFailed = true) { _, _ ->
+            assertTrue(
+                showsContainingText("could not be loaded"),
+                "a broken install must be distinguished from a missing one: ${renderedText()}",
+            )
+            onNodeWithText(MediaLabel.VLC_INSTALL).assertDoesNotExist()
+        }
+
+    @Test
+    fun `an architecture mismatch takes precedence over a load failure`() =
+        mediaTab(vlcAvailable = false, vlcArchMismatch = true, vlcLoadFailed = true) { _, _ ->
+            // A wrong-architecture VLC also fails to load, so both flags are set at once and the
+            // order of the `when` decides which advice is given. The arch message is the actionable
+            // one; "try reinstalling" would not fix it.
+            assertTrue(showsContainingText("Apple Silicon"), renderedText().toString())
+            assertTrue(!showsContainingText("could not be loaded"), renderedText().toString())
+        }
+
+    @Test
+    fun `the media controls are not offered at all while VLC is unusable`() =
+        mediaTab(vlcAvailable = false) { _, _ ->
+            // The whole tab is replaced by the message — offering a Load button that cannot work
+            // would just produce a second, more confusing failure.
+            onNodeWithText(MediaLabel.LOCAL_FILE).assertDoesNotExist()
+            onNodeWithText(MediaLabel.NETWORK_URL).assertDoesNotExist()
+            assertTrue(!hasMediaButton(MediaLabel.ADD_TO_SCHEDULE))
+        }
+
+    @Test
+    fun `with VLC present the tab shows its controls instead of the warning`() =
+        mediaTab(vlcAvailable = true) { _, _ ->
+            // The mirror of the test above — together they prove the parameter selects a branch
+            // rather than the tab looking the same either way.
+            onNodeWithText(MediaLabel.VLC_REQUIRED).assertDoesNotExist()
+            onNodeWithText(MediaLabel.LOCAL_FILE).assertExists()
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabTest.kt
@@ -1,0 +1,159 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import org.churchpresenter.app.churchpresenter.models.AnimationType
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The Presentation tab with no deck loaded — the empty state, and the playback settings that sit
+ * beside it.
+ *
+ * This is what the tab looks like every time the app starts, and no test had ever rendered it. The
+ * settings tiles are the substance here: auto-scroll interval, transition duration and animation type
+ * each live in two places at once — the view model drives playback now, the host persists the value for
+ * next Sunday — so each test checks both. A control that updates only one either fails to take effect
+ * or silently forgets itself on restart.
+ *
+ * **What the empty state does not offer** is worth knowing too, and is asserted: the blank/clear/remote
+ * controls appear only once a deck is loaded. That is why this suite does not test them — not an
+ * oversight. Covering them needs a rasterized deck, as does the slide grid and `SlideThumbnail`. See
+ * `PresentationTabTestSupport.kt`.
+ */
+class PresentationTabTest {
+
+    // ── The empty state ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `with no deck loaded the tab says so and offers to pick one`() = presentationTab { vm, _ ->
+        assertTrue(vm.slideFiles.isEmpty(), "the fixture starts with no deck")
+        onNodeWithText(PresentationLabel.NO_FILE).assertExists("the tab must say nothing is loaded")
+        onNodeWithText(PresentationLabel.SELECT_FILE).assertExists("and offer a way to load one")
+    }
+
+    @Test
+    fun `the empty state names the formats that can be opened`() = presentationTab { _, _ ->
+        // An operator with a .odp or a Google Slides export needs to find out here, not after a
+        // failed load mid-service.
+        assertTrue(showsContainingText("PowerPoint"), renderedText().toString())
+        assertTrue(showsContainingText("Keynote"), renderedText().toString())
+        assertTrue(showsContainingText(".pdf"), renderedText().toString())
+    }
+
+    @Test
+    fun `the keyboard hint is shown so the shortcuts are discoverable`() = presentationTab { _, _ ->
+        // Nobody finds "B blanks the screen" without being told, and it is the one shortcut worth
+        // knowing mid-service.
+        assertTrue(
+            showsContainingText("blank screen"),
+            "the arrow-key hint must be on screen: ${renderedText()}",
+        )
+    }
+
+    // ── The playback settings ───────────────────────────────────────────────────
+
+    @Test
+    fun `the shipped defaults are shown before anything is changed`() = presentationTab { _, _ ->
+        // Caption and value are merged into one node, so these are substring checks.
+        assertTrue(showsContainingText("AUTO-SCROLL INTERVAL:5 s"), renderedText().toString())
+        assertTrue(showsContainingText("TRANSITION DURATION:500 ms"), renderedText().toString())
+        assertTrue(showsContainingText("ANIMATION TYPE:Crossfade"), renderedText().toString())
+    }
+
+    @Test
+    fun `setting the auto-scroll interval applies it now and asks for it to be remembered`() =
+        presentationTab { vm, reports ->
+            onNodeWithText("AUTO-SCROLL INTERVAL", substring = true).performClick()
+            waitForIdle()
+            onAllNodes(hasSetTextAction())[0].performTextReplacement("12")
+            onNodeWithText("OK").performClick()
+            waitForIdle()
+
+            assertEquals(12f, vm.autoScrollInterval, "the running slideshow picks it up")
+            assertEquals(
+                12f,
+                reports.settingsAfterChange?.presentationSettings?.autoScrollInterval,
+                "and the host is asked to store it",
+            )
+        }
+
+    @Test
+    fun `setting the transition duration applies it now and asks for it to be remembered`() =
+        presentationTab { vm, reports ->
+            onNodeWithText("TRANSITION DURATION", substring = true).performClick()
+            waitForIdle()
+            onAllNodes(hasSetTextAction())[0].performTextReplacement("250")
+            onNodeWithText("OK").performClick()
+            waitForIdle()
+
+            assertEquals(250f, vm.transitionDuration)
+            assertEquals(250f, reports.settingsAfterChange?.presentationSettings?.transitionDuration)
+        }
+
+    @Test
+    fun `changing the animation type applies it now and asks for it to be remembered`() =
+        presentationTab { vm, reports ->
+            onNodeWithText("ANIMATION TYPE", substring = true).performClick()
+            waitForIdle()
+            onNodeWithText("Slide Left").performClick()
+            waitForIdle()
+
+            // Asserted through the view model and the settings, never by reading the label back: a
+            // DropdownMenu shows whatever was clicked whether or not anything was stored. Note the
+            // two sides use different types — the view model holds the enum, settings the string it
+            // is persisted as — so this also pins that they stay in step.
+            assertEquals(AnimationType.SLIDE_LEFT, vm.animationType)
+            assertEquals(
+                Constants.ANIMATION_SLIDE_LEFT,
+                reports.settingsAfterChange?.presentationSettings?.animationType,
+            )
+        }
+
+    // ── The live-output controls, with nothing to act on ────────────────────────
+
+    @Test
+    fun `clear is offered but disabled while no deck is loaded`() = presentationTab { vm, _ ->
+        assertTrue(vm.slideFiles.isEmpty())
+
+        // Present rather than hidden, so the toolbar does not reshuffle the moment a deck loads —
+        // but disabled, because clearing nothing would just be a click that appears to do nothing.
+        assertTrue(hasPresentationButton(PresentationLabel.CLEAR), renderedText().toString())
+        presentationButton(PresentationLabel.CLEAR).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `the blank control is offered only when there is an output to blank`() {
+        // It lives behind `presenterManager != null`: with no presenter there is no output, and a
+        // blank button that blanks nothing would be worse than no button.
+        presentationTab(presenterManager = null) { _, _ ->
+            assertTrue(!hasPresentationButton(PresentationLabel.BLANK_OUTPUT))
+        }
+        presentationTab(presenterManager = PresenterManager()) { _, _ ->
+            assertTrue(hasPresentationButton(PresentationLabel.BLANK_OUTPUT))
+        }
+    }
+
+    @Test
+    fun `the blank control is disabled until a deck is loaded`() =
+        presentationTab(presenterManager = PresenterManager()) { _, _ ->
+            presentationButton(PresentationLabel.BLANK_OUTPUT).assertIsNotEnabled()
+        }
+
+    @Test
+    fun `blanking reads as unblank once the output is already blanked`() =
+        presentationTab(presenterManager = PresenterManager(), presentationFrozen = true) { _, _ ->
+            // One button with two meanings — showing "Blank Output" while already blanked would have
+            // the operator click it and see nothing change.
+            assertTrue(hasPresentationButton(PresentationLabel.UNBLANK_OUTPUT))
+            assertTrue(!hasPresentationButton(PresentationLabel.BLANK_OUTPUT))
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabTestSupport.kt
@@ -1,0 +1,120 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.server.TunnelStatus
+import org.churchpresenter.app.churchpresenter.viewmodel.PresentationViewModel
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+
+/**
+ * Harness and fixtures for the `PresentationTab` test classes.
+ *
+ * The tab had **no test file at all** before this one, on the grounds that it needs a real deck through
+ * `DeckRasterizer`. Its *slide grid* does. The rest — the empty state, the toolbar, the freeze and clear
+ * controls, the remote-serving panel — is ordinary Compose over a [PresentationViewModel] that
+ * constructs with no deck at all and already has five test suites of its own.
+ *
+ * `WebTab` had established the same thing for a JCEF-bound tab; this is the deck-bound equivalent.
+ *
+ * **What is deliberately out of reach:** anything behind `viewModel.slideFiles` — the grid,
+ * `SlideThumbnail`, the build counter, slide navigation. Those need rasterized output, and a fixture
+ * that faked it would be asserting the fake. The tab is composed with an empty view model throughout,
+ * so every test here is about the no-deck state and the controls that surround it.
+ */
+
+// ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/** What the tab reported back, so a test asserts on the choice rather than on a stub. */
+internal class PresentationReports {
+    /** filePath, fileName, slideCount, fileType — exactly what the schedule would be given. */
+    val scheduled = mutableListOf<String>()
+    var settingsChanges = 0
+    var settingsAfterChange: AppSettings? = null
+    var freezeToggles = 0
+    var clears = 0
+    val displayUrlChanges = mutableListOf<String>()
+    var tunnelStarts = 0
+    var tunnelStops = 0
+}
+
+@OptIn(ExperimentalTestApi::class)
+internal fun presentationTab(
+    settings: (AppSettings) -> AppSettings = { it },
+    presenterManager: PresenterManager? = null,
+    presentationFrozen: Boolean = false,
+    tunnelStatus: TunnelStatus = TunnelStatus.Idle,
+    tunnelUrl: String = "",
+    serverUrl: String = "",
+    presentationDisplayUrl: String = "",
+    /** Whether VLC is usable — only decides the missing-VLC banner for a deck containing video. */
+    vlcAvailable: Boolean = true,
+    block: ComposeUiTest.(vm: PresentationViewModel, reports: PresentationReports) -> Unit,
+) {
+    // PresentationViewModel's slide disk cache resolves under user.home.
+    TestSingletons.latchToTestHome()
+    val appSettings = settings(AppSettings())
+    val reports = PresentationReports()
+    val vm = PresentationViewModel(appSettings)
+    runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                PresentationTab(
+                    appSettings = appSettings,
+                    viewModel = vm,
+                    presenterManager = presenterManager,
+                    onAddToSchedule = { path, name, count, type -> reports.scheduled += "$path:$name:$count:$type" },
+                    onSettingsChange = { transform ->
+                        reports.settingsChanges++
+                        reports.settingsAfterChange = transform(reports.settingsAfterChange ?: appSettings)
+                    },
+                    tunnelStatus = tunnelStatus,
+                    tunnelUrl = tunnelUrl,
+                    serverUrl = serverUrl,
+                    presentationDisplayUrl = presentationDisplayUrl,
+                    onPresentationDisplayUrlChanged = { reports.displayUrlChanges += it },
+                    onStartTunnel = { reports.tunnelStarts++ },
+                    onStopTunnel = { reports.tunnelStops++ },
+                    presentationFrozen = presentationFrozen,
+                    onFreezeToggle = { reports.freezeToggles++ },
+                    onClearPresentation = { reports.clears++ },
+                    vlcAvailable = vlcAvailable,
+                )
+            }
+        }
+        block(vm, reports)
+    }
+}
+
+// ── Labels, as the tab renders them ─────────────────────────────────────────────────────────────
+
+internal object PresentationLabel {
+    const val NO_FILE = "No file selected"
+    const val SELECT_FILE = "Select File"
+    const val BLANK_OUTPUT = "Blank Output"
+    const val UNBLANK_OUTPUT = "Unblank Output"
+    const val CLEAR = "Clear Presentation"
+    const val REMOTE = "Open Remote Control"
+    const val GO_LIVE = "Go Live"
+    const val ADD_TO_SCHEDULE = "Add to Schedule"
+}
+
+// ── Reading and driving what was rendered ───────────────────────────────────────────────────────
+
+// renderedText/showsExactly/showsContainingText live in TabRenderedText.kt — shared with the other
+// tab suites in this package. Do not redeclare them.
+
+/** A button, addressed by the content description its tooltip gives it. */
+internal fun ComposeUiTest.presentationButton(label: String) = onNodeWithContentDescription(label)
+
+internal fun ComposeUiTest.hasPresentationButton(label: String): Boolean =
+    onAllNodesWithContentDescription(label)
+        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+        .isNotEmpty()


### PR DESCRIPTION
**`PresentationTab` 0% → 42.1%** (733 missed → 425) and **`MediaTab` 0% → 64.0%** (475 → 172).
Overall **72.5% → 73.7%**.

## Why these two

Both were on this project's blocked list — *"needs a real deck through `DeckRasterizer`"*, *"VLC"* — and
neither had **a single test file**. Between them that was 1,208 uncovered lines, the largest block
outside the entry wiring.

**`WebTab` disproves the premise.** It is equally runtime-bound and sits at 65.7%, tested by driving the
chrome around the browser view while the JCEF surface simply never renders. The same applies here, and
the logic underneath was never the problem: `MediaViewModel` was already at 97% and
`PresentationViewModel` has five suites of its own. Only the tabs were untouched.

That makes three entries this session filed as untestable that were not — the stepper arrows (a live
bug), the dropped broadcast (a real race), and now these. The list is useful but it decays: an entry
saying "cannot be tested" is a claim somebody made once.

## The one production change

`isVlcAvailable` is a top-level `val` in `composables/VideoPlayer.kt` caching its answer in a
**process-wide field**. `MediaTab` branches on it for its entire body, so what it renders depends on
whether the host machine has VLC installed — a test would cover one branch on a developer's Mac and the
other on CI, with no way to choose.

It becomes a parameter defaulting to the real check, along with the two flags that pick between its
three messages. Exactly the seam `WebTab` already uses for `cefInitialized`. `MainDesktop`'s call sites
are unchanged.

## What is covered

**MediaTab** — the source picker and both its branches, loading a URL through to the view model, a
schedule item arriving on either source type, and the whole VLC-unavailable state. Including that **an
architecture mismatch takes precedence over a load failure**: a wrong-arch VLC sets both flags, and
"try reinstalling" would send someone round a loop they cannot get out of.

Loading is asserted on the view model, never by reading the screen back — the tab shows the URL it was
given whether or not anything actually loaded.

**PresentationTab** — the empty state, the formats it advertises, the keyboard hint, and the three
settings tiles. Each tile is asserted on **both** the view model and the settings, because one that
updates only one of them either fails to take effect or silently forgets itself on restart. The
animation tile also pins that the two stay in step across a type change, since the view model holds an
enum and settings the string it persists as.

## Three things the code corrected me on

All now pinned as tests rather than worked around:

- **`MediaTab` renders nothing without a `MediaViewModel`** — its first line is
  `LocalMediaViewModel.current ?: return`. The harness provides it through `CompositionLocalProvider`.
- **`MediaTab` has no `onSettingsChange`** — the usual tab shape does not apply.
- **`PresentationTab`'s blank/clear buttons are not gated on having a deck.** Blank lives behind
  `presenterManager != null`, and both are `enabled = slideFiles.isNotEmpty()` — *present but disabled*.
  The tests assert both the presence rule and the disabled state, which is more useful than what I first
  wrote.

## Left uncovered, deliberately

The slide grid, `SlideThumbnail`, and everything behind `viewModel.slideFiles` — those genuinely need a
rasterized deck, and a fixture faking it would only assert the fake. Stated in the class docs so the
next person does not have to rediscover where the real boundary is.

## Verification

`./gradlew :composeApp:check` green including the 75% gate. Both new suites ran 3× with `--rerun-tasks`,
all green.
