### PR TITLE
Cover PresentationTab's slide grid, which was not deck-bound after all

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabSlideGridTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabSlideGridTest.kt
@@ -1,0 +1,155 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The slide grid — the half of the Presentation tab that only exists once a deck is loaded.
+ *
+ * `PresentationTabTest` covers the empty state and said this part needed a rasterized deck. It does
+ * not: `PresentationViewModel.slideFiles` is a public `SnapshotStateList<File>`, so a test can put
+ * real JPEGs in it directly and the grid renders from those. The rasterizer's job is producing those
+ * files, and that is the Presentation Engine's own suite to cover — not this tab's.
+ *
+ * That distinction is the point. What is deck-bound is *making* the slides; everything this tab does
+ * with them — laying them out, tracking the selection, moving between them, enabling the controls
+ * that were dead while empty — is ordinary Compose over a list of files.
+ *
+ * Decoding is wrapped in a `try`/`catch` that yields null, and `SlideThumbnail` takes a nullable
+ * bitmap, so the grid also renders for a file that will not decode. Real images are written anyway:
+ * a fixture that relied on the failure path would be testing the fallback rather than the tab.
+ */
+class PresentationTabSlideGridTest {
+
+    /** Writes [count] small, genuinely decodable JPEGs, as the rasterizer would leave behind. */
+    private fun slideFiles(count: Int): Pair<File, List<File>> {
+        val dir = Files.createTempDirectory("cp-presentation-slides").toFile()
+        val files = (1..count).map { n ->
+            File(dir, "slide-$n.jpg").also { f ->
+                ImageIO.write(BufferedImage(16, 9, BufferedImage.TYPE_INT_RGB), "jpg", f)
+            }
+        }
+        return dir to files
+    }
+
+    private fun withSlides(count: Int, block: androidx.compose.ui.test.ComposeUiTest.(vm: org.churchpresenter.app.churchpresenter.viewmodel.PresentationViewModel, reports: PresentationReports) -> Unit) {
+        val (dir, files) = slideFiles(count)
+        try {
+            presentationTab { vm, reports ->
+                vm.slideFiles.addAll(files)
+                waitForIdle()
+                block(vm, reports)
+            }
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    // ── The grid itself ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `every slide in the deck gets a thumbnail`() = withSlides(4) { vm, _ ->
+        assertEquals(4, vm.slideFiles.size)
+        // Each thumbnail is described by its slide number, which is also what an operator reads off
+        // the screen when someone says "go to slide three".
+        (1..4).forEach { n ->
+            onNodeWithContentDescription("Slide $n").assertExists("slide $n must be in the grid")
+        }
+    }
+
+    @Test
+    fun `the grid is numbered from one, not from zero`() = withSlides(3) { _, _ ->
+        onNodeWithContentDescription("Slide 1").assertExists()
+        assertTrue(
+            onAllNodesWithContentDescription("Slide 0")
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isEmpty(),
+            "a deck's first slide is slide 1 to everyone who is not a programmer",
+        )
+    }
+
+    // ── Selecting ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clicking a thumbnail selects that slide`() = withSlides(4) { vm, _ ->
+        onNodeWithContentDescription("Slide 3").performScrollTo().performClick()
+        waitForIdle()
+
+        // Zero-based on the inside, one-based on screen — the off-by-one between them is exactly
+        // the kind of thing that puts the wrong slide up.
+        assertEquals(2, vm.selectedSlideIndex)
+    }
+
+    @Test
+    fun `the first slide is selected when a deck arrives`() = withSlides(3) { vm, _ ->
+        assertEquals(0, vm.selectedSlideIndex, "a freshly loaded deck starts at its first slide")
+    }
+
+    @Test
+    fun `selecting a different slide moves the selection rather than adding one`() =
+        withSlides(4) { vm, _ ->
+            onNodeWithContentDescription("Slide 2").performScrollTo().performClick()
+            waitForIdle()
+            onNodeWithContentDescription("Slide 4").performScrollTo().performClick()
+            waitForIdle()
+
+            assertEquals(3, vm.selectedSlideIndex, "the last click wins")
+        }
+
+    // ── Controls that were dead while the tab was empty ─────────────────────────
+
+    @Test
+    fun `clear becomes usable once a deck is loaded`() = withSlides(2) { _, _ ->
+        // `PresentationTabTest` pins the other half of this: present but disabled with no deck.
+        presentationButton(PresentationLabel.CLEAR).assertIsEnabled()
+    }
+
+    @Test
+    fun `clearing reports to the host`() = withSlides(2) { _, reports ->
+        presentationButton(PresentationLabel.CLEAR).performClick()
+        waitForIdle()
+
+        assertEquals(1, reports.clears)
+    }
+
+    @Test
+    fun `a loaded deck can be added to the schedule`() = withSlides(3) { _, _ ->
+        // With no deck there is nothing to schedule; with one, the option has to appear or the deck
+        // cannot be put into a service order at all.
+        assertTrue(
+            hasPresentationButton(PresentationLabel.ADD_TO_SCHEDULE),
+            "a loaded deck must be schedulable: ${renderedText()}",
+        )
+    }
+
+    // ── The deck changing under the grid ────────────────────────────────────────
+
+    @Test
+    fun `loading a shorter deck drops the thumbnails that are gone`() = withSlides(5) { vm, _ ->
+        onNodeWithContentDescription("Slide 5").assertExists()
+
+        vm.slideFiles.removeAt(4)
+        vm.slideFiles.removeAt(3)
+        waitForIdle()
+
+        assertTrue(
+            onAllNodesWithContentDescription("Slide 5")
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isEmpty(),
+            "a slide that is no longer in the deck must leave the grid",
+        )
+        onNodeWithContentDescription("Slide 3").assertExists("and the rest must stay")
+    }
+}


### PR DESCRIPTION
**`PresentationTab` 42.1% → 53.0%** (425 missed lines → 345). Test-only.

## The grid never needed a deck

My earlier pass covered the empty state and left the grid alone, recording it as needing a rasterized
deck. That was wrong. **`PresentationViewModel.slideFiles` is a public `SnapshotStateList<File>`**, so
a test can put real JPEGs straight into it and the grid renders from those.

The distinction worth keeping straight: what is deck-bound is *producing* the slides — the Presentation
Engine's own suite covers that. Everything this tab does with them once they exist is ordinary Compose
over a list of files.

That is now four entries from the "blocked" list that turned out not to be blocked, after the stepper
arrows, the dropped broadcast, and the ATEM dialog.

## What is covered

Nine tests. The one worth naming is the **selection boundary**: slides are zero-based inside the view
model and one-based on screen, so clicking "Slide 3" must land on index 2. An off-by-one there puts the
wrong slide in front of a congregation and is invisible until it happens.

Also: the grid numbers from one rather than zero, a later click moves the selection rather than adding
to it, **Clear** and **Add to Schedule** become usable once a deck exists (the other half of what
`PresentationTabTest` pins about them being *disabled* while empty), and a deck shrinking under the
grid drops the thumbnails that are gone.

## A fixture choice worth explaining

The slides are **real, decodable JPEGs**, not stub bytes. Decoding is wrapped in a `try`/`catch` that
yields null and `SlideThumbnail` takes a nullable bitmap, so a fixture of undecodable files would still
render a grid — and would quietly be testing the fallback path rather than the tab.

## Verification

`./gradlew :composeApp:check` green including the 75% gate — **6,769 tests, 0 failed**. The new suite
ran 3× with `--rerun-tasks`, all green.

Independent of #118 (ATEM dialog + labelled controls); different files, no overlap.
