### PR TITLE
Lift the sidebar splitters out of MainDesktop and test their drag

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
@@ -99,6 +99,8 @@ import kotlinx.coroutines.withContext
 import androidx.compose.ui.graphics.toComposeImageBitmap
 
 import org.churchpresenter.app.churchpresenter.composables.ConnectionStatusRow
+import org.churchpresenter.app.churchpresenter.composables.PanelResizeHandle
+import org.churchpresenter.app.churchpresenter.composables.resizedPanelWidth
 import org.churchpresenter.app.churchpresenter.composables.isVlcAvailable
 import org.churchpresenter.app.churchpresenter.composables.rememberTokenGate
 import org.churchpresenter.app.churchpresenter.composables.LivePreviewPanel
@@ -1610,71 +1612,34 @@ fun MainDesktop(
                 } // end if (schedule panel visible)
 
                 // Drag handle + collapse toggle between schedule and main content
-                Box(
-                    modifier = Modifier
-                        .width(16.dp)
-                        .fillMaxHeight()
-                        .background(MaterialTheme.colorScheme.surfaceVariant)
-                        // Keyed only on scheduleCollapsed (not the persisted width, which
-                        // saveScheduleWidth() rewrites at the end of every drag) — otherwise
-                        // this coroutine gets torn down and relaunched after every gesture,
-                        // which is what made the second drag onward unreliable. Matches the
-                        // working pattern in SongsTab.kt's column-resize handles.
-                        .pointerInput(scheduleCollapsed) {
-                            if (!scheduleCollapsed) {
-                                detectHorizontalDragGestures(
-                                    onDragEnd = ::saveScheduleWidth
-                                ) { _, amount ->
-                                    val cap = maxScheduleState.value
-                                    schedulePanelPx = (schedulePanelPx + amount).coerceIn(
-                                        minOf(with(density) { 160.dp.toPx() }, cap),
-                                        cap
-                                    )
-                                }
-                            }
-                        }
-                        .pointerHoverIcon(
-                            if (scheduleCollapsed) PointerIcon.Default
-                            else PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR))
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (!scheduleCollapsed) {
-                        val dotColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
-                        Column(
-                            modifier = Modifier.align(Alignment.TopCenter).padding(top = 8.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) { repeat(3) { Box(Modifier.size(3.dp).background(dotColor, CircleShape)) } }
-                        Column(
-                            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) { repeat(3) { Box(Modifier.size(3.dp).background(dotColor, CircleShape)) } }
-                    }
-                    IconButton(
-                        onClick = {
-                            scheduleCollapsed = !scheduleCollapsed
-                            onSettingsChangeState.value { s ->
-                                if (isMaximized) s.copy(maximizedLayout = s.maximizedLayout.copy(schedulePanelCollapsed = scheduleCollapsed))
-                                else s.copy(windowedLayout = s.windowedLayout.copy(schedulePanelCollapsed = scheduleCollapsed))
-                            }
-                        },
-                        modifier = Modifier.wrapContentHeight()
-                    ) {
-                        Icon(
-                            painter = painterResource(
-                                if (scheduleCollapsed) Res.drawable.ic_arrow_right
-                                else Res.drawable.ic_arrow_left
-                            ),
-                            contentDescription = stringResource(
-                                if (scheduleCollapsed) Res.string.tooltip_expand_schedule
-                                else Res.string.tooltip_collapse_schedule
-                            ),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                PanelResizeHandle(
+                    collapsed = scheduleCollapsed,
+                    onResize = { amount ->
+                        val cap = maxScheduleState.value
+                        schedulePanelPx = resizedPanelWidth(
+                            currentPx = schedulePanelPx,
+                            dragAmount = amount,
+                            invert = false,
+                            minPx = with(density) { 160.dp.toPx() },
+                            maxPx = cap,
                         )
-                    }
-                }
+                    },
+                    onResizeEnd = ::saveScheduleWidth,
+                    onToggleCollapsed = {
+                        scheduleCollapsed = !scheduleCollapsed
+                        onSettingsChangeState.value { s ->
+                            if (isMaximized) s.copy(maximizedLayout = s.maximizedLayout.copy(schedulePanelCollapsed = scheduleCollapsed))
+                            else s.copy(windowedLayout = s.windowedLayout.copy(schedulePanelCollapsed = scheduleCollapsed))
+                        }
+                    },
+                    icon = painterResource(
+                        if (scheduleCollapsed) Res.drawable.ic_arrow_right else Res.drawable.ic_arrow_left
+                    ),
+                    contentDescription = stringResource(
+                        if (scheduleCollapsed) Res.string.tooltip_expand_schedule
+                        else Res.string.tooltip_collapse_schedule
+                    ),
+                )
 
                 Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
                     Row(
@@ -2017,70 +1982,35 @@ fun MainDesktop(
                 }
 
                 // Right drag handle + collapse toggle for preview panel
-                Box(
-                    modifier = Modifier
-                        .width(16.dp)
-                        .fillMaxHeight()
-                        .background(MaterialTheme.colorScheme.surfaceVariant)
-                        // Keyed only on previewCollapsed — see the matching comment on the
-                        // schedule handle's pointerInput above for why the persisted width
-                        // must not be part of this key.
-                        .pointerInput(previewCollapsed) {
-                            if (!previewCollapsed) {
-                                detectHorizontalDragGestures(
-                                    onDragEnd = ::savePreviewWidth
-                                ) { _, amount ->
-                                    val cap = maxPreviewState.value
-                                    // Invert drag direction: dragging left increases width
-                                    previewPanelPx = (previewPanelPx - amount).coerceIn(
-                                        minOf(with(density) { 150.dp.toPx() }, cap),
-                                        cap
-                                    )
-                                }
-                            }
-                        }
-                        .pointerHoverIcon(
-                            if (previewCollapsed) PointerIcon.Default
-                            else PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR))
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (!previewCollapsed) {
-                        val dotColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
-                        Column(
-                            modifier = Modifier.align(Alignment.TopCenter).padding(top = 8.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) { repeat(3) { Box(Modifier.size(3.dp).background(dotColor, CircleShape)) } }
-                        Column(
-                            modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) { repeat(3) { Box(Modifier.size(3.dp).background(dotColor, CircleShape)) } }
-                    }
-                    IconButton(
-                        onClick = {
-                            previewCollapsed = !previewCollapsed
-                            onSettingsChangeState.value { s ->
-                                if (isMaximized) s.copy(maximizedLayout = s.maximizedLayout.copy(previewPanelCollapsed = previewCollapsed))
-                                else s.copy(windowedLayout = s.windowedLayout.copy(previewPanelCollapsed = previewCollapsed))
-                            }
-                        },
-                        modifier = Modifier.wrapContentHeight()
-                    ) {
-                        Icon(
-                            painter = painterResource(
-                                if (previewCollapsed) Res.drawable.ic_arrow_left
-                                else Res.drawable.ic_arrow_right
-                            ),
-                            contentDescription = stringResource(
-                                if (previewCollapsed) Res.string.tooltip_expand_schedule
-                                else Res.string.tooltip_collapse_schedule
-                            ),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                PanelResizeHandle(
+                    collapsed = previewCollapsed,
+                    // Inverted: this panel is on the right, so dragging left widens it.
+                    onResize = { amount ->
+                        val cap = maxPreviewState.value
+                        previewPanelPx = resizedPanelWidth(
+                            currentPx = previewPanelPx,
+                            dragAmount = amount,
+                            invert = true,
+                            minPx = with(density) { 150.dp.toPx() },
+                            maxPx = cap,
                         )
-                    }
-                }
+                    },
+                    onResizeEnd = ::savePreviewWidth,
+                    onToggleCollapsed = {
+                        previewCollapsed = !previewCollapsed
+                        onSettingsChangeState.value { s ->
+                            if (isMaximized) s.copy(maximizedLayout = s.maximizedLayout.copy(previewPanelCollapsed = previewCollapsed))
+                            else s.copy(windowedLayout = s.windowedLayout.copy(previewPanelCollapsed = previewCollapsed))
+                        }
+                    },
+                    icon = painterResource(
+                        if (previewCollapsed) Res.drawable.ic_arrow_left else Res.drawable.ic_arrow_right
+                    ),
+                    contentDescription = stringResource(
+                        if (previewCollapsed) Res.string.tooltip_expand_schedule
+                        else Res.string.tooltip_collapse_schedule
+                    ),
+                )
 
                 // Collapsible preview panel (right sidebar)
                 if (!previewCollapsed || previewVisibleFraction.value > 0f) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/PanelResizeHandle.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/PanelResizeHandle.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
@@ -107,7 +108,7 @@ internal fun PanelResizeHandle(
 }
 
 @Composable
-private fun GripDots(color: androidx.compose.ui.graphics.Color, modifier: Modifier) {
+private fun GripDots(color: Color, modifier: Modifier) {
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/PanelResizeHandle.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/PanelResizeHandle.kt
@@ -1,0 +1,116 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import java.awt.Cursor
+
+/** The strip's width, and the size of its grip dots. */
+private val HANDLE_WIDTH = 16.dp
+private val DOT_SIZE = 3.dp
+
+/**
+ * The new width a panel takes after a drag of [dragAmount] pixels.
+ *
+ * [invert] is for a panel on the *right*: dragging left has to make it wider, so the amount is
+ * subtracted rather than added. The floor is `minOf(minPx, maxPx)`, not `minPx` — on a window too
+ * narrow to give the panel its minimum, the cap wins and `coerceIn` would otherwise be handed a
+ * reversed range and throw.
+ */
+internal fun resizedPanelWidth(
+    currentPx: Float,
+    dragAmount: Float,
+    invert: Boolean,
+    minPx: Float,
+    maxPx: Float,
+): Float {
+    val moved = if (invert) currentPx - dragAmount else currentPx + dragAmount
+    return moved.coerceIn(minOf(minPx, maxPx), maxPx)
+}
+
+/**
+ * The draggable strip between a side panel and the content beside it: grip dots, a resize cursor,
+ * and the button that collapses the panel.
+ *
+ * Extracted from `MainDesktop` so the gesture can be driven by a test. Both splitters — schedule on
+ * the left, preview on the right — were inline in a 2,000-line composable that only runs under a
+ * real display, which left the app's two most-used drag handles with no coverage at all. They are
+ * also where a drag-handle regression has already happened once, hence the keying note below.
+ *
+ * [onResize] is called with the raw horizontal drag amount and is expected to apply
+ * [resizedPanelWidth]; [onResizeEnd] fires once when the gesture finishes, which is where the
+ * caller persists the width.
+ */
+@Composable
+internal fun PanelResizeHandle(
+    collapsed: Boolean,
+    onResize: (dragAmount: Float) -> Unit,
+    onResizeEnd: () -> Unit,
+    onToggleCollapsed: () -> Unit,
+    icon: Painter,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .width(HANDLE_WIDTH)
+            .fillMaxHeight()
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            // Keyed only on `collapsed` -- never on the width being dragged. The caller persists
+            // that width in onResizeEnd, so keying on it would tear this coroutine down and
+            // relaunch it at the end of every gesture, which is what made the second drag onward
+            // unreliable before. Matches SongsTab's column-resize handles.
+            .pointerInput(collapsed) {
+                if (!collapsed) {
+                    detectHorizontalDragGestures(onDragEnd = onResizeEnd) { _, amount ->
+                        onResize(amount)
+                    }
+                }
+            }
+            .pointerHoverIcon(
+                if (collapsed) PointerIcon.Default else PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR))
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        if (!collapsed) {
+            val dotColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.4f)
+            GripDots(dotColor, Modifier.align(Alignment.TopCenter).padding(top = 8.dp))
+            GripDots(dotColor, Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp))
+        }
+        IconButton(onClick = onToggleCollapsed, modifier = Modifier.wrapContentHeight()) {
+            Icon(
+                painter = icon,
+                contentDescription = contentDescription,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun GripDots(color: androidx.compose.ui.graphics.Color, modifier: Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) { repeat(3) { Box(Modifier.size(DOT_SIZE).background(color, CircleShape)) } }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/PanelResizeHandleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/PanelResizeHandleTest.kt
@@ -1,0 +1,209 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The draggable strip between a side panel and the content beside it.
+ *
+ * There are two of these — the schedule panel on the left and the preview on the right — and until
+ * this suite neither had a test: both were inline in `MainDesktop`, which only runs under a real
+ * display and is excluded from the coverage gate. They are also the app's most-used drag handles,
+ * and the place a drag-handle regression has already happened: a `pointerInput` keyed on the width
+ * the gesture itself rewrites is torn down and relaunched at the end of every drag, so **the first
+ * drag works and the rest do not**. A single-drag test cannot see that, so the case below drags
+ * three times and is the reason this suite exists.
+ *
+ * The gesture is asserted through the callbacks rather than a rendered width: the caller owns the
+ * width (it clamps and persists it), so what this component is responsible for is reporting the
+ * drag at all, once per gesture, and only while expanded.
+ */
+class PanelResizeHandleTest {
+
+    private companion object {
+        const val HANDLE = "panel_resize_handle"
+        const val TOGGLE = "collapse"
+    }
+
+    private class Reports {
+        val drags = mutableListOf<Float>()
+        var ends = 0
+        var toggles = 0
+        fun travelled(): Float = drags.sum()
+    }
+
+    /**
+     * Composes the handle the way `MainDesktop` uses it: a width the drag rewrites, and which the
+     * end of the gesture persists.
+     *
+     * That state is the whole point of the harness. Held in a `mutableStateOf` that the callbacks
+     * write, every drag forces a recomposition — which is the only condition under which a
+     * `pointerInput` key that includes the width can churn and kill the gesture. Without it the
+     * repeat-drag test below passes even against a handle keyed on something that changes every
+     * composition, and it was written that way first.
+     */
+
+    private fun ComposeUiTest.handle(collapsed: Boolean = false): Reports {
+        val reports = Reports()
+        setContent {
+            MaterialTheme {
+                var widthPx by remember { mutableStateOf(120f) }
+                var savedPx by remember { mutableStateOf(120f) }
+                Box(modifier = Modifier.size(200.dp)) {
+                    PanelResizeHandle(
+                        collapsed = collapsed,
+                        onResize = { amount ->
+                            reports.drags += amount
+                            widthPx = resizedPanelWidth(widthPx, amount, invert = false, minPx = 50f, maxPx = 300f)
+                        },
+                        onResizeEnd = { reports.ends++; savedPx = widthPx },
+                        onToggleCollapsed = { reports.toggles++ },
+                        icon = ColorPainter(Color.Gray),
+                        contentDescription = TOGGLE,
+                        modifier = Modifier.testTag(HANDLE),
+                    )
+                }
+            }
+        }
+        return reports
+    }
+
+    /** One drag across the handle, [dx] pixels, in eight steps. */
+    private fun ComposeUiTest.drag(dx: Float) {
+        val bounds = onNodeWithTag(HANDLE).fetchSemanticsNode().boundsInRoot
+        val start = Offset(bounds.center.x, bounds.top + 30f)
+        onNodeWithTag(HANDLE).performMouseInput {
+            moveTo(start)
+            press()
+            repeat(8) { step -> moveTo(Offset(start.x + dx * (step + 1) / 8f, start.y)) }
+            release()
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun `dragging the handle reports the distance travelled`() = runComposeUiTest {
+        val reports = handle()
+
+        drag(dx = 40f)
+
+        assertTrue(reports.drags.isNotEmpty(), "the drag must be reported at all")
+        assertTrue(
+            abs(reports.travelled() - 40f) <= 8f,
+            "the reported amounts must add up to the distance dragged, was ${reports.travelled()}",
+        )
+        assertEquals(1, reports.ends, "and the end of the gesture fires once, where the width is saved")
+    }
+
+    @Test
+    fun `dragging left reports negative amounts`() = runComposeUiTest {
+        // Sign is load-bearing: the right-hand panel inverts it, so a handle that reported
+        // magnitude only would widen the preview when it should narrow it.
+        val reports = handle()
+
+        drag(dx = -40f)
+
+        assertTrue(reports.travelled() < 0f, "leftward travel must be negative, was ${reports.travelled()}")
+    }
+
+    @Test
+    fun `the handle keeps working on the second and third drag`() = runComposeUiTest {
+        // The regression this suite exists for. Each drag is asserted on its own, because the
+        // failure is not "no drags" but "only the first one".
+        val reports = handle()
+
+        drag(dx = 30f)
+        val first = reports.drags.size
+        assertTrue(first > 0, "first drag reported nothing")
+
+        drag(dx = 30f)
+        val second = reports.drags.size - first
+        assertTrue(second > 0, "second drag reported nothing -- the handle stopped after one gesture")
+
+        drag(dx = -30f)
+        val third = reports.drags.size - first - second
+        assertTrue(third > 0, "third drag reported nothing")
+
+        assertEquals(3, reports.ends, "each gesture must end exactly once")
+    }
+
+    @Test
+    fun `a collapsed handle does not resize`() = runComposeUiTest {
+        // Collapsed, the panel has no width to drag; the strip is only a place to click the
+        // expand button, and a drag on it must not report anything.
+        val reports = handle(collapsed = true)
+
+        drag(dx = 40f)
+
+        assertTrue(reports.drags.isEmpty(), "a collapsed panel must not resize, got ${reports.drags}")
+        assertEquals(0, reports.ends)
+    }
+
+    @Test
+    fun `the collapse button is reachable whether the panel is open or shut`() {
+        listOf(false to "expanded", true to "collapsed").forEach { (collapsed, name) ->
+            runComposeUiTest {
+                // Collapsed is the state that matters: if the button were inside the
+                // `if (!collapsed)` block with the grip dots, a collapsed panel could never be
+                // reopened.
+                val reports = handle(collapsed = collapsed)
+
+                onNodeWithContentDescription(TOGGLE).performClick()
+
+                assertEquals(1, reports.toggles, "$name: the toggle must fire")
+            }
+        }
+    }
+
+    // ── The width arithmetic the callers apply ──────────────────────────────────
+
+    @Test
+    fun `a left-hand panel grows as the handle moves right`() {
+        assertEquals(140f, resizedPanelWidth(100f, dragAmount = 40f, invert = false, minPx = 50f, maxPx = 300f))
+        assertEquals(60f, resizedPanelWidth(100f, dragAmount = -40f, invert = false, minPx = 50f, maxPx = 300f))
+    }
+
+    @Test
+    fun `a right-hand panel grows as the handle moves left`() {
+        assertEquals(140f, resizedPanelWidth(100f, dragAmount = -40f, invert = true, minPx = 50f, maxPx = 300f))
+        assertEquals(60f, resizedPanelWidth(100f, dragAmount = 40f, invert = true, minPx = 50f, maxPx = 300f))
+    }
+
+    @Test
+    fun `the width stays between its minimum and the window's cap`() {
+        assertEquals(50f, resizedPanelWidth(100f, dragAmount = -500f, invert = false, minPx = 50f, maxPx = 300f))
+        assertEquals(300f, resizedPanelWidth(100f, dragAmount = 500f, invert = false, minPx = 50f, maxPx = 300f))
+    }
+
+    @Test
+    fun `a window too narrow for the minimum clamps to the cap instead of throwing`() {
+        // `coerceIn` throws on a reversed range, and the cap really can fall below the minimum:
+        // it is derived from the window width, which the user can drag smaller than the panel's
+        // own floor.
+        assertEquals(40f, resizedPanelWidth(100f, dragAmount = 500f, invert = false, minPx = 150f, maxPx = 40f))
+        assertEquals(40f, resizedPanelWidth(100f, dragAmount = -500f, invert = false, minPx = 150f, maxPx = 40f))
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/PanelResizeHandleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/PanelResizeHandleTest.kt
@@ -65,7 +65,6 @@ class PanelResizeHandleTest {
      * repeat-drag test below passes even against a handle keyed on something that changes every
      * composition, and it was written that way first.
      */
-
     private fun ComposeUiTest.handle(collapsed: Boolean = false): Reports {
         val reports = Reports()
         setContent {


### PR DESCRIPTION
Follow-up to #115. The schedule and preview panels are resized by the same 16dp strip, **written twice**, inline in `MainDesktop` — a composable that only runs under a real display and is excluded from the coverage gate. So the app's two most-used drag handles had no test at all.

They are also where a drag-handle regression has already happened, and the fix survives only as a comment:

> *"Keyed only on `scheduleCollapsed` (not the persisted width, which `saveScheduleWidth()` rewrites at the end of every drag) — otherwise this coroutine gets torn down and relaunched after every gesture, **which is what made the second drag onward unreliable**."*

## The extraction

`composables/PanelResizeHandle.kt` takes the collapsed flag, the drag callbacks and the toggle. The callers keep only what actually differs between the two: drag direction (the right-hand panel inverts, because dragging left has to widen it), the minimum width (160dp vs 150dp), and which arrow the button shows. `MainDesktop` loses 127 lines of duplicated strip.

`resizedPanelWidth` carries the clamp as a pure function, including the case that would otherwise throw: the cap comes from the window width, so a window narrower than the panel's own minimum hands `coerceIn` a reversed range. `minOf(minPx, maxPx)` is what stops that, and it now has a test saying so.

## The test that took two attempts

**This is the part worth reading.** The repeat-drag case — three gestures, each asserted separately, because the failure is not "no drags" but "only the first" — passed on its first writing *even with the gesture keyed on something that changes every composition*. It was not testing what it claimed: nothing in the harness recomposed between drags, so a churning key never churned.

The harness now holds the width the drag rewrites and persists it on release, exactly as `MainDesktop` does. Mutation-verified both ways: keyed on that width, `the handle keeps working on the second and third drag` fails (and so does the single-drag case); keyed on `collapsed` alone, all green.

Also covered: the drag's *sign* (the inverted panel depends on it), that a collapsed panel reports no resize, that `onResizeEnd` fires exactly once per gesture — that is where the width is persisted — and that the collapse button is reachable while collapsed, since if it had been inside the `if (!collapsed)` block with the grip dots, a collapsed panel could never be reopened.

## Checks

`./gradlew :composeApp:check` green — 6,742 tests, 75.3%. New suite run three times with `--rerun-tasks`. No behaviour change intended: the strip's width, dots, cursor, keying and callbacks are the originals, and the two call sites pass the same values they computed inline.