### PR TITLE
Cover the schedule reorder drag, and record the stale-build rule

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -93,6 +93,10 @@ Presentation deps in `composeApp/build.gradle.kts` are mirrored in
 bash cleanup_check.sh                  # repo code-quality report
 ```
 
+A failure that makes no sense — unresolved references to symbols that exist, unrelated suites
+failing, a `NoClassDefFoundError` at runtime — is a stale build. `clean` does not clear it;
+`--rerun-tasks` does.
+
 Presentation Engine tooling (from that module's root):
 ```bash
 ./gradlew test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabReorderDragTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabReorderDragTest.kt
@@ -1,0 +1,126 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performMouseInput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Dragging a schedule row by its grip to reorder it.
+ *
+ * This is the gesture behind the fatal `NoClassDefFoundError: DragItemGeometry` of 2026-07-31: the
+ * `Move` branch builds a `DragItemGeometry` per visible row to hit-test the drop target, and it was
+ * the first line to touch a class the running build's output was missing. The source was never
+ * wrong — the class had been on `main` since 25 July — so the crash was a stale compile, not a
+ * defect. This test is what makes that distinction cheap to re-check: it runs the same branch in
+ * process, so a build that could not load the class fails here rather than under someone's mouse.
+ *
+ * It is driven through the **grip dots**, not the row body. The body's copy of the gesture takes
+ * `requireShift = true` and a test cannot set `keyboardModifiers` on an injected pointer event —
+ * the same blocker `PicturesTab`'s reorder is recorded as having. The grip's copy takes
+ * `requireShift = false`, which is what makes this reachable at all.
+ *
+ * The gesture arms only after the pointer has travelled `DRAG_HANDLE_THRESHOLD` (4dp), and it arms
+ * on the iteration *after* the move that crosses it, so the drag is injected as several small steps
+ * rather than one jump: the first couple arm it, the rest move the cursor far enough to change the
+ * drop target. `moveItem` is asserted on the view model, not on the screen, because the row order
+ * is what a service actually runs on.
+ */
+class ScheduleTabReorderDragTest {
+
+    /** The grip sits just inside the card's left edge: 3dp row padding, a 3dp accent bar, 5dp gap. */
+    private fun ComposeUiTest.gripOf(cardIndex: Int): Offset {
+        val card = onAllNodesWithTag(SCHEDULE_ROW_CARD_TAG).fetchSemanticsNodes()[cardIndex].boundsInRoot
+        return Offset(card.left + 13f, card.center.y)
+    }
+
+    private fun ComposeUiTest.cardHeight(): Float =
+        onAllNodesWithTag(SCHEDULE_ROW_CARD_TAG).fetchSemanticsNodes()[0].boundsInRoot.height
+
+    /** Presses [from]'s grip and drags [dy] pixels in eight steps, ending with a release. */
+    private fun ComposeUiTest.dragRow(from: Int, dy: Float) {
+        val start = gripOf(from)
+        onRoot().performMouseInput {
+            moveTo(start)
+            press()
+            repeat(8) { step -> moveTo(Offset(start.x, start.y + dy * (step + 1) / 8f)) }
+            release()
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun `dragging a row down by its grip moves it past its neighbour`() =
+        scheduleTab(seed = {
+            addSong(songNumber = 1, title = "First Song", songbook = "Hymnal")
+            addSong(songNumber = 2, title = "Second Song", songbook = "Hymnal")
+            addSong(songNumber = 3, title = "Third Song", songbook = "Hymnal")
+        }) { vm, _ ->
+            val step = cardHeight() + 3f
+
+            dragRow(from = 0, dy = step * 1.5f)
+
+            assertEquals(
+                listOf("2 - Second Song", "1 - First Song", "3 - Third Song"),
+                vm.scheduleItems.map { it.displayText },
+                "the dragged row must land below the one it was dragged past",
+            )
+        }
+
+    @Test
+    fun `a grip press that goes nowhere leaves the order alone`() =
+        scheduleTab(seed = {
+            addSong(songNumber = 1, title = "First Song", songbook = "Hymnal")
+            addSong(songNumber = 2, title = "Second Song", songbook = "Hymnal")
+        }) { vm, _ ->
+            // Under the 4dp arming threshold: a click on the grip is not a drag, and must not
+            // reorder anything.
+            dragRow(from = 0, dy = 2f)
+
+            assertEquals(
+                listOf("1 - First Song", "2 - Second Song"),
+                vm.scheduleItems.map { it.displayText },
+                "a press that never armed must not move a row",
+            )
+        }
+
+    @Test
+    fun `the grip keeps working on the second and third drag`() =
+        scheduleTab(seed = {
+            addSong(songNumber = 1, title = "First Song", songbook = "Hymnal")
+            addSong(songNumber = 2, title = "Second Song", songbook = "Hymnal")
+            addSong(songNumber = 3, title = "Third Song", songbook = "Hymnal")
+        }) { vm, _ ->
+            // The failure mode this repo has hit before on drag handles: a `pointerInput` keyed on
+            // something the gesture itself rewrites tears its coroutine down at the end of every
+            // drag, so the first one works and the rest do not (see the schedule splitter's own
+            // comment in MainDesktop.kt). One drag can never see it; three can.
+            val step = cardHeight() + 3f
+
+            dragRow(from = 0, dy = step * 1.5f)
+            assertEquals(
+                listOf("2 - Second Song", "1 - First Song", "3 - Third Song"),
+                vm.scheduleItems.map { it.displayText },
+                "first drag",
+            )
+
+            dragRow(from = 0, dy = step * 1.5f)
+            assertEquals(
+                listOf("1 - First Song", "2 - Second Song", "3 - Third Song"),
+                vm.scheduleItems.map { it.displayText },
+                "second drag -- the one that used to stop working",
+            )
+
+            dragRow(from = 1, dy = step * 1.5f)
+            assertEquals(
+                listOf("1 - First Song", "3 - Third Song", "2 - Second Song"),
+                vm.scheduleItems.map { it.displayText },
+                "third drag, from a different row",
+            )
+        }
+}


### PR DESCRIPTION
Comes out of investigating Sentry `c0745264` — a fatal `NoClassDefFoundError: DragItemGeometry` at `ScheduleTab.kt:474`, in the reorder drag's `Move` branch.

**That crash was not a defect.** The local report names the running build (`26.6.79 (6b0b537a)`), and `ScheduleDragMath.kt` is in that commit's tree and has been on `main` since 25 July. The source was complete; the *compiled output* the app ran from was missing the class, so `ScheduleTab` was loaded against a class that had never been written. Nothing in the build can remove it either — proguard is `isEnabled.set(false)`, `includeAllModules = true`, no jar filtering, same source set as its only caller.

Verified fixed rather than assumed: `clean` + `jvmJar --rerun-tasks` puts `DragItemGeometry.class` in both `build/classes` and the jar, and `check --rerun-tasks` is green.

## What this adds

**`ScheduleTabReorderDragTest`** — the gesture had no test at all. Every existing schedule suite asserts on what a row *says*, so the `Move` branch that builds a `DragItemGeometry` per visible row had never been executed by anything but a mouse. That is how a build missing the class reached a person instead of a test run.

It is driven through the **grip dots**. The row body's copy of the gesture takes `requireShift = true`, and a test cannot set `keyboardModifiers` on an injected pointer event — the blocker `PicturesTab`'s reorder is recorded as having. The grip's copy does not, which is what makes this reachable. Mutation-checked: flipping the grip to `requireShift = true` fails all three tests, so they are not passing vacuously.

**Three drags, not one.** The failure this repo has hit before on drag handles is a `pointerInput` keyed on something the gesture itself rewrites, tearing its coroutine down at the end of every drag so the first works and the rest do not — see the schedule splitter's own comment in `MainDesktop.kt:1618`. A single drag can never see it. The third comes from a different row.

This also closes the reorder gesture the coverage notes had recorded as "reachable in principle … not attempted".

**`AGENT.md`** gets the rule that cost the time, and only the rule — three lines under Commands: a failure that makes no sense is a stale build, `clean` does not clear it, `--rerun-tasks` does. No narrative; that file bans them.

## Not covered, and worth knowing

The **sidebar splitters** — `MainDesktop.kt:1623` and `:2028` — still have no tests, and `MainDesktop.kt` is 0% and excluded from the gate. They are where the historical drag-handle bug actually happened. A follow-up PR lifts them into a testable composable.

## Checks

`./gradlew :composeApp:check --rerun-tasks` green — 6,735 tests, 75.4%. The new suite run three times with `--rerun-tasks`; 1.30s + 0.07s + 0.10s, the first being the usual one-off Compose warm-up.