### PR TITLE
Fix the flaky CDP event test

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCacheTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCacheTest.kt
@@ -92,8 +92,19 @@ class SharedBrowserFrameCacheTest {
         fun stop() = server.stop(0, 0)
 
         /** Pushes an arbitrary CDP event frame straight to the connected client, bypassing the
-         *  automatic id/result echo above. */
-        fun sendEvent(json: String) = runBlocking { sessions.forEach { it.send(Frame.Text(json)) } }
+         *  automatic id/result echo above.
+         *
+         *  Waits for the session first. `CdpConnection.connect` returning means the *client* side
+         *  of the handshake finished; the server's own handler coroutine — the one that runs
+         *  `sessions.add(this)` — may not have been dispatched yet. Sending into an empty list is
+         *  silent, so the frame goes nowhere and the test waiting on it fails a timeout later,
+         *  with nothing to say why. */
+        fun sendEvent(json: String) {
+            val deadline = System.currentTimeMillis() + 5_000
+            while (sessions.isEmpty() && System.currentTimeMillis() < deadline) Thread.sleep(5)
+            if (sessions.isEmpty()) throw AssertionError("no client session connected to the fake CDP server")
+            runBlocking { sessions.forEach { it.send(Frame.Text(json)) } }
+        }
     }
 
     private fun startFakeCdpBrowser(): FakeCdpBrowser = FakeCdpBrowser().also { servers.add(it); it.start() }


### PR DESCRIPTION
`SharedBrowserFrameCacheTest` > `a main-frame navigation event invokes onUrlChanged with the new URL` failed on CI with `timed out after 5000ms waiting for onUrlChanged to be invoked`, having passed on the run that introduced it (#120).

It is a race in the test's own fake server, not in `CdpConnection`. `sendEvent` fans the frame out to `sessions`, which the server's handler coroutine populates with `sessions.add(this)`. `CdpConnection.connect` returning `true` only means the **client** side of the handshake finished — the server's handler may not have been dispatched yet. When it has not, `sessions` is empty, `forEach` sends to nobody without complaint, and the test then burns its full 5s timeout waiting for a callback that was never going to fire.

`sendEvent` now waits for the session to exist before sending, and throws naming that cause if it never appears — so the failure, if it ever does happen, says what went wrong instead of pointing at `onUrlChanged`.

Verified with `--rerun-tasks` three times, green each time; the suite runs in 0.9s.