### PR TITLE
redesign of schedule tab

### DIFF
--- a/composeApp/src/jvmMain/composeResources/drawable/ic_remove.xml
+++ b/composeApp/src/jvmMain/composeResources/drawable/ic_remove.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13H5v-2h14v2z"/>
+</vector>

--- a/composeApp/src/jvmMain/composeResources/values-be/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-be/strings.xml
@@ -816,6 +816,11 @@
     <string name="settings_export_failed">Не ўдалося экспартаваць налады.</string>
     <string name="settings_import_failed">Не ўдалося імпартаваць налады. Файл можа быць пашкоджаны.</string>
     <string name="schedule_add_files">Дадаць файлы…</string>
+    <string name="schedule_item_count">%1$d элементаў</string>
+    <string name="schedule_density_compact">Кампактны</string>
+    <string name="schedule_density_normal">Звычайны</string>
+    <string name="schedule_density_detailed">Падрабязны</string>
+    <string name="schedule_kind_lower_third">Ніжняя траціна</string>
     <string name="schedule_drop_hint">Перацягніце файлы сюды, каб дадаць у праграму</string>
     <string name="schedule_note_placeholder">Дадаць нататку…</string>
     <string name="screen_number">Экран %1$d</string>

--- a/composeApp/src/jvmMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-cs/strings.xml
@@ -850,6 +850,11 @@
     <string name="settings_export_failed">Export nastavení se nezdařil.</string>
     <string name="settings_import_failed">Import nastavení se nezdařil. Soubor může být neplatný.</string>
     <string name="schedule_add_files">Přidat soubory…</string>
+    <string name="schedule_item_count">%1$d položek</string>
+    <string name="schedule_density_compact">Kompaktní</string>
+    <string name="schedule_density_normal">Normální</string>
+    <string name="schedule_density_detailed">Podrobný</string>
+    <string name="schedule_kind_lower_third">Spodní třetina</string>
     <string name="schedule_drop_hint">Přetáhněte soubory sem pro přidání do programu</string>
     <string name="schedule_note_placeholder">Přidat poznámku…</string>
     <string name="screen_number">Obrazovka %1$d</string>

--- a/composeApp/src/jvmMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-de/strings.xml
@@ -816,6 +816,11 @@
     <string name="settings_export_failed">Einstellungen konnten nicht exportiert werden.</string>
     <string name="settings_import_failed">Einstellungen konnten nicht importiert werden. Die Datei ist möglicherweise ungültig.</string>
     <string name="schedule_add_files">Dateien hinzufügen…</string>
+    <string name="schedule_item_count">%1$d Elemente</string>
+    <string name="schedule_density_compact">Kompakt</string>
+    <string name="schedule_density_normal">Normal</string>
+    <string name="schedule_density_detailed">Detailliert</string>
+    <string name="schedule_kind_lower_third">Unteres Drittel</string>
     <string name="schedule_drop_hint">Dateien hierher ziehen, um sie zum Programm hinzuzufügen</string>
     <string name="schedule_note_placeholder">Notiz hinzufügen…</string>
     <string name="screen_number">Bildschirm %1$d</string>

--- a/composeApp/src/jvmMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-es/strings.xml
@@ -513,6 +513,11 @@
     <string name="schedule_drop_hint">Arrastra archivos aquí para añadirlos al programa</string>
     <string name="schedule_note_placeholder">Añadir nota…</string>
     <string name="schedule_add_files">Añadir archivos…</string>
+    <string name="schedule_item_count">%1$d elementos</string>
+    <string name="schedule_density_compact">Compacta</string>
+    <string name="schedule_density_normal">Normal</string>
+    <string name="schedule_density_detailed">Detallada</string>
+    <string name="schedule_kind_lower_third">Rótulo inferior</string>
 
     <!-- Add Label Dialog -->
     <string name="add_label">Añadir etiqueta</string>

--- a/composeApp/src/jvmMain/composeResources/values-et/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-et/strings.xml
@@ -546,6 +546,11 @@
     <string name="tooltip_expand_schedule">Laienda kava</string>
     <string name="schedule_drop_hint">Lohista failid siia, et lisada need kavasse</string>
     <string name="schedule_add_files">Lisa faile…</string>
+    <string name="schedule_item_count">%1$d elementi</string>
+    <string name="schedule_density_compact">Kompaktne</string>
+    <string name="schedule_density_normal">Tavaline</string>
+    <string name="schedule_density_detailed">Üksikasjalik</string>
+    <string name="schedule_kind_lower_third">Alumine kolmandik</string>
 
     <!-- Add Label Dialog -->
     <string name="add_label">Lisa silt</string>

--- a/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
@@ -513,6 +513,11 @@
     <string name="schedule_drop_hint">Faites glisser des fichiers ici pour les ajouter au programme</string>
     <string name="schedule_note_placeholder">Ajouter une note…</string>
     <string name="schedule_add_files">Ajouter des fichiers…</string>
+    <string name="schedule_item_count">%1$d éléments</string>
+    <string name="schedule_density_compact">Compact</string>
+    <string name="schedule_density_normal">Normal</string>
+    <string name="schedule_density_detailed">Détaillé</string>
+    <string name="schedule_kind_lower_third">Bandeau inférieur</string>
 
     <!-- Add Label Dialog -->
     <string name="add_label">Ajouter une étiquette</string>

--- a/composeApp/src/jvmMain/composeResources/values-kk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-kk/strings.xml
@@ -816,6 +816,11 @@
     <string name="settings_export_failed">Параметрлерді экспорттау сәтсіз аяқталды.</string>
     <string name="settings_import_failed">Параметрлерді импорттау сәтсіз аяқталды. Файл жарамсыз болуы мүмкін.</string>
     <string name="schedule_add_files">Файлдар қосу…</string>
+    <string name="schedule_item_count">%1$d элемент</string>
+    <string name="schedule_density_compact">Ықшам</string>
+    <string name="schedule_density_normal">Қалыпты</string>
+    <string name="schedule_density_detailed">Толық</string>
+    <string name="schedule_kind_lower_third">Төменгі үштен бір</string>
     <string name="schedule_drop_hint">Бағдарламаға қосу үшін файлдарды осында сүйреңіз</string>
     <string name="schedule_note_placeholder">Ескертпе қосу…</string>
     <string name="screen_number">Экран %1$d</string>

--- a/composeApp/src/jvmMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-nl/strings.xml
@@ -513,6 +513,11 @@
     <string name="schedule_drop_hint">Sleep bestanden hier om toe te voegen aan programma</string>
     <string name="schedule_note_placeholder">Notitie toevoegen…</string>
     <string name="schedule_add_files">Bestanden toevoegen…</string>
+    <string name="schedule_item_count">%1$d items</string>
+    <string name="schedule_density_compact">Compact</string>
+    <string name="schedule_density_normal">Normaal</string>
+    <string name="schedule_density_detailed">Gedetailleerd</string>
+    <string name="schedule_kind_lower_third">Lower Third</string>
 
     <!-- Add Label Dialog -->
     <string name="add_label">Label toevoegen</string>

--- a/composeApp/src/jvmMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-pl/strings.xml
@@ -815,6 +815,11 @@
     <string name="settings_export_failed">Nie udało się wyeksportować ustawień.</string>
     <string name="settings_import_failed">Nie udało się zaimportować ustawień. Plik może być nieprawidłowy.</string>
     <string name="schedule_add_files">Dodaj pliki…</string>
+    <string name="schedule_item_count">%1$d elementów</string>
+    <string name="schedule_density_compact">Kompaktowy</string>
+    <string name="schedule_density_normal">Normalny</string>
+    <string name="schedule_density_detailed">Szczegółowy</string>
+    <string name="schedule_kind_lower_third">Dolna trzecia</string>
     <string name="schedule_drop_hint">Przeciągnij pliki tutaj, aby dodać do programu</string>
     <string name="schedule_note_placeholder">Dodaj notatkę…</string>
     <string name="screen_number">Ekran %1$d</string>

--- a/composeApp/src/jvmMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-pt/strings.xml
@@ -513,6 +513,11 @@
     <string name="schedule_drop_hint">Arraste arquivos aqui para adicionar ao roteiro</string>
     <string name="schedule_note_placeholder">Adicionar nota…</string>
     <string name="schedule_add_files">Adicionar Arquivos…</string>
+    <string name="schedule_item_count">%1$d itens</string>
+    <string name="schedule_density_compact">Compacto</string>
+    <string name="schedule_density_normal">Normal</string>
+    <string name="schedule_density_detailed">Detalhado</string>
+    <string name="schedule_kind_lower_third">Lower Third</string>
 
     <!-- Add Label Dialog -->
     <string name="add_label">Adicionar Rótulo</string>

--- a/composeApp/src/jvmMain/composeResources/values-ro/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-ro/strings.xml
@@ -529,6 +529,11 @@
     <string name="schedule_drop_hint">Glisați fișiere aici pentru a le adăuga la program</string>
     <string name="schedule_note_placeholder">Adaugă notă…</string>
     <string name="schedule_add_files">Adaugă Fișiere…</string>
+    <string name="schedule_item_count">%1$d elemente</string>
+    <string name="schedule_density_compact">Compact</string>
+    <string name="schedule_density_normal">Normal</string>
+    <string name="schedule_density_detailed">Detaliat</string>
+    <string name="schedule_kind_lower_third">Lower Third</string>
 
     <!-- Add Label Dialog -->
     <string name="add_label">Adaugă Etichetă</string>

--- a/composeApp/src/jvmMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-ru/strings.xml
@@ -839,6 +839,11 @@
     <string name="settings_export_failed">Не удалось экспортировать настройки.</string>
     <string name="settings_import_failed">Не удалось импортировать настройки. Файл может быть повреждён.</string>
     <string name="schedule_add_files">Добавить файлы…</string>
+    <string name="schedule_item_count">%1$d элементов</string>
+    <string name="schedule_density_compact">Компактный</string>
+    <string name="schedule_density_normal">Обычный</string>
+    <string name="schedule_density_detailed">Подробный</string>
+    <string name="schedule_kind_lower_third">Нижняя треть</string>
     <string name="schedule_drop_hint">Перетащите файлы сюда, чтобы добавить в программу</string>
     <string name="schedule_note_placeholder">Добавить заметку…</string>
     <string name="screen_number">Экран %1$d</string>

--- a/composeApp/src/jvmMain/composeResources/values-sk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-sk/strings.xml
@@ -513,6 +513,11 @@
     <string name="schedule_drop_hint">Pretiahnite súbory sem a pridajte ich do programu</string>
     <string name="schedule_note_placeholder">Pridať poznámku…</string>
     <string name="schedule_add_files">Pridať súbory…</string>
+    <string name="schedule_item_count">%1$d položiek</string>
+    <string name="schedule_density_compact">Kompaktné</string>
+    <string name="schedule_density_normal">Normálne</string>
+    <string name="schedule_density_detailed">Podrobné</string>
+    <string name="schedule_kind_lower_third">Lower Third</string>
 
     <!-- Add Label Dialog -->
     <string name="add_label">Pridať štítok</string>

--- a/composeApp/src/jvmMain/composeResources/values-uk/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-uk/strings.xml
@@ -816,6 +816,11 @@
     <string name="settings_export_failed">Не вдалося експортувати налаштування.</string>
     <string name="settings_import_failed">Не вдалося імпортувати налаштування. Файл може бути пошкоджений.</string>
     <string name="schedule_add_files">Додати файли…</string>
+    <string name="schedule_item_count">%1$d елементів</string>
+    <string name="schedule_density_compact">Компактний</string>
+    <string name="schedule_density_normal">Звичайний</string>
+    <string name="schedule_density_detailed">Детальний</string>
+    <string name="schedule_kind_lower_third">Нижня третина</string>
     <string name="schedule_drop_hint">Перетягніть файли сюди, щоб додати до програми</string>
     <string name="schedule_note_placeholder">Додати нотатку…</string>
     <string name="screen_number">Екран %1$d</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -603,6 +603,11 @@
     <string name="tooltip_expand_schedule">Expand Schedule</string>
     <string name="schedule_drop_hint">Drag files here to add to schedule</string>
     <string name="schedule_add_files">Add Files…</string>
+    <string name="schedule_item_count">%1$d items</string>
+    <string name="schedule_density_compact">Compact</string>
+    <string name="schedule_density_normal">Normal</string>
+    <string name="schedule_density_detailed">Detailed</string>
+    <string name="schedule_kind_lower_third">Lower Third</string>
 
     <!-- Add Label Dialog -->
     <string name="add_label">Add Label</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ColorPickerDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ColorPickerDialog.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -174,7 +175,8 @@ fun ColorPickerDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .aspectRatio(1f)
-                        .clip(RoundedCornerShape(8.dp)),
+                        .clip(RoundedCornerShape(8.dp))
+                        .testTag("colorPickerSvPanel"),
                 )
 
                 // ── Hue rainbow bar ─────────────────────────────────────────
@@ -187,7 +189,8 @@ fun ColorPickerDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(24.dp)
-                        .clip(RoundedCornerShape(12.dp)),
+                        .clip(RoundedCornerShape(12.dp))
+                        .testTag("colorPickerHueBar"),
                 )
 
                 // ── Preview swatch + hex text field ─────────────────────────
@@ -246,6 +249,7 @@ fun ColorPickerDialog(
                                     .size(24.dp)
                                     .background(recentColor, RoundedCornerShape(4.dp))
                                     .border(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.4f), RoundedCornerShape(4.dp))
+                                    .testTag("recentColor_$recentHex")
                                     .clickable {
                                         val (h, s, v) = cpColorToHsv(recentColor)
                                         hue = h; saturation = s; brightness = v
@@ -284,7 +288,7 @@ fun ColorPickerDialog(
 // ── Sub-composables ──────────────────────────────────────────────────────────
 
 @Composable
-private fun SvPanel(
+internal fun SvPanel(
     hue: Float,
     saturation: Float,
     brightness: Float,
@@ -331,7 +335,7 @@ private fun SvPanel(
 }
 
 @Composable
-private fun HueBar(
+internal fun HueBar(
     hue: Float,
     onHueChange: (Float) -> Unit,
     modifier: Modifier = Modifier,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ColorPickerDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ColorPickerDialog.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.drag
@@ -133,6 +135,15 @@ fun ColorPickerDialog(
             shape = RoundedCornerShape(16.dp),
             color = MaterialTheme.colorScheme.surface,
             tonalElevation = 8.dp,
+            // No fixed heightIn cap: this Dialog is a Compose overlay layer bounded by whatever
+            // window hosts it (AddLabelDialog's own fixed 500x400 native window, or the much
+            // taller Options/Settings window), not an independent OS window — so an unscrollable
+            // Column here can silently push the Cancel/OK row past the small AddLabelDialog
+            // window's edge with nowhere to grow. A hardcoded dp cap "fixes" that by capping this
+            // dialog's height in EVERY host, including tall ones with plenty of room, artificially
+            // truncating content that would otherwise fit — the scrollable middle section below is
+            // enough on its own: it consumes only whatever height is actually left over after the
+            // fixed title/button rows, scrolling if that's not enough, sized to nothing if it is.
             modifier = Modifier.width(300.dp),
         ) {
             Column(
@@ -144,6 +155,11 @@ fun ColorPickerDialog(
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurface,
                 )
+
+                Column(
+                    modifier = Modifier.weight(1f, fill = false).verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
 
                 // ── Saturation / Brightness square ──────────────────────────
                 SvPanel(
@@ -238,6 +254,7 @@ fun ColorPickerDialog(
                             )
                         }
                     }
+                }
                 }
 
                 // ── Buttons ─────────────────────────────────────────────────

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/AddLabelDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/AddLabelDialog.kt
@@ -54,10 +54,17 @@ fun AddLabelDialog(
     if (!isVisible) return
 
     val mainWindowState = LocalMainWindowState.current
+    // Height is 640dp, not 400dp: the nested ColorPickerDialog opened from either color field is
+    // a Compose overlay bound to THIS window's own bounds (not an independent OS window), and its
+    // full content — SV panel, hue bar, swatch/hex row, AND a fully populated (12-color, 2-row)
+    // "Recent colors" list — needs ~590dp of height to render without scrolling. 400dp cut off
+    // everything past the SV panel with no visible scrollbar to hint more was there; a first pass
+    // at 560dp still cropped the recent-color swatches down to an unrecognizable sliver. 640dp
+    // leaves ~50dp of slack over the measured worst case.
     val dialogState = rememberDialogState(
-        position = centeredOnMainWindow(mainWindowState, 500.dp, 400.dp),
+        position = centeredOnMainWindow(mainWindowState, 500.dp, 640.dp),
         width = 500.dp,
-        height = 400.dp
+        height = 640.dp
     )
 
     DialogWindow(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -214,7 +214,6 @@ import churchpresenter.composeapp.generated.resources.hold_live
 import churchpresenter.composeapp.generated.resources.ic_drag_dots
 import churchpresenter.composeapp.generated.resources.move_translation_down
 import churchpresenter.composeapp.generated.resources.move_translation_up
-import churchpresenter.composeapp.generated.resources.song_language_primary
 import churchpresenter.composeapp.generated.resources.swap_bibles
 import churchpresenter.composeapp.generated.resources.swap_bibles_hint
 import churchpresenter.composeapp.generated.resources.verse
@@ -2292,21 +2291,6 @@ private fun TranslationOrderPanel(
                                 overflow = TextOverflow.Ellipsis,
                                 modifier = Modifier.weight(1f, fill = false),
                             )
-                            if (isPrimary) {
-                                Surface(
-                                    shape = RoundedCornerShape(4.dp),
-                                    color = MaterialTheme.colorScheme.tertiaryContainer,
-                                ) {
-                                    Text(
-                                        text = stringResource(Res.string.song_language_primary).uppercase(),
-                                        style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
-                                        color = MaterialTheme.colorScheme.onTertiaryContainer,
-                                        maxLines = 1,
-                                        softWrap = false,
-                                        modifier = Modifier.padding(horizontal = 6.dp, vertical = 1.dp),
-                                    )
-                                }
-                            }
                         }
                         Text(
                             text = translation.fileName,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -85,6 +86,8 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.zIndex
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -142,7 +145,6 @@ import churchpresenter.composeapp.generated.resources.tooltip_move_up
 import churchpresenter.composeapp.generated.resources.tooltip_new_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_open_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_remove
-import churchpresenter.composeapp.generated.resources.tooltip_remove_from_schedule
 import churchpresenter.composeapp.generated.resources.tooltip_save_schedule
 import kotlin.math.abs
 import kotlinx.coroutines.launch
@@ -367,7 +369,6 @@ fun ScheduleTab(
             onRedo = { viewModel.redo() },
             onAddLabel = onAddLabel,
             onImportPlanningCenter = { showPlanningCenterImport = true },
-            onRemoveSelected = { viewModel.selectedItemId?.let { viewModel.removeItem(it) } },
             onClearSchedule = { viewModel.clearSchedule() }
         )
 
@@ -539,13 +540,15 @@ fun ScheduleTab(
                 // composition gives those lambdas a list that cannot shrink under them.
                 itemsIndexed(rows, key = { _, item -> item.id }) { index, item ->
                     val isDraggingThis = isDragActive && draggingFromIndex == index
-                    val nextIsSection = rows.getOrNull(index + 1) is ScheduleItem.LabelItem
+                    // Every row is spaced the same, labels included: the extra room a section
+                    // used to get above it (and, briefly, below it too) made the heading float
+                    // away from the list rather than sit in it.
 
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
                             .animateItem()
-                            .padding(bottom = if (nextIsSection) 12.dp else 3.dp)
+                            .padding(bottom = 3.dp)
                             .alpha(if (isDraggingThis) 0.35f else 1f)
                             .reorderGesture(index, requireShift = true)
                     ) {
@@ -743,7 +746,6 @@ private fun ScheduleHeader(
     onRedo: () -> Unit,
     onAddLabel: () -> Unit,
     onImportPlanningCenter: () -> Unit,
-    onRemoveSelected: () -> Unit,
     onClearSchedule: () -> Unit
 ) {
     Column(
@@ -765,16 +767,16 @@ private fun ScheduleHeader(
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface
             )
-            Box(
-                modifier = Modifier
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh, RoundedCornerShape(5.dp))
-                    .padding(horizontal = 7.dp, vertical = 2.dp)
-            ) {
+            // The count sits in the same pill the toolbars use rather than a chunkier box of its
+            // own: same corner radius, same border, same 2dp inset, so the three groups along this
+            // header read as one family instead of one of them looking padded out.
+            PillGroup {
                 Text(
                     text = stringResource(Res.string.schedule_item_count, itemCount),
                     style = MaterialTheme.typography.labelSmall,
                     fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 5.dp, vertical = 2.dp)
                 )
             }
             Spacer(modifier = Modifier.weight(1f))
@@ -789,17 +791,44 @@ private fun ScheduleHeader(
                     iconTint = if (canZoomOut) MaterialTheme.colorScheme.onSurfaceVariant
                                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
                 )
-                Text(
-                    text = when (density) {
-                        ScheduleDensity.COMPACT -> stringResource(Res.string.schedule_density_compact)
-                        ScheduleDensity.NORMAL -> stringResource(Res.string.schedule_density_normal)
-                        ScheduleDensity.DETAILED -> stringResource(Res.string.schedule_density_detailed)
-                    },
-                    style = MaterialTheme.typography.labelSmall,
-                    fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 4.dp)
-                )
+                val compactName = stringResource(Res.string.schedule_density_compact)
+                val normalName = stringResource(Res.string.schedule_density_normal)
+                val detailedName = stringResource(Res.string.schedule_density_detailed)
+                // The two outer rungs borrow their neighbour's name: they change how much room a
+                // card takes, not what it shows.
+                val densityName = when (density) {
+                    ScheduleDensity.EXTRA_COMPACT, ScheduleDensity.COMPACT -> compactName
+                    ScheduleDensity.NORMAL -> normalName
+                    ScheduleDensity.DETAILED, ScheduleDensity.EXTRA_DETAILED -> detailedName
+                }
+                Box(
+                    modifier = Modifier.padding(horizontal = 4.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    // Holds the width of the longest of the three names so the +/- buttons keep
+                    // their place as the label changes under them -- and stays right in every
+                    // locale, which a hardcoded dp would not: "Detailed" is "Detailliert" in
+                    // German and "Подробный" in Russian. Invisible and semantics-free, so a test
+                    // or a screen reader still sees one label.
+                    listOf(compactName, normalName, detailedName).forEach { name ->
+                        Text(
+                            text = name,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            softWrap = false,
+                            modifier = Modifier.alpha(0f).clearAndSetSemantics {}
+                        )
+                    }
+                    Text(
+                        text = densityName,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        maxLines = 1,
+                        softWrap = false
+                    )
+                }
                 TooltipIconButton(
                     painter = painterResource(Res.drawable.ic_add),
                     text = stringResource(Res.string.tooltip_schedule_zoom_in),
@@ -819,6 +848,9 @@ private fun ScheduleHeader(
             verticalArrangement = Arrangement.spacedBy(4.dp),
             itemVerticalAlignment = Alignment.CenterVertically
         ) {
+            // One pill, which wraps inside itself when the panel gets too narrow -- see
+            // [PillGroup]. It stays a single group at any width; only the icons move, one at a
+            // time, onto a second line of the same pill.
             PillGroup {
                 // New Schedule clears the whole list — the same weight as Clear Schedule at the
                 // tail of this toolbar, so it stays a plain icon button rather than the kind of
@@ -847,7 +879,26 @@ private fun ScheduleHeader(
                     iconSize = 14.dp,
                     iconTint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+                // Clear sits with the other whole-schedule actions rather than at the tail: it
+                // is the same kind of thing as New, and moving it here is what lets a narrow
+                // panel settle on two lines instead of three -- the four file-level icons fill
+                // the first, the four editing ones the second.
+                // No "Remove from Schedule" alongside it: that acted on the current selection, so
+                // it did nothing at all until a row had been clicked, with nothing on the button
+                // to say so -- and every row now carries its own Remove. The menu item and the
+                // Delete shortcut still reach `ScheduleTabActions.removeSelected`, unchanged.
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_delete),
+                    text = stringResource(Res.string.tooltip_clear_schedule),
+                    onClick = onClearSchedule,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = MaterialTheme.colorScheme.error
+                )
                 PillDivider()
+                // Undo and Redo wrap as a pair: they read as one control, and a line break
+                // between them would put Redo alone at the start of the second row.
+                Row(verticalAlignment = Alignment.CenterVertically) {
                 TooltipIconButton(
                     painter = painterResource(Res.drawable.ic_undo),
                     text = stringResource(Res.string.tooltip_undo),
@@ -868,6 +919,7 @@ private fun ScheduleHeader(
                     iconTint = if (canRedo) MaterialTheme.colorScheme.onSurfaceVariant
                                else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
                 )
+                }
                 PillDivider()
                 TooltipIconButton(
                     painter = painterResource(Res.drawable.ic_label),
@@ -885,37 +937,28 @@ private fun ScheduleHeader(
                     iconSize = 14.dp,
                     iconTint = MaterialTheme.colorScheme.onSurfaceVariant
                 )
-                PillDivider()
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_close),
-                    text = stringResource(Res.string.tooltip_remove_from_schedule),
-                    onClick = onRemoveSelected,
-                    buttonSize = 26.dp,
-                    iconSize = 14.dp,
-                    iconTint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_delete),
-                    text = stringResource(Res.string.tooltip_clear_schedule),
-                    onClick = onClearSchedule,
-                    buttonSize = 26.dp,
-                    iconSize = 14.dp,
-                    iconTint = MaterialTheme.colorScheme.error
-                )
             }
         }
     }
 }
 
-/** A rounded, bordered pill housing a row of compact icon buttons — the toolbar's visual grouping. */
+/**
+ * A rounded, bordered pill housing compact icon buttons — the toolbar's visual grouping.
+ *
+ * Lays its buttons out in a `FlowRow`, so a pill too wide for the panel wraps *inside itself*: the
+ * buttons move onto a second line one at a time and the pill grows to hold them, staying one group
+ * with one border rather than clipping its tail or splitting into two pills that read as unrelated.
+ * At a width that fits, the FlowRow is a plain row and nothing moves.
+ */
 @Composable
 private fun PillGroup(content: @Composable () -> Unit) {
-    Row(
+    FlowRow(
         modifier = Modifier
             .background(MaterialTheme.colorScheme.surfaceContainerHigh, RoundedCornerShape(8.dp))
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
             .padding(2.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+        itemVerticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(1.dp)
     ) { content() }
 }
@@ -949,7 +992,13 @@ private fun ScheduleRowActionButton(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    buttonSize: Dp = 27.dp,
+    // One size for every button in the strip. The play/edit button used to be 30dp against the
+    // others' 27dp, and Row's CenterVertically did not save them: mixed heights came out sharing a
+    // bottom edge, so the four small buttons sat ~1.5dp low -- a visible wobble at Compact, where
+    // the card is barely taller than the buttons. Wrapping them in a uniform-height Box does not
+    // help either, IconButton's own minimum-interactive sizing escapes it. Their emphasis comes
+    // from [iconSize] instead, which is what actually reads at this scale.
+    buttonSize: Dp = 30.dp,
     iconSize: Dp = 13.dp,
     iconTint: Color? = null,
     colors: IconButtonColors = IconButtonDefaults.iconButtonColors()
@@ -1089,18 +1138,32 @@ internal fun handleDroppedFiles(files: List<File>, viewModel: ScheduleViewModel)
     }
 }
 
+/** The strip's button and icon sizes: one size for a content row, a smaller pair for a section. */
+private val ACTION_BUTTON_SIZE = 30.dp
+private val ACTION_ICON_SIZE = 13.dp
+private val SECTION_ACTION_BUTTON_SIZE = 22.dp
+private val SECTION_ACTION_ICON_SIZE = 12.dp
+
+/** A section's own vertical padding, fixed rather than density-scaled -- it heads a group, so it
+ *  stays the same slim band however large the cards under it grow. */
+private val SECTION_ROW_PADDING = 3.dp
+
 /** Vertical padding inside a card at each density rung. */
 private fun ScheduleDensity.rowPadding(): Dp = when (this) {
+    ScheduleDensity.EXTRA_COMPACT -> 2.dp
     ScheduleDensity.COMPACT -> 4.dp
     ScheduleDensity.NORMAL -> 7.dp
     ScheduleDensity.DETAILED -> 9.dp
+    ScheduleDensity.EXTRA_DETAILED -> 13.dp
 }
 
 /** Minimum card height at each density rung. */
 private fun ScheduleDensity.rowMinHeight(): Dp = when (this) {
+    ScheduleDensity.EXTRA_COMPACT -> 26.dp
     ScheduleDensity.COMPACT -> 32.dp
     ScheduleDensity.NORMAL -> 42.dp
     ScheduleDensity.DETAILED -> 54.dp
+    ScheduleDensity.EXTRA_DETAILED -> 68.dp
 }
 
 /**
@@ -1118,6 +1181,18 @@ private fun scheduleChipColors(paletteIndex: Int): Pair<Color, Color> {
         else -> scheme.errorContainer to scheme.onErrorContainer
     }
 }
+
+/**
+ * Test tags for one schedule row's geometry.
+ *
+ * Both name a container that draws rather than reads — a card and a scrim — so neither publishes
+ * text or a description a test could find it by, and both carry an invariant about *where* they
+ * are rather than what they say.
+ */
+internal const val SCHEDULE_ROW_CARD_TAG = "schedule_row_card"
+
+/** The hover-revealed action strip, whose gradient scrim has to cover the card behind it. */
+internal const val SCHEDULE_ROW_ACTIONS_TAG = "schedule_row_actions"
 
 @Composable
 private fun ScheduleItemRow(
@@ -1176,6 +1251,7 @@ private fun ScheduleItemRow(
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .testTag(SCHEDULE_ROW_CARD_TAG)
             .hoverable(interactionSource)
             .clip(CARD_SHAPE)
             .background(cardBg, CARD_SHAPE)
@@ -1187,10 +1263,19 @@ private fun ScheduleItemRow(
                 .padding(
                     start = 3.dp,
                     end = 6.dp,
-                    top = density.rowPadding(),
-                    bottom = density.rowPadding()
+                    // A section is a heading, not a card of content: it takes the height of its
+                    // own single line rather than the density's, which had it standing as tall as
+                    // the items it heads -- at Detailed, 70dp of band for one word.
+                    top = if (isSection) SECTION_ROW_PADDING else density.rowPadding(),
+                    bottom = if (isSection) SECTION_ROW_PADDING else density.rowPadding()
                 )
-                .heightIn(min = density.rowMinHeight()),
+                .heightIn(min = if (isSection) 0.dp else density.rowMinHeight())
+                // The row's own height, resolved from its children's intrinsics rather than left
+                // to the LazyColumn's unbounded height constraint. Without it every `fillMax*`
+                // inside this row is a no-op -- there is no bounded height to fill -- which is why
+                // the title column wrapped its text and sat at the top of the card, and why the
+                // action strip's scrim was only as tall as the buttons themselves.
+                .height(IntrinsicSize.Min),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -1266,7 +1351,13 @@ private fun ScheduleItemRow(
                         .initialPassCombinedClickable(
                             onClick = { onSelect() },
                             onDoubleClick = if (!isSection) { { onPresent() } } else null
-                        )
+                        ),
+                    // Centred, because fillMaxSize above stretches this Column to whichever
+                    // sibling is taller and the action-button row usually is: at Compact a single
+                    // title line is ~20dp against the buttons' 30dp, so a top-aligned title sat
+                    // visibly high in its own card. Normal and Detailed hid it because their
+                    // detail lines make this Column the taller sibling.
+                    verticalArrangement = Arrangement.Center
                 ) {
                     if (isSection) {
                         Text(
@@ -1282,18 +1373,10 @@ private fun ScheduleItemRow(
                         ScheduleItemContent(item = item, density = density, isSelected = isSelected)
                     }
 
-                    // Note preview when collapsed
-                    if (note.isNotEmpty() && !noteExpanded) {
-                        Text(
-                            text = note,
-                            style = MaterialTheme.typography.bodySmall,
-                            fontStyle = FontStyle.Italic,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.padding(top = 2.dp)
-                        )
-                    }
+                    // No note preview here: the row below the card draws the saved note, with
+                    // the button that opens it for editing. Both were drawn on the same
+                    // `note.isNotEmpty() && !noteExpanded` condition, so every item carrying a note
+                    // showed it twice -- once italic under its title and again in its own band.
                 }
 
                 // Hover-revealed action buttons — always present (so they stay reachable by
@@ -1305,6 +1388,11 @@ private fun ScheduleItemRow(
                 Row(
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
+                        .testTag(SCHEDULE_ROW_ACTIONS_TAG)
+                        // Fills the row's height so the gradient scrim covers the whole card behind
+                        // it. At the buttons' own ~30dp it was a band floating in the middle of a
+                        // 54dp Detailed card, with the card's background showing above and below.
+                        .fillMaxHeight()
                         .alpha(actionsAlpha)
                         .background(
                             Brush.horizontalGradient(
@@ -1321,22 +1409,32 @@ private fun ScheduleItemRow(
                     horizontalArrangement = Arrangement.spacedBy(1.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
+                    // On a section these shrink with the row: at their usual 30dp they would be
+                    // the tallest thing in it and the heading could never get shorter than a card.
+                    val actionSize = if (isSection) SECTION_ACTION_BUTTON_SIZE else ACTION_BUTTON_SIZE
+                    val actionIcon = if (isSection) SECTION_ACTION_ICON_SIZE else ACTION_ICON_SIZE
                     ScheduleRowActionButton(
                         painter = painterResource(Res.drawable.ic_arrow_up),
                         text = stringResource(Res.string.tooltip_move_up),
                         onClick = onMoveUp,
+                        buttonSize = actionSize,
+                        iconSize = actionIcon,
                         iconTint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     ScheduleRowActionButton(
                         painter = painterResource(Res.drawable.ic_arrow_down),
                         text = stringResource(Res.string.tooltip_move_down),
                         onClick = onMoveDown,
+                        buttonSize = actionSize,
+                        iconSize = actionIcon,
                         iconTint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                     ScheduleRowActionButton(
                         painter = painterResource(Res.drawable.ic_note),
                         text = stringResource(Res.string.tooltip_note),
                         onClick = { noteExpanded = !noteExpanded },
+                        buttonSize = actionSize,
+                        iconSize = actionIcon,
                         iconTint = if (note.isNotEmpty() || noteExpanded) MaterialTheme.colorScheme.primary
                                    else MaterialTheme.colorScheme.onSurfaceVariant
                     )
@@ -1344,6 +1442,8 @@ private fun ScheduleItemRow(
                         painter = painterResource(Res.drawable.ic_close),
                         text = stringResource(Res.string.tooltip_remove),
                         onClick = onRemove,
+                        buttonSize = actionSize,
+                        iconSize = actionIcon,
                         iconTint = MaterialTheme.colorScheme.error
                     )
                     // Slightly larger than the other four, matching the reference design — but
@@ -1357,8 +1457,8 @@ private fun ScheduleItemRow(
                             text = stringResource(Res.string.tooltip_edit_label),
                             onClick = onEditLabel,
                             modifier = Modifier.padding(start = 2.dp),
-                            buttonSize = 30.dp,
-                            iconSize = 15.dp,
+                            buttonSize = actionSize,
+                            iconSize = SECTION_ACTION_ICON_SIZE,
                             iconTint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     } else {
@@ -1367,7 +1467,6 @@ private fun ScheduleItemRow(
                             text = stringResource(Res.string.tooltip_go_live),
                             onClick = onPresent,
                             modifier = Modifier.padding(start = 2.dp),
-                            buttonSize = 30.dp,
                             iconSize = 15.dp,
                             iconTint = MaterialTheme.colorScheme.onSurfaceVariant
                         )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTab.kt
@@ -1,9 +1,15 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import org.churchpresenter.app.churchpresenter.composables.finalPassCombinedClickable
 import org.churchpresenter.app.churchpresenter.composables.initialPassCombinedClickable
@@ -18,7 +24,9 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -28,19 +36,21 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.TextButton
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -50,11 +60,20 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -68,8 +87,10 @@ import androidx.compose.ui.zIndex
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.file_chooser_open_schedule
 import churchpresenter.composeapp.generated.resources.file_chooser_save_schedule
@@ -87,13 +108,16 @@ import churchpresenter.composeapp.generated.resources.ic_play
 import churchpresenter.composeapp.generated.resources.ic_check
 import churchpresenter.composeapp.generated.resources.ic_note
 import churchpresenter.composeapp.generated.resources.ic_redo
+import churchpresenter.composeapp.generated.resources.ic_remove
 import churchpresenter.composeapp.generated.resources.ic_save
 import churchpresenter.composeapp.generated.resources.ic_undo
-import churchpresenter.composeapp.generated.resources.ic_zoom_in
-import churchpresenter.composeapp.generated.resources.ic_zoom_out
 import churchpresenter.composeapp.generated.resources.pause_duration_ms
 import churchpresenter.composeapp.generated.resources.planning_center_import_title
 import churchpresenter.composeapp.generated.resources.schedule
+import churchpresenter.composeapp.generated.resources.schedule_density_compact
+import churchpresenter.composeapp.generated.resources.schedule_density_detailed
+import churchpresenter.composeapp.generated.resources.schedule_density_normal
+import churchpresenter.composeapp.generated.resources.schedule_item_count
 import churchpresenter.composeapp.generated.resources.schedule_note_placeholder
 import churchpresenter.composeapp.generated.resources.tooltip_note
 import churchpresenter.composeapp.generated.resources.tooltip_note_clear
@@ -122,6 +146,7 @@ import churchpresenter.composeapp.generated.resources.tooltip_remove_from_schedu
 import churchpresenter.composeapp.generated.resources.tooltip_save_schedule
 import kotlin.math.abs
 import kotlinx.coroutines.launch
+import org.churchpresenter.app.churchpresenter.composables.ConditionalTooltipArea
 import org.churchpresenter.app.churchpresenter.composables.TooltipIconButton
 import org.churchpresenter.app.churchpresenter.data.settings.PlanningCenterSettings
 import org.churchpresenter.app.churchpresenter.dialogs.PlanningCenterImportDialog
@@ -133,18 +158,22 @@ import org.churchpresenter.app.churchpresenter.utils.Utils
 import org.churchpresenter.app.churchpresenter.utils.DroppedFileAction
 import org.churchpresenter.app.churchpresenter.utils.IMAGE_EXTENSIONS
 import org.churchpresenter.app.churchpresenter.utils.DragItemGeometry
+import org.churchpresenter.app.churchpresenter.utils.ScheduleDensity
 import org.churchpresenter.app.churchpresenter.utils.classifyDroppedFile
 import org.churchpresenter.app.churchpresenter.utils.dragDropTarget
 import org.churchpresenter.app.churchpresenter.utils.scheduleCanZoomIn
 import org.churchpresenter.app.churchpresenter.utils.scheduleCanZoomOut
-import org.churchpresenter.app.churchpresenter.utils.scheduleShowCardActions
-import org.churchpresenter.app.churchpresenter.utils.scheduleSingleLineCards
+import org.churchpresenter.app.churchpresenter.utils.scheduleDensityFor
+import org.churchpresenter.app.churchpresenter.utils.scheduleShowDetailLine
+import org.churchpresenter.app.churchpresenter.utils.scheduleShowKindDetails
 import org.churchpresenter.app.churchpresenter.utils.scheduleZoomIn
 import org.churchpresenter.app.churchpresenter.utils.scheduleZoomOut
 import org.churchpresenter.app.churchpresenter.viewmodel.ScheduleViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.announcementTimerSubtext
 import org.churchpresenter.app.churchpresenter.viewmodel.scheduleItemDetailText
 import org.churchpresenter.app.churchpresenter.viewmodel.scheduleItemGlyph
+import org.churchpresenter.app.churchpresenter.viewmodel.scheduleItemKindLabel
+import org.churchpresenter.app.churchpresenter.viewmodel.scheduleItemPaletteIndex
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import java.awt.datatransfer.DataFlavor
@@ -190,7 +219,7 @@ data class ScheduleTabActions(
     val addDictionary: (number: String, word: String, transliteration: String, definition: String) -> Unit = { _, _, _, _ -> }
 )
 
-/** The card zoom percentage a schedule opens at; the rung ladder itself lives in ScheduleZoom.kt. */
+/** The card density percentage a schedule opens at; the rung ladder itself lives in ScheduleZoom.kt. */
 private const val ZOOM_DEFAULT = 100
 
 /** How far the pointer must travel on a card's icon before it becomes a reorder drag. */
@@ -198,6 +227,9 @@ private val DRAG_HANDLE_THRESHOLD = 4.dp
 
 /** Height of the drop-here-to-remove zone at the bottom of the list, shown while dragging. */
 private val DELETE_ZONE_HEIGHT = 56.dp
+
+/** Corner radius shared by every card (section or item) in the list. */
+private val CARD_SHAPE = RoundedCornerShape(9.dp)
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -315,139 +347,36 @@ fun ScheduleTab(
     val scheduleItems = viewModel.scheduleItems
     val selectedItemId = viewModel.selectedItemId
     var showPlanningCenterImport by remember { mutableStateOf(false) }
+    val density = scheduleDensityFor(itemZoomPercent)
 
-    Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
+    Column(modifier = modifier.fillMaxSize()) {
 
-        // Schedule toolbar buttons — row 1: file ops, label/website, add/remove/clear
-        FlowRow(
-            modifier = Modifier.fillMaxWidth().padding(bottom = 2.dp),
-            horizontalArrangement = Arrangement.spacedBy(2.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp)
-        ) {
-            // File operations
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_add),
-                text = stringResource(Res.string.tooltip_new_schedule),
-                onClick = { viewModel.newSchedule() },
-                buttonSize = 32.dp,
-                iconTint = MaterialTheme.colorScheme.onSurface
-            )
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_folder),
-                text = stringResource(Res.string.tooltip_open_schedule),
-                onClick = { scope.launch { viewModel.loadSchedule(strOpenSchedule.value, strFileFilter.value) } },
-                buttonSize = 32.dp,
-                iconTint = MaterialTheme.colorScheme.onSurface
-            )
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_save),
-                text = stringResource(Res.string.tooltip_save_schedule),
-                onClick = { scope.launch { viewModel.saveSchedule(strSaveScheduleAs.value, strFileFilter.value) } },
-                buttonSize = 32.dp,
-                iconTint = MaterialTheme.colorScheme.onSurface
-            )
-
-            Spacer(modifier = Modifier.width(4.dp))
-
-            // Undo / Redo
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_undo),
-                text = stringResource(Res.string.tooltip_undo),
-                onClick = { viewModel.undo() },
-                enabled = viewModel.canUndo,
-                buttonSize = 32.dp,
-                iconTint = if (viewModel.canUndo) MaterialTheme.colorScheme.onSurface
-                           else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-            )
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_redo),
-                text = stringResource(Res.string.tooltip_redo),
-                onClick = { viewModel.redo() },
-                enabled = viewModel.canRedo,
-                buttonSize = 32.dp,
-                iconTint = if (viewModel.canRedo) MaterialTheme.colorScheme.onSurface
-                           else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
-            )
-
-            Spacer(modifier = Modifier.width(4.dp))
-
-            // Label
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_label),
-                text = stringResource(Res.string.tooltip_add_label),
-                onClick = onAddLabel,
-                buttonSize = 32.dp,
-                iconTint = MaterialTheme.colorScheme.onSurface
-            )
-
-            // Import from Planning Center
-            TooltipIconButton(
-                painter = rememberVectorPainter(Icons.Default.CloudDownload),
-                text = stringResource(Res.string.planning_center_import_title),
-                onClick = { showPlanningCenterImport = true },
-                buttonSize = 32.dp,
-                iconTint = MaterialTheme.colorScheme.onSurface
-            )
-
-            Spacer(modifier = Modifier.width(4.dp))
-
-            // Remove / Clear
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_close),
-                text = stringResource(Res.string.tooltip_remove_from_schedule),
-                onClick = { viewModel.selectedItemId?.let { viewModel.removeItem(it) } },
-                buttonSize = 32.dp,
-                iconTint = MaterialTheme.colorScheme.onSurface
-            )
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_delete),
-                text = stringResource(Res.string.tooltip_clear_schedule),
-                onClick = { viewModel.clearSchedule() },
-                buttonSize = 32.dp,
-                iconTint = MaterialTheme.colorScheme.onSurface
-            )
-        }
-
-        // Schedule header + zoom controls (buttons wrap as a group)
-        FlowRow(
-            modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(2.dp),
-            verticalArrangement = Arrangement.spacedBy(2.dp),
-            itemVerticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = stringResource(Res.string.schedule),
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(end = 6.dp)
-            )
-            // Card zoom controls (own Row so FlowRow wraps them as one group)
-            Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_zoom_out),
-                    text = stringResource(Res.string.tooltip_schedule_zoom_out),
-                    onClick = { onItemZoomChange(scheduleZoomOut(itemZoomPercent)) },
-                    enabled = scheduleCanZoomOut(itemZoomPercent),
-                    buttonSize = 32.dp,
-                    iconTint = MaterialTheme.colorScheme.onSurface
-                )
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_zoom_in),
-                    text = stringResource(Res.string.tooltip_schedule_zoom_in),
-                    onClick = { onItemZoomChange(scheduleZoomIn(itemZoomPercent)) },
-                    enabled = scheduleCanZoomIn(itemZoomPercent),
-                    buttonSize = 32.dp,
-                    iconTint = MaterialTheme.colorScheme.onSurface
-                )
-            }
-        }
+        ScheduleHeader(
+            itemCount = scheduleItems.count { it !is ScheduleItem.LabelItem },
+            density = density,
+            onZoomOut = { onItemZoomChange(scheduleZoomOut(itemZoomPercent)) },
+            onZoomIn = { onItemZoomChange(scheduleZoomIn(itemZoomPercent)) },
+            canZoomOut = scheduleCanZoomOut(itemZoomPercent),
+            canZoomIn = scheduleCanZoomIn(itemZoomPercent),
+            onNewSchedule = { viewModel.newSchedule() },
+            onOpenSchedule = { scope.launch { viewModel.loadSchedule(strOpenSchedule.value, strFileFilter.value) } },
+            onSaveSchedule = { scope.launch { viewModel.saveSchedule(strSaveScheduleAs.value, strFileFilter.value) } },
+            canUndo = viewModel.canUndo,
+            canRedo = viewModel.canRedo,
+            onUndo = { viewModel.undo() },
+            onRedo = { viewModel.redo() },
+            onAddLabel = onAddLabel,
+            onImportPlanningCenter = { showPlanningCenterImport = true },
+            onRemoveSelected = { viewModel.selectedItemId?.let { viewModel.removeItem(it) } },
+            onClearSchedule = { viewModel.clearSchedule() }
+        )
 
         // Schedule items list with drag-and-drop support
         val viewModelState = rememberUpdatedState(viewModel)
         var listHeightPx by remember { mutableStateOf(0) }
         Box(
             modifier = Modifier.weight(1f).fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceVariant)
                 .onSizeChanged { listHeightPx = it.height }
         ) {
             val listState = rememberLazyListState()
@@ -460,14 +389,7 @@ fun ScheduleTab(
             var dragItemHeight by remember { mutableStateOf(50f) }
             var isOverDeleteZone by remember { mutableStateOf(false) }
 
-            // Card zoom: applied per item by overriding LocalDensity around ScheduleItemRow.
-            // Below 100% the card also sheds parts, before it starts shrinking.
             val baseDensity = LocalDensity.current
-            val zoomedDensity = remember(baseDensity, itemZoomPercent) {
-                Density(baseDensity.density * itemZoomPercent / 100f, baseDensity.fontScale)
-            }
-            val showCardActions = scheduleShowCardActions(itemZoomPercent)
-            val singleLineCards = scheduleSingleLineCards(itemZoomPercent)
 
             // Reorder gesture, shared by the whole-card shift+drag and the per-card icon handle.
             // The handle path arms only after real movement so a plain click still selects the card.
@@ -607,8 +529,8 @@ fun ScheduleTab(
             LazyColumn(
                 state = listState,
                 modifier = Modifier.fillMaxSize()
-                    .background(MaterialTheme.colorScheme.surface)
-                    .padding(end = 12.dp)
+                    .padding(horizontal = 8.dp)
+                    .padding(top = 6.dp, bottom = 10.dp, end = 4.dp)
             ) {
                 // A fixed copy, not the live list. `itemsIndexed` reads `items[index]` inside the key
                 // and content-type lambdas it builds, and those run when the lazy layout rebuilds its
@@ -617,21 +539,20 @@ fun ScheduleTab(
                 // composition gives those lambdas a list that cannot shrink under them.
                 itemsIndexed(rows, key = { _, item -> item.id }) { index, item ->
                     val isDraggingThis = isDragActive && draggingFromIndex == index
+                    val nextIsSection = rows.getOrNull(index + 1) is ScheduleItem.LabelItem
 
-                    Column(modifier = Modifier.animateItem()) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .animateItem()
+                            .padding(bottom = if (nextIsSection) 12.dp else 3.dp)
                             .alpha(if (isDraggingThis) 0.35f else 1f)
                             .reorderGesture(index, requireShift = true)
                     ) {
-                        // Scaling the density scales every dp and sp inside the card at once
-                        CompositionLocalProvider(LocalDensity provides zoomedDensity) {
                         ScheduleItemRow(
                             item = item,
                             dragHandleModifier = Modifier.reorderGesture(index, requireShift = false),
-                            showActions = showCardActions,
-                            singleLine = singleLineCards,
+                            density = density,
                             isSelected = item.id == selectedItemId,
                             note = viewModel.getNote(item.id),
                             onSelect = {
@@ -667,18 +588,7 @@ fun ScheduleTab(
                             },
                             onNoteChanged = { viewModel.setNote(item.id, it) }
                         )
-                        }
                     }
-
-                    // Against the same fixed copy `index` came from, so a row cannot ask whether it is
-                    // last against a list of a different length.
-                    if (index < rows.size - 1) {
-                        HorizontalDivider(
-                            thickness = 1.dp,
-                            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f)
-                        )
-                    }
-                    } // Column
                 }
             }
 
@@ -730,7 +640,7 @@ fun ScheduleTab(
                                 scaleY = 1.04f
                                 shadowElevation = 20f
                             }
-                            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(4.dp))
+                            .background(MaterialTheme.colorScheme.surfaceContainerHigh, CARD_SHAPE)
                             .padding(horizontal = 12.dp, vertical = 8.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalAlignment = Alignment.CenterVertically
@@ -753,33 +663,29 @@ fun ScheduleTab(
             }
         }
 
-        // Add Files button at the bottom
-        Box(modifier = Modifier.fillMaxWidth().padding(top = 4.dp), contentAlignment = Alignment.Center) {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Button(
-                    shape = RoundedCornerShape(6.dp),
-                    onClick = {
-                        scope.launch {
-                            val files = FileChooser.platformInstance.chooseMultiple(
-                                path = null,
-                                title = "Add Files to Schedule",
-                                filters = emptyList(),
-                                selectDirectory = false
-                            )
-                            if (files != null) {
-                                handleDroppedFiles(files.map(Path::toFile), viewModel)
-                            }
+        // Add Files button at the bottom — dashed outline (a drop-target look), not a filled
+        // button, matching the reference design.
+        Row(
+            modifier = Modifier.fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainer)
+                .padding(10.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            ScheduleAddFilesButton(
+                onClick = {
+                    scope.launch {
+                        val files = FileChooser.platformInstance.chooseMultiple(
+                            path = null,
+                            title = "Add Files to Schedule",
+                            filters = emptyList(),
+                            selectDirectory = false
+                        )
+                        if (files != null) {
+                            handleDroppedFiles(files.map(Path::toFile), viewModel)
                         }
-                    },
-                    modifier = Modifier.width(200.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                ) {
-                    Text(stringResource(Res.string.schedule_add_files))
+                    }
                 }
-            }
+            )
         }
 
         PlanningCenterImportDialog(
@@ -811,6 +717,330 @@ fun ScheduleTab(
             },
             onConnected = onPlanningCenterConnected,
             onDisconnect = onPlanningCenterDisconnect
+        )
+    }
+}
+
+/**
+ * The panel header: title, item count, the Compact/Normal/Detailed density toggle, and the
+ * toolbar (file ops, undo/redo, add-section, import, remove/clear) grouped into pill containers.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ScheduleHeader(
+    itemCount: Int,
+    density: ScheduleDensity,
+    onZoomOut: () -> Unit,
+    onZoomIn: () -> Unit,
+    canZoomOut: Boolean,
+    canZoomIn: Boolean,
+    onNewSchedule: () -> Unit,
+    onOpenSchedule: () -> Unit,
+    onSaveSchedule: () -> Unit,
+    canUndo: Boolean,
+    canRedo: Boolean,
+    onUndo: () -> Unit,
+    onRedo: () -> Unit,
+    onAddLabel: () -> Unit,
+    onImportPlanningCenter: () -> Unit,
+    onRemoveSelected: () -> Unit,
+    onClearSchedule: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .padding(10.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            itemVerticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(Res.string.schedule),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Box(
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh, RoundedCornerShape(5.dp))
+                    .padding(horizontal = 7.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = stringResource(Res.string.schedule_item_count, itemCount),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            PillGroup {
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_remove),
+                    text = stringResource(Res.string.tooltip_schedule_zoom_out),
+                    onClick = onZoomOut,
+                    enabled = canZoomOut,
+                    buttonSize = 24.dp,
+                    iconSize = 13.dp,
+                    iconTint = if (canZoomOut) MaterialTheme.colorScheme.onSurfaceVariant
+                               else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
+                )
+                Text(
+                    text = when (density) {
+                        ScheduleDensity.COMPACT -> stringResource(Res.string.schedule_density_compact)
+                        ScheduleDensity.NORMAL -> stringResource(Res.string.schedule_density_normal)
+                        ScheduleDensity.DETAILED -> stringResource(Res.string.schedule_density_detailed)
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_add),
+                    text = stringResource(Res.string.tooltip_schedule_zoom_in),
+                    onClick = onZoomIn,
+                    enabled = canZoomIn,
+                    buttonSize = 24.dp,
+                    iconSize = 13.dp,
+                    iconTint = if (canZoomIn) MaterialTheme.colorScheme.onSurfaceVariant
+                               else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
+                )
+            }
+        }
+
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            itemVerticalAlignment = Alignment.CenterVertically
+        ) {
+            PillGroup {
+                // New Schedule clears the whole list — the same weight as Clear Schedule at the
+                // tail of this toolbar, so it stays a plain icon button rather than the kind of
+                // prominent "+" button a genuinely additive action would get.
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_add),
+                    text = stringResource(Res.string.tooltip_new_schedule),
+                    onClick = onNewSchedule,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_folder),
+                    text = stringResource(Res.string.tooltip_open_schedule),
+                    onClick = onOpenSchedule,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_save),
+                    text = stringResource(Res.string.tooltip_save_schedule),
+                    onClick = onSaveSchedule,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                PillDivider()
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_undo),
+                    text = stringResource(Res.string.tooltip_undo),
+                    onClick = onUndo,
+                    enabled = canUndo,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = if (canUndo) MaterialTheme.colorScheme.onSurfaceVariant
+                               else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
+                )
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_redo),
+                    text = stringResource(Res.string.tooltip_redo),
+                    onClick = onRedo,
+                    enabled = canRedo,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = if (canRedo) MaterialTheme.colorScheme.onSurfaceVariant
+                               else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.35f)
+                )
+                PillDivider()
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_label),
+                    text = stringResource(Res.string.tooltip_add_label),
+                    onClick = onAddLabel,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                TooltipIconButton(
+                    painter = rememberVectorPainter(Icons.Default.CloudDownload),
+                    text = stringResource(Res.string.planning_center_import_title),
+                    onClick = onImportPlanningCenter,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                PillDivider()
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_close),
+                    text = stringResource(Res.string.tooltip_remove_from_schedule),
+                    onClick = onRemoveSelected,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                TooltipIconButton(
+                    painter = painterResource(Res.drawable.ic_delete),
+                    text = stringResource(Res.string.tooltip_clear_schedule),
+                    onClick = onClearSchedule,
+                    buttonSize = 26.dp,
+                    iconSize = 14.dp,
+                    iconTint = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}
+
+/** A rounded, bordered pill housing a row of compact icon buttons — the toolbar's visual grouping. */
+@Composable
+private fun PillGroup(content: @Composable () -> Unit) {
+    Row(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh, RoundedCornerShape(8.dp))
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(8.dp))
+            .padding(2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(1.dp)
+    ) { content() }
+}
+
+@Composable
+private fun PillDivider() {
+    VerticalDivider(
+        modifier = Modifier.height(14.dp).padding(horizontal = 2.dp),
+        color = MaterialTheme.colorScheme.outlineVariant,
+        thickness = 1.dp
+    )
+}
+
+/**
+ * Same shape as [TooltipIconButton], but anchors its tooltip well to the left of the button
+ * instead of above or below it. Row-action buttons sit mid-row, only ~3dp from the next card,
+ * with several sibling buttons packed 1dp apart on both sides — the app-wide default
+ * (below-center) spills onto the card underneath, an above-center placement spills onto the row
+ * above's own buttons, and even a small leftward nudge lands on the very next sibling button
+ * (each is only ~27-30dp wide). A big enough leftward offset clears the whole button cluster
+ * (five or six buttons, under 180dp total) regardless of which one triggered it, landing on the
+ * row's own (non-interactive) title text instead — the only placement that can't cover a control
+ * in this row or any other. A local copy avoids widening [TooltipIconButton]'s own signature with
+ * an experimental-API parameter, which would force every one of its call sites across the app to
+ * opt in for no benefit to them.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ScheduleRowActionButton(
+    painter: Painter,
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    buttonSize: Dp = 27.dp,
+    iconSize: Dp = 13.dp,
+    iconTint: Color? = null,
+    colors: IconButtonColors = IconButtonDefaults.iconButtonColors()
+) {
+    ConditionalTooltipArea(
+        // `anchor` is the point on the BUTTON to align to; `alignment` is which point ON THE
+        // TOOLTIP touches it. Leaving `alignment` at its default (BottomCenter) — as an earlier
+        // version of this did — puts the tooltip's bottom-center on the button's left-center
+        // point, so it still extends upward and sideways back over the row instead of clearing
+        // it. `alignment = CenterStart` puts the tooltip's own left edge there instead, so the
+        // whole tooltip extends purely leftward from a small gap off the button, staying level
+        // with this row (never another row's controls) the entire time. (`CenterEnd` looks like
+        // the intuitive choice but is backwards — per Compose's ComponentRect math it anchors the
+        // tooltip's LEFT edge to the point, extending the tooltip rightward on top of the button.)
+        tooltipPlacement = TooltipPlacement.ComponentRect(
+            anchor = Alignment.CenterStart,
+            alignment = Alignment.CenterStart,
+            offset = DpOffset((-8).dp, 0.dp)
+        ),
+        tooltip = {
+            Surface(
+                color = MaterialTheme.colorScheme.inverseSurface,
+                shape = MaterialTheme.shapes.extraSmall,
+                tonalElevation = 4.dp
+            ) {
+                Text(
+                    text = text,
+                    color = MaterialTheme.colorScheme.inverseOnSurface,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                )
+            }
+        }
+    ) {
+        IconButton(onClick = onClick, modifier = modifier.size(buttonSize), colors = colors) {
+            Image(
+                painter = painter,
+                contentDescription = text,
+                modifier = Modifier.size(iconSize),
+                colorFilter = iconTint?.let { ColorFilter.tint(it) }
+            )
+        }
+    }
+}
+
+/** The dashed drop-target-styled "Add Files…" button at the foot of the panel. */
+@Composable
+private fun ScheduleAddFilesButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val hovered by interactionSource.collectIsHoveredAsState()
+    val shape = RoundedCornerShape(8.dp)
+    val borderColor = if (hovered) MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
+                       else MaterialTheme.colorScheme.outlineVariant
+    val contentColor = if (hovered) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant
+    val bg = if (hovered) MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
+             else MaterialTheme.colorScheme.surfaceContainerHigh
+    val strokeWidthPx = with(LocalDensity.current) { 1.dp.toPx() }
+    val cornerRadiusPx = with(LocalDensity.current) { 8.dp.toPx() }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(32.dp)
+            .hoverable(interactionSource)
+            .clip(shape)
+            .background(bg, shape)
+            .drawWithContent {
+                drawContent()
+                drawRoundRect(
+                    color = borderColor,
+                    style = Stroke(width = strokeWidthPx, pathEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 4f))),
+                    cornerRadius = CornerRadius(cornerRadiusPx)
+                )
+            }
+            .clickable(interactionSource = interactionSource, indication = null, onClick = onClick),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            painter = painterResource(Res.drawable.ic_add),
+            contentDescription = null,
+            tint = contentColor,
+            modifier = Modifier.size(11.dp)
+        )
+        Spacer(modifier = Modifier.width(7.dp))
+        Text(
+            text = stringResource(Res.string.schedule_add_files),
+            color = contentColor,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.SemiBold
         )
     }
 }
@@ -859,15 +1089,42 @@ internal fun handleDroppedFiles(files: List<File>, viewModel: ScheduleViewModel)
     }
 }
 
+/** Vertical padding inside a card at each density rung. */
+private fun ScheduleDensity.rowPadding(): Dp = when (this) {
+    ScheduleDensity.COMPACT -> 4.dp
+    ScheduleDensity.NORMAL -> 7.dp
+    ScheduleDensity.DETAILED -> 9.dp
+}
+
+/** Minimum card height at each density rung. */
+private fun ScheduleDensity.rowMinHeight(): Dp = when (this) {
+    ScheduleDensity.COMPACT -> 32.dp
+    ScheduleDensity.NORMAL -> 42.dp
+    ScheduleDensity.DETAILED -> 54.dp
+}
+
+/**
+ * One row of a small rotating theme palette for a type-icon chip's background/foreground — not a
+ * distinct hue per content type (that would mean hardcoded colors), but enough variety that
+ * adjacent kinds in a service read as visually different.
+ */
+@Composable
+private fun scheduleChipColors(paletteIndex: Int): Pair<Color, Color> {
+    val scheme = MaterialTheme.colorScheme
+    return when (paletteIndex % 4) {
+        0 -> scheme.primaryContainer to scheme.onPrimaryContainer
+        1 -> scheme.secondaryContainer to scheme.onSecondaryContainer
+        2 -> scheme.tertiaryContainer to scheme.onTertiaryContainer
+        else -> scheme.errorContainer to scheme.onErrorContainer
+    }
+}
+
 @Composable
 private fun ScheduleItemRow(
     item: ScheduleItem,
-    /** Applied to the type-indicator icon, which doubles as the drag-to-reorder handle. */
+    /** Applied to the grip dots, which double as the drag-to-reorder handle. */
     dragHandleModifier: Modifier = Modifier,
-    /** Below 100% zoom the action-button row (and with it the note editor) is dropped. */
-    showActions: Boolean = true,
-    /** At 98% zoom and below the card collapses to just its icon and primary line. */
-    singleLine: Boolean = false,
+    density: ScheduleDensity,
     isSelected: Boolean,
     note: String,
     onSelect: () -> Unit,
@@ -878,12 +1135,9 @@ private fun ScheduleItemRow(
     onEditLabel: () -> Unit = {},
     onNoteChanged: (String) -> Unit = {}
 ) {
-    val rowBackgroundColor = if (item is ScheduleItem.LabelItem) {
-        Utils.parseHexColor(item.backgroundColor)
-    } else {
-        if (isSelected) MaterialTheme.colorScheme.surfaceVariant
-        else MaterialTheme.colorScheme.surface
-    }
+    val interactionSource = remember(item.id) { MutableInteractionSource() }
+    val hovered by interactionSource.collectIsHoveredAsState()
+    val actionsAlpha by animateFloatAsState(if (hovered) 1f else 0f, label = "scheduleRowActionsAlpha")
 
     var noteExpanded by remember(item.id) { mutableStateOf(false) }
     var noteText by remember(item.id) { mutableStateOf(note) }
@@ -893,336 +1147,275 @@ private fun ScheduleItemRow(
         if (noteText != note) noteText = note
     }
 
-    // The row-select/present click lives on two separately-scoped modifiers rather than one
-    // wrapping the whole row: the content area uses Initial-pass (survives the LazyColumn
-    // scroll-gesture-eats-clicks issue on ARM Mac, see ClickModifiers.kt), while the button
-    // toolbar row below uses Final-pass so its own IconButtons (Remove, Move Up/Down, etc.) win
-    // the hit-test first — an Initial-pass handler wrapping the whole row consumes every click
-    // before a nested button's own Main-pass clickable ever sees it, which silently breaks every
-    // button in the toolbar.
+    val isSection = item is ScheduleItem.LabelItem
+    val sectionAccent = if (item is ScheduleItem.LabelItem) Utils.parseHexColor(item.textColor) else Color.Unspecified
+
+    val cardBg = when {
+        isSection -> Utils.parseHexColor(item.backgroundColor)
+        isSelected -> MaterialTheme.colorScheme.surfaceContainerHigh
+        else -> MaterialTheme.colorScheme.surfaceContainer
+    }
+    // A label's text/background are both user-chosen (Add Label dialog). WCAG's contrast ratio
+    // is luminance-only, so two colors close in hue (navy text on a mid-blue background, say)
+    // can clear the AA 4.5:1 minimum for normal text on paper while still reading as low-contrast
+    // to the eye — going to the AAA threshold (7:1) catches those near-miss same-hue pairs too.
+    // Only the rendered title falls back to white/black; the accent bar and border stay the
+    // user's actual color, and the stored colors are untouched either way.
+    val sectionText = if (isSection) Utils.ensureContrast(sectionAccent, cardBg, minRatio = 7.0) else sectionAccent
+    val cardBorder = when {
+        isSection -> sectionAccent.copy(alpha = 0.35f)
+        isSelected -> MaterialTheme.colorScheme.primary.copy(alpha = 0.4f)
+        else -> MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+    }
+    val leftAccent = when {
+        isSection -> sectionAccent
+        isSelected -> MaterialTheme.colorScheme.primary
+        else -> Color.Transparent
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(rowBackgroundColor)
+            .hoverable(interactionSource)
+            .clip(CARD_SHAPE)
+            .background(cardBg, CARD_SHAPE)
+            .border(1.dp, cardBorder, CARD_SHAPE)
     ) {
-        // The trailing Go Live button lives OUTSIDE the content row's clickable (an Initial-pass
-        // handler would eat its clicks — see the comment above), so they sit side by side here.
-        Row(verticalAlignment = Alignment.CenterVertically) {
-        Row(
-            modifier = Modifier
-                .weight(1f)
-                .padding(
-                    // Tight on the left so the grip dots sit at the very edge of the card
-                    start = 2.dp,
-                    end = if (showActions) 12.dp else 4.dp,
-                    top = if (singleLine) 4.dp else 8.dp,
-                    // Without the action row below, the card needs its own bottom padding
-                    bottom = if (showActions) 2.dp else if (singleLine) 4.dp else 8.dp
-                )
-                .then(
-                    if (item !is ScheduleItem.LabelItem) {
-                        Modifier.initialPassCombinedClickable(
-                            onClick = { onSelect() },
-                            onDoubleClick = { onPresent() }
-                        )
-                    } else Modifier
-                ),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            // Grip dots + type indicator — together they form the drag-to-reorder handle
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(6.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .pointerHoverIcon(PointerIcon.Hand)
-                    .then(dragHandleModifier)
-            ) {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_drag_dots),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f),
-                    modifier = Modifier.width(4.dp).height(16.dp)
-                )
-                Text(
-                    text = scheduleItemGlyph(item),
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.width(24.dp)
-                )
-            }
-
-            // Item content (row-wide click handling now lives on the outer Column above,
-            // so both this content area and the button toolbar row below are selectable)
-            Column(modifier = Modifier.weight(1f)) {
-                when (item) {
-                    is ScheduleItem.LabelItem -> {
-                        // Display label text with custom text color
-                        Text(
-                            text = item.text,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium,
-                            color = Utils.parseHexColor(item.textColor),
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                    is ScheduleItem.SongItem -> {
-                        val textColor = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant
-                                else MaterialTheme.colorScheme.onSurface
-                        if (item.songNumber > 0) {
-                            Text(
-                                maxLines = 1,
-                                text = item.songNumber.toString(),
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = FontWeight.Bold,
-                                color = textColor
-                            )
-                        }
-                        Text(
-                            maxLines = 1,
-                            text = item.title,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium,
-                            color = textColor
-                        )
-                        if (item.songbook.isNotBlank() && !singleLine) {
-                            Text(
-                                maxLines = 1,
-                                // Songbook names are often long paths/editions whose distinguishing
-                                // part is at the END, so clip the front instead of the tail
-                                overflow = TextOverflow.StartEllipsis,
-                                text = item.songbook,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                            )
-                        }
-                    }
-                    else -> {
-                        Text(
-                            maxLines = 1,
-                            text = item.displayText,
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium,
-                            color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant
-                                    else MaterialTheme.colorScheme.onSurface
-                        )
-                    }
-                }
-
-                when {
-                    singleLine -> {} // collapsed card: primary line only
-                    else -> when (item) {
-                    is ScheduleItem.SongItem -> {} // already handled above
-                    is ScheduleItem.BibleVerseItem -> Text(
-                        maxLines = 1,
-                        text = scheduleItemDetailText(item).orEmpty(),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
-                    is ScheduleItem.PictureItem -> Text(
-                        maxLines = 1,
-                        text = scheduleItemDetailText(item).orEmpty(),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
-                    is ScheduleItem.PresentationItem -> Text(
-                        maxLines = 1,
-                        text = scheduleItemDetailText(item).orEmpty(),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
-                    is ScheduleItem.MediaItem -> Text(
-                        maxLines = 1,
-                        text = scheduleItemDetailText(item).orEmpty(),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
-                    is ScheduleItem.LowerThirdItem -> Text(
-                        maxLines = 1,
-                        text = if (item.pauseAtFrame) stringResource(Res.string.pause_duration_ms, item.pauseDurationMs) else "",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
-                    is ScheduleItem.LabelItem -> { /* no secondary text */ }
-                    is ScheduleItem.AnnouncementItem -> {
-                        // Duration (count-up) and the live Clock have no fixed h:m:s to preview here —
-                        // their live value only exists once the item is triggered, so show nothing.
-                        val timerSubtext = announcementTimerSubtext(item)
-                        if (item.isTimer && timerSubtext != null) {
-                            Text(
-                                maxLines = 1,
-                                text = timerSubtext,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                        else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                            )
-                        }
-                    }
-                    is ScheduleItem.WebsiteItem -> Text(
-                        maxLines = 1,
-                        text = item.url,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
-                    is ScheduleItem.SceneItem -> { /* no secondary text */ }
-                    is ScheduleItem.DictionaryItem -> Text(
-                        maxLines = 1,
-                        text = item.transliteration,
-                        style = MaterialTheme.typography.bodySmall,
-                        color = if (isSelected) MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
-                                else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                    )
-                }
-                }
-
-                // Note preview when collapsed
-                if (note.isNotEmpty() && !noteExpanded && !singleLine) {
-                    Text(
-                        text = note,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontStyle = FontStyle.Italic,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-                        maxLines = 1,
-                        modifier = Modifier.padding(top = 2.dp)
-                    )
-                }
-            }
-        }
-        // With the action row hidden, Go Live (Edit for labels) stays on the content row itself
-        if (!showActions) {
-            if (item is ScheduleItem.LabelItem) {
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_edit),
-                    text = stringResource(Res.string.tooltip_edit_label),
-                    onClick = onEditLabel,
-                    modifier = Modifier.padding(end = 8.dp),
-                    buttonSize = 24.dp,
-                    iconSize = 14.dp,
-                    iconTint = MaterialTheme.colorScheme.primary
-                )
-            } else {
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_play),
-                    text = stringResource(Res.string.tooltip_go_live),
-                    onClick = onPresent,
-                    modifier = Modifier.padding(end = 8.dp),
-                    buttonSize = 24.dp,
-                    iconSize = 16.dp,
-                    iconTint = MaterialTheme.colorScheme.primary
-                )
-            }
-        }
-        }
-
-        // Action buttons (second, more compact line) — dropped below 100% zoom
-        if (showActions) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 32.dp, end = 12.dp, bottom = 4.dp)
-                .then(
-                    if (item !is ScheduleItem.LabelItem) {
-                        Modifier.finalPassCombinedClickable(
-                            onClick = { onSelect() },
-                            onDoubleClick = { onPresent() }
-                        )
-                    } else Modifier
-                ),
-            horizontalArrangement = Arrangement.SpaceBetween,
+                .padding(
+                    start = 3.dp,
+                    end = 6.dp,
+                    top = density.rowPadding(),
+                    bottom = density.rowPadding()
+                )
+                .heightIn(min = density.rowMinHeight()),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Remove button
-            TooltipIconButton(
-                painter = painterResource(Res.drawable.ic_close),
-                text = stringResource(Res.string.tooltip_remove),
-                onClick = onRemove,
-                buttonSize = 28.dp,
-                iconSize = 16.dp,
-                iconTint = MaterialTheme.colorScheme.error
-            )
-
+            // Left accent bar (decorative) + grip dots + type icon — the grip and icon together
+            // form the drag-to-reorder handle, matching their combined touch target before this
+            // redesign rather than shrinking it down to the 4dp-wide grip glyph alone.
             Row(
-                horizontalArrangement = Arrangement.spacedBy(2.dp),
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Move up button
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_arrow_up),
-                    text = stringResource(Res.string.tooltip_move_up),
-                    onClick = onMoveUp,
-                    buttonSize = 28.dp,
-                    iconSize = 16.dp,
-                    iconTint = MaterialTheme.colorScheme.onSurface
+                Box(
+                    modifier = Modifier
+                        .width(3.dp)
+                        .height(24.dp)
+                        .background(leftAccent, RoundedCornerShape(2.dp))
                 )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(5.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .pointerHoverIcon(PointerIcon.Hand)
+                        .then(dragHandleModifier)
+                ) {
+                    Icon(
+                        painter = painterResource(Res.drawable.ic_drag_dots),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f),
+                        modifier = Modifier
+                            .width(4.dp)
+                            .height(16.dp)
+                    )
+                    if (!isSection) {
+                        val (chipBg, chipFg) = scheduleChipColors(scheduleItemPaletteIndex(item))
+                        Box(
+                            modifier = Modifier
+                                .size(26.dp)
+                                .background(chipBg, RoundedCornerShape(7.dp)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = scheduleItemGlyph(item),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = chipFg
+                            )
+                        }
+                    }
+                }
+            }
 
-                // Move down button
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_arrow_down),
-                    text = stringResource(Res.string.tooltip_move_down),
-                    onClick = onMoveDown,
-                    buttonSize = 28.dp,
-                    iconSize = 16.dp,
-                    iconTint = MaterialTheme.colorScheme.onSurface
-                )
+            // Content takes the row's full remaining width — the action buttons below overlay on
+            // top of it (only while hovered) rather than reserving their own permanent column, so
+            // text is never squeezed to make room for controls that are usually hidden.
+            Box(modifier = Modifier.weight(1f)) {
+                // Selecting/presenting lives here (Initial-pass: survives the LazyColumn
+                // scroll-gesture-eats-clicks issue on ARM Mac). The overlaid action row below is a
+                // separate sibling in this Box (painted after, so it sits on top) — its own
+                // buttons keep their normal click handling untouched.
+                //
+                // fillMaxSize, not fillMaxWidth: the Box's height is whichever sibling is
+                // taller, which can be the action-button row rather than this Column's own
+                // wrapped text (a single Compact-density title line is shorter than the row of
+                // 27-30dp buttons). fillMaxWidth alone left this Column's clickable bounds at
+                // just its text's own height, so clicking the card below the text but still
+                // inside the row's visible bounds hit nothing.
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        // Selection applies to section rows too — otherwise a label can never
+                        // become `selectedItemId`, and the toolbar's "Remove from Schedule"
+                        // button (which acts on the current selection) can't touch it. Only
+                        // double-click-to-present stays disabled for sections: there's nothing
+                        // to go live with.
+                        .initialPassCombinedClickable(
+                            onClick = { onSelect() },
+                            onDoubleClick = if (!isSection) { { onPresent() } } else null
+                        )
+                ) {
+                    if (isSection) {
+                        Text(
+                            text = item.displayText,
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 1.sp,
+                            color = sectionText,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    } else {
+                        ScheduleItemContent(item = item, density = density, isSelected = isSelected)
+                    }
 
-                // Note toggle button
-                TooltipIconButton(
-                    painter = painterResource(Res.drawable.ic_note),
-                    text = stringResource(Res.string.tooltip_note),
-                    onClick = { noteExpanded = !noteExpanded },
-                    buttonSize = 28.dp,
-                    iconSize = 16.dp,
-                    iconTint = if (note.isNotEmpty() || noteExpanded) MaterialTheme.colorScheme.primary
-                               else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
-                )
+                    // Note preview when collapsed
+                    if (note.isNotEmpty() && !noteExpanded) {
+                        Text(
+                            text = note,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontStyle = FontStyle.Italic,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.padding(top = 2.dp)
+                        )
+                    }
+                }
 
-                // Show Edit button for labels, Go Live button for other items
-                if (item is ScheduleItem.LabelItem) {
-                    TooltipIconButton(
-                        painter = painterResource(Res.drawable.ic_edit),
-                        text = stringResource(Res.string.tooltip_edit_label),
-                        onClick = onEditLabel,
-                        buttonSize = 28.dp,
-                        iconSize = 14.dp,
-                        colors = IconButtonDefaults.iconButtonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = MaterialTheme.colorScheme.onPrimary
+                // Hover-revealed action buttons — always present (so they stay reachable by
+                // keyboard and testable), only their opacity tracks hover. A scrim fading from
+                // transparent to the card's own background sits behind them so they stay legible
+                // over whatever text they're overlapping. Also carries its own Final-pass
+                // select/present click: a nested button's Main-pass click wins first, and only a
+                // click that lands here without hitting a button falls through to select the card.
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .alpha(actionsAlpha)
+                        .background(
+                            Brush.horizontalGradient(
+                                0f to Color.Transparent,
+                                0.35f to cardBg.copy(alpha = 0.82f),
+                                1f to cardBg.copy(alpha = 0.82f)
+                            )
+                        )
+                        .padding(start = 20.dp)
+                        .finalPassCombinedClickable(
+                            onClick = { onSelect() },
+                            onDoubleClick = if (!isSection) { { onPresent() } } else null
                         ),
-                        iconTint = MaterialTheme.colorScheme.onPrimary
+                    horizontalArrangement = Arrangement.spacedBy(1.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    ScheduleRowActionButton(
+                        painter = painterResource(Res.drawable.ic_arrow_up),
+                        text = stringResource(Res.string.tooltip_move_up),
+                        onClick = onMoveUp,
+                        iconTint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                } else {
-                    TooltipIconButton(
-                        painter = painterResource(Res.drawable.ic_play),
-                        text = stringResource(Res.string.tooltip_go_live),
-                        onClick = onPresent,
-                        buttonSize = 28.dp,
-                        iconSize = 16.dp,
-                        iconTint = MaterialTheme.colorScheme.primary
+                    ScheduleRowActionButton(
+                        painter = painterResource(Res.drawable.ic_arrow_down),
+                        text = stringResource(Res.string.tooltip_move_down),
+                        onClick = onMoveDown,
+                        iconTint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    ScheduleRowActionButton(
+                        painter = painterResource(Res.drawable.ic_note),
+                        text = stringResource(Res.string.tooltip_note),
+                        onClick = { noteExpanded = !noteExpanded },
+                        iconTint = if (note.isNotEmpty() || noteExpanded) MaterialTheme.colorScheme.primary
+                                   else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    ScheduleRowActionButton(
+                        painter = painterResource(Res.drawable.ic_close),
+                        text = stringResource(Res.string.tooltip_remove),
+                        onClick = onRemove,
+                        iconTint = MaterialTheme.colorScheme.error
+                    )
+                    // Slightly larger than the other four, matching the reference design — but
+                    // NOT permanently filled with color: the reference only does that for
+                    // whichever item is currently live, a concept this app doesn't track per
+                    // schedule item, so every row would otherwise show a "live-looking" button
+                    // that never actually means anything.
+                    if (isSection) {
+                        ScheduleRowActionButton(
+                            painter = painterResource(Res.drawable.ic_edit),
+                            text = stringResource(Res.string.tooltip_edit_label),
+                            onClick = onEditLabel,
+                            modifier = Modifier.padding(start = 2.dp),
+                            buttonSize = 30.dp,
+                            iconSize = 15.dp,
+                            iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    } else {
+                        ScheduleRowActionButton(
+                            painter = painterResource(Res.drawable.ic_play),
+                            text = stringResource(Res.string.tooltip_go_live),
+                            onClick = onPresent,
+                            modifier = Modifier.padding(start = 2.dp),
+                            buttonSize = 30.dp,
+                            iconSize = 15.dp,
+                            iconTint = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 }
             }
         }
 
-        // Inline note editor
+        // Saved note preview, or the inline editor — either way it always gets its own row so
+        // opening/closing it never fights the hover-alpha of the action buttons above.
+        if (note.isNotEmpty() && !noteExpanded) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 38.dp, end = 8.dp, bottom = 7.dp)
+                    .background(MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.35f), RoundedCornerShape(6.dp))
+                    .padding(start = 8.dp, end = 2.dp, top = 4.dp, bottom = 4.dp),
+                verticalAlignment = Alignment.Top
+            ) {
+                Text(
+                    text = note,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                    modifier = Modifier.weight(1f).padding(top = 2.dp, bottom = 2.dp)
+                )
+                ScheduleRowActionButton(
+                    painter = painterResource(Res.drawable.ic_edit),
+                    text = stringResource(Res.string.tooltip_note),
+                    onClick = { noteExpanded = true },
+                    iconSize = 11.dp,
+                    iconTint = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f)
+                )
+            }
+        }
+
         AnimatedVisibility(visible = noteExpanded) {
             val noteInteractionSource = remember { MutableInteractionSource() }
             val noteFieldFocused by noteInteractionSource.collectIsFocusedAsState()
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 36.dp, end = 12.dp, bottom = 8.dp)
+                    .padding(start = 38.dp, end = 8.dp, bottom = 7.dp)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh, RoundedCornerShape(7.dp))
                     .border(
                         width = 1.dp,
                         color = if (noteFieldFocused) MaterialTheme.colorScheme.primary
-                                else MaterialTheme.colorScheme.outline,
-                        shape = RoundedCornerShape(4.dp)
+                                else MaterialTheme.colorScheme.outlineVariant,
+                        shape = RoundedCornerShape(7.dp)
                     ),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -1231,7 +1424,7 @@ private fun ScheduleItemRow(
                     onValueChange = { noteText = it },
                     modifier = Modifier
                         .weight(1f)
-                        .padding(horizontal = 12.dp, vertical = 10.dp),
+                        .padding(horizontal = 10.dp, vertical = 8.dp),
                     textStyle = MaterialTheme.typography.bodySmall.copy(
                         color = MaterialTheme.colorScheme.onSurface
                     ),
@@ -1244,16 +1437,12 @@ private fun ScheduleItemRow(
                                 Text(
                                     stringResource(Res.string.schedule_note_placeholder),
                                     style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
                                 )
                             }
                             innerTextField()
                         }
                     }
-                )
-                VerticalDivider(
-                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f),
-                    thickness = 1.dp
                 )
                 TooltipIconButton(
                     painter = painterResource(Res.drawable.ic_check),
@@ -1262,13 +1451,9 @@ private fun ScheduleItemRow(
                         onNoteChanged(noteText)
                         noteExpanded = false
                     },
-                    buttonSize = 36.dp,
-                    iconSize = 18.dp,
-                    iconTint = MaterialTheme.colorScheme.inverseSurface
-                )
-                VerticalDivider(
-                    color = MaterialTheme.colorScheme.outline.copy(alpha = 0.4f),
-                    thickness = 1.dp
+                    buttonSize = 32.dp,
+                    iconSize = 15.dp,
+                    iconTint = MaterialTheme.colorScheme.primary
                 )
                 TooltipIconButton(
                     painter = painterResource(Res.drawable.ic_close),
@@ -1277,12 +1462,137 @@ private fun ScheduleItemRow(
                         noteText = ""
                         onNoteChanged("")
                     },
-                    buttonSize = 36.dp,
-                    iconSize = 18.dp,
+                    modifier = Modifier.padding(end = 4.dp),
+                    buttonSize = 32.dp,
+                    iconSize = 15.dp,
                     iconTint = MaterialTheme.colorScheme.error
                 )
             }
         }
+    }
+}
+
+/** The title line and, at Normal/Detailed density, the per-type detail line(s) below it. */
+@Composable
+private fun ScheduleItemContent(item: ScheduleItem, density: ScheduleDensity, isSelected: Boolean) {
+    val titleColor = if (isSelected) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface
+    val detailColor = MaterialTheme.colorScheme.onSurfaceVariant
+
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        if (item is ScheduleItem.SongItem && item.songNumber > 0) {
+            Text(
+                text = item.songNumber.toString(),
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+        }
+        Text(
+            // A song's own displayText prepends its number ("42 - Amazing Grace") for contexts
+            // without room for the two as separate elements; here the number already has its own
+            // Text above, so the title alone avoids showing it twice.
+            text = if (item is ScheduleItem.SongItem) item.title else item.displayText,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+            color = titleColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false)
+        )
+    }
+
+    if (!scheduleShowDetailLine(density.percent)) return
+
+    when (item) {
+        is ScheduleItem.SongItem -> if (item.songbook.isNotBlank()) {
+            Text(
+                text = item.songbook,
+                style = MaterialTheme.typography.bodySmall,
+                color = detailColor,
+                maxLines = 1,
+                // Songbook names are often long paths/editions whose distinguishing part is at the
+                // END, so clip the front instead of the tail
+                overflow = TextOverflow.StartEllipsis
+            )
+        }
+        is ScheduleItem.BibleVerseItem -> Text(
+            text = scheduleItemDetailText(item).orEmpty(),
+            style = MaterialTheme.typography.bodySmall, color = detailColor, maxLines = 1, overflow = TextOverflow.Ellipsis
+        )
+        is ScheduleItem.PictureItem -> Text(
+            text = scheduleItemDetailText(item).orEmpty(),
+            style = MaterialTheme.typography.bodySmall, color = detailColor, maxLines = 1, overflow = TextOverflow.Ellipsis
+        )
+        is ScheduleItem.PresentationItem -> if (!scheduleShowKindDetails(density.percent)) {
+            Text(
+                text = scheduleItemDetailText(item).orEmpty(),
+                style = MaterialTheme.typography.bodySmall, color = detailColor, maxLines = 1, overflow = TextOverflow.Ellipsis
+            )
+        }
+        is ScheduleItem.MediaItem -> if (!scheduleShowKindDetails(density.percent)) {
+            Text(
+                text = scheduleItemDetailText(item).orEmpty(),
+                style = MaterialTheme.typography.bodySmall, color = detailColor, maxLines = 1, overflow = TextOverflow.Ellipsis
+            )
+        }
+        is ScheduleItem.LowerThirdItem -> if (item.pauseAtFrame) {
+            Text(
+                text = stringResource(Res.string.pause_duration_ms, item.pauseDurationMs),
+                style = MaterialTheme.typography.bodySmall, color = detailColor, maxLines = 1
+            )
+        }
+        is ScheduleItem.AnnouncementItem -> {
+            val timerSubtext = announcementTimerSubtext(item)
+            if (item.isTimer && timerSubtext != null) {
+                Text(
+                    text = timerSubtext,
+                    style = MaterialTheme.typography.bodySmall, color = detailColor, maxLines = 1
+                )
+            }
+        }
+        is ScheduleItem.WebsiteItem -> Text(
+            text = item.url,
+            style = MaterialTheme.typography.bodySmall, color = detailColor, maxLines = 1, overflow = TextOverflow.Ellipsis
+        )
+        is ScheduleItem.DictionaryItem -> Text(
+            text = item.transliteration,
+            style = MaterialTheme.typography.bodySmall, color = detailColor, maxLines = 1, overflow = TextOverflow.Ellipsis
+        )
+        is ScheduleItem.LabelItem, is ScheduleItem.SceneItem -> { /* no secondary text */ }
+    }
+
+    // Detailed density adds the uppercase type chip (and, for file-backed items, the path)
+    if (scheduleShowKindDetails(density.percent)) {
+        val path = when (item) {
+            is ScheduleItem.PresentationItem -> item.filePath
+            is ScheduleItem.MediaItem -> item.mediaUrl
+            else -> null
+        }
+        Row(
+            modifier = Modifier.padding(top = 3.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val (chipBg, chipFg) = scheduleChipColors(scheduleItemPaletteIndex(item))
+            Box(
+                modifier = Modifier.background(chipBg, RoundedCornerShape(4.dp)).padding(horizontal = 6.dp, vertical = 1.dp)
+            ) {
+                Text(
+                    text = stringResource(scheduleItemKindLabel(item)).uppercase(),
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 9.sp),
+                    fontWeight = FontWeight.Bold,
+                    color = chipFg
+                )
+            }
+            if (path != null) {
+                Text(
+                    text = path,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = detailColor.copy(alpha = 0.7f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoom.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoom.kt
@@ -1,38 +1,52 @@
 package org.churchpresenter.app.churchpresenter.utils
 
-import kotlin.math.abs
-
 /**
- * The schedule card zoom ladder. Zoom snaps to fixed rungs (so a value persisted before the ladder
- * existed still resolves to the nearest one), and below full size the card sheds its action buttons
- * and then collapses to a single line before it starts shrinking. Extracted from ScheduleTab so the
- * rung math and the two shed/collapse thresholds are tested without the Compose controls.
+ * The schedule card density ladder: three fixed rungs (Compact / Normal / Detailed) rather than a
+ * continuous zoom. The persisted setting stays a plain `Int` (`AppSettings.scheduleItemZoomPercent`,
+ * pre-dating this ladder) so a value saved under the old 11-rung 70-150 scheme still resolves to the
+ * nearest rung here. Extracted from ScheduleTab so the rung math is tested without the Compose
+ * controls.
  */
 
-internal val ZOOM_LEVELS = listOf(70, 80, 90, 98, 99, 100, 110, 120, 130, 140, 150)
-private const val ZOOM_HIDE_ACTIONS_BELOW = 100
-private const val ZOOM_SINGLE_LINE_AT_OR_BELOW = 98
+internal enum class ScheduleDensity(val percent: Int) {
+    COMPACT(70),
+    NORMAL(100),
+    DETAILED(150),
+}
 
-/** The rung nearest [percent], so a value persisted before the ladder existed still resolves. */
-internal fun nearestZoomIndex(percent: Int): Int =
-    ZOOM_LEVELS.indices.minBy { abs(ZOOM_LEVELS[it] - percent) }
+/** The rung nearest [percent], so a value persisted before or after this ladder still resolves. */
+internal fun scheduleDensityFor(percent: Int): ScheduleDensity = when {
+    percent <= 90 -> ScheduleDensity.COMPACT
+    percent < 120 -> ScheduleDensity.NORMAL
+    else -> ScheduleDensity.DETAILED
+}
 
-/** The next rung up from [percent] (clamped at the top rung). */
-internal fun scheduleZoomIn(percent: Int): Int =
-    ZOOM_LEVELS[(nearestZoomIndex(percent) + 1).coerceAtMost(ZOOM_LEVELS.lastIndex)]
+/** The next rung up from [percent] (clamped at Detailed). */
+internal fun scheduleZoomIn(percent: Int): Int {
+    val density = scheduleDensityFor(percent)
+    val next = ScheduleDensity.entries.getOrElse(density.ordinal + 1) { density }
+    return next.percent
+}
 
-/** The next rung down from [percent] (clamped at the bottom rung). */
-internal fun scheduleZoomOut(percent: Int): Int =
-    ZOOM_LEVELS[(nearestZoomIndex(percent) - 1).coerceAtLeast(0)]
+/** The next rung down from [percent] (clamped at Compact). */
+internal fun scheduleZoomOut(percent: Int): Int {
+    val density = scheduleDensityFor(percent)
+    val prev = ScheduleDensity.entries.getOrElse(density.ordinal - 1) { density }
+    return prev.percent
+}
 
-/** Whether there is a higher rung to zoom into. */
-internal fun scheduleCanZoomIn(percent: Int): Boolean = nearestZoomIndex(percent) < ZOOM_LEVELS.lastIndex
+/** Whether there is a higher rung to move into. */
+internal fun scheduleCanZoomIn(percent: Int): Boolean =
+    scheduleDensityFor(percent) != ScheduleDensity.DETAILED
 
-/** Whether there is a lower rung to zoom out to. */
-internal fun scheduleCanZoomOut(percent: Int): Boolean = nearestZoomIndex(percent) > 0
+/** Whether there is a lower rung to move out to. */
+internal fun scheduleCanZoomOut(percent: Int): Boolean =
+    scheduleDensityFor(percent) != ScheduleDensity.COMPACT
 
-/** At or above full size the cards keep their action buttons; below it they shed them. */
-internal fun scheduleShowCardActions(percent: Int): Boolean = percent >= ZOOM_HIDE_ACTIONS_BELOW
+/** Normal and Detailed show the row's secondary (grey) detail line; Compact shows title only. */
+internal fun scheduleShowDetailLine(percent: Int): Boolean =
+    scheduleDensityFor(percent) != ScheduleDensity.COMPACT
 
-/** At or below the collapse threshold the cards render a single line only. */
-internal fun scheduleSingleLineCards(percent: Int): Boolean = percent <= ZOOM_SINGLE_LINE_AT_OR_BELOW
+/** Only Detailed shows the type-kind chip and (when present) the file path. */
+internal fun scheduleShowKindDetails(percent: Int): Boolean =
+    scheduleDensityFor(percent) == ScheduleDensity.DETAILED

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoom.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoom.kt
@@ -1,24 +1,35 @@
 package org.churchpresenter.app.churchpresenter.utils
 
 /**
- * The schedule card density ladder: three fixed rungs (Compact / Normal / Detailed) rather than a
- * continuous zoom. The persisted setting stays a plain `Int` (`AppSettings.scheduleItemZoomPercent`,
+ * The schedule card density ladder: five fixed rungs rather than a continuous zoom -- Compact,
+ * Normal and Detailed, plus one step smaller and one step larger than those. The two outer rungs
+ * reuse their neighbour's name in the UI: they change how much room a card takes, not what it
+ * shows, so a fourth and fifth label would name a distinction that is not there. The persisted setting stays a plain `Int` (`AppSettings.scheduleItemZoomPercent`,
  * pre-dating this ladder) so a value saved under the old 11-rung 70-150 scheme still resolves to the
  * nearest rung here. Extracted from ScheduleTab so the rung math is tested without the Compose
  * controls.
  */
 
 internal enum class ScheduleDensity(val percent: Int) {
+    EXTRA_COMPACT(55),
     COMPACT(70),
     NORMAL(100),
     DETAILED(150),
+    EXTRA_DETAILED(200),
 }
 
-/** The rung nearest [percent], so a value persisted before or after this ladder still resolves. */
+/**
+ * The rung nearest [percent], so a value persisted before or after this ladder still resolves.
+ *
+ * The three middle rungs keep the bands the old 70-150 scheme used, so nothing anyone has saved
+ * moves; the two outer rungs are only reachable by stepping past the ends with the +/- controls.
+ */
 internal fun scheduleDensityFor(percent: Int): ScheduleDensity = when {
+    percent <= 60 -> ScheduleDensity.EXTRA_COMPACT
     percent <= 90 -> ScheduleDensity.COMPACT
     percent < 120 -> ScheduleDensity.NORMAL
-    else -> ScheduleDensity.DETAILED
+    percent <= 175 -> ScheduleDensity.DETAILED
+    else -> ScheduleDensity.EXTRA_DETAILED
 }
 
 /** The next rung up from [percent] (clamped at Detailed). */
@@ -37,16 +48,20 @@ internal fun scheduleZoomOut(percent: Int): Int {
 
 /** Whether there is a higher rung to move into. */
 internal fun scheduleCanZoomIn(percent: Int): Boolean =
-    scheduleDensityFor(percent) != ScheduleDensity.DETAILED
+    scheduleDensityFor(percent) != ScheduleDensity.entries.last()
 
 /** Whether there is a lower rung to move out to. */
 internal fun scheduleCanZoomOut(percent: Int): Boolean =
-    scheduleDensityFor(percent) != ScheduleDensity.COMPACT
+    scheduleDensityFor(percent) != ScheduleDensity.entries.first()
 
-/** Normal and Detailed show the row's secondary (grey) detail line; Compact shows title only. */
-internal fun scheduleShowDetailLine(percent: Int): Boolean =
-    scheduleDensityFor(percent) != ScheduleDensity.COMPACT
+/** The two smallest rungs show the title alone; the rest add the secondary (grey) detail line. */
+internal fun scheduleShowDetailLine(percent: Int): Boolean = when (scheduleDensityFor(percent)) {
+    ScheduleDensity.EXTRA_COMPACT, ScheduleDensity.COMPACT -> false
+    else -> true
+}
 
-/** Only Detailed shows the type-kind chip and (when present) the file path. */
-internal fun scheduleShowKindDetails(percent: Int): Boolean =
-    scheduleDensityFor(percent) == ScheduleDensity.DETAILED
+/** Only the two largest rungs show the type-kind chip and (when present) the file path. */
+internal fun scheduleShowKindDetails(percent: Int): Boolean = when (scheduleDensityFor(percent)) {
+    ScheduleDensity.DETAILED, ScheduleDensity.EXTRA_DETAILED -> true
+    else -> false
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Utils.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Utils.kt
@@ -33,6 +33,40 @@ object Utils {
         }
     }
 
+    /**
+     * WCAG 2 relative luminance of [color], in the 0..1 range contrast-ratio math uses.
+     * https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
+     */
+    private fun relativeLuminance(color: Color): Double {
+        fun channel(c: Float): Double {
+            val cs = c.toDouble()
+            return if (cs <= 0.03928) cs / 12.92 else Math.pow((cs + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * channel(color.red) + 0.7152 * channel(color.green) + 0.0722 * channel(color.blue)
+    }
+
+    /** WCAG 2 contrast ratio between two colors — 1:1 (identical) up to 21:1 (black on white). */
+    fun contrastRatio(a: Color, b: Color): Double {
+        val l1 = relativeLuminance(a) + 0.05
+        val l2 = relativeLuminance(b) + 0.05
+        return if (l1 > l2) l1 / l2 else l2 / l1
+    }
+
+    /**
+     * [foreground] as-is if it already meets [minRatio] against [background] — WCAG AA for
+     * normal text is 4.5:1, the default — otherwise whichever of pure white or pure black
+     * contrasts better with [background]. For user-chosen color pairs (e.g. a schedule label's
+     * saved text/background) that can land close enough to unreadable; this only changes what's
+     * rendered, never what's stored, so the original picked color is still shown if the user
+     * reopens the editor.
+     */
+    fun ensureContrast(foreground: Color, background: Color, minRatio: Double = 4.5): Color {
+        if (contrastRatio(foreground, background) >= minRatio) return foreground
+        val whiteContrast = contrastRatio(Color.White, background)
+        val blackContrast = contrastRatio(Color.Black, background)
+        return if (whiteContrast >= blackContrast) Color.White else Color.Black
+    }
+
     fun parseHexColor(hexColor: String): Color {
         if (hexColor.equals("transparent", ignoreCase = true)) return Color.Transparent
         return try {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplay.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplay.kt
@@ -1,7 +1,19 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
+import churchpresenter.composeapp.generated.resources.Res
+import churchpresenter.composeapp.generated.resources.announcements
+import churchpresenter.composeapp.generated.resources.bible
+import churchpresenter.composeapp.generated.resources.media_tab_title
+import churchpresenter.composeapp.generated.resources.pictures
+import churchpresenter.composeapp.generated.resources.presentation
+import churchpresenter.composeapp.generated.resources.schedule_kind_lower_third
+import churchpresenter.composeapp.generated.resources.songs
+import churchpresenter.composeapp.generated.resources.tab_canvas
+import churchpresenter.composeapp.generated.resources.tab_dictionary
+import churchpresenter.composeapp.generated.resources.tab_web
 import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.jetbrains.compose.resources.StringResource
 
 /**
  * How a schedule item is labelled in the list — its type glyph, its grey detail line, and an
@@ -38,6 +50,41 @@ internal fun scheduleItemDetailText(item: ScheduleItem): String? = when (item) {
     is ScheduleItem.PresentationItem -> "${item.fileType.uppercase()} - ${item.filePath}"
     is ScheduleItem.MediaItem -> "${item.mediaType.uppercase()} - ${item.mediaUrl}"
     else -> null
+}
+
+/**
+ * Which of a small rotating set of theme colors a row's type-icon chip uses — not a distinct hue per
+ * type (that would mean hardcoded colors, against project standards), but enough variety that
+ * adjacent kinds in a service read as visually different. [ScheduleItem.LabelItem] rows render as
+ * section headers with their own user-chosen color instead, so they never consult this.
+ */
+internal fun scheduleItemPaletteIndex(item: ScheduleItem): Int = when (item) {
+    is ScheduleItem.SongItem -> 0
+    is ScheduleItem.BibleVerseItem -> 1
+    is ScheduleItem.PresentationItem -> 2
+    is ScheduleItem.PictureItem -> 3
+    is ScheduleItem.MediaItem -> 0
+    is ScheduleItem.LowerThirdItem -> 1
+    is ScheduleItem.AnnouncementItem -> 2
+    is ScheduleItem.WebsiteItem -> 3
+    is ScheduleItem.SceneItem -> 0
+    is ScheduleItem.DictionaryItem -> 1
+    is ScheduleItem.LabelItem -> 0
+}
+
+/** The row's type name, shown as a small uppercase chip at the Detailed density. */
+internal fun scheduleItemKindLabel(item: ScheduleItem): StringResource = when (item) {
+    is ScheduleItem.SongItem -> Res.string.songs
+    is ScheduleItem.BibleVerseItem -> Res.string.bible
+    is ScheduleItem.PresentationItem -> Res.string.presentation
+    is ScheduleItem.PictureItem -> Res.string.pictures
+    is ScheduleItem.MediaItem -> Res.string.media_tab_title
+    is ScheduleItem.LowerThirdItem -> Res.string.schedule_kind_lower_third
+    is ScheduleItem.AnnouncementItem -> Res.string.announcements
+    is ScheduleItem.WebsiteItem -> Res.string.tab_web
+    is ScheduleItem.SceneItem -> Res.string.tab_canvas
+    is ScheduleItem.DictionaryItem -> Res.string.tab_dictionary
+    is ScheduleItem.LabelItem -> Res.string.songs // unused — LabelItem renders as a section header
 }
 
 /**

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/ColorPickerDialogTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/ColorPickerDialogTest.kt
@@ -1,0 +1,267 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import java.io.File
+import kotlin.math.abs
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * [SvPanel] and [HueBar] (widened from `private` to `internal` for this) are the two drag
+ * surfaces behind [ColorPickerDialog] — a bare `Box` with its own `pointerInput`/`awaitEachGesture`
+ * drag detector and a `Canvas`, no semantics of its own, the same shape as `SlimSlider`. Tests
+ * below drive them by tag and read back the resulting saturation/brightness or hue through the
+ * `onChanged`/`onHueChange` callback rather than any drawn pixel, then a separate group drives the
+ * full [ColorPickerDialog] end to end and asserts on the hex it ultimately reports through
+ * [onColorSelected] — the outcome a caller actually observes, not the dialog's internal text state.
+ *
+ * `SvPanel`/`HueBar` size themselves from the `Modifier` passed by the caller (`onSizeChanged`), so
+ * geometry expectations here are derived from the node's own measured size rather than a hardcoded
+ * pixel count, keeping them independent of test-environment density.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ColorPickerDialogTest {
+
+    private val recentColorsFile = File(System.getProperty("user.home"), ".churchpresenter/recent_colors.json")
+
+    @BeforeTest
+    fun freshRecentColors() {
+        recentColorsFile.delete()
+        RecentColors.colors.clear()
+    }
+
+    @AfterTest
+    fun cleanupRecentColors() {
+        recentColorsFile.delete()
+        RecentColors.colors.clear()
+    }
+
+    // ── SvPanel ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `dragging to the panel's center reports half saturation and half brightness`() = runComposeUiTest {
+        var saturation: Float? = null
+        var brightness: Float? = null
+        setContent {
+            SvPanel(
+                hue = 0f,
+                saturation = 0f,
+                brightness = 0f,
+                onChanged = { s, v -> saturation = s; brightness = v },
+                modifier = Modifier.testTag("sv").size(200.dp),
+            )
+        }
+        val size = onNodeWithTag("sv").fetchSemanticsNode().size
+        onNodeWithTag("sv").performTouchInput {
+            down(Offset(size.width / 2f, size.height / 2f))
+            up()
+        }
+        assertApprox(0.5f, requireNotNull(saturation), "center saturation")
+        assertApprox(0.5f, requireNotNull(brightness), "center brightness")
+    }
+
+    @Test
+    fun `dragging to the top-left corner reports zero saturation and full brightness`() = runComposeUiTest {
+        var saturation: Float? = null
+        var brightness: Float? = null
+        setContent {
+            SvPanel(
+                hue = 0f,
+                saturation = 1f,
+                brightness = 1f,
+                onChanged = { s, v -> saturation = s; brightness = v },
+                modifier = Modifier.testTag("sv").size(200.dp),
+            )
+        }
+        onNodeWithTag("sv").performTouchInput {
+            down(Offset(0f, 0f))
+            up()
+        }
+        assertApprox(0f, requireNotNull(saturation), "top-left saturation")
+        assertApprox(1f, requireNotNull(brightness), "top-left brightness (y=0 is full brightness)")
+    }
+
+    @Test
+    fun `dragging past the bottom-right edge clamps to full saturation and zero brightness`() = runComposeUiTest {
+        var saturation: Float? = null
+        var brightness: Float? = null
+        setContent {
+            SvPanel(
+                hue = 0f,
+                saturation = 0f,
+                brightness = 0f,
+                onChanged = { s, v -> saturation = s; brightness = v },
+                modifier = Modifier.testTag("sv").size(200.dp),
+            )
+        }
+        val size = onNodeWithTag("sv").fetchSemanticsNode().size
+        onNodeWithTag("sv").performTouchInput {
+            down(Offset(size.width / 2f, size.height / 2f))
+            moveTo(Offset(size.width + 500f, size.height + 500f))
+            up()
+        }
+        assertEquals(1f, saturation, "dragging past the right edge must clamp saturation to 1")
+        assertEquals(0f, brightness, "dragging past the bottom edge must clamp brightness to 0")
+    }
+
+    @Test
+    fun `a plain tap (no drag) still reports the tapped position`() = runComposeUiTest {
+        var reported = false
+        setContent {
+            SvPanel(
+                hue = 0f,
+                saturation = 0f,
+                brightness = 0f,
+                onChanged = { _, _ -> reported = true },
+                modifier = Modifier.testTag("sv").size(200.dp),
+            )
+        }
+        onNodeWithTag("sv").performTouchInput { click(Offset(10f, 10f)) }
+        assertTrue(reported, "even a tap with no drag must fire onChanged once, from the initial down")
+    }
+
+    // ── HueBar ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `dragging to the bar's horizontal center reports a hue of 180`() = runComposeUiTest {
+        var hue: Float? = null
+        setContent {
+            HueBar(
+                hue = 0f,
+                onHueChange = { hue = it },
+                modifier = Modifier.testTag("hue").width(200.dp).height(24.dp),
+            )
+        }
+        val size = onNodeWithTag("hue").fetchSemanticsNode().size
+        onNodeWithTag("hue").performTouchInput {
+            down(Offset(size.width / 2f, size.height / 2f))
+            up()
+        }
+        assertApprox(180f, requireNotNull(hue), "center hue", tol = 2f)
+    }
+
+    @Test
+    fun `dragging to the bar's start reports a hue of 0`() = runComposeUiTest {
+        var hue: Float? = null
+        setContent {
+            HueBar(
+                hue = 200f,
+                onHueChange = { hue = it },
+                modifier = Modifier.testTag("hue").width(200.dp).height(24.dp),
+            )
+        }
+        onNodeWithTag("hue").performTouchInput { down(Offset(0f, 0f)); up() }
+        assertApprox(0f, requireNotNull(hue), "start hue")
+    }
+
+    @Test
+    fun `dragging past the bar's right edge clamps the hue to 360`() = runComposeUiTest {
+        var hue: Float? = null
+        setContent {
+            HueBar(
+                hue = 0f,
+                onHueChange = { hue = it },
+                modifier = Modifier.testTag("hue").width(200.dp).height(24.dp),
+            )
+        }
+        val size = onNodeWithTag("hue").fetchSemanticsNode().size
+        onNodeWithTag("hue").performTouchInput {
+            down(Offset(size.width / 2f, size.height / 2f))
+            moveTo(Offset(size.width + 500f, size.height / 2f))
+            up()
+        }
+        assertEquals(360f, hue, "dragging past the right edge must clamp the hue to 360")
+    }
+
+    // ── Full ColorPickerDialog ─────────────────────────────────────────────────
+
+    @Test
+    fun `dragging the SV panel then confirming reports the dragged saturation and brightness`() = runComposeUiTest {
+        var result: String? = null
+        setContent {
+            MaterialTheme {
+                ColorPickerDialog(initialHex = "#FF0000", onDismiss = {}, onColorSelected = { result = it })
+            }
+        }
+        val size = onNodeWithTag("colorPickerSvPanel").fetchSemanticsNode().size
+        onNodeWithTag("colorPickerSvPanel").performTouchInput {
+            down(Offset(size.width / 2f, size.height / 2f))
+            up()
+        }
+        onNodeWithText("OK").performClick()
+        // Red's hue (0) held fixed, dragged to the panel's center (s=0.5, v=0.5).
+        val expected = cpColorToHex(cpHsvToColor(0f, 0.5f, 0.5f))
+        assertEquals(expected, result, "confirming after an SV drag must report the dragged saturation/brightness")
+    }
+
+    @Test
+    fun `dragging the hue bar then confirming reports the new hue at full saturation and value`() = runComposeUiTest {
+        var result: String? = null
+        setContent {
+            MaterialTheme {
+                ColorPickerDialog(initialHex = "#FF0000", onDismiss = {}, onColorSelected = { result = it })
+            }
+        }
+        val size = onNodeWithTag("colorPickerHueBar").fetchSemanticsNode().size
+        onNodeWithTag("colorPickerHueBar").performTouchInput {
+            down(Offset(size.width / 2f, size.height / 2f))
+            up()
+        }
+        onNodeWithText("OK").performClick()
+        // Red (hue 0, s=1, v=1) dragged to the bar's center (hue ~180) with saturation/value untouched.
+        val expectedHue180 = cpColorToHex(cpHsvToColor(180f, 1f, 1f))
+        assertEquals(expectedHue180, result, "confirming after a hue drag must report the new hue at full saturation/value")
+    }
+
+    @Test
+    fun `clicking a recent color then confirming reports exactly that color`() = runComposeUiTest {
+        RecentColors.add("#00FF00")
+        var result: String? = null
+        setContent {
+            MaterialTheme {
+                ColorPickerDialog(initialHex = "#FF0000", onDismiss = {}, onColorSelected = { result = it })
+            }
+        }
+        onNodeWithTag("recentColor_#00FF00").performClick()
+        onNodeWithText("OK").performClick()
+        assertEquals("#00FF00", result, "picking a recent color and confirming must report that exact color")
+    }
+
+    @Test
+    fun `cancel reports no color`() = runComposeUiTest {
+        var dismissed = false
+        var selected: String? = null
+        setContent {
+            MaterialTheme {
+                ColorPickerDialog(
+                    initialHex = "#FF0000",
+                    onDismiss = { dismissed = true },
+                    onColorSelected = { selected = it },
+                )
+            }
+        }
+        onNodeWithText("Cancel").performClick()
+        assertTrue(dismissed, "Cancel must dismiss the dialog")
+        assertEquals(null, selected, "Cancel must not report a color")
+    }
+
+    private fun assertApprox(expected: Float, actual: Float, what: String, tol: Float = 0.02f) =
+        assertTrue(abs(expected - actual) <= tol, "$what: expected ~$expected, was $actual")
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabTranslationOrderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabTranslationOrderTest.kt
@@ -96,19 +96,6 @@ class BibleTabTranslationOrderTest {
         }
 
     @Test
-    fun `only the first translation is badged as primary`() =
-        bibleTab(settings = three) { _, _ ->
-            openOrderPanel()
-
-            // The badge is what tells the operator which one drives the book and chapter list.
-            assertEquals(
-                1,
-                renderedText().count { it.equals("PRIMARY", ignoreCase = true) },
-                "exactly one row is the navigation bible: ${renderedText()}",
-            )
-        }
-
-    @Test
     fun `the panel explains both ways to reorder`() =
         bibleTab(settings = three) { _, _ ->
             openOrderPanel()

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabActionsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabActionsTest.kt
@@ -81,11 +81,14 @@ class ScheduleTabActionsTest {
         }
 
     @Test
-    fun `the toolbar's remove takes the selected row`() =
-        scheduleTab(seed = { seedService() }) { vm, _ ->
+    fun `remove-selected takes the selected row`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            // Driven through the action set rather than a toolbar button: the toolbar no longer
+            // carries a remove, because it did nothing until a row had been clicked and said so
+            // nowhere. The menu item and the Delete shortcut still land here.
             onNodeWithText("Notices").performClick()
             waitForIdle()
-            button(ScheduleLabel.REMOVE_SELECTED).performClick()
+            registeredActions(reports).removeSelected()
             waitForIdle()
 
             assertEquals(
@@ -95,8 +98,8 @@ class ScheduleTabActionsTest {
         }
 
     @Test
-    fun `clicking a label row selects it, so the toolbar's remove can clear it too`() =
-        scheduleTab(seed = { seedService() }) { vm, _ ->
+    fun `clicking a label row selects it, so remove-selected can clear it too`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
             // "Welcome" is the label seedService() adds first. A label row used to skip its click
             // handler entirely (nothing to select or present), which also meant it could never
             // become the toolbar's selected row — this is the fix for that.
@@ -108,20 +111,20 @@ class ScheduleTabActionsTest {
                 "clicking a label row must select it, the same as any other row",
             )
 
-            button(ScheduleLabel.REMOVE_SELECTED).performClick()
+            registeredActions(reports).removeSelected()
             waitForIdle()
 
             assertEquals(
                 listOf("42 - Amazing Grace", "John 3:16", "Notices"),
                 vm.scheduleItems.map { it.displayText },
-                "a selected label must be removable from the toolbar, not just its own row button",
+                "a selected label must be removable from the menu, not just its own row button",
             )
         }
 
     @Test
-    fun `the toolbar's remove does nothing when nothing is selected`() =
-        scheduleTab(seed = { seedService() }) { vm, _ ->
-            button(ScheduleLabel.REMOVE_SELECTED).performClick()
+    fun `remove-selected does nothing when nothing is selected`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            registeredActions(reports).removeSelected()
             waitForIdle()
 
             assertEquals(4, vm.scheduleItems.size, "no row is removed at random")

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabActionsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabActionsTest.kt
@@ -95,6 +95,30 @@ class ScheduleTabActionsTest {
         }
 
     @Test
+    fun `clicking a label row selects it, so the toolbar's remove can clear it too`() =
+        scheduleTab(seed = { seedService() }) { vm, _ ->
+            // "Welcome" is the label seedService() adds first. A label row used to skip its click
+            // handler entirely (nothing to select or present), which also meant it could never
+            // become the toolbar's selected row — this is the fix for that.
+            onNodeWithText("Welcome").performClick()
+            waitForIdle()
+            assertEquals(
+                vm.scheduleItems.first().id,
+                vm.selectedItemId,
+                "clicking a label row must select it, the same as any other row",
+            )
+
+            button(ScheduleLabel.REMOVE_SELECTED).performClick()
+            waitForIdle()
+
+            assertEquals(
+                listOf("42 - Amazing Grace", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+                "a selected label must be removable from the toolbar, not just its own row button",
+            )
+        }
+
+    @Test
     fun `the toolbar's remove does nothing when nothing is selected`() =
         scheduleTab(seed = { seedService() }) { vm, _ ->
             button(ScheduleLabel.REMOVE_SELECTED).performClick()

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabRowLayoutTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabRowLayoutTest.kt
@@ -1,0 +1,216 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Where a schedule row's parts actually land, at each density.
+ *
+ * Both invariants here are about geometry rather than content, and both were broken in the redesign
+ * in ways no existing test could see: every suite asserted on what a row *says*, and a row that says
+ * the right thing in the wrong place passes all of them.
+ *
+ *  * **The title sits on the row's centreline.** The content column is stretched to whichever
+ *    sibling is taller, and at Compact that is the action-button row — a single ~20dp title line
+ *    against ~30dp of buttons — so a top-aligned title sat visibly high in its own card. Normal and
+ *    Detailed masked it: their detail lines make the content column the taller sibling, so there is
+ *    no slack for it to sit at the top of.
+ *  * **The hover scrim covers the card.** The action strip's gradient is its own background, so it
+ *    is exactly as tall as the strip. Left at the buttons' ~30dp inside a 54dp Detailed card, it was
+ *    a band floating in the middle with the card's own background showing above and below it.
+ *
+ * The type chip is the reference for the centreline: it is laid out `CenterVertically` in the row,
+ * so its centre *is* the row's centre, and comparing against it needs no font metrics — which is
+ * what makes this safe across the three target platforms. The tolerance is 2dp-ish in pixels rather
+ * than exact, because a text line's own centre and a 26dp box's centre round differently.
+ */
+class ScheduleTabRowLayoutTest {
+
+    private companion object {
+        /** Compact / Normal / Detailed, as `scheduleDensityFor` resolves them. */
+        const val COMPACT = 70
+        const val NORMAL = 100
+        const val DETAILED = 150
+    }
+
+    /** A song row's own type chip, which is `CenterVertically` and so marks the row's centreline. */
+    private fun ComposeUiTest.chipCentreY(): Float =
+        onNodeWithText("♪").fetchSemanticsNode().boundsInRoot.center.y
+
+    private fun ComposeUiTest.titleCentreY(): Float =
+        onNodeWithText("Amazing Grace", substring = true).fetchSemanticsNode().boundsInRoot.center.y
+
+    private fun ComposeUiTest.assertTitleOnCentreline(density: String) {
+        val chip = chipCentreY()
+        val title = titleCentreY()
+
+        assertTrue(
+            abs(chip - title) <= 3f,
+            "$density: the title must sit on the row's centreline, not float above it " +
+                "(chip centre $chip, title centre $title)",
+        )
+    }
+
+    @Test
+    fun `the title is vertically centred at Compact`() =
+        scheduleTab(itemZoomPercent = COMPACT, seed = { addSong(songNumber = 42, title = "Amazing Grace", songbook = "Hymnal") }) { _, _ ->
+            // The regression: with the action buttons taller than the single title line, the
+            // stretched content column left the title at the top of its own card.
+            assertTitleOnCentreline("Compact")
+        }
+
+    @Test
+    fun `the type chip stays on the card's centreline at every density`() {
+        listOf(COMPACT to "Compact", NORMAL to "Normal", DETAILED to "Detailed").forEach { (percent, name) ->
+            scheduleTab(itemZoomPercent = percent, seed = { addSong(songNumber = 42, title = "Amazing Grace", songbook = "Hymnal") }) { _, _ ->
+                // The chip is the row's own alignment made visible: it is laid out
+                // `CenterVertically`, so if it drifts off the card's centre the row's height is
+                // coming from somewhere other than its content -- which is exactly what the
+                // intrinsic-height fix changed. Cheap insurance that the fix did not trade the
+                // Compact bug for a Detailed one.
+                val card = onNodeWithTag(SCHEDULE_ROW_CARD_TAG).fetchSemanticsNode().boundsInRoot
+                val chip = onNodeWithText("\u266a").fetchSemanticsNode().boundsInRoot
+
+                assertTrue(
+                    abs(chip.center.y - card.center.y) <= 3f,
+                    "$name: the type chip must stay on the card's centreline " +
+                        "(card centre ${card.center.y}, chip centre ${chip.center.y})",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `the hover action strip covers the whole card at every density`() {
+        listOf(COMPACT to "Compact", NORMAL to "Normal", DETAILED to "Detailed").forEach { (percent, name) ->
+            scheduleTab(itemZoomPercent = percent, seed = { addSong(songNumber = 42, title = "Amazing Grace", songbook = "Hymnal") }) { _, _ ->
+                val card = onNodeWithTag(SCHEDULE_ROW_CARD_TAG).fetchSemanticsNode().boundsInRoot
+                val actions = onNodeWithTag(SCHEDULE_ROW_ACTIONS_TAG).fetchSemanticsNode().boundsInRoot
+
+                // The strip carries the scrim as its background, so its height IS the scrim's. It
+                // sits inside the card's vertical padding, which is 4/7/9dp a side by density --
+                // hence "most of the card" rather than all of it. At the buttons' own ~30dp inside
+                // a 54dp+ Detailed card this was nowhere close.
+                assertTrue(
+                    actions.height >= card.height * 0.6f,
+                    "$name: the scrim must cover the card behind it, not float as a band in the " +
+                        "middle (card ${card.height}px, strip ${actions.height}px)",
+                )
+                assertTrue(
+                    abs(actions.center.y - card.center.y) <= 3f,
+                    "$name: and it must stay centred on the card (card centre ${card.center.y}, " +
+                        "strip centre ${actions.center.y})",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `every action button sits on the card's centreline`() {
+        listOf(COMPACT to "Compact", NORMAL to "Normal", DETAILED to "Detailed").forEach { (percent, name) ->
+            scheduleTab(itemZoomPercent = percent, seed = { addSong(songNumber = 42, title = "Amazing Grace", songbook = "Hymnal") }) { _, _ ->
+                // The play button used to be 30dp against the others' 27dp, and Row's
+                // CenterVertically did not rescue the mix: they came out sharing a bottom edge, so
+                // the four small ones sat ~1.5dp low. Visible as a wobble along the strip at
+                // Compact, where the card is barely taller than the buttons themselves.
+                val card = onNodeWithTag(SCHEDULE_ROW_CARD_TAG).fetchSemanticsNode().boundsInRoot
+                listOf(
+                    ScheduleLabel.MOVE_UP, ScheduleLabel.MOVE_DOWN, ScheduleLabel.NOTE,
+                    ScheduleLabel.REMOVE, ScheduleLabel.GO_LIVE,
+                ).forEach { label ->
+                    val button = onNodeWithContentDescription(label).fetchSemanticsNode().boundsInRoot
+                    assertTrue(
+                        abs(button.center.y - card.center.y) <= 1f,
+                        "$name: $label must sit on the card's centreline " +
+                            "(card ${card.center.y}, button ${button.center.y})",
+                    )
+                }
+            }
+        }
+    }
+
+    // ── A label is a heading, not a card ────────────────────────────────────────
+
+    @Test
+    fun `a label row is only as tall as its own text, at every density`() {
+        listOf(COMPACT to "Compact", NORMAL to "Normal", DETAILED to "Detailed").forEach { (percent, name) ->
+            scheduleTab(itemZoomPercent = percent, seed = {
+                addSong(songNumber = 1, title = "First Song", songbook = "Hymnal")
+                addLabel("WELCOME", "#FFFFFF", "#203040")
+            }) { _, _ ->
+                // It used to take the density's own row height and its full padding, so at
+                // Detailed one word sat in a 70dp band as tall as the items it heads.
+                val cards = onAllNodesWithTag(SCHEDULE_ROW_CARD_TAG).fetchSemanticsNodes().map { it.boundsInRoot }
+                val song = cards[0]
+                val label = cards[1]
+                val text = onNodeWithText("WELCOME").fetchSemanticsNode().boundsInRoot
+
+                assertTrue(
+                    label.height < song.height,
+                    "$name: a heading must be slimmer than the cards under it " +
+                        "(label ${label.height}px, song ${song.height}px)",
+                )
+                assertTrue(
+                    label.height - text.height <= 16f,
+                    "$name: and no taller than its own text needs (label ${label.height}px, " +
+                        "text ${text.height}px)",
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a label's own padding is even above and below its text`() =
+        scheduleTab(itemZoomPercent = NORMAL, seed = { addLabel("WELCOME", "#FFFFFF", "#203040") }) { _, _ ->
+            val card = onNodeWithTag(SCHEDULE_ROW_CARD_TAG).fetchSemanticsNode().boundsInRoot
+            val text = onNodeWithText("WELCOME").fetchSemanticsNode().boundsInRoot
+
+            val above = text.top - card.top
+            val below = card.bottom - text.bottom
+
+            assertTrue(abs(above - below) <= 1f, "the band must sit evenly around its text ($above above, $below below)")
+        }
+
+    // ── One note per item ───────────────────────────────────────────────────────
+
+    @Test
+    fun `a saved note is drawn once, not once per place that can draw it`() =
+        scheduleTab(seed = {
+            addSong(songNumber = 1, title = "First Song", songbook = "Hymnal")
+            setNote(scheduleItems[0].id, "bring the second verse down")
+        }) { _, _ ->
+            // Two previews were drawn on the same `note.isNotEmpty() && !noteExpanded` condition --
+            // an italic line under the title and the band below the card -- so every item carrying
+            // a note showed it twice.
+            assertEquals(
+                1,
+                onAllNodesWithText("bring the second verse down", substring = true).fetchSemanticsNodes().size,
+                "a note belongs in one place on its row",
+            )
+        }
+
+    @Test
+    fun `a label row is spaced like every other row`() =
+        scheduleTab(seed = {
+            addSong(songNumber = 1, title = "First Song", songbook = "Hymnal")
+            addLabel("WELCOME", "#FFFFFF", "#203040")
+            addSong(songNumber = 2, title = "Second Song", songbook = "Hymnal")
+        }) { _, _ ->
+            val cards = onAllNodesWithTag(SCHEDULE_ROW_CARD_TAG).fetchSemanticsNodes().map { it.boundsInRoot }
+            val above = cards[1].top - cards[0].bottom
+            val below = cards[2].top - cards[1].bottom
+
+            assertTrue(abs(above - below) <= 1f, "even above and below ($above / $below)")
+            assertTrue(above <= 4f, "and no roomier than the gap between two ordinary rows ($above)")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabTestSupport.kt
@@ -2,6 +2,8 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
@@ -11,7 +13,10 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import org.churchpresenter.app.churchpresenter.TestSingletons
@@ -67,6 +72,8 @@ internal class ScheduleReports {
 @OptIn(ExperimentalTestApi::class)
 internal fun scheduleTab(
     itemZoomPercent: Int = 100,
+    /** Constrains the panel, for the layout tests that need it narrow enough to wrap. */
+    width: Dp? = null,
     seed: ScheduleViewModel.() -> Unit = {},
     block: ComposeUiTest.(vm: ScheduleViewModel, reports: ScheduleReports) -> Unit,
 ) {
@@ -81,6 +88,7 @@ internal fun scheduleTab(
         runComposeUiTest {
             setContent {
                 MaterialTheme {
+                    Box(modifier = if (width != null) Modifier.width(width) else Modifier) {
                     ScheduleTab(
                         scheduleViewModel = vm,
                         itemZoomPercent = itemZoomPercent,
@@ -100,6 +108,7 @@ internal fun scheduleTab(
                         onPresentLowerThird = { reports.presented += it },
                         onPresentDictionary = { reports.presented += it },
                     )
+                    }
                 }
             }
             block(vm, reports)
@@ -171,7 +180,6 @@ internal object ScheduleLabel {
     const val UNDO = "Undo (Ctrl+Z)"
     const val REDO = "Redo (Ctrl+Shift+Z)"
     const val ADD_LABEL = "Add Label"
-    const val REMOVE_SELECTED = "Remove from Schedule"
     const val CLEAR = "Clear Schedule"
     const val ZOOM_IN = "Zoom In"
     const val ZOOM_OUT = "Zoom Out"

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabToolbarWrapTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabToolbarWrapTest.kt
@@ -1,0 +1,79 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * How the schedule toolbar behaves as the panel narrows.
+ *
+ * The panel is resizable and lives beside the tabs, so it is routinely dragged narrow mid-service.
+ * The toolbar's buttons used to sit in one fixed `Row` inside a pill: a `FlowRow` breaks between its
+ * items and never inside one, so the pill simply overflowed and clipped its own tail — the buttons
+ * past the edge were unreachable, with nothing to say they existed.
+ *
+ * What has to hold, in order of how it fails:
+ *
+ *  * **Nothing moves while it fits.** A toolbar that reflows early costs the operator the muscle
+ *    memory of where each icon is.
+ *  * **Then one icon at a time**, into the same pill rather than a second one — it stays one group.
+ *  * **Undo and Redo never split.** They read as one control; Redo alone at the start of a line
+ *    looks like a different thing.
+ *
+ * Rows are compared by `top`, not by exact pixels: the assertion is which line a button landed on,
+ * which is what an operator sees, and it survives the font metrics differing across platforms.
+ */
+class ScheduleTabToolbarWrapTest {
+
+    private val allButtons = listOf(
+        ScheduleLabel.NEW, "Open Schedule", "Save Schedule", ScheduleLabel.CLEAR,
+        ScheduleLabel.UNDO, ScheduleLabel.REDO, ScheduleLabel.ADD_LABEL,
+    )
+
+    private fun ComposeUiTest.rowOf(label: String): Float =
+        onNodeWithContentDescription(label).fetchSemanticsNode().boundsInRoot.top
+
+    @Test
+    fun `a wide panel keeps the whole toolbar on one line`() =
+        scheduleTab(seed = { seedService() }) { _, _ ->
+            val rows = allButtons.map { rowOf(it) }.distinct()
+
+            assertEquals(1, rows.size, "nothing may wrap while it fits: buttons landed on $rows")
+        }
+
+    @Test
+    fun `a narrow panel moves one icon at a time onto a second line`() =
+        scheduleTab(width = 200.dp, seed = { seedService() }) { _, _ ->
+            val rows = allButtons.map { rowOf(it) }
+
+            assertEquals(2, rows.distinct().size, "it must wrap rather than clip: $rows")
+            assertEquals(
+                1, rows.count { it == rows.max() },
+                "only the button that no longer fits moves down, not a whole group: $rows",
+            )
+        }
+
+    @Test
+    fun `a panel narrow enough to wrap still settles on two lines`() =
+        scheduleTab(width = 150.dp, seed = { seedService() }) { _, _ ->
+            // Clear sits with New/Open/Save rather than at the tail, which is what makes this fit
+            // in two: four file-level icons on the first line, four editing ones on the second.
+            // Ordered the old way, 150dp needed three.
+            assertEquals(2, allButtons.map { rowOf(it) }.distinct().size, "two lines, not three")
+        }
+
+    @Test
+    fun `undo and redo stay on the same line however narrow it gets`() =
+        scheduleTab(width = 130.dp, seed = { seedService() }) { _, _ ->
+            // 130dp is past what two lines can hold, which is where the pair would otherwise be
+            // split by the break.
+            assertTrue(allButtons.map { rowOf(it) }.distinct().size >= 3, "fixture must actually be cramped")
+
+            assertEquals(rowOf(ScheduleLabel.UNDO), rowOf(ScheduleLabel.REDO), "the pair must not be broken up")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoomTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoomTest.kt
@@ -12,6 +12,21 @@ import kotlin.test.assertTrue
  */
 class ScheduleZoomTest {
 
+    // ── The enum itself ────────────────────────────────────────────────────────
+
+    @Test fun `the ladder is Compact, Normal, Detailed in that order, at 70, 100, 150 percent`() {
+        assertEquals(
+            listOf(ScheduleDensity.COMPACT, ScheduleDensity.NORMAL, ScheduleDensity.DETAILED),
+            ScheduleDensity.entries,
+            "scheduleZoomIn/Out walk the ladder by ordinal, so the declared order IS the step order",
+        )
+        assertEquals(70, ScheduleDensity.COMPACT.percent)
+        assertEquals(100, ScheduleDensity.NORMAL.percent)
+        assertEquals(150, ScheduleDensity.DETAILED.percent)
+    }
+
+    // ── scheduleDensityFor ────────────────────────────────────────────────────
+
     @Test fun `a legacy low percent resolves to Compact`() {
         assertEquals(ScheduleDensity.COMPACT, scheduleDensityFor(70))
         assertEquals(ScheduleDensity.COMPACT, scheduleDensityFor(90))
@@ -29,17 +44,39 @@ class ScheduleZoomTest {
         assertEquals(ScheduleDensity.DETAILED, scheduleDensityFor(500))
     }
 
-    @Test fun `zooming in steps to the next rung up`() =
-        assertEquals(150, scheduleZoomIn(100))
+    @Test fun `percents at or below zero still resolve to Compact rather than throwing`() {
+        assertEquals(ScheduleDensity.COMPACT, scheduleDensityFor(0))
+        assertEquals(ScheduleDensity.COMPACT, scheduleDensityFor(-100))
+    }
 
-    @Test fun `zooming out steps to the next rung down`() =
-        assertEquals(70, scheduleZoomOut(100))
+    // ── scheduleZoomIn / scheduleZoomOut ─────────────────────────────────────
 
-    @Test fun `zooming in at the top rung stays put`() =
-        assertEquals(150, scheduleZoomIn(150))
+    @Test fun `zooming in steps to the next rung up, from every starting rung`() {
+        assertEquals(100, scheduleZoomIn(70), "Compact -> Normal")
+        assertEquals(150, scheduleZoomIn(100), "Normal -> Detailed")
+        assertEquals(150, scheduleZoomIn(150), "Detailed is the top rung, so it stays put")
+    }
 
-    @Test fun `zooming out at the bottom rung stays put`() =
-        assertEquals(70, scheduleZoomOut(70))
+    @Test fun `zooming out steps to the next rung down, from every starting rung`() {
+        assertEquals(70, scheduleZoomOut(70), "Compact is the bottom rung, so it stays put")
+        assertEquals(70, scheduleZoomOut(100), "Normal -> Compact")
+        assertEquals(100, scheduleZoomOut(150), "Detailed -> Normal")
+    }
+
+    @Test fun `zooming steps by rung, not by the raw legacy percent`() {
+        // 80 and 140 are legacy values that resolve to Compact and Detailed respectively, but
+        // neither is one of the ladder's own three percents — the step must still land exactly on
+        // the neighbouring rung's percent, not drift from the raw input.
+        assertEquals(100, scheduleZoomIn(80), "a legacy Compact-range percent still steps to Normal's 100")
+        assertEquals(100, scheduleZoomOut(140), "a legacy Detailed-range percent still steps to Normal's 100")
+    }
+
+    @Test fun `zooming in then out from the middle rung returns to where it started`() {
+        assertEquals(100, scheduleZoomOut(scheduleZoomIn(100)))
+        assertEquals(100, scheduleZoomIn(scheduleZoomOut(100)))
+    }
+
+    // ── scheduleCanZoomIn / scheduleCanZoomOut ───────────────────────────────
 
     @Test fun `can-zoom flags respect the ladder ends`() {
         assertFalse(scheduleCanZoomOut(70), "already at Compact")
@@ -47,6 +84,13 @@ class ScheduleZoomTest {
         assertFalse(scheduleCanZoomIn(150), "already at Detailed")
         assertTrue(scheduleCanZoomOut(150))
     }
+
+    @Test fun `both can-zoom flags are true in the middle rung`() {
+        assertTrue(scheduleCanZoomIn(100), "Normal can still step up to Detailed")
+        assertTrue(scheduleCanZoomOut(100), "Normal can still step down to Compact")
+    }
+
+    // ── Display flags ─────────────────────────────────────────────────────────
 
     @Test fun `Compact hides the detail line, Normal and Detailed show it`() {
         assertFalse(scheduleShowDetailLine(70))

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoomTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoomTest.kt
@@ -6,23 +6,33 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * The schedule card density ladder: Compact / Normal / Detailed. Pins the rung resolution (so a
- * value saved under the old continuous zoom still lands on a sensible rung), the clamped step, and
- * which rungs show the detail line vs the kind chip.
+ * The schedule card density ladder: Compact / Normal / Detailed, plus one rung smaller and one
+ * larger than those. Pins the rung resolution (so a value saved under the old continuous zoom still
+ * lands on a sensible rung), the clamped step, and which rungs show the detail line vs the kind
+ * chip.
+ *
+ * The three original rungs keep their percents and their bands, so nothing anyone has already saved
+ * moves when the ladder grows at the ends. The outer two are only reachable by stepping past what
+ * used to be the end.
  */
 class ScheduleZoomTest {
 
     // ── The enum itself ────────────────────────────────────────────────────────
 
-    @Test fun `the ladder is Compact, Normal, Detailed in that order, at 70, 100, 150 percent`() {
+    @Test fun `the ladder runs smallest to largest, with the original three unmoved`() {
         assertEquals(
-            listOf(ScheduleDensity.COMPACT, ScheduleDensity.NORMAL, ScheduleDensity.DETAILED),
+            listOf(
+                ScheduleDensity.EXTRA_COMPACT, ScheduleDensity.COMPACT, ScheduleDensity.NORMAL,
+                ScheduleDensity.DETAILED, ScheduleDensity.EXTRA_DETAILED,
+            ),
             ScheduleDensity.entries,
             "scheduleZoomIn/Out walk the ladder by ordinal, so the declared order IS the step order",
         )
-        assertEquals(70, ScheduleDensity.COMPACT.percent)
+        assertEquals(55, ScheduleDensity.EXTRA_COMPACT.percent)
+        assertEquals(70, ScheduleDensity.COMPACT.percent, "unchanged, so a saved 70 still means Compact")
         assertEquals(100, ScheduleDensity.NORMAL.percent)
         assertEquals(150, ScheduleDensity.DETAILED.percent)
+        assertEquals(200, ScheduleDensity.EXTRA_DETAILED.percent)
     }
 
     // ── scheduleDensityFor ────────────────────────────────────────────────────
@@ -39,28 +49,41 @@ class ScheduleZoomTest {
     }
 
     @Test fun `a legacy high percent resolves to Detailed`() {
+        // 150 was the top of the old scheme, so everything a user could have saved lands here
+        // rather than on the new rung above it.
         assertEquals(ScheduleDensity.DETAILED, scheduleDensityFor(120))
         assertEquals(ScheduleDensity.DETAILED, scheduleDensityFor(150))
-        assertEquals(ScheduleDensity.DETAILED, scheduleDensityFor(500))
+        assertEquals(ScheduleDensity.DETAILED, scheduleDensityFor(175))
     }
 
-    @Test fun `percents at or below zero still resolve to Compact rather than throwing`() {
-        assertEquals(ScheduleDensity.COMPACT, scheduleDensityFor(0))
-        assertEquals(ScheduleDensity.COMPACT, scheduleDensityFor(-100))
+    @Test fun `the outer rungs resolve past the old scheme's ends`() {
+        assertEquals(ScheduleDensity.EXTRA_DETAILED, scheduleDensityFor(200))
+        assertEquals(ScheduleDensity.EXTRA_DETAILED, scheduleDensityFor(500))
+        assertEquals(ScheduleDensity.EXTRA_COMPACT, scheduleDensityFor(55))
+        assertEquals(ScheduleDensity.EXTRA_COMPACT, scheduleDensityFor(60))
+    }
+
+    @Test fun `percents at or below zero still resolve to the smallest rung rather than throwing`() {
+        assertEquals(ScheduleDensity.EXTRA_COMPACT, scheduleDensityFor(0))
+        assertEquals(ScheduleDensity.EXTRA_COMPACT, scheduleDensityFor(-100))
     }
 
     // ── scheduleZoomIn / scheduleZoomOut ─────────────────────────────────────
 
     @Test fun `zooming in steps to the next rung up, from every starting rung`() {
+        assertEquals(70, scheduleZoomIn(55), "the smallest rung -> Compact")
         assertEquals(100, scheduleZoomIn(70), "Compact -> Normal")
         assertEquals(150, scheduleZoomIn(100), "Normal -> Detailed")
-        assertEquals(150, scheduleZoomIn(150), "Detailed is the top rung, so it stays put")
+        assertEquals(200, scheduleZoomIn(150), "Detailed -> the largest rung")
+        assertEquals(200, scheduleZoomIn(200), "the largest rung is the top, so it stays put")
     }
 
     @Test fun `zooming out steps to the next rung down, from every starting rung`() {
-        assertEquals(70, scheduleZoomOut(70), "Compact is the bottom rung, so it stays put")
+        assertEquals(55, scheduleZoomOut(55), "the smallest rung is the bottom, so it stays put")
+        assertEquals(55, scheduleZoomOut(70), "Compact -> the smallest rung")
         assertEquals(70, scheduleZoomOut(100), "Normal -> Compact")
         assertEquals(100, scheduleZoomOut(150), "Detailed -> Normal")
+        assertEquals(150, scheduleZoomOut(200), "the largest rung -> Detailed")
     }
 
     @Test fun `zooming steps by rung, not by the raw legacy percent`() {
@@ -79,10 +102,14 @@ class ScheduleZoomTest {
     // ── scheduleCanZoomIn / scheduleCanZoomOut ───────────────────────────────
 
     @Test fun `can-zoom flags respect the ladder ends`() {
-        assertFalse(scheduleCanZoomOut(70), "already at Compact")
-        assertTrue(scheduleCanZoomIn(70))
-        assertFalse(scheduleCanZoomIn(150), "already at Detailed")
-        assertTrue(scheduleCanZoomOut(150))
+        // These are what grey out the -/+ controls, so they have to move with the ladder's ends
+        // rather than stay pinned to Compact and Detailed.
+        assertFalse(scheduleCanZoomOut(55), "already at the smallest rung")
+        assertTrue(scheduleCanZoomIn(55))
+        assertFalse(scheduleCanZoomIn(200), "already at the largest rung")
+        assertTrue(scheduleCanZoomOut(200))
+        assertTrue(scheduleCanZoomOut(70), "Compact is no longer the bottom")
+        assertTrue(scheduleCanZoomIn(150), "Detailed is no longer the top")
     }
 
     @Test fun `both can-zoom flags are true in the middle rung`() {
@@ -92,15 +119,19 @@ class ScheduleZoomTest {
 
     // ── Display flags ─────────────────────────────────────────────────────────
 
-    @Test fun `Compact hides the detail line, Normal and Detailed show it`() {
+    @Test fun `the two smallest rungs hide the detail line, the rest show it`() {
+        assertFalse(scheduleShowDetailLine(55))
         assertFalse(scheduleShowDetailLine(70))
         assertTrue(scheduleShowDetailLine(100))
         assertTrue(scheduleShowDetailLine(150))
+        assertTrue(scheduleShowDetailLine(200))
     }
 
-    @Test fun `only Detailed shows the kind chip`() {
+    @Test fun `only the two largest rungs show the kind chip`() {
+        assertFalse(scheduleShowKindDetails(55))
         assertFalse(scheduleShowKindDetails(70))
         assertFalse(scheduleShowKindDetails(100))
         assertTrue(scheduleShowKindDetails(150))
+        assertTrue(scheduleShowKindDetails(200))
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoomTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ScheduleZoomTest.kt
@@ -6,29 +6,34 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * The schedule card zoom ladder. Zoom snaps to fixed rungs and the two rungs just below 100 strip
- * the card (drop actions, then collapse to one line) before it shrinks. These pin the rung math,
- * the clamped step, and the two shed/collapse thresholds.
+ * The schedule card density ladder: Compact / Normal / Detailed. Pins the rung resolution (so a
+ * value saved under the old continuous zoom still lands on a sensible rung), the clamped step, and
+ * which rungs show the detail line vs the kind chip.
  */
 class ScheduleZoomTest {
 
-    @Test fun `an exact percent resolves to its own rung`() =
-        assertEquals(5, nearestZoomIndex(100)) // ZOOM_LEVELS[5] == 100
+    @Test fun `a legacy low percent resolves to Compact`() {
+        assertEquals(ScheduleDensity.COMPACT, scheduleDensityFor(70))
+        assertEquals(ScheduleDensity.COMPACT, scheduleDensityFor(90))
+    }
 
-    @Test fun `a between-rungs percent resolves to the nearest rung`() =
-        assertEquals(1, nearestZoomIndex(84)) // closer to 80 than 90
+    @Test fun `a legacy mid percent resolves to Normal`() {
+        assertEquals(ScheduleDensity.NORMAL, scheduleDensityFor(100))
+        assertEquals(ScheduleDensity.NORMAL, scheduleDensityFor(91))
+        assertEquals(ScheduleDensity.NORMAL, scheduleDensityFor(119))
+    }
 
-    @Test fun `a percent below the ladder resolves to the lowest rung`() =
-        assertEquals(0, nearestZoomIndex(40))
-
-    @Test fun `a percent above the ladder resolves to the highest rung`() =
-        assertEquals(ZOOM_LEVELS.lastIndex, nearestZoomIndex(500))
+    @Test fun `a legacy high percent resolves to Detailed`() {
+        assertEquals(ScheduleDensity.DETAILED, scheduleDensityFor(120))
+        assertEquals(ScheduleDensity.DETAILED, scheduleDensityFor(150))
+        assertEquals(ScheduleDensity.DETAILED, scheduleDensityFor(500))
+    }
 
     @Test fun `zooming in steps to the next rung up`() =
-        assertEquals(110, scheduleZoomIn(100))
+        assertEquals(150, scheduleZoomIn(100))
 
     @Test fun `zooming out steps to the next rung down`() =
-        assertEquals(99, scheduleZoomOut(100))
+        assertEquals(70, scheduleZoomOut(100))
 
     @Test fun `zooming in at the top rung stays put`() =
         assertEquals(150, scheduleZoomIn(150))
@@ -37,21 +42,21 @@ class ScheduleZoomTest {
         assertEquals(70, scheduleZoomOut(70))
 
     @Test fun `can-zoom flags respect the ladder ends`() {
-        assertFalse(scheduleCanZoomOut(70), "already at the smallest rung")
+        assertFalse(scheduleCanZoomOut(70), "already at Compact")
         assertTrue(scheduleCanZoomIn(70))
-        assertFalse(scheduleCanZoomIn(150), "already at the largest rung")
+        assertFalse(scheduleCanZoomIn(150), "already at Detailed")
         assertTrue(scheduleCanZoomOut(150))
     }
 
-    @Test fun `card actions show at full size and hide just below it`() {
-        assertTrue(scheduleShowCardActions(100))
-        assertTrue(scheduleShowCardActions(110))
-        assertFalse(scheduleShowCardActions(99))
+    @Test fun `Compact hides the detail line, Normal and Detailed show it`() {
+        assertFalse(scheduleShowDetailLine(70))
+        assertTrue(scheduleShowDetailLine(100))
+        assertTrue(scheduleShowDetailLine(150))
     }
 
-    @Test fun `cards collapse to a single line at or below the collapse rung`() {
-        assertTrue(scheduleSingleLineCards(98))
-        assertTrue(scheduleSingleLineCards(70))
-        assertFalse(scheduleSingleLineCards(99))
+    @Test fun `only Detailed shows the kind chip`() {
+        assertFalse(scheduleShowKindDetails(70))
+        assertFalse(scheduleShowKindDetails(100))
+        assertTrue(scheduleShowKindDetails(150))
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/UtilsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/UtilsTest.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.utils
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import java.util.Locale
+import kotlin.math.abs
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -108,6 +109,76 @@ class UtilsSystemTest {
         assertTrue(
             Utils.systemFontFamilyOrDefault("") != FontFamily.Default,
             "if this now equals FontFamily.Default, the fallback became reachable — update this test",
+        )
+    }
+}
+
+/**
+ * [Utils.contrastRatio] and [Utils.ensureContrast] back the WCAG-driven text-color fallback
+ * `ScheduleTab` applies to a section label's own user-chosen text/background pair — the only two
+ * callers of [Utils.contrastRatio] in the app, and previously with no direct test of their own
+ * (`ThemeTest` re-derives the same WCAG math independently for its theme-palette checks, rather
+ * than exercising this code). The ratio math is [private] `relativeLuminance`, reached only through
+ * these two public functions.
+ */
+class UtilsContrastTest {
+
+    private fun assertApprox(expected: Double, actual: Double, tolerance: Double = 0.01) =
+        assertTrue(abs(expected - actual) <= tolerance, "expected ~$expected, was $actual")
+
+    // ── contrastRatio ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `black on white is the maximum WCAG ratio, 21 to 1`() =
+        assertApprox(21.0, Utils.contrastRatio(Color.Black, Color.White))
+
+    @Test
+    fun `a color against itself has the minimum ratio, 1 to 1`() {
+        assertApprox(1.0, Utils.contrastRatio(Color.Red, Color.Red))
+        assertApprox(1.0, Utils.contrastRatio(Color.White, Color.White))
+    }
+
+    @Test
+    fun `the ratio is symmetric regardless of argument order`() {
+        val ab = Utils.contrastRatio(Color.Red, Color.Blue)
+        val ba = Utils.contrastRatio(Color.Blue, Color.Red)
+        assertApprox(ab, ba)
+    }
+
+    // ── ensureContrast ────────────────────────────────────────────────────────
+
+    @Test
+    fun `a foreground that already meets the minimum ratio is returned unchanged`() {
+        // Black on white comfortably clears the 4.5 default, so ensureContrast must be a no-op —
+        // never silently replacing a color pair the caller's own choice already satisfies.
+        assertEquals(Color.Black, Utils.ensureContrast(Color.Black, Color.White))
+    }
+
+    @Test
+    fun `a foreground that fails the ratio is replaced by whichever of white or black contrasts better`() {
+        // White text on white background has nowhere near enough contrast; black is the obvious
+        // rescue, so this also confirms the substitution actually engages rather than passing the
+        // original color through by accident.
+        assertEquals(Color.Black, Utils.ensureContrast(Color.White, Color.White))
+        // A near-black foreground on a black background is the mirror case: white must win.
+        assertEquals(Color.White, Utils.ensureContrast(Color(0x22, 0x22, 0x22), Color.Black))
+    }
+
+    @Test
+    fun `minRatio changes the outcome for a pair that clears AA but not AAA`() {
+        // Medium green (#008000) on white measures ~5.1:1 — above the 4.5 default (AA) but below
+        // the stricter 7.0 ScheduleTab uses for its label text (AAA), so the same pair must resolve
+        // two different ways depending on which threshold is asked for.
+        val green = Color(0, 128, 0)
+        assertEquals(
+            green,
+            Utils.ensureContrast(green, Color.White, minRatio = 4.5),
+            "5.1:1 clears the default AA threshold, so the original color must come back untouched",
+        )
+        assertEquals(
+            Color.Black,
+            Utils.ensureContrast(green, Color.White, minRatio = 7.0),
+            "the same 5.1:1 pair fails AAA, so it must fall back to whichever of white/black wins — black, on white",
         )
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplayTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleItemDisplayTest.kt
@@ -1,5 +1,16 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
+import churchpresenter.composeapp.generated.resources.Res
+import churchpresenter.composeapp.generated.resources.announcements
+import churchpresenter.composeapp.generated.resources.bible
+import churchpresenter.composeapp.generated.resources.media_tab_title
+import churchpresenter.composeapp.generated.resources.pictures
+import churchpresenter.composeapp.generated.resources.presentation
+import churchpresenter.composeapp.generated.resources.schedule_kind_lower_third
+import churchpresenter.composeapp.generated.resources.songs
+import churchpresenter.composeapp.generated.resources.tab_canvas
+import churchpresenter.composeapp.generated.resources.tab_dictionary
+import churchpresenter.composeapp.generated.resources.tab_web
 import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import kotlin.test.Test
@@ -36,6 +47,59 @@ class ScheduleItemDisplayTest {
             assertEquals(glyph, scheduleItemGlyph(item), item::class.simpleName)
         }
     }
+
+    // ── palette index (exhaustive over the sealed type) ────────────────────────
+
+    @Test
+    fun `every schedule item type resolves to its declared palette slot`() {
+        val cases = listOf(
+            ScheduleItem.SongItem(id = "1", songNumber = 1, title = "t", songbook = "b") to 0,
+            ScheduleItem.BibleVerseItem(id = "2", bookName = "John", chapter = 3, verseNumber = 16, verseText = "x") to 1,
+            ScheduleItem.PresentationItem(id = "3", filePath = "/d.pptx", fileName = "d", slideCount = 1, fileType = "pptx") to 2,
+            ScheduleItem.PictureItem(id = "4", folderPath = "/p", folderName = "p", imageCount = 1) to 3,
+            ScheduleItem.MediaItem(id = "5", mediaUrl = "/m.mp4", mediaTitle = "m", mediaType = "local") to 0,
+            ScheduleItem.LowerThirdItem(id = "6", presetId = "p", presetLabel = "p", pauseAtFrame = false, pauseDurationMs = 0L) to 1,
+            ScheduleItem.AnnouncementItem(id = "7", text = "a") to 2,
+            ScheduleItem.WebsiteItem(id = "8", url = "https://x") to 3,
+            ScheduleItem.SceneItem(id = "9", sceneId = "s", sceneName = "s") to 0,
+            ScheduleItem.DictionaryItem(id = "10", number = "1", word = "w", transliteration = "t", definition = "d") to 1,
+            ScheduleItem.LabelItem(id = "11", text = "l", textColor = "#fff", backgroundColor = "#000") to 0,
+        )
+        for ((item, index) in cases) {
+            assertEquals(index, scheduleItemPaletteIndex(item), item::class.simpleName)
+        }
+    }
+
+    // ── kind label (exhaustive over the sealed type) ────────────────────────────
+
+    @Test
+    fun `every schedule item type maps to its own tab's string resource`() {
+        val cases = listOf(
+            ScheduleItem.SongItem(id = "1", songNumber = 1, title = "t", songbook = "b") to Res.string.songs,
+            ScheduleItem.BibleVerseItem(id = "2", bookName = "John", chapter = 3, verseNumber = 16, verseText = "x") to Res.string.bible,
+            ScheduleItem.PresentationItem(id = "3", filePath = "/d.pptx", fileName = "d", slideCount = 1, fileType = "pptx") to Res.string.presentation,
+            ScheduleItem.PictureItem(id = "4", folderPath = "/p", folderName = "p", imageCount = 1) to Res.string.pictures,
+            ScheduleItem.MediaItem(id = "5", mediaUrl = "/m.mp4", mediaTitle = "m", mediaType = "local") to Res.string.media_tab_title,
+            ScheduleItem.LowerThirdItem(id = "6", presetId = "p", presetLabel = "p", pauseAtFrame = false, pauseDurationMs = 0L) to Res.string.schedule_kind_lower_third,
+            ScheduleItem.AnnouncementItem(id = "7", text = "a") to Res.string.announcements,
+            ScheduleItem.WebsiteItem(id = "8", url = "https://x") to Res.string.tab_web,
+            ScheduleItem.SceneItem(id = "9", sceneId = "s", sceneName = "s") to Res.string.tab_canvas,
+            ScheduleItem.DictionaryItem(id = "10", number = "1", word = "w", transliteration = "t", definition = "d") to Res.string.tab_dictionary,
+        )
+        for ((item, resource) in cases) {
+            assertEquals(resource, scheduleItemKindLabel(item), item::class.simpleName)
+        }
+    }
+
+    @Test
+    fun `LabelItem's kind label is unused but still resolves without throwing`() =
+        // LabelItem renders as a section header, never through this chip, but the function stays
+        // exhaustive over the sealed type — this pins that the placeholder branch is at least
+        // harmless if a future refactor ever did reach it.
+        assertEquals(
+            Res.string.songs,
+            scheduleItemKindLabel(ScheduleItem.LabelItem(id = "1", text = "l", textColor = "#fff", backgroundColor = "#000")),
+        )
 
     // ── detail line ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
<img width="368" height="771" alt="Screenshot 2026-07-31 at 6 55 40 AM" src="https://github.com/user-attachments/assets/5ecec4f7-ebe8-4ad8-bcb6-9892937cccbe" />
<img width="362" height="682" alt="Screenshot 2026-07-31 at 6 55 49 AM" src="https://github.com/user-attachments/assets/572a74bc-3c16-4dc9-a9dc-3409c950e2bb" />
<img width="361" height="763" alt="Screenshot 2026-07-31 at 6 55 55 AM" src="https://github.com/user-attachments/assets/d2dd75d9-eecd-4fc9-a705-335f25954692" />
