### PR TITLE
Cover resolving a scheduled lower third back to a preset

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdScheduleSelectionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdScheduleSelectionTest.kt
@@ -1,0 +1,88 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Clicking a lower third in the schedule and landing on it in this tab.
+ *
+ * The schedule stores a *label*, not a path, so the tab has to resolve it back to a file on disk —
+ * and the two do not always agree. A preset stored as "Welcome" has to match `Welcome.json`, and an
+ * item saved on another machine, or before a rename, may match nothing at all.
+ *
+ * Getting this wrong during a service is quiet and expensive: the operator clicks the item they
+ * queued, the tab shows whatever was already selected, and they go live with the wrong graphic. So
+ * the miss case matters as much as the hit — what must NOT happen is landing on the wrong preset.
+ *
+ * See `LowerThirdTabTestSupport.kt` for the harness; the fixture folder holds "Welcome" and
+ * "Speaker Name".
+ */
+class LowerThirdScheduleSelectionTest {
+
+    private fun item(label: String, id: String = "preset-1") =
+        ScheduleItem.LowerThirdItem(
+            id = "sched-1",
+            presetId = id,
+            presetLabel = label,
+            pauseAtFrame = false,
+            pauseDurationMs = 0L,
+        )
+
+    @Test
+    fun `an item naming a preset selects that preset`() =
+        lowerThirdTab(selectedLowerThirdItem = item("Welcome")) { _ ->
+            waitForIdle()
+
+            // Asserted as the *disappearance of the empty prompt*, not the presence of the name:
+            // "Welcome" is also a row in the preset list, so looking for it would pass whether or
+            // not anything was selected.
+            assertTrue(
+                !showsContainingText(LowerThirdLabel.SELECT_PRESET),
+                "the scheduled preset must actually be selected: ${renderedText()}",
+            )
+        }
+
+    @Test
+    fun `the label is matched without its file extension`() =
+        lowerThirdTab(selectedLowerThirdItem = item("Speaker Name")) { _ ->
+            waitForIdle()
+
+            // On disk it is "Speaker Name.json"; the schedule stores the bare name.
+            assertTrue(!showsContainingText(LowerThirdLabel.SELECT_PRESET), renderedText().toString())
+        }
+
+    @Test
+    fun `an item matching no preset leaves the selection alone`() =
+        lowerThirdTab(selectedLowerThirdItem = item("Deleted Since Last Sunday")) { _ ->
+            waitForIdle()
+
+            // The preset was removed or renamed after the service was built. Selecting nothing is
+            // the honest outcome; selecting *something* would put an unrelated graphic one click
+            // from going live.
+            assertTrue(
+                showsContainingText(LowerThirdLabel.SELECT_PRESET),
+                "nothing must be selected: ${renderedText()}",
+            )
+        }
+
+    @Test
+    fun `the preset id is used when the label does not match`() =
+        lowerThirdTab(selectedLowerThirdItem = item(label = "Renamed", id = "Welcome")) { _ ->
+            waitForIdle()
+
+            // Label first, id second — the fallback is what keeps an older schedule working after
+            // someone renames a preset's label but not its file.
+            assertTrue(!showsContainingText(LowerThirdLabel.SELECT_PRESET), renderedText().toString())
+        }
+
+    @Test
+    fun `no scheduled item leaves the tab on its empty prompt`() = lowerThirdTab { _ ->
+        assertTrue(
+            showsContainingText(LowerThirdLabel.SELECT_PRESET),
+            "with nothing scheduled the tab asks for a choice: ${renderedText()}",
+        )
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdTabTestSupport.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.data.settings.AtemSettings
 import org.churchpresenter.app.churchpresenter.server.AtemState
 import org.churchpresenter.app.churchpresenter.data.settings.StreamingSettings
@@ -87,6 +88,8 @@ internal fun lowerThirdTab(
      * the tab looks for the majority of churches, who have no switcher.
      */
     atemReachable: Boolean = false,
+    /** A lower third clicked in the schedule, which the tab resolves back to one of its presets. */
+    selectedLowerThirdItem: ScheduleItem.LowerThirdItem? = null,
     block: ComposeUiTest.(reports: LowerThirdReports) -> Unit,
 ) {
     val reports = LowerThirdReports()
@@ -121,6 +124,7 @@ internal fun lowerThirdTab(
                             reports.live += presetName
                             reports.liveJson = json
                         },
+                        selectedLowerThirdItem = selectedLowerThirdItem,
                         queryAtemState = queryAtemState,
                         probeAtemReachable = { _, _ -> atemReachable },
                     )


### PR DESCRIPTION
`LowerThird` **69.1% → 70.4%**. Stacked on #118 — merge that first.

## What this covers

The schedule stores a preset's **label**, not a path, so clicking a lower third in the service order
makes this tab resolve that label back to a file on disk. The two do not always agree: a preset renamed
or deleted after the service was built matches nothing.

Getting it wrong is quiet and expensive — the operator clicks the item they queued, the tab keeps
whatever was already selected, and they go live with the wrong graphic. So the **miss case is covered
as carefully as the hit**: what must not happen is landing on the wrong preset.

Also covered: the label is matched without its `.json` extension, and the preset **id** is used as a
fallback when the label does not match, which keeps an older schedule working after someone renames a
label but not a file.

## An assertion shape worth copying

Every test asserts the **disappearance of the empty prompt**, not the presence of the preset's name.
The name is also a row in the preset list, so asserting on it would pass whether or not anything was
selected — the vacuous-assertion shape this project has been bitten by repeatedly. The no-match test
asserts the prompt is still *there*, so the pair proves the prompt genuinely tracks selection rather
than being incidentally absent.

## On the upload path, which I was asked to look at

Measured rather than assumed: **#118's dialog tests already took this file from 41.7% to 69.1%**, so
the "capped at ~42%" note in the plan is long dead.

Of the 197 lines left, the upload orchestration is ~65. The remainder is a `JOptionPane` confirm
(headless-blocked), `LowerThirdSequencer` (network), and the list-resize drag.

**I considered seaming the upload and decided against it for now.** It needs stubs for *both*
`LottieRenderCache.prepare` (which renders to disk) and `AtemClient`; its success path contains a
literal `delay(800)`; and the decisions it actually makes are thin — `AtemUploadStatus`, the state it
publishes, is already at **100%**. The list-resize drag is the better remaining target in this file.

## Verification

`./gradlew :composeApp:check` green including the 75% gate — **6,793 tests, 0 failed**. `*LowerThird*`
ran 3× with `--rerun-tasks`, all green.
