### PR TITLE
Schedule labels: theme colours by default, every theme as a preset, and a history

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
@@ -2191,8 +2191,9 @@ fun MainDesktop(
             editingLabelItem = null
         },
         existingText = editingLabelItem?.text ?: "",
-        existingTextColor = editingLabelItem?.textColor ?: "#FFFFFF",
-        existingBackgroundColor = editingLabelItem?.backgroundColor ?: "#2196F3",
+        // Empty, not a hardcoded pair: a new label picks its colours up from the active theme.
+        existingTextColor = editingLabelItem?.textColor.orEmpty(),
+        existingBackgroundColor = editingLabelItem?.backgroundColor.orEmpty(),
         isEdit = editingLabelItem != null
     )
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LabelColors.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LabelColors.kt
@@ -1,0 +1,203 @@
+@file:OptIn(ExperimentalLayoutApi::class)
+
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import churchpresenter.composeapp.generated.resources.Res
+import churchpresenter.composeapp.generated.resources.recent
+import churchpresenter.composeapp.generated.resources.theme
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
+import org.churchpresenter.app.churchpresenter.ui.theme.colorSchemeFor
+import org.churchpresenter.app.churchpresenter.utils.Utils
+import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
+import org.jetbrains.compose.resources.stringResource
+import java.io.File
+
+/** A schedule label's two colours: the band it is drawn on, and the text on that band. */
+@Serializable
+internal data class LabelColors(val background: String, val text: String)
+
+/** Case-insensitive equality: the pickers hand back upper-case hex, saved labels may not be. */
+internal fun LabelColors.matches(other: LabelColors): Boolean =
+    background.equals(other.background, ignoreCase = true) && text.equals(other.text, ignoreCase = true)
+
+/**
+ * The colour pairs a new label can be started from: one per theme the app ships, plus the current
+ * theme's own card tone at the head of the list.
+ *
+ * Every theme, not five roles of the active one -- an operator running Dark still wants an
+ * Ocean-blue or Forest-green section band, and the nine palettes are the set of colours this app
+ * already stands behind. Each theme contributes its `primaryContainer`/`onPrimaryContainer`, the
+ * accent pair that gives a palette its character; [ThemeMode.SYSTEM] contributes nothing because it
+ * is not a palette, it resolves to Light or Dark.
+ *
+ * The first entry is the default and is deliberately not an accent: it is the tone an ordinary
+ * schedule card is drawn in, because a label is a heading *in* the list rather than a slab across
+ * it. Its bold, letter-spaced text and the accent bar beside it are what mark it as a heading.
+ */
+@Composable
+internal fun themeLabelPresets(): List<LabelColors> {
+    val current = MaterialTheme.colorScheme
+    val palettes = ThemeMode.entries
+        .filter { it != ThemeMode.SYSTEM }
+        .map { colorSchemeFor(it) }
+        .map { LabelColors(cpColorToHex(it.primaryContainer), cpColorToHex(it.onPrimaryContainer)) }
+    return buildList {
+        add(LabelColors(cpColorToHex(current.surfaceContainer), cpColorToHex(current.onSurface)))
+        // Distinct pairs only: Light and Dark are what SYSTEM resolves to, and two themes sharing
+        // an accent would show as two swatches doing the same thing.
+        palettes.forEach { pair -> if (none { it.matches(pair) }) add(pair) }
+    }
+}
+
+/**
+ * The label colour pairs this user has actually chosen, newest first, across runs.
+ *
+ * Pairs, not single colours: a band and its text are picked together and only make sense together,
+ * so the existing per-colour [RecentColors] list cannot serve this. A theme preset is never
+ * recorded here — those already have their own column, and repeating them would push out the custom
+ * combinations this list exists to keep.
+ *
+ * The file is resolved per call rather than latched at class-init, so a test can point `user.home`
+ * at a temp directory and have this follow it.
+ */
+internal object RecentLabelColors {
+    private const val MAX = 8
+    private fun file() = File(System.getProperty("user.home"), ".churchpresenter/recent_label_colors.json")
+
+    val combos = mutableStateListOf<LabelColors>()
+
+    init { load() }
+
+    fun add(colors: LabelColors) {
+        val normalised = LabelColors(colors.background.uppercase(), colors.text.uppercase())
+        combos.remove(normalised)
+        combos.add(0, normalised)
+        while (combos.size > MAX) combos.removeLast()
+        save()
+    }
+
+    internal fun load() {
+        combos.clear()
+        try {
+            val f = file()
+            if (!f.exists()) return
+            val json = Json { ignoreUnknownKeys = true }
+            combos.addAll(json.decodeFromString<List<LabelColors>>(f.readText()).take(MAX))
+        } catch (_: Exception) {
+            // A corrupt or half-written file is not worth failing the dialog over: an empty
+            // history is the same as a first run.
+        }
+    }
+
+    private fun save() {
+        try {
+            val f = file()
+            f.parentFile?.mkdirs()
+            f.writeText(Json.encodeToString(combos.toList()))
+        } catch (_: Exception) {}
+    }
+}
+
+/**
+ * The two swatch columns above the pickers: what the theme offers, and what this user has picked
+ * before.
+ *
+ * Each swatch is the pair itself -- the band's colour with its own text drawn on it -- because a
+ * band and a text colour only mean anything together, and a row of plain colour chips would say
+ * nothing about whether the two read against each other. The recent column is left out entirely
+ * when there is no history rather than shown empty.
+ */
+@Composable
+internal fun LabelColorColumns(
+    presets: List<LabelColors>,
+    recents: List<LabelColors>,
+    onPick: (LabelColors) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+        LabelColorColumn(
+            title = stringResource(Res.string.theme),
+            colors = presets,
+            tagPrefix = LABEL_PRESET_TAG,
+            onPick = onPick,
+            modifier = Modifier.weight(1f),
+        )
+        if (recents.isNotEmpty()) {
+            LabelColorColumn(
+                title = stringResource(Res.string.recent),
+                colors = recents,
+                tagPrefix = LABEL_RECENT_TAG,
+                onPick = onPick,
+                modifier = Modifier.weight(1f),
+            )
+        }
+    }
+}
+
+/** Test tags for the swatches; the colours themselves are theme-derived, so nothing else names them. */
+internal const val LABEL_PRESET_TAG = "labelPreset"
+internal const val LABEL_RECENT_TAG = "labelRecent"
+
+@Composable
+private fun LabelColorColumn(
+    title: String,
+    colors: List<LabelColors>,
+    tagPrefix: String,
+    onPick: (LabelColors) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            colors.forEachIndexed { index, pair ->
+                val background = parseHexColor(pair.background)
+                Box(
+                    modifier = Modifier
+                        .size(width = 34.dp, height = 24.dp)
+                        .clip(RoundedCornerShape(5.dp))
+                        .background(background)
+                        .border(1.dp, MaterialTheme.colorScheme.outlineVariant, RoundedCornerShape(5.dp))
+                        .testTag("${tagPrefix}_$index")
+                        .clickable { onPick(pair) },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Aa",
+                        style = MaterialTheme.typography.labelSmall,
+                        // What the label will actually look like, contrast fix included: the row
+                        // itself renders through ensureContrast, so a swatch showing the raw pair
+                        // would promise something the schedule does not draw.
+                        color = Utils.ensureContrast(parseHexColor(pair.text), background, minRatio = 7.0),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/AddLabelDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/AddLabelDialog.kt
@@ -39,6 +39,11 @@ import churchpresenter.composeapp.generated.resources.label_text
 import churchpresenter.composeapp.generated.resources.ok
 import churchpresenter.composeapp.generated.resources.text_color
 import org.churchpresenter.app.churchpresenter.composables.ColorPickerField
+import org.churchpresenter.app.churchpresenter.composables.LabelColorColumns
+import org.churchpresenter.app.churchpresenter.composables.LabelColors
+import org.churchpresenter.app.churchpresenter.composables.RecentLabelColors
+import org.churchpresenter.app.churchpresenter.composables.matches
+import org.churchpresenter.app.churchpresenter.composables.themeLabelPresets
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -47,8 +52,9 @@ fun AddLabelDialog(
     onDismiss: () -> Unit,
     onConfirm: (text: String, textColor: String, backgroundColor: String) -> Unit,
     existingText: String = "",
-    existingTextColor: String = "#FFFFFF",
-    existingBackgroundColor: String = "#2196F3",
+    /** Blank means "no colour chosen yet" — the content resolves it from the theme. */
+    existingTextColor: String = "",
+    existingBackgroundColor: String = "",
     isEdit: Boolean = false
 ) {
     if (!isVisible) return
@@ -98,13 +104,19 @@ internal fun AddLabelDialogContent(
     onDismiss: () -> Unit,
     onConfirm: (text: String, textColor: String, backgroundColor: String) -> Unit,
     existingText: String = "",
-    existingTextColor: String = "#FFFFFF",
-    existingBackgroundColor: String = "#2196F3",
+    existingTextColor: String = "",
+    existingBackgroundColor: String = "",
     isEdit: Boolean = false
 ) {
+    // A new label starts on the theme's own first preset, which is the tone an ordinary schedule
+    // card is drawn in -- a label is a heading *in* the list, not a slab across it. It still reads
+    // as one: the row draws its text bold and letter-spaced with the accent bar beside it.
+    val presets = themeLabelPresets()
+    val themeBackground = presets.first().background
+    val themeText = presets.first().text
     var labelText by remember { mutableStateOf(existingText) }
-    var textColor by remember { mutableStateOf(existingTextColor) }
-    var backgroundColor by remember { mutableStateOf(existingBackgroundColor) }
+    var textColor by remember { mutableStateOf(existingTextColor.ifBlank { themeText }) }
+    var backgroundColor by remember { mutableStateOf(existingBackgroundColor.ifBlank { themeBackground }) }
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -152,6 +164,17 @@ internal fun AddLabelDialogContent(
                         singleLine = true,
                     )
                 }
+
+                // Theme presets and this user's own history, side by side: pick a pair in one
+                // click, or fall through to the two pickers below for something new.
+                LabelColorColumns(
+                    presets = presets,
+                    recents = RecentLabelColors.combos.toList(),
+                    onPick = { picked ->
+                        backgroundColor = picked.background
+                        textColor = picked.text
+                    },
+                )
 
                 // Text color picker
                 Row(
@@ -211,6 +234,10 @@ internal fun AddLabelDialogContent(
                     shape = RoundedCornerShape(6.dp),
                     onClick = {
                         if (labelText.isNotBlank()) {
+                            val chosen = LabelColors(background = backgroundColor, text = textColor)
+                            // A preset is not history: it has its own column already, and
+                            // recording it would push out the custom pairs this list is for.
+                            if (presets.none { it.matches(chosen) }) RecentLabelColors.add(chosen)
                             onConfirm(labelText.trim(), textColor, backgroundColor)
                             onDismiss()
                         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/Theme.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/Theme.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.LocalScrollbarStyle
 import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
@@ -419,24 +420,34 @@ private val MochaColorScheme = darkColorScheme(
     inverseOnSurface = Color.Black,
 )
 
+/**
+ * The palette a [ThemeMode] paints with, without applying it.
+ *
+ * Lets one theme's colours be offered inside another — the schedule-label presets show every
+ * theme's own accent so an operator on Dark can still colour a section Ocean-blue or Forest-green.
+ * [ThemeMode.SYSTEM] is not a palette of its own; it resolves to Light or Dark, so callers listing
+ * palettes skip it.
+ */
+internal fun colorSchemeFor(themeMode: ThemeMode, systemDark: Boolean = true): ColorScheme = when (themeMode) {
+    ThemeMode.LIGHT -> LightColorScheme
+    ThemeMode.DARK -> DarkColorScheme
+    ThemeMode.SYSTEM -> if (systemDark) DarkColorScheme else LightColorScheme
+    ThemeMode.WARM -> WarmColorScheme
+    ThemeMode.OCEAN -> OceanColorScheme
+    ThemeMode.ROSE -> RoseColorScheme
+    ThemeMode.MIDNIGHT -> MidnightColorScheme
+    ThemeMode.FOREST -> ForestColorScheme
+    ThemeMode.MOCHA -> MochaColorScheme
+    ThemeMode.STUDIO -> StudioColorScheme
+}
+
 @Composable
 fun ChurchPresenterTheme(
     themeMode: ThemeMode = ThemeMode.SYSTEM,
     content: @Composable () -> Unit
 ) {
     val systemDark = isSystemInDarkTheme()
-    val colorScheme = when (themeMode) {
-        ThemeMode.LIGHT -> LightColorScheme
-        ThemeMode.DARK -> DarkColorScheme
-        ThemeMode.SYSTEM -> if (systemDark) DarkColorScheme else LightColorScheme
-        ThemeMode.WARM -> WarmColorScheme
-        ThemeMode.OCEAN -> OceanColorScheme
-        ThemeMode.ROSE -> RoseColorScheme
-        ThemeMode.MIDNIGHT -> MidnightColorScheme
-        ThemeMode.FOREST -> ForestColorScheme
-        ThemeMode.MOCHA -> MochaColorScheme
-        ThemeMode.STUDIO -> StudioColorScheme
-    }
+    val colorScheme = colorSchemeFor(themeMode, systemDark)
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/LabelColorsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/LabelColorsTest.kt
@@ -15,7 +15,6 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 /**

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/LabelColorsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/LabelColorsTest.kt
@@ -1,0 +1,195 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.ui.theme.ChurchPresenterTheme
+import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * The colours a schedule label can be started from: the theme's own pairs, and this user's history.
+ *
+ * A label carries two colours that only mean anything together — a band and the text on it — so
+ * neither the presets nor the history are lists of colours; they are lists of *pairs*, which is why
+ * the existing per-colour [RecentColors] could not serve this.
+ *
+ * `user.home` is swapped per test because [RecentLabelColors] persists there. It resolves its file
+ * per call rather than latching one at class-init, which is what makes that swap work — the
+ * `PicturesTab` recent-folders singleton is the counter-example, and is recorded as untestable for
+ * exactly the latching this one avoids.
+ */
+class LabelColorsTest {
+
+    private lateinit var tempHome: File
+    private var realHome: String? = null
+
+    @BeforeTest
+    fun isolateHome() {
+        TestSingletons.latchToTestHome()
+        realHome = System.getProperty("user.home")
+        tempHome = Files.createTempDirectory("cp-label-colors").toFile()
+        System.setProperty("user.home", tempHome.absolutePath)
+        RecentLabelColors.load()
+    }
+
+    @AfterTest
+    fun restoreHome() {
+        realHome?.let { System.setProperty("user.home", it) }
+        tempHome.deleteRecursively()
+        RecentLabelColors.load()
+    }
+
+    // ── The theme's own pairs ───────────────────────────────────────────────────
+
+    @Test
+    fun `the first preset is the tone an ordinary schedule card is drawn in`() = runComposeUiTest {
+        // The point of the default: a label is a heading *in* the list, not a slab across it. Its
+        // own bold, letter-spaced text and accent bar are what mark it as a heading.
+        var expected = ""
+        var actual = ""
+        setContent {
+            ChurchPresenterTheme(themeMode = ThemeMode.DARK) {
+                expected = cpColorToHex(MaterialTheme.colorScheme.surfaceContainer)
+                actual = themeLabelPresets().first().background
+            }
+        }
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `the presets offer every theme the app ships`() = runComposeUiTest {
+        // The point of the column: an operator on Dark still wants an Ocean-blue or Forest-green
+        // section band. SYSTEM contributes nothing -- it is not a palette, it resolves to Light or
+        // Dark -- and duplicates are dropped, so the count is the distinct palettes plus the
+        // current theme's card tone at the head.
+        var presets: List<LabelColors> = emptyList()
+        var ocean = ""
+        var forest = ""
+        var mocha = ""
+        setContent {
+            ChurchPresenterTheme(themeMode = ThemeMode.DARK) { presets = themeLabelPresets() }
+            ChurchPresenterTheme(themeMode = ThemeMode.OCEAN) { ocean = cpColorToHex(MaterialTheme.colorScheme.primaryContainer) }
+            ChurchPresenterTheme(themeMode = ThemeMode.FOREST) { forest = cpColorToHex(MaterialTheme.colorScheme.primaryContainer) }
+            ChurchPresenterTheme(themeMode = ThemeMode.MOCHA) { mocha = cpColorToHex(MaterialTheme.colorScheme.primaryContainer) }
+        }
+
+        val bands = presets.map { it.background }
+        listOf("Ocean" to ocean, "Forest" to forest, "Mocha" to mocha).forEach { (name, band) ->
+            assertTrue(band in bands, "$name is missing from the presets: $bands")
+        }
+        assertEquals(bands.distinct(), bands, "two swatches doing the same thing is one too many")
+    }
+
+    // ── The history ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a pair used is remembered, newest first`() {
+        RecentLabelColors.add(LabelColors("#111111", "#EEEEEE"))
+        RecentLabelColors.add(LabelColors("#222222", "#DDDDDD"))
+
+        assertEquals(
+            listOf(LabelColors("#222222", "#DDDDDD"), LabelColors("#111111", "#EEEEEE")),
+            RecentLabelColors.combos.toList(),
+        )
+    }
+
+    @Test
+    fun `using a pair again moves it up rather than duplicating it`() {
+        RecentLabelColors.add(LabelColors("#111111", "#EEEEEE"))
+        RecentLabelColors.add(LabelColors("#222222", "#DDDDDD"))
+        RecentLabelColors.add(LabelColors("#111111", "#EEEEEE"))
+
+        assertEquals(2, RecentLabelColors.combos.size, "a repeat is not a new entry")
+        assertEquals(LabelColors("#111111", "#EEEEEE"), RecentLabelColors.combos.first())
+    }
+
+    @Test
+    fun `the history survives a restart`() {
+        RecentLabelColors.add(LabelColors("#123456", "#ABCDEF"))
+
+        RecentLabelColors.load()   // what a fresh process does
+
+        assertEquals(listOf(LabelColors("#123456", "#ABCDEF")), RecentLabelColors.combos.toList())
+    }
+
+    @Test
+    fun `the history is bounded`() {
+        repeat(12) { RecentLabelColors.add(LabelColors("#%06X".format(it), "#FFFFFF")) }
+
+        assertTrue(RecentLabelColors.combos.size <= 8, "was ${RecentLabelColors.combos.size}")
+        assertEquals("#00000B", RecentLabelColors.combos.first().background, "the newest is kept")
+        assertEquals("#000004", RecentLabelColors.combos.last().background, "and the oldest fell off")
+    }
+
+    @Test
+    fun `a differently-cased hex is the same pair`() {
+        RecentLabelColors.add(LabelColors("#abcdef", "#123456"))
+        RecentLabelColors.add(LabelColors("#ABCDEF", "#123456"))
+
+        assertEquals(1, RecentLabelColors.combos.size)
+    }
+
+    // ── The columns ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clicking a swatch picks both of its colours at once`() = runComposeUiTest {
+        var picked: LabelColors? = null
+        val pairs = listOf(LabelColors("#111111", "#EEEEEE"), LabelColors("#222222", "#DDDDDD"))
+        setContent {
+            MaterialTheme {
+                LabelColorColumns(presets = pairs, recents = emptyList(), onPick = { picked = it })
+            }
+        }
+
+        onNodeWithTag("${LABEL_PRESET_TAG}_1").performClick()
+
+        // Both, not one: picking a band and leaving the old text behind is how a label ends up
+        // unreadable.
+        assertEquals(LabelColors("#222222", "#DDDDDD"), picked)
+    }
+
+    @Test
+    fun `the recent column is absent until there is history`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LabelColorColumns(
+                    presets = listOf(LabelColors("#111111", "#EEEEEE")),
+                    recents = emptyList(),
+                    onPick = {},
+                )
+            }
+        }
+
+        onNodeWithTag("${LABEL_RECENT_TAG}_0").assertDoesNotExist()
+        onNodeWithTag("${LABEL_PRESET_TAG}_0").assertExists()
+    }
+
+    @Test
+    fun `both columns are shown once history exists`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LabelColorColumns(
+                    presets = listOf(LabelColors("#111111", "#EEEEEE")),
+                    recents = listOf(LabelColors("#222222", "#DDDDDD")),
+                    onPick = {},
+                )
+            }
+        }
+
+        onNodeWithTag("${LABEL_PRESET_TAG}_0").assertExists()
+        onNodeWithTag("${LABEL_RECENT_TAG}_0").assertExists()
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/AddLabelContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/AddLabelContentTest.kt
@@ -3,6 +3,10 @@
 package org.churchpresenter.app.churchpresenter.dialogs
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import org.churchpresenter.app.churchpresenter.composables.cpColorToHex
+import org.churchpresenter.app.churchpresenter.ui.theme.ChurchPresenterTheme
+import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -18,6 +22,13 @@ import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.runComposeUiTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import androidx.compose.ui.test.onNodeWithTag
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.composables.LABEL_PRESET_TAG
+import org.churchpresenter.app.churchpresenter.composables.LabelColors
+import org.churchpresenter.app.churchpresenter.composables.RecentLabelColors
+import java.nio.file.Files
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNull
 
 /**
@@ -60,17 +71,27 @@ class AddLabelContentTest {
         waitForIdle()
     }
 
+    /** What the theme in force offers a new label, captured as the content resolves it. */
+    private class Defaults {
+        var text: String = ""
+        var background: String = ""
+    }
+
     private fun dialog(
         existingText: String = "",
-        existingTextColor: String = "#FFFFFF",
-        existingBackgroundColor: String = "#2196F3",
+        existingTextColor: String = "",
+        existingBackgroundColor: String = "",
         isEdit: Boolean = false,
+        themeMode: ThemeMode? = null,
+        defaults: Defaults = Defaults(),
         block: ComposeUiTest.(Result) -> Unit,
     ) {
         val result = Result()
         runComposeUiTest {
             setContent {
-                MaterialTheme {
+                val body = @Composable {
+                    defaults.text = cpColorToHex(MaterialTheme.colorScheme.onSurface)
+                    defaults.background = cpColorToHex(MaterialTheme.colorScheme.surfaceContainer)
                     AddLabelDialogContent(
                         onDismiss = { result.dismissed++ },
                         onConfirm = { text, textColor, backgroundColor ->
@@ -82,6 +103,8 @@ class AddLabelContentTest {
                         isEdit = isEdit,
                     )
                 }
+                if (themeMode == null) MaterialTheme { body() }
+                else ChurchPresenterTheme(themeMode = themeMode) { body() }
             }
             block(result)
         }
@@ -102,9 +125,45 @@ class AddLabelContentTest {
     // ── Field defaults ──────────────────────────────────────────────────────────
 
     @Test
-    fun `a brand new label starts with the default colours`() = dialog {
-        onNodeWithText("#FFFFFF").assertExists()
-        onNodeWithText("#2196F3").assertExists()
+    fun `a brand new label starts with the theme's own colours`() {
+        val defaults = Defaults()
+        dialog(defaults = defaults) {
+            // Not a fixed white-on-blue: that pair belonged to no palette here and sat oddly in the
+            // eight themes that are not the light one.
+            onNodeWithText(defaults.text).assertExists()
+            onNodeWithText(defaults.background).assertExists()
+        }
+    }
+
+    @Test
+    fun `the default colours change with the theme`() {
+        // The point of the change: nine themes, and a new label should look like it belongs to
+        // whichever one is on rather than to the light one.
+        val light = Defaults()
+        val forest = Defaults()
+        dialog(themeMode = ThemeMode.LIGHT, defaults = light) {
+            onNodeWithText(light.background).assertExists()
+        }
+        dialog(themeMode = ThemeMode.FOREST, defaults = forest) {
+            onNodeWithText(forest.background).assertExists()
+        }
+
+        assertNotEquals(
+            light.background, forest.background,
+            "a themed default that is the same in every theme is not themed",
+        )
+    }
+
+    @Test
+    fun `editing keeps the saved colours, theme or no theme`() = dialog(
+        existingTextColor = "#123456",
+        existingBackgroundColor = "#ABCDEF",
+        isEdit = true,
+    ) {
+        // A label saved months ago must come back as it was, not be recoloured by the theme in
+        // force when it is next opened.
+        onNodeWithText("#123456").assertExists()
+        onNodeWithText("#ABCDEF").assertExists()
     }
 
     @Test
@@ -148,11 +207,14 @@ class AddLabelContentTest {
     // ── Confirming ──────────────────────────────────────────────────────────────
 
     @Test
-    fun `OK hands back the typed text and both colours`() = dialog { result ->
-        onNodeWithText("Enter label text...").performTextInput("Welcome")
-        onNodeWithText("OK").performClick()
+    fun `OK hands back the typed text and both colours`() {
+        val defaults = Defaults()
+        dialog(defaults = defaults) { result ->
+            onNodeWithText("Enter label text...").performTextInput("Welcome")
+            onNodeWithText("OK").performClick()
 
-        assertEquals(Triple("Welcome", "#FFFFFF", "#2196F3"), result.confirmed)
+            assertEquals(Triple("Welcome", defaults.text, defaults.background), result.confirmed)
+        }
     }
 
     @Test
@@ -193,52 +255,68 @@ class AddLabelContentTest {
     // ── Colour pickers ──────────────────────────────────────────────────────────
 
     @Test
-    fun `changing the text colour is reflected in what OK confirms`() = dialog { result ->
-        onNodeWithText("Enter label text...").performTextInput("Welcome")
-        openColorField("#FFFFFF")
-        confirmColorPickerWith("#123456")
+    fun `changing the text colour is reflected in what OK confirms`() {
+        val defaults = Defaults()
+        dialog(defaults = defaults) { result ->
+            onNodeWithText("Enter label text...").performTextInput("Welcome")
+            openColorField(defaults.text)
+            confirmColorPickerWith("#123456")
 
-        onNodeWithText("OK").performClick()
+            onNodeWithText("OK").performClick()
 
-        assertEquals("#123456", result.confirmed?.second)
-        assertEquals("#2196F3", result.confirmed?.third, "the background colour must be untouched by editing the text colour")
+            assertEquals("#123456", result.confirmed?.second)
+            assertEquals(
+                defaults.background, result.confirmed?.third,
+                "the background colour must be untouched by editing the text colour",
+            )
+        }
     }
 
     @Test
-    fun `changing the background colour is reflected in what OK confirms`() = dialog { result ->
-        onNodeWithText("Enter label text...").performTextInput("Welcome")
-        openColorField("#2196F3")
-        confirmColorPickerWith("#654321")
+    fun `changing the background colour is reflected in what OK confirms`() {
+        val defaults = Defaults()
+        dialog(defaults = defaults) { result ->
+            onNodeWithText("Enter label text...").performTextInput("Welcome")
+            openColorField(defaults.background)
+            confirmColorPickerWith("#654321")
 
-        onNodeWithText("OK").performClick()
+            onNodeWithText("OK").performClick()
 
-        assertEquals("#FFFFFF", result.confirmed?.second, "the text colour must be untouched by editing the background colour")
-        assertEquals("#654321", result.confirmed?.third)
+            assertEquals(
+                defaults.text, result.confirmed?.second,
+                "the text colour must be untouched by editing the background colour",
+            )
+            assertEquals("#654321", result.confirmed?.third)
+        }
     }
 
     @Test
-    fun `both colours can be changed independently before confirming`() = dialog { result ->
-        onNodeWithText("Enter label text...").performTextInput("Welcome")
-        openColorField("#FFFFFF")
-        confirmColorPickerWith("#111111")
-        openColorField("#2196F3")
-        confirmColorPickerWith("#222222")
+    fun `both colours can be changed independently before confirming`() {
+        val defaults = Defaults()
+        dialog(defaults = defaults) { result ->
+            onNodeWithText("Enter label text...").performTextInput("Welcome")
+            openColorField(defaults.text)
+            confirmColorPickerWith("#111111")
+            openColorField(defaults.background)
+            confirmColorPickerWith("#222222")
 
-        onNodeWithText("OK").performClick()
+            onNodeWithText("OK").performClick()
 
-        assertEquals(Triple("Welcome", "#111111", "#222222"), result.confirmed)
+            assertEquals(Triple("Welcome", "#111111", "#222222"), result.confirmed)
+        }
     }
 
     @Test
     fun `every optional parameter can be left to its own default`() = runComposeUiTest {
+        var themeBackground = ""
         setContent {
             MaterialTheme {
+                themeBackground = cpColorToHex(MaterialTheme.colorScheme.surfaceContainer)
                 AddLabelDialogContent(onDismiss = {}, onConfirm = { _, _, _ -> })
             }
         }
         onNodeWithText("Add Label").assertExists()
-        onNodeWithText("#FFFFFF").assertExists()
-        onNodeWithText("#2196F3").assertExists()
+        onNodeWithText(themeBackground).assertExists()
     }
 
     // ── AddLabelDialog itself, via its isVisible guard ─────────────────────────
@@ -269,5 +347,61 @@ class AddLabelContentTest {
             )
         }
         onNodeWithText("Edit Label").assertDoesNotExist()
+    }
+
+    // ── History ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a custom pair is remembered, a theme preset is not`() {
+        TestSingletons.latchToTestHome()
+        val realHome = System.getProperty("user.home")
+        val tempHome = Files.createTempDirectory("cp-label-dialog").toFile()
+        System.setProperty("user.home", tempHome.absolutePath)
+        RecentLabelColors.load()
+        val defaults = Defaults()
+        try {
+            // Confirming on the untouched default -- which is a theme preset -- must leave the
+            // history alone: presets have their own column, and recording them would push out the
+            // custom pairs the history exists to keep.
+            dialog(defaults = defaults) { _ ->
+                onNodeWithText("Enter label text...").performTextInput("Welcome")
+                onNodeWithText("OK").performClick()
+            }
+            assertEquals(emptyList(), RecentLabelColors.combos.toList(), "a preset is not history")
+
+            // A colour of the user's own is the case the history exists for.
+            dialog(defaults = defaults) { _ ->
+                onNodeWithText("Enter label text...").performTextInput("Welcome")
+                openColorField(defaults.background)
+                confirmColorPickerWith("#654321")
+                onNodeWithText("OK").performClick()
+            }
+
+            assertEquals(
+                listOf(LabelColors("#654321", defaults.text)),
+                RecentLabelColors.combos.toList(),
+                "the pair actually used is what gets kept",
+            )
+        } finally {
+            System.setProperty("user.home", realHome)
+            tempHome.deleteRecursively()
+            RecentLabelColors.load()
+        }
+    }
+
+    @Test
+    fun `picking a swatch sets both colours at once`() {
+        val defaults = Defaults()
+        dialog(defaults = defaults) { result ->
+            onNodeWithText("Enter label text...").performTextInput("Welcome")
+            // The second preset, whatever the theme makes it -- the swatch is the pair, so one
+            // click has to move the band and its text together.
+            onNodeWithTag("${LABEL_PRESET_TAG}_1").performClick()
+            onNodeWithText("OK").performClick()
+
+            val confirmed = result.confirmed
+            assertNotEquals(defaults.background, confirmed?.third, "the band must have changed")
+            assertNotEquals(defaults.text, confirmed?.second, "and its text with it")
+        }
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/ThemeSurfaceRampTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/ThemeSurfaceRampTest.kt
@@ -140,4 +140,24 @@ class ThemeSurfaceRampTest {
             "the old baseline card must fail the bar this test sets",
         )
     }
+
+    @Test
+    fun `every theme's label swatch reads its own text on its own band`() {
+        // The schedule-label presets show one pair per theme -- primaryContainer with its own
+        // onPrimaryContainer -- so every scheme's accent pair has to work as a band with text on
+        // it, not just as a button. A label whose text does not read on its band is a section
+        // heading nobody can see.
+        everyTheme { s ->
+            val accent = contrast(s.onPrimaryContainer, s.primaryContainer)
+            val card = contrast(s.onSurface, s.surfaceContainer)
+            when {
+                accent < 4.5 ->
+                    "accent swatch ${hex(s.onPrimaryContainer)} on ${hex(s.primaryContainer)} is only %.2f:1".format(accent)
+                // The head of the list, and the default a new label opens on.
+                card < 4.5 ->
+                    "card swatch ${hex(s.onSurface)} on ${hex(s.surfaceContainer)} is only %.2f:1".format(card)
+                else -> null
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add Label opened on `#FFFFFF` text over `#2196F3` — a pair belonging to no palette in the app. On any of the eight themes that are not the light one, a new section heading arrived as a blue slab.

## The default

A new label now starts on **the tone an ordinary schedule card is drawn in** (`surfaceContainer` with `onSurface` text), so it looks like part of the list it was added to. It still reads as a heading — the row draws its text bold and letter-spaced with the accent bar beside it.

That is a deliberate walk-back from my first attempt, which used `primaryContainer`. That *is* the theme's colour, but it is the **accent** slot — `#004881` in Dark — so it read as foreign for the same reason the old blue did. Worth recording, because "follow the theme" and "use the theme's accent" are not the same instruction.

## Two columns above the pickers

**THEME** — one pair per theme the app ships, each theme's own `primaryContainer`/`onPrimaryContainer`:

| | band | text | | | band | text |
|---|---|---|---|---|---|---|
| Light | `#DDE1E7` | `#1A202C` | | Midnight | `#003180` | `#D6E3FF` |
| Dark | `#004881` | `#D1E4FF` | | Forest | `#005030` | `#B0E8C8` |
| Warm | `#EDD9BC` | `#2E1A05` | | Mocha | `#301050` | `#EDD8FF` |
| Ocean | `#BFDDED` | `#001F2E` | | Studio | `#2A1E08` | `#E8D49A` |
| Rose | `#EDD0D6` | `#2E0A12` | | | | |

So an operator running Dark can still colour a section Ocean-blue or Forest-green. `SYSTEM` contributes nothing — it is a resolution to Light or Dark, not a palette — and duplicate pairs are dropped so no two swatches do the same thing.

**RECENT** — this user's own history, 8 deep, newest first, de-duplicated case-insensitively, persisted to `~/.churchpresenter/recent_label_colors.json`. It appears only once there is some.

**A theme preset is never recorded in RECENT.** It has a column already, and recording it would push out the custom pairs that column exists to keep.

Each swatch is the *pair*, drawn as "Aa" in its own text colour on its own band — a band and its text only mean anything together, and a plain colour chip says nothing about whether the two read against each other. The swatch renders through `ensureContrast` exactly as the schedule row does, so it promises what will actually be drawn.

## Two things worth knowing for anyone extending this

- **`colorSchemeFor(themeMode)` is new in `Theme.kt`**, and `ChurchPresenterTheme` now uses it too, so the mode-to-palette mapping exists once rather than twice.
- **`RecentLabelColors` resolves its file per call** instead of latching one at class-init. That is the whole difference between this and the `PicturesTab` recents singleton, which is recorded as untestable precisely because it latches `user.home` before a test can point it anywhere.

`tertiaryContainer` is deliberately unused: exactly **1 of 9** schemes declares it, so anything built on it would be Material's baseline lavender in the other eight — the fallback that once made settings cards invisible.

## Checks

`./gradlew :composeApp:check` green — 6,748 tests, 75.2%. New and changed suites run three times with `--rerun-tasks`, and the dialog driven by hand in the running app.

`ThemeSurfaceRampTest` gains an invariant this now depends on: **every theme's swatch must clear WCAG AA as a band with text on it**, not merely declare the roles. Declaring a role and the two contrasting are different claims.