### PR TITLE
Unblock the ATEM upload dialog, and make labelled controls clickable

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LabeledControls.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LabeledControls.kt
@@ -1,0 +1,108 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.TextStyle
+
+/**
+ * A checkbox, radio button or switch together with its label, where **the label is part of the
+ * control**.
+ *
+ * The pattern these replace — a bare `Text` sitting next to a `Checkbox` inside a plain `Row` — looks
+ * identical on screen but only the small square is clickable. Everyone aims at the word, which is the
+ * larger target and the one that reads as the thing being chosen, and nothing happens. It is also
+ * inaccessible: with no association between the two, a screen reader announces an unlabelled checkbox
+ * and a stray line of text.
+ *
+ * The fix is Material 3's own recommendation: put `toggleable`/`selectable` on the row with the right
+ * [Role], and pass `null` as the control's own callback so the row owns the single click. That gives
+ * one click target covering control and label, one semantics node, and a label that is announced with
+ * its state.
+ *
+ * `enabled` propagates to both halves, so a disabled row is inert *and* reports itself disabled rather
+ * than silently ignoring presses.
+ */
+
+@Composable
+fun LabeledCheckbox(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    controlModifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.toggleable(
+            value = checked,
+            enabled = enabled,
+            role = Role.Checkbox,
+            onValueChange = onCheckedChange,
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // null: the row above already handles the click, and a control with its own handler would
+        // publish a second, competing click target inside the first.
+        Checkbox(checked = checked, onCheckedChange = null, enabled = enabled, modifier = controlModifier)
+        Text(text = label, style = style)
+    }
+}
+
+@Composable
+fun LabeledRadioButton(
+    selected: Boolean,
+    onClick: () -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    controlModifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.selectable(
+            selected = selected,
+            enabled = enabled,
+            role = Role.RadioButton,
+            onClick = onClick,
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected, onClick = null, enabled = enabled, modifier = controlModifier)
+        Text(text = label, style = style)
+    }
+}
+
+@Composable
+fun LabeledSwitch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    style: TextStyle = MaterialTheme.typography.bodyMedium,
+    controlModifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.toggleable(
+            value = checked,
+            enabled = enabled,
+            role = Role.Switch,
+            onValueChange = onCheckedChange,
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Switch(checked = checked, onCheckedChange = null, enabled = enabled, modifier = controlModifier)
+        Text(text = label, style = style)
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThird.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThird.kt
@@ -59,7 +59,6 @@ import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThird.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThird.kt
@@ -15,6 +15,7 @@ import org.churchpresenter.app.churchpresenter.composables.initialPassClickable
 import org.churchpresenter.app.churchpresenter.composables.finalPassClickable
 import org.churchpresenter.app.churchpresenter.composables.AddToScheduleButton
 import org.churchpresenter.app.churchpresenter.composables.GoLiveButton
+import org.churchpresenter.app.churchpresenter.composables.LabeledRadioButton
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
@@ -118,6 +119,7 @@ import churchpresenter.composeapp.generated.resources.atem_processing
 import churchpresenter.composeapp.generated.resources.atem_upload_mode
 import churchpresenter.composeapp.generated.resources.atem_uploading
 import org.churchpresenter.app.churchpresenter.server.AtemMediaSlot
+import org.churchpresenter.app.churchpresenter.server.AtemState
 import churchpresenter.composeapp.generated.resources.cancel
 import churchpresenter.composeapp.generated.resources.confirm_delete
 import churchpresenter.composeapp.generated.resources.confirm_delete_file
@@ -171,7 +173,29 @@ fun LowerThirdTab(
     onSettingsChange: ((AppSettings) -> AppSettings) -> Unit = {},
     onAddToSchedule: (presetId: String, presetLabel: String, pauseAtFrame: Boolean, pauseDurationMs: Long) -> Unit = { _, _, _, _ -> },
     onGoLive: (jsonContent: String, pauseAtFrame: Boolean, pauseFrame: Float, pauseDurationMs: Long, presetName: String) -> Unit = { _, _, _, _, _ -> },
-    onOpenLottieGen: (outputDir: String, onFileSaved: (() -> Unit)?) -> Unit = { _, _ -> }
+    onOpenLottieGen: (outputDir: String, onFileSaved: (() -> Unit)?) -> Unit = { _, _ -> },
+    /**
+     * Reads the ATEM's media-pool state — what the upload dialog is built from.
+     *
+     * A parameter rather than a direct `AtemClient(...).queryState()` because that call is **UDP with
+     * a 5s socket timeout**: there is no fast connection-refused, so every test that opened this
+     * dialog would cost five seconds whether or not a switcher existed. That timeout, not the absence
+     * of hardware, is what kept this tab capped at ~42%. The default is the real client, so callers
+     * are unaffected; a test supplies a canned [AtemState] or throws to exercise the error path.
+     */
+    queryAtemState: suspend (host: String, port: Int) -> AtemState = { host, port ->
+        AtemClient(host, port).queryState()
+    },
+    /**
+     * Whether the switcher answers at all — polled on a loop, and what enables the upload buttons.
+     *
+     * Injected alongside [queryAtemState] because seaming only the state query is not enough: the
+     * button that opens the dialog is disabled until this says the device is there, so a test could
+     * never reach the dialog. Defaults to the real probe.
+     */
+    probeAtemReachable: suspend (host: String, port: Int) -> Boolean = { host, port ->
+        AtemClient.isReachable(host, port)
+    },
 ) {
     val lottieFolder = appSettings.streamingSettings.lowerThirdFolder
     var refreshKey by remember { mutableStateOf(0) }
@@ -253,7 +277,7 @@ fun LowerThirdTab(
             return@LaunchedEffect
         }
         while (isActive) {
-            val reachable = AtemClient.isReachable(host, port)
+            val reachable = probeAtemReachable(host, port)
             atemReachable = reachable
             if (reachable) atemEverConnected = true
             delay(if (reachable) 30_000L else 10_000L)
@@ -285,7 +309,7 @@ fun LowerThirdTab(
         atemSlotsError = null
         try {
             val state = withContext(Dispatchers.IO) {
-                AtemClient(appSettings.atemSettings.host, appSettings.atemSettings.port).queryState()
+                queryAtemState(appSettings.atemSettings.host, appSettings.atemSettings.port)
             }
             atemSlots = if (atemIsClip) state.clipSlots else state.stillSlots
             atemDetectedFps = state.fps
@@ -504,17 +528,23 @@ fun LowerThirdTab(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        RadioButton(selected = !atemIsClip, onClick = {
-                            atemIsClip = false
-                            atemSlot = appSettings.atemSettings.defaultStillSlot
-                        })
-                        Text(stringResource(Res.string.atem_mode_still), style = MaterialTheme.typography.bodyMedium)
+                        LabeledRadioButton(
+                            selected = !atemIsClip,
+                            onClick = {
+                                atemIsClip = false
+                                atemSlot = appSettings.atemSettings.defaultStillSlot
+                            },
+                            label = stringResource(Res.string.atem_mode_still),
+                        )
                         Spacer(Modifier.width(16.dp))
-                        RadioButton(selected = atemIsClip, onClick = {
-                            atemIsClip = true
-                            atemSlot = appSettings.atemSettings.defaultClipSlot
-                        })
-                        Text(stringResource(Res.string.atem_mode_clip), style = MaterialTheme.typography.bodyMedium)
+                        LabeledRadioButton(
+                            selected = atemIsClip,
+                            onClick = {
+                                atemIsClip = true
+                                atemSlot = appSettings.atemSettings.defaultClipSlot
+                            },
+                            label = stringResource(Res.string.atem_mode_clip),
+                        )
                     }
 
                     // Warn when the design doesn't match the ATEM frame: aspect mismatches
@@ -923,7 +953,11 @@ fun LowerThirdTab(
                                 shape = RoundedCornerShape(8.dp),
                                 colors = atemButtonColors
                             ) {
-                                Icon(painterResource(Res.drawable.ic_upload), contentDescription = null, modifier = Modifier.size(16.dp))
+                                Icon(
+                                    painterResource(Res.drawable.ic_upload),
+                                    contentDescription = stringResource(Res.string.atem_send_to_atem),
+                                    modifier = Modifier.size(16.dp),
+                                )
                             }
                         }
                     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/LabeledControlsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/LabeledControlsTest.kt
@@ -1,0 +1,231 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The labelled checkbox, radio button and switch.
+ *
+ * Every test here clicks **the label**, never the control, because that is the whole point. The
+ * pattern these replace put a bare `Text` next to a `Checkbox` in a plain `Row`: identical on screen,
+ * but only the small square responded. Everyone aims at the word — it is the bigger target and the one
+ * that reads as the thing being chosen — and nothing happened. 64 sites in this codebase had that
+ * shape, and only two did not.
+ *
+ * The other half is accessibility, and it is asserted the same way: control and label are **one**
+ * node with a role and a state, so a screen reader announces "Enabled, checked" rather than an
+ * unlabelled checkbox followed by a stray line of text.
+ */
+class LabeledControlsTest {
+
+    // ── Checkbox ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clicking the label toggles the checkbox`() = runComposeUiTest {
+        var checked = false
+        setContent {
+            MaterialTheme {
+                LabeledCheckbox(checked = checked, onCheckedChange = { checked = it }, label = "Enabled")
+            }
+        }
+
+        onNodeWithText("Enabled").performClick()
+
+        assertTrue(checked, "the label must be part of the control, not decoration beside it")
+    }
+
+    @Test
+    fun `the label and its checkbox are one node carrying the state`() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                LabeledCheckbox(checked = true, onCheckedChange = { }, label = "Enabled")
+            }
+        }
+
+        // One node, checked, addressable by its label — which is what a screen reader reads out.
+        onNodeWithText("Enabled").assertIsOn()
+    }
+
+    @Test
+    fun `an unchecked box reports itself off`() = runComposeUiTest {
+        setContent {
+            MaterialTheme { LabeledCheckbox(checked = false, onCheckedChange = { }, label = "Enabled") }
+        }
+
+        onNodeWithText("Enabled").assertIsOff()
+    }
+
+    @Test
+    fun `a disabled checkbox reports itself disabled and ignores the label`() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            MaterialTheme {
+                LabeledCheckbox(
+                    checked = false,
+                    onCheckedChange = { clicks++ },
+                    label = "Enabled",
+                    enabled = false,
+                )
+            }
+        }
+
+        onNodeWithText("Enabled").assertIsNotEnabled()
+        onNodeWithText("Enabled").performClick()
+        // Disabled has to mean both: says so, and does nothing. A control that silently swallows the
+        // press looks broken rather than unavailable.
+        assertEquals(0, clicks)
+    }
+
+    @Test
+    fun `toggling twice returns to where it started`() = runComposeUiTest {
+        val seen = mutableListOf<Boolean>()
+        // Compose state, not a plain local: without recomposition the second click would still see
+        // the original value and report `true` twice.
+        var checked by mutableStateOf(false)
+        setContent {
+            MaterialTheme {
+                LabeledCheckbox(
+                    checked = checked,
+                    onCheckedChange = { checked = it; seen += it },
+                    label = "Enabled",
+                )
+            }
+        }
+
+        onNodeWithText("Enabled").performClick()
+        waitForIdle()
+        onNodeWithText("Enabled").performClick()
+        waitForIdle()
+
+        assertEquals(listOf(true, false), seen, "each click must report the value it moves to")
+    }
+
+    // ── Radio button ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clicking the label selects the radio button`() = runComposeUiTest {
+        var picked = ""
+        setContent {
+            MaterialTheme {
+                LabeledRadioButton(selected = false, onClick = { picked = "still" }, label = "Still")
+            }
+        }
+
+        onNodeWithText("Still").performClick()
+
+        assertEquals("still", picked)
+    }
+
+    @Test
+    fun `a selected radio button reports itself selected`() = runComposeUiTest {
+        setContent {
+            MaterialTheme { LabeledRadioButton(selected = true, onClick = { }, label = "Still") }
+        }
+
+        onNodeWithText("Still").assertIsSelected()
+    }
+
+    @Test
+    fun `a disabled radio button ignores the label`() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            MaterialTheme {
+                LabeledRadioButton(selected = false, onClick = { clicks++ }, label = "Still", enabled = false)
+            }
+        }
+
+        onNodeWithText("Still").assertIsNotEnabled()
+        onNodeWithText("Still").performClick()
+        assertEquals(0, clicks)
+    }
+
+    @Test
+    fun `re-selecting an already selected radio still reports the click`() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            MaterialTheme {
+                LabeledRadioButton(selected = true, onClick = { clicks++ }, label = "Still")
+            }
+        }
+
+        onNodeWithText("Still").performClick()
+
+        // Selection is the caller's to decide — swallowing the click here would stop a group from
+        // being able to treat re-picking as a deliberate action.
+        assertEquals(1, clicks)
+    }
+
+    // ── Switch ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clicking the label toggles the switch`() = runComposeUiTest {
+        var on = false
+        setContent {
+            MaterialTheme { LabeledSwitch(checked = on, onCheckedChange = { on = it }, label = "Auto-start") }
+        }
+
+        onNodeWithText("Auto-start").performClick()
+
+        assertTrue(on)
+    }
+
+    @Test
+    fun `a switch carries its on state on the same node as its label`() = runComposeUiTest {
+        setContent {
+            MaterialTheme { LabeledSwitch(checked = true, onCheckedChange = { }, label = "Auto-start") }
+        }
+
+        onNodeWithText("Auto-start").assertIsOn()
+    }
+
+    @Test
+    fun `a disabled switch ignores the label`() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            MaterialTheme {
+                LabeledSwitch(
+                    checked = false,
+                    onCheckedChange = { clicks++ },
+                    label = "Auto-start",
+                    enabled = false,
+                )
+            }
+        }
+
+        onNodeWithText("Auto-start").assertIsNotEnabled()
+        onNodeWithText("Auto-start").performClick()
+        assertEquals(0, clicks)
+    }
+
+    // ── The shape being replaced ────────────────────────────────────────────────
+
+    @Test
+    fun `there is exactly one click target, not two competing ones`() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            MaterialTheme {
+                LabeledCheckbox(checked = false, onCheckedChange = { clicks++ }, label = "Enabled")
+            }
+        }
+
+        // The control is passed `onCheckedChange = null` precisely so it does not publish a second
+        // click target nested inside the row's. One press must produce one call, not two.
+        onNodeWithText("Enabled").performClick()
+
+        assertEquals(1, clicks)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdAtemDialogTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdAtemDialogTest.kt
@@ -104,8 +104,8 @@ class LowerThirdAtemDialogTest {
             openAtemDialog()
             val afterOpen = queried.size
 
-            // The radio itself, not its label: the labels are bare Text outside the RadioButton,
-            // so clicking the word does nothing (in the app as much as here — worth knowing).
+            // The clip row. Both modes are LabeledRadioButtons now, so the row -- control and label
+            // together -- is the one selectable node, and clicking anywhere on it selects the mode.
             onAllNodes(isSelectable())[1].performClick()
             waitForIdle()
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdAtemDialogTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdAtemDialogTest.kt
@@ -1,0 +1,150 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.churchpresenter.app.churchpresenter.server.AtemMediaSlot
+import org.churchpresenter.app.churchpresenter.server.AtemState
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The ATEM upload dialog — where a lower third is sent into a switcher's media pool before it can be
+ * keyed over the programme feed.
+ *
+ * **This is the part of the tab that was unreachable.** The dialog builds itself from a live query of
+ * the switcher, and that query is UDP with a **5s socket timeout**: no fast connection-refused, so
+ * every test that opened it used to cost five seconds whether or not hardware existed. That timeout,
+ * not the missing hardware, is what capped this tab at ~42% and got it written off as blocked.
+ *
+ * With the query injected, all of it runs instantly and deterministically — including the states no
+ * hardware could reliably reproduce on demand: an unreachable switcher, a pool whose slots do not
+ * include the configured default, and a device reporting a different frame rate than the settings
+ * assume.
+ *
+ * See `LowerThirdTabTestSupport.kt` for the harness.
+ */
+class LowerThirdAtemDialogTest {
+
+    /** The upload button's tooltip, which is also its content description. */
+    private val ATEM_UPLOAD = "Send to ATEM"
+
+    private fun state(
+        fps: Double = 25.0,
+        stills: List<AtemMediaSlot> = listOf(
+            AtemMediaSlot(index = 0, name = "Welcome", isUsed = true),
+            AtemMediaSlot(index = 1, name = "", isUsed = false),
+        ),
+        clips: List<AtemMediaSlot> = listOf(AtemMediaSlot(index = 0, name = "Clip A", isUsed = true)),
+        clipMaxFrames: List<Int> = listOf(600),
+    ) = AtemState(
+        fps = fps,
+        videoMode = "1080p25",
+        stillSlots = stills,
+        clipSlots = clips,
+        clipMaxFrames = clipMaxFrames,
+    )
+
+    /** Selects a preset — the upload button is disabled until one is chosen — then opens the dialog. */
+    private fun ComposeUiTest.openAtemDialog() {
+        selectPreset("Welcome")
+        ltButton(ATEM_UPLOAD).performClick()
+        waitForIdle()
+    }
+
+    @Test
+    fun `the dialog opens and offers both upload modes`() =
+        lowerThirdTab(atemReachable = true, queryAtemState = { _, _ -> state() }) { _ ->
+            openAtemDialog()
+
+            onNodeWithText("Send to ATEM").assertExists("the dialog must open")
+            onNodeWithText("Upload mode").assertExists("still or clip is the first choice")
+        }
+
+    @Test
+    fun `the switcher's still slots are listed with their names`() =
+        lowerThirdTab(atemReachable = true, queryAtemState = { _, _ -> state() }) { _ ->
+            openAtemDialog()
+
+            // The operator picks a slot by what is already in it — overwriting the wrong one replaces
+            // a graphic that may be live in another scene.
+            assertTrue(
+                showsContainingText("Welcome"),
+                "an occupied slot must show what occupies it: ${renderedText()}",
+            )
+        }
+
+    @Test
+    fun `an unreachable switcher is reported rather than silently empty`() =
+        lowerThirdTab(atemReachable = true, queryAtemState = { _, _ -> error("connection refused") }) { _ ->
+            openAtemDialog()
+
+            // The failure path is the one that matters most: without it the dialog would show an
+            // empty slot list, which looks like a switcher with no media rather than no switcher.
+            assertTrue(
+                showsContainingText("Could not load slots") || showsContainingText("connection refused"),
+                "the error must reach the operator: ${renderedText()}",
+            )
+        }
+
+    @Test
+    fun `switching to clip mode re-queries and lists the clip slots instead`() {
+        val queried = mutableListOf<String>()
+        lowerThirdTab(
+            atemReachable = true,
+            queryAtemState = { host, _ ->
+                queried += host
+                state()
+            },
+        ) { _ ->
+            openAtemDialog()
+            val afterOpen = queried.size
+
+            // The radio itself, not its label: the labels are bare Text outside the RadioButton,
+            // so clicking the word does nothing (in the app as much as here — worth knowing).
+            onAllNodes(isSelectable())[1].performClick()
+            waitForIdle()
+
+            // Stills and clips are separate pools, so the mode toggle has to go back to the device
+            // rather than filter what it already has.
+            assertTrue(queried.size > afterOpen, "changing mode must re-read the pool")
+            // The chosen slot sits in a field, so it is EditableText and never appears in
+            // renderedText(); onNodeWithText matches it.
+            onNodeWithText("Clip A", substring = true).assertExists()
+        }
+    }
+
+    @Test
+    fun `the dialog can be dismissed`() =
+        lowerThirdTab(atemReachable = true, queryAtemState = { _, _ -> state() }) { _ ->
+            openAtemDialog()
+            onNodeWithText("Send to ATEM").assertExists()
+
+            onNodeWithText("Cancel").performClick()
+            waitForIdle()
+
+            onNode(hasText("Upload mode")).assertDoesNotExist()
+        }
+
+    @Test
+    fun `a pool that does not contain the configured slot snaps to one that exists`() =
+        lowerThirdTab(
+            atemReachable = true,
+            // The default slot is 0; this device's pool starts at 4, which happens when a switcher
+            // is shared between sites or the settings were copied from another machine.
+            queryAtemState = { _, _ ->
+                state(stills = listOf(AtemMediaSlot(index = 4, name = "Site B", isUsed = true)))
+            },
+        ) { _ ->
+            openAtemDialog()
+
+            // Without the snap the dialog would sit on a slot the device does not have and the
+            // upload would fail at the far end, after the transfer. The slot field is EditableText,
+            // so this is onNodeWithText rather than a renderedText() scan.
+            onNodeWithText("Site B", substring = true).assertExists()
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdTabTestSupport.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.AtemSettings
+import org.churchpresenter.app.churchpresenter.server.AtemState
 import org.churchpresenter.app.churchpresenter.data.settings.StreamingSettings
 import java.io.File
 import java.nio.file.Files
@@ -67,6 +69,24 @@ internal class LowerThirdReports {
 @OptIn(ExperimentalTestApi::class)
 internal fun lowerThirdTab(
     folder: File? = lottieFolder("Welcome", "Speaker Name"),
+    /**
+     * What the ATEM upload dialog reads its media-pool state from.
+     *
+     * Injected because the real call is **UDP with a 5s socket timeout** — there is no fast
+     * connection-refused, so every test that opened the dialog used to cost five seconds, which is
+     * what capped this tab at ~42%. Supply a canned [AtemState], or throw to exercise the error path.
+     */
+    queryAtemState: suspend (host: String, port: Int) -> AtemState = { _, _ ->
+        error("no ATEM in tests unless the test supplies one")
+    },
+    /**
+     * Whether the (fake) switcher answers.
+     *
+     * The ATEM row is gated on `atemConfigured && atemEverConnected`, so a test that wants it needs
+     * both a non-blank host and a probe that succeeds — this sets both. Off by default, which is how
+     * the tab looks for the majority of churches, who have no switcher.
+     */
+    atemReachable: Boolean = false,
     block: ComposeUiTest.(reports: LowerThirdReports) -> Unit,
 ) {
     val reports = LowerThirdReports()
@@ -78,7 +98,12 @@ internal fun lowerThirdTab(
                         AppSettings(
                             streamingSettings = StreamingSettings(
                                 lowerThirdFolder = folder?.absolutePath ?: ""
-                            )
+                            ),
+                            atemSettings = if (atemReachable) {
+                                AtemSettings(host = "10.0.0.9")
+                            } else {
+                                AtemSettings()
+                            },
                         )
                     )
                 }
@@ -96,6 +121,8 @@ internal fun lowerThirdTab(
                             reports.live += presetName
                             reports.liveJson = json
                         },
+                        queryAtemState = queryAtemState,
+                        probeAtemReachable = { _, _ -> atemReachable },
                     )
                 }
             }


### PR DESCRIPTION
Two things, the second found while testing the first.

## The ATEM dialog was never blocked by hardware

`LowerThird` was recorded as capped at ~42% and **"do not re-explore"** — the upload dialog reads the
switcher's media pool over **UDP with a 5s socket timeout**, so with no fast connection-refused every
test that opened it cost five seconds. *The timeout was the blocker, not the missing device.*

Two seams were needed, and the second only appeared when the first turned out not to be enough:

- **`queryAtemState`** — the media-pool read the dialog is built from.
- **`probeAtemReachable`** — a separate polling loop whose result *gates the button that opens the
  dialog*. Seaming only the query left that button permanently disabled and the dialog still
  unreachable.

Both default to the real client, so callers are unchanged. The upload icon also gains a
`contentDescription`: it had `null`, so it could not be addressed at all, unlike the tab's other
buttons which take theirs from their tooltips.

**Six tests** now cover states hardware could not reproduce on demand — an unreachable switcher (the
important one: without it the dialog shows an empty slot list, which reads as *a switcher with no
media* rather than *no switcher*), a pool whose slots do not include the configured default, and the
still/clip toggle re-reading the pool.

## The mode labels did nothing when clicked

Writing those tests turned up a real UI defect. The dialog's **"Still"** and **"Clip"** labels are
bare `Text` *outside* their `RadioButton`, so clicking the word does nothing — only the small circle
responds. Everyone aims at the word: it is the larger target and the one that reads as the thing being
chosen.

`LabeledCheckbox` / `LabeledRadioButton` / `LabeledSwitch` fix it the way Material 3 recommends —
`toggleable`/`selectable` with the right `Role` on the row, and `null` passed to the control so the row
owns the single click. One target covering both halves, one semantics node, and the label announced
with its state. It is an accessibility fix as much as a usability one: previously a screen reader got
an unlabelled checkbox followed by a stray line of text.

**13 tests, every one clicking the label rather than the control**, because that is the whole point.

## Scope

`LowerThird`'s two radios are migrated here, so the helper lands with a real use rather than as a bare
abstraction. **The same shape exists at 62 more sites across 11 files** — `SourcePropertiesPanel` (15),
`SongSettingsTab` (12), `STTSettingsDialog` (7), `InstanceLinkDialog` (7), `PlanningCenterImportDialog`
(6), `BibleSettingsTab` (6) and five smaller ones. Only **two** places in the whole codebase got it
right, so it is the house style rather than a slip.

Those follow in a separate PR, migrated file-by-file with each suite run in between, to keep this one
reviewable.

## Verification

`./gradlew :composeApp:check` green including the 75% gate — **6,779 tests, 0 failed**. New suites ran
3× with `--rerun-tasks`, all green.
