### PR TITLE
Make labelled controls clickable: 13 more sites in three files

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -209,6 +209,7 @@ import javax.swing.filechooser.FileNameExtensionFilter
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 import org.churchpresenter.app.churchpresenter.data.readTranslationTitle
+import org.churchpresenter.app.churchpresenter.composables.LabeledCheckbox
 
 @Composable
 fun SourcePropertiesPanel(
@@ -458,20 +459,18 @@ private fun TextProperties(source: SceneSource.TextSource, onUpdate: (SceneSourc
         onColorChange = { onUpdate(source.copy(fontColor = it)) },
         label = stringResource(Res.string.canvas_font_color)
     )
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-        Checkbox(
-            checked = isTransparentBg,
-            onCheckedChange = { checked ->
+    LabeledCheckbox(
+        checked = isTransparentBg,
+        onCheckedChange = { checked ->
                 onUpdate(source.copy(
                     backgroundColor = if (checked) "#00000000" else "#000000"
                 ))
-            }
-        )
-        Text(stringResource(Res.string.canvas_transparent_bg), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
+            },
+        label = stringResource(Res.string.canvas_transparent_bg),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        spacing = 4.dp,
+    )
     if (!isTransparentBg) {
         ColorPickerField(
             color = source.backgroundColor,
@@ -489,16 +488,14 @@ private fun ColorProperties(source: SceneSource.ColorSource, onUpdate: (SceneSou
         onColorChange = { onUpdate(source.copy(color = it)) },
         label = stringResource(Res.string.canvas_color_1)
     )
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-        Checkbox(
-            checked = source.isGradient,
-            onCheckedChange = { onUpdate(source.copy(isGradient = it)) }
-        )
-        Text(stringResource(Res.string.canvas_gradient), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
+    LabeledCheckbox(
+        checked = source.isGradient,
+        onCheckedChange = { onUpdate(source.copy(isGradient = it)) },
+        label = stringResource(Res.string.canvas_gradient),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        spacing = 4.dp,
+    )
     PropertySlider("${stringResource(Res.string.canvas_color_1)} ${stringResource(Res.string.canvas_opacity)}", source.sourceOpacity, 0f, 1f) { v ->
         onUpdate(source.copy(sourceOpacity = v))
     }
@@ -568,20 +565,14 @@ private fun VideoProperties(source: SceneSource.VideoSource, onUpdate: (SceneSou
         }
     }
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-        Checkbox(
-            checked = source.loop,
-            onCheckedChange = { onUpdate(source.copy(loop = it)) }
-        )
-        Text(
-            stringResource(Res.string.canvas_video_loop),
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
-    }
+    LabeledCheckbox(
+        checked = source.loop,
+        onCheckedChange = { onUpdate(source.copy(loop = it)) },
+        label = stringResource(Res.string.canvas_video_loop),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        spacing = 4.dp,
+    )
 
     PropertySlider(stringResource(Res.string.canvas_video_volume), source.volume, 0f, 1f) { v ->
         onUpdate(source.copy(volume = v))
@@ -619,13 +610,14 @@ private fun BrowserProperties(source: SceneSource.BrowserSource, onUpdate: (Scen
     PropertyTextField(stringResource(Res.string.canvas_fps), source.fps.toString()) { v ->
         v.toIntOrNull()?.let { onUpdate(source.copy(fps = it.coerceIn(1, 60))) }
     }
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Checkbox(
-            checked = source.forceTransparent,
-            onCheckedChange = { onUpdate(source.copy(forceTransparent = it)) }
-        )
-        Text(stringResource(Res.string.canvas_transparent_bg), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
+    LabeledCheckbox(
+        checked = source.forceTransparent,
+        onCheckedChange = { onUpdate(source.copy(forceTransparent = it)) },
+        label = stringResource(Res.string.canvas_transparent_bg),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        spacing = 4.dp,
+    )
     PropertyTextField(stringResource(Res.string.canvas_custom_css), source.customCss) { v ->
         onUpdate(source.copy(customCss = v))
     }
@@ -641,20 +633,14 @@ private fun ShapeProperties(source: SceneSource.ShapeSource, onUpdate: (SceneSou
     val isStrokeOnly = source.shapeType in listOf("line", "arrow", "freehand")
 
     if (!isStrokeOnly) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            Checkbox(
-                checked = source.showStroke,
-                onCheckedChange = { onUpdate(source.copy(showStroke = it)) }
-            )
-            Text(
-                stringResource(Res.string.canvas_shape_show_stroke),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
+        LabeledCheckbox(
+            checked = source.showStroke,
+            onCheckedChange = { onUpdate(source.copy(showStroke = it)) },
+            label = stringResource(Res.string.canvas_shape_show_stroke),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            spacing = 4.dp,
+        )
     }
 
     if (isStrokeOnly || source.showStroke) {
@@ -691,20 +677,14 @@ private fun ShapeProperties(source: SceneSource.ShapeSource, onUpdate: (SceneSou
     if (!isStrokeOnly) {
         HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
 
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            Checkbox(
-                checked = source.isGradient,
-                onCheckedChange = { onUpdate(source.copy(isGradient = it)) }
-            )
-            Text(
-                stringResource(Res.string.canvas_gradient),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
+        LabeledCheckbox(
+            checked = source.isGradient,
+            onCheckedChange = { onUpdate(source.copy(isGradient = it)) },
+            label = stringResource(Res.string.canvas_gradient),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            spacing = 4.dp,
+        )
         if (source.isGradient) {
             ColorPickerField(
                 color = source.gradientColor2,
@@ -749,18 +729,30 @@ private fun ClockProperties(source: SceneSource.ClockSource, onUpdate: (SceneSou
             onSelectedChange = { onUpdate(source.copy(timeFormat = if (it == format12hLabel) "12h" else "24h")) }
         )
     }
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Checkbox(checked = source.showHours, onCheckedChange = { onUpdate(source.copy(showHours = it)) })
-        Text(stringResource(Res.string.canvas_clock_show_hours), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Checkbox(checked = source.showSeconds, onCheckedChange = { onUpdate(source.copy(showSeconds = it)) })
-        Text(stringResource(Res.string.canvas_clock_show_seconds), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Checkbox(checked = source.bold, onCheckedChange = { onUpdate(source.copy(bold = it)) })
-        Text(stringResource(Res.string.canvas_text_bold), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
+    LabeledCheckbox(
+        checked = source.showHours,
+        onCheckedChange = { onUpdate(source.copy(showHours = it)) },
+        label = stringResource(Res.string.canvas_clock_show_hours),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        spacing = 4.dp,
+    )
+    LabeledCheckbox(
+        checked = source.showSeconds,
+        onCheckedChange = { onUpdate(source.copy(showSeconds = it)) },
+        label = stringResource(Res.string.canvas_clock_show_seconds),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        spacing = 4.dp,
+    )
+    LabeledCheckbox(
+        checked = source.bold,
+        onCheckedChange = { onUpdate(source.copy(bold = it)) },
+        label = stringResource(Res.string.canvas_text_bold),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        spacing = 4.dp,
+    )
     PropertyTextField(stringResource(Res.string.canvas_clock_font_size), source.fontSize.toString()) { v ->
         v.toIntOrNull()?.let { onUpdate(source.copy(fontSize = it.coerceIn(8, 500))) }
     }
@@ -888,10 +880,14 @@ private fun QRCodeProperties(source: SceneSource.QRCodeSource, onUpdate: (SceneS
             onSelectedChange = { onUpdate(source.copy(wifiEncryption = it)) },
             modifier = Modifier.fillMaxWidth()
         )
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-            Checkbox(checked = source.wifiHidden, onCheckedChange = { onUpdate(source.copy(wifiHidden = it)) })
-            Text(stringResource(Res.string.canvas_qr_wifi_hidden), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
+        LabeledCheckbox(
+            checked = source.wifiHidden,
+            onCheckedChange = { onUpdate(source.copy(wifiHidden = it)) },
+            label = stringResource(Res.string.canvas_qr_wifi_hidden),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            spacing = 4.dp,
+        )
     } else {
         PropertyTextField(stringResource(Res.string.canvas_qr_content), source.content) { v ->
             onUpdate(source.copy(content = v))
@@ -902,13 +898,14 @@ private fun QRCodeProperties(source: SceneSource.QRCodeSource, onUpdate: (SceneS
         onColorChange = { onUpdate(source.copy(foregroundColor = it)) },
         label = stringResource(Res.string.canvas_qr_foreground)
     )
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-        Checkbox(
-            checked = source.transparentBackground,
-            onCheckedChange = { onUpdate(source.copy(transparentBackground = it)) }
-        )
-        Text(stringResource(Res.string.canvas_transparent_bg), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-    }
+    LabeledCheckbox(
+        checked = source.transparentBackground,
+        onCheckedChange = { onUpdate(source.copy(transparentBackground = it)) },
+        label = stringResource(Res.string.canvas_transparent_bg),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        spacing = 4.dp,
+    )
     if (!source.transparentBackground) {
         ColorPickerField(
             color = source.backgroundColor,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanel.kt
@@ -2046,10 +2046,20 @@ private fun BibleProperties(
         label = stringResource(Res.string.canvas_font_color)
     )
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        Checkbox(checked = source.bold, onCheckedChange = { onUpdate(source.copy(bold = it)) })
-        Text(stringResource(Res.string.canvas_text_bold), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Checkbox(checked = source.italic, onCheckedChange = { onUpdate(source.copy(italic = it)) })
-        Text(stringResource(Res.string.canvas_text_italic), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        LabeledCheckbox(
+            checked = source.bold,
+            onCheckedChange = { onUpdate(source.copy(bold = it)) },
+            label = stringResource(Res.string.canvas_text_bold),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        LabeledCheckbox(
+            checked = source.italic,
+            onCheckedChange = { onUpdate(source.copy(italic = it)) },
+            label = stringResource(Res.string.canvas_text_italic),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 
     Spacer(modifier = Modifier.height(4.dp))
@@ -2065,10 +2075,20 @@ private fun BibleProperties(
         label = stringResource(Res.string.canvas_bible_ref_color)
     )
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        Checkbox(checked = source.referenceBold, onCheckedChange = { onUpdate(source.copy(referenceBold = it)) })
-        Text(stringResource(Res.string.canvas_text_bold), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Checkbox(checked = source.referenceItalic, onCheckedChange = { onUpdate(source.copy(referenceItalic = it)) })
-        Text(stringResource(Res.string.canvas_text_italic), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        LabeledCheckbox(
+            checked = source.referenceBold,
+            onCheckedChange = { onUpdate(source.copy(referenceBold = it)) },
+            label = stringResource(Res.string.canvas_text_bold),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        LabeledCheckbox(
+            checked = source.referenceItalic,
+            onCheckedChange = { onUpdate(source.copy(referenceItalic = it)) },
+            label = stringResource(Res.string.canvas_text_italic),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 
     Spacer(modifier = Modifier.height(4.dp))

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/STTSettingsDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/STTSettingsDialog.kt
@@ -173,23 +173,25 @@ internal fun STTSettingsDialogContent(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    Checkbox(
+                    LabeledCheckbox(
                         checked = engine.enabled,
-                        onCheckedChange = { onSettingsChange { s -> s.copy(bibleEngineSettings = s.bibleEngineSettings.copy(enabled = it)) } }
+                        onCheckedChange = { onSettingsChange { s -> s.copy(bibleEngineSettings = s.bibleEngineSettings.copy(enabled = it)) } },
+                        label = stringResource(Res.string.bible_engine_detect),
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
-                    Text(stringResource(Res.string.bible_engine_detect), color = MaterialTheme.colorScheme.onSurface)
                     // Toggle hidden for now — engine always runs locally (runLocal defaults true).
                     // Flip to true to expose the local/remote choice again.
                     @Suppress("KotlinConstantConditions")
                     val showRunEngineLocallyToggle = false
                     if (showRunEngineLocallyToggle) {
                         Spacer(Modifier.weight(1f))
-                        Checkbox(
+                        LabeledCheckbox(
                             checked = engine.runLocal,
                             enabled = engine.enabled,
-                            onCheckedChange = { onSettingsChange { s -> s.copy(bibleEngineSettings = s.bibleEngineSettings.copy(runLocal = it)) } }
+                            onCheckedChange = { onSettingsChange { s -> s.copy(bibleEngineSettings = s.bibleEngineSettings.copy(runLocal = it)) } },
+                            label = stringResource(Res.string.bible_engine_run_local),
+                            color = MaterialTheme.colorScheme.onSurface,
                         )
-                        Text(stringResource(Res.string.bible_engine_run_local), color = MaterialTheme.colorScheme.onSurface)
                     }
                 }
                 AnimatedVisibility(visible = engine.enabled) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/STTSettingsDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/STTSettingsDialog.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTab.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import org.churchpresenter.app.churchpresenter.composables.SettingsTextField
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTab.kt
@@ -79,6 +79,7 @@ import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.AtemSettings
 import org.churchpresenter.app.churchpresenter.server.AtemClient
 import org.jetbrains.compose.resources.stringResource
+import org.churchpresenter.app.churchpresenter.composables.LabeledSwitch
 
 @Composable
 fun AtemSettingsTab(
@@ -483,77 +484,38 @@ fun AtemSettingsTab(
                 Spacer(Modifier.height(8.dp))
 
                 // Key type: drive the API / Go Live key as a downstream keyer instead of upstream
-                Row(
+                LabeledSwitch(
+                    checked = atem.useDownstreamKey,
+                    onCheckedChange = { update { copy(useDownstreamKey = it) } },
+                    label = "Downstream keyer (DSK)",
+                    supporting = "Drive the key as a downstream keyer instead of an upstream keyer (USK)",
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Switch(
-                        checked = atem.useDownstreamKey,
-                        onCheckedChange = { update { copy(useDownstreamKey = it) } }
-                    )
-                    Column {
-                        Text(
-                            "Downstream keyer (DSK)",
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        Text(
-                            "Drive the key as a downstream keyer instead of an upstream keyer (USK)",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                        )
-                    }
-                }
+                    spacing = 12.dp,
+                )
 
                 Spacer(Modifier.height(8.dp))
 
                 // Quick upload: one-press upload to the default slots, no dialog
-                Row(
+                LabeledSwitch(
+                    checked = atem.quickUpload,
+                    onCheckedChange = { update { copy(quickUpload = it) } },
+                    label = stringResource(Res.string.atem_quick_upload),
+                    supporting = stringResource(Res.string.atem_quick_upload_hint),
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Switch(
-                        checked = atem.quickUpload,
-                        onCheckedChange = { update { copy(quickUpload = it) } }
-                    )
-                    Column {
-                        Text(
-                            stringResource(Res.string.atem_quick_upload),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        Text(
-                            stringResource(Res.string.atem_quick_upload_hint),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                        )
-                    }
-                }
+                    spacing = 12.dp,
+                )
 
                 Spacer(Modifier.height(8.dp))
 
                 // Go Live drives the key: the tab's Go Live runs the timed key sequence
-                Row(
+                LabeledSwitch(
+                    checked = atem.goLiveKey,
+                    onCheckedChange = { update { copy(goLiveKey = it) } },
+                    label = stringResource(Res.string.atem_golive_key),
+                    supporting = stringResource(Res.string.atem_golive_key_hint),
                     modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    Switch(
-                        checked = atem.goLiveKey,
-                        onCheckedChange = { update { copy(goLiveKey = it) } }
-                    )
-                    Column {
-                        Text(
-                            stringResource(Res.string.atem_golive_key),
-                            style = MaterialTheme.typography.bodyMedium
-                        )
-                        Text(
-                            stringResource(Res.string.atem_golive_key_hint),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                        )
-                    }
-                }
+                    spacing = 12.dp,
+                )
             }
 
             // Kept as its own card so background uploads (Settings → Backgrounds) are never

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BibleSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BibleSettingsTab.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BibleSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BibleSettingsTab.kt
@@ -384,16 +384,14 @@ private fun LeftColumn(
                 range = 0..200,
             )
             Spacer(Modifier.width(4.dp))
-            Checkbox(
+            LabeledCheckbox(
                 checked = settings.bibleSettings.multiTranslationDivider,
                 onCheckedChange = { enabled ->
                     onSettingsChange { app ->
                         app.copy(bibleSettings = app.bibleSettings.copy(multiTranslationDivider = enabled))
                     }
                 },
-            )
-            Text(
-                text = stringResource(Res.string.bible_translation_divider),
+                label = stringResource(Res.string.bible_translation_divider),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/CompanionSatelliteSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/CompanionSatelliteSettingsTab.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/CompanionSatelliteSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/CompanionSatelliteSettingsTab.kt
@@ -75,6 +75,7 @@ import org.churchpresenter.app.churchpresenter.models.CompanionSurfacePlacement
 import org.churchpresenter.app.churchpresenter.models.CompanionSurfaceSlot
 import org.churchpresenter.app.churchpresenter.viewmodel.CompanionSatelliteViewModel
 import org.jetbrains.compose.resources.stringResource
+import org.churchpresenter.app.churchpresenter.composables.LabeledSwitch
 
 @Composable
 fun CompanionSatelliteSettingsTab(
@@ -405,20 +406,14 @@ private fun CompanionConnectionCard(
 
         Spacer(Modifier.height(8.dp))
 
-        Row(
+        LabeledSwitch(
+            checked = connection.autoConnect,
+            onCheckedChange = { onUpdate { copy(autoConnect = it) } },
+            label = stringResource(Res.string.companion_satellite_autoconnect),
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Switch(
-                checked = connection.autoConnect,
-                onCheckedChange = { onUpdate { copy(autoConnect = it) } }
-            )
-            Text(
-                stringResource(Res.string.companion_satellite_autoconnect),
-                style = MaterialTheme.typography.bodyMedium
-            )
-        }
+            style = MaterialTheme.typography.bodyMedium,
+            spacing = 12.dp,
+        )
 
         if (canRemove) {
             Spacer(Modifier.height(8.dp))

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
@@ -205,6 +205,7 @@ import org.jetbrains.compose.resources.stringResource
 import java.awt.GraphicsEnvironment
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
+import org.churchpresenter.app.churchpresenter.composables.LabeledSwitch
 
 /**
  * One physical display, reduced to what this tab needs of it: its index in the device list (which is
@@ -1071,22 +1072,19 @@ fun ProjectionSettingsTab(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                            Switch(
-                                checked = output.browserSourceEnabled,
-                                onCheckedChange = { checked ->
+                        LabeledSwitch(
+                            checked = output.browserSourceEnabled,
+                            onCheckedChange = { checked ->
                                     val updated = output.copy(browserSourceEnabled = checked)
                                     onSettingsChange { s ->
                                         s.copy(projectionSettings = s.projectionSettings.withBrowserSourceOutput(i, updated))
                                     }
-                                }
-                            )
-                            Text(
-                                text = stringResource(Res.string.browser_source_enabled),
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        }
+                                },
+                            label = stringResource(Res.string.browser_source_enabled),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            spacing = 4.dp,
+                        )
                         Text(
                             text = stringResource(Res.string.browser_source_output_label, i + 1),
                             style = MaterialTheme.typography.bodyMedium

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTab.kt
@@ -57,7 +57,6 @@ import androidx.compose.material3.OutlinedButton
 import org.churchpresenter.app.churchpresenter.composables.NumberSettingsTextField
 import org.churchpresenter.app.churchpresenter.composables.SettingsTextField
 import org.churchpresenter.app.churchpresenter.models.Scene
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -1075,11 +1074,11 @@ fun ProjectionSettingsTab(
                         LabeledSwitch(
                             checked = output.browserSourceEnabled,
                             onCheckedChange = { checked ->
-                                    val updated = output.copy(browserSourceEnabled = checked)
-                                    onSettingsChange { s ->
-                                        s.copy(projectionSettings = s.projectionSettings.withBrowserSourceOutput(i, updated))
-                                    }
-                                },
+                                val updated = output.copy(browserSourceEnabled = checked)
+                                onSettingsChange { s ->
+                                    s.copy(projectionSettings = s.projectionSettings.withBrowserSourceOutput(i, updated))
+                                }
+                            },
                             label = stringResource(Res.string.browser_source_enabled),
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTab.kt
@@ -123,6 +123,7 @@ import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.utils.calculateAutoFitFontSize
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
 import org.jetbrains.compose.resources.stringResource
+import org.churchpresenter.app.churchpresenter.composables.LabeledCheckbox
 
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -184,44 +185,34 @@ private fun TitleSlideColumn(
 ) {
     SettingsSection(title = stringResource(Res.string.song_title_slide)) {
         Column {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Checkbox(
-                    checked = settings.songSettings.titleSlideEnabled,
-                    onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(titleSlideEnabled = it)) } },
-                    modifier = Modifier.size(24.dp).testTag("song_titleSlideEnabled")
-                )
-                Text(stringResource(Res.string.enabled), style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(start = 8.dp))
-            }
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Checkbox(
-                    checked = settings.songSettings.titleSlideShowSongNumber,
-                    onCheckedChange = if (settings.songSettings.titleSlideEnabled) {
-                        { checked ->
-                            onSettingsChange { s ->
-                                s.copy(songSettings = s.songSettings.copy(titleSlideShowSongNumber = checked))
-                            }
-                        }
-                    } else null,
-                    enabled = settings.songSettings.titleSlideEnabled,
-                    modifier = Modifier.size(24.dp).testTag("song_titleSlideShowSongNumber")
-                )
-                Text(
-                    text = stringResource(Res.string.show_song_number_before_title),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = if (settings.songSettings.titleSlideEnabled) {
+            LabeledCheckbox(
+                checked = settings.songSettings.titleSlideEnabled,
+                onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(titleSlideEnabled = it)) } },
+                controlModifier = Modifier.size(24.dp),
+                label = stringResource(Res.string.enabled),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("song_titleSlideEnabled"),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            LabeledCheckbox(
+                checked = settings.songSettings.titleSlideShowSongNumber,
+                // The old code disabled this by passing a null callback; `enabled` below already
+                // makes the row inert, and the helper needs one or the other, not both.
+                onCheckedChange = { checked ->
+                    onSettingsChange { s ->
+                        s.copy(songSettings = s.songSettings.copy(titleSlideShowSongNumber = checked))
+                    }
+                },
+                enabled = settings.songSettings.titleSlideEnabled,
+                controlModifier = Modifier.size(24.dp),
+                label = stringResource(Res.string.show_song_number_before_title),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("song_titleSlideShowSongNumber"),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (settings.songSettings.titleSlideEnabled) {
                         MaterialTheme.colorScheme.onSurface
                     } else {
                         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                     },
-                    modifier = Modifier.padding(start = 8.dp)
-                )
-            }
+            )
         }
     }
 }
@@ -358,17 +349,13 @@ private fun LeftColumn(
     val sameLowerThird = settings.songSettings.songNumberLowerThirdPosition == settings.songSettings.titleLowerThirdPosition &&
             settings.songSettings.songNumberLowerThirdHorizontalAlignment == settings.songSettings.titleLowerThirdHorizontalAlignment
     AnimatedVisibility(visible = sameFullscreen || sameLowerThird) {
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Checkbox(
-                checked = settings.songSettings.songNumberBeforeTitle,
-                onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(songNumberBeforeTitle = it)) } },
-                modifier = Modifier.testTag("song_songNumberBeforeTitle")
-            )
-            Text(stringResource(Res.string.number_before_title), style = MaterialTheme.typography.bodyMedium)
-        }
+        LabeledCheckbox(
+            checked = settings.songSettings.songNumberBeforeTitle,
+            onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(songNumberBeforeTitle = it)) } },
+            label = stringResource(Res.string.number_before_title),
+            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("song_songNumberBeforeTitle"),
+            style = MaterialTheme.typography.bodyMedium,
+        )
     }
     } // end song_number SettingsSection
 
@@ -595,45 +582,33 @@ private fun LeftColumn(
     Spacer(modifier = Modifier.height(4.dp))
 
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(
-                checked = settings.songSettings.fadeIn,
-                onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(fadeIn = it)) } },
-                modifier = Modifier.size(24.dp).testTag("song_fadeIn")
-            )
-            Text(
-                text = stringResource(Res.string.fade_in),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(start = 4.dp)
-            )
-        }
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(
-                checked = settings.songSettings.fadeOut,
-                onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(fadeOut = it)) } },
-                modifier = Modifier.size(24.dp).testTag("song_fadeOut")
-            )
-            Text(
-                text = stringResource(Res.string.fade_out),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(start = 4.dp)
-            )
-        }
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(
-                checked = settings.songSettings.crossfade,
-                onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(crossfade = it)) } },
-                modifier = Modifier.size(24.dp).testTag("song_crossfade")
-            )
-            Text(
-                text = stringResource(Res.string.animation_crossfade),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(start = 4.dp)
-            )
-        }
+        LabeledCheckbox(
+            checked = settings.songSettings.fadeIn,
+            onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(fadeIn = it)) } },
+            controlModifier = Modifier.size(24.dp),
+            label = stringResource(Res.string.fade_in),
+            modifier = Modifier.testTag("song_fadeIn"),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        LabeledCheckbox(
+            checked = settings.songSettings.fadeOut,
+            onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(fadeOut = it)) } },
+            controlModifier = Modifier.size(24.dp),
+            label = stringResource(Res.string.fade_out),
+            modifier = Modifier.testTag("song_fadeOut"),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        LabeledCheckbox(
+            checked = settings.songSettings.crossfade,
+            onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(crossfade = it)) } },
+            controlModifier = Modifier.size(24.dp),
+            label = stringResource(Res.string.animation_crossfade),
+            modifier = Modifier.testTag("song_crossfade"),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
     }
 
     // ── Bilingual Layout ──
@@ -864,14 +839,14 @@ private fun RightColumn(
                 tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.auto_fit_checkbox_tooltip), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
                 tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(
-                        checked = settings.songSettings.lyricsFontSizeAutoFit,
-                        onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lyricsFontSizeAutoFit = it)) } },
-                        modifier = Modifier.size(24.dp).testTag("song_lyricsFontSizeAutoFit")
-                    )
-                    Text(stringResource(Res.string.auto_fit), style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(start = 4.dp))
-                }
+                LabeledCheckbox(
+                    checked = settings.songSettings.lyricsFontSizeAutoFit,
+                    onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lyricsFontSizeAutoFit = it)) } },
+                    controlModifier = Modifier.size(24.dp),
+                    label = stringResource(Res.string.auto_fit),
+                    modifier = Modifier.testTag("song_lyricsFontSizeAutoFit"),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
             }
             if (presenterManager != null) {
                 TooltipArea(
@@ -1022,14 +997,14 @@ private fun RightColumn(
                 tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.auto_fit_checkbox_tooltip), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
                 tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(
-                        checked = settings.songSettings.lyricsLowerThirdFontSizeAutoFit,
-                        onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lyricsLowerThirdFontSizeAutoFit = it)) } },
-                        modifier = Modifier.size(24.dp).testTag("song_lyricsLowerThirdFontSizeAutoFit")
-                    )
-                    Text(stringResource(Res.string.auto_fit), style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(start = 4.dp))
-                }
+                LabeledCheckbox(
+                    checked = settings.songSettings.lyricsLowerThirdFontSizeAutoFit,
+                    onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lyricsLowerThirdFontSizeAutoFit = it)) } },
+                    controlModifier = Modifier.size(24.dp),
+                    label = stringResource(Res.string.auto_fit),
+                    modifier = Modifier.testTag("song_lyricsLowerThirdFontSizeAutoFit"),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
             }
             if (presenterManager != null) {
                 TooltipArea(
@@ -1198,14 +1173,14 @@ private fun LookAheadColumn(
                 tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.auto_fit_checkbox_tooltip), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
                 tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(
-                        checked = settings.songSettings.lookAheadFontSizeAutoFit,
-                        onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lookAheadFontSizeAutoFit = it)) } },
-                        modifier = Modifier.size(24.dp).testTag("song_lookAheadFontSizeAutoFit")
-                    )
-                    Text(stringResource(Res.string.auto_fit), style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(start = 4.dp))
-                }
+                LabeledCheckbox(
+                    checked = settings.songSettings.lookAheadFontSizeAutoFit,
+                    onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lookAheadFontSizeAutoFit = it)) } },
+                    controlModifier = Modifier.size(24.dp),
+                    label = stringResource(Res.string.auto_fit),
+                    modifier = Modifier.testTag("song_lookAheadFontSizeAutoFit"),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
             }
         }
     }
@@ -1260,14 +1235,14 @@ private fun LookAheadColumn(
                 tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.auto_fit_checkbox_tooltip), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
                 tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(
-                        checked = settings.songSettings.lookAheadNextFontSizeAutoFit,
-                        onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lookAheadNextFontSizeAutoFit = it)) } },
-                        modifier = Modifier.size(24.dp).testTag("song_lookAheadNextFontSizeAutoFit")
-                    )
-                    Text(stringResource(Res.string.auto_fit), style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(start = 4.dp))
-                }
+                LabeledCheckbox(
+                    checked = settings.songSettings.lookAheadNextFontSizeAutoFit,
+                    onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lookAheadNextFontSizeAutoFit = it)) } },
+                    controlModifier = Modifier.size(24.dp),
+                    label = stringResource(Res.string.auto_fit),
+                    modifier = Modifier.testTag("song_lookAheadNextFontSizeAutoFit"),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
             }
         }
     }
@@ -1372,14 +1347,14 @@ private fun LookAheadColumn(
                 tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.auto_fit_checkbox_tooltip), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
                 tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(
-                        checked = settings.songSettings.lowerThirdLookAheadFontSizeAutoFit,
-                        onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lowerThirdLookAheadFontSizeAutoFit = it)) } },
-                        modifier = Modifier.size(24.dp).testTag("song_lowerThirdLookAheadFontSizeAutoFit")
-                    )
-                    Text(stringResource(Res.string.auto_fit), style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(start = 4.dp))
-                }
+                LabeledCheckbox(
+                    checked = settings.songSettings.lowerThirdLookAheadFontSizeAutoFit,
+                    onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lowerThirdLookAheadFontSizeAutoFit = it)) } },
+                    controlModifier = Modifier.size(24.dp),
+                    label = stringResource(Res.string.auto_fit),
+                    modifier = Modifier.testTag("song_lowerThirdLookAheadFontSizeAutoFit"),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
             }
         }
     }
@@ -1434,14 +1409,14 @@ private fun LookAheadColumn(
                 tooltip = { Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall, tonalElevation = 4.dp) { Text(stringResource(Res.string.auto_fit_checkbox_tooltip), color = MaterialTheme.colorScheme.inverseOnSurface, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), style = MaterialTheme.typography.bodySmall) } },
                 tooltipPlacement = TooltipPlacement.ComponentRect(anchor = Alignment.BottomCenter, offset = DpOffset(0.dp, 4.dp))
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(
-                        checked = settings.songSettings.lowerThirdLookAheadNextFontSizeAutoFit,
-                        onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lowerThirdLookAheadNextFontSizeAutoFit = it)) } },
-                        modifier = Modifier.size(24.dp).testTag("song_lowerThirdLookAheadNextFontSizeAutoFit")
-                    )
-                    Text(stringResource(Res.string.auto_fit), style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(start = 4.dp))
-                }
+                LabeledCheckbox(
+                    checked = settings.songSettings.lowerThirdLookAheadNextFontSizeAutoFit,
+                    onCheckedChange = { onSettingsChange { s -> s.copy(songSettings = s.songSettings.copy(lowerThirdLookAheadNextFontSizeAutoFit = it)) } },
+                    controlModifier = Modifier.size(24.dp),
+                    label = stringResource(Res.string.auto_fit),
+                    modifier = Modifier.testTag("song_lowerThirdLookAheadNextFontSizeAutoFit"),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
             }
         }
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/AtemSettingsTabTestSupport.kt
@@ -221,21 +221,17 @@ internal fun ComposeUiTest.atemPortBox(): SemanticsNodeInteraction = nodeAt(host
 /**
  * The switch captioned [caption].
  *
- * Every switch on the tab sits to the left of a two-line caption block, so the switch wanted is the
- * one whose row the caption's first line shares.
+ * The switch and its caption are one node: `LabeledSwitch` puts `toggleable` on the row, so the
+ * toggleable node carries both lines of the caption. This used to hunt for a switch positioned to the
+ * left of the caption's first line, which is what the hand-rolled `Row(Switch, Column(Text, Text))`
+ * required — and which also meant clicking the caption did nothing.
  */
 internal fun ComposeUiTest.atemSwitchFor(caption: String): SemanticsNodeInteraction {
-    val label = onAllNodes(SemanticsMatcher("switch caption \"$caption\"") { node ->
-        node.config.getOrNull(SemanticsProperties.Text).orEmpty().any { it.text == caption }
-    }).fetchSemanticsNodes(atLeastOneRootRequired = false)
-        .minByOrNull { it.boundsInRoot.top }
-        ?: error("no switch captioned \"$caption\" on screen")
-    val bounds = label.boundsInRoot
     val switch = atemSwitches().fetchSemanticsNodes(atLeastOneRootRequired = false)
-        .filter { it.boundsInRoot.right <= bounds.left }
-        .filter { it.boundsInRoot.top < bounds.bottom && it.boundsInRoot.bottom > bounds.top }
-        .maxByOrNull { it.boundsInRoot.left }
-        ?: error("no switch beside the caption \"$caption\"")
+        .firstOrNull { node ->
+            node.config.getOrNull(SemanticsProperties.Text).orEmpty().any { it.text == caption }
+        }
+        ?: error("no switch captioned \"$caption\" on screen")
     return nodeAt(switch.boundsInRoot)
 }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTabTest.kt
@@ -4,7 +4,6 @@ package org.churchpresenter.app.churchpresenter.dialogs.tabs
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertCountEquals
-import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsOff

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTabTest.kt
@@ -5,6 +5,7 @@ package org.churchpresenter.app.churchpresenter.dialogs.tabs
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertHasNoClickAction
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
@@ -62,9 +63,12 @@ class SongSettingsTabTest {
 
     @Test
     fun `the title-slide number checkbox is disabled while the title slide is off`() = songTab { get ->
+        // Reports itself disabled rather than simply having no click action. The old code disabled
+        // this by passing a null callback, which removed the action outright; LabeledCheckbox marks
+        // the row disabled instead, which is what a screen reader needs in order to say so.
         onNodeWithTag("song_titleSlideShowSongNumber")
             .performScrollTo()
-            .assertHasNoClickAction()
+            .assertIsNotEnabled()
         assertEquals(
             true,
             get().songSettings.titleSlideShowSongNumber,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SongSettingsTabTestSupport.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.hasImeAction
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
@@ -209,7 +210,10 @@ internal fun ComposeUiTest.segmentedButton(text: String, row: Int): SemanticsNod
 
 /** The "Auto" push-buttons next to the lyrics font sizes; only rendered with a PresenterManager. */
 internal fun ComposeUiTest.autoFitButtons(): SemanticsNodeInteractionCollection =
-    onAllNodes(hasClickAction() and hasText("Auto"))
+    // Not toggleable: the auto-fit *checkboxes* beside these buttons carry the same "Auto" label,
+    // and since they became LabeledCheckbox their row is clickable too, so text + click alone now
+    // matches four nodes rather than two.
+    onAllNodes(hasClickAction() and hasText("Auto") and !isToggleable())
 
 // ── Actions ─────────────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Second increment. **13 sites** across `SourcePropertiesPanel` (11), `ProjectionSettingsTab` (1) and
`CompanionSatelliteSettingsTab` (1).

**32 of ~63 sites now migrated; 31 remain**, all irregular shapes that need hand work rather than a
transform (two-line labels, rows holding an icon or a thumbnail between control and label).

Stacked on #122, which is stacked on #118 — merge in that order.

## Method, unchanged

Each file converted → compiled → tested before starting the next, with every diff audited for content
the transform might have dropped. **Every removed line is `Row`/control/`Text` boilerplate.**

## One more guard, and why it matters

`ProjectionSettingsTab` prompted it: **rows that already own the click must be left alone.**

Two sites in this codebase were written correctly from the start — `Row(.clickable { … })` with
`onCheckedChange = null` on the control, which is exactly the shape the helper produces. Converting one
would have nested a **second click target inside the first**.

The transform now skips any row whose modifier already carries `clickable`/`selectable`/`toggleable`,
and any control already passed a null callback. That also explains the original survey's result — the
2-out-of-64 correct sites were not accidents, and they should stay as they are.

## Verification

`./gradlew :composeApp:check` green including the 75% gate — **6,788 tests, 0 failed**. Affected suites
ran 3× with `--rerun-tasks`, all green.
