### PR TITLE
Fix the flaky announcement-ticker test

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresenterManagerAnnouncementTimerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresenterManagerAnnouncementTimerTest.kt
@@ -171,16 +171,21 @@ class PresenterManagerAnnouncementTimerTest {
     // the background never overwrites whatever is on screen. goLive sets the live flag; pausing then
     // stops the ticker while leaving that flag set, so the gate can be exercised without a live tick.
 
-    /** Arms the live flag the way going live does, then stops the ticker so nothing ticks under us. */
-    private fun PresenterManager.armLiveTicker() {
-        goLiveAnnouncementTimer(
-            timerMode = Constants.TIMER_MODE_DURATION,
-            timerHours = 0, timerMinutes = 5, timerSeconds = 0,
-            targetHour = 0, targetMinute = 0, targetSecond = 0,
-            liveClockFormat = "HH:mm", timerExpiredText = "",
-        )
-        pauseAnnouncementTimer()
-    }
+    /**
+     * Sets the live flag the gate reads, and nothing else.
+     *
+     * It used to go live with a real five-minute countdown and then pause it. `pauseAnnouncementTimer`
+     * only *cancels* the ticker job, and cancellation is cooperative: a ticker already dispatched
+     * could still get its first `pushAnnouncementTextIfLive("05:00")` in afterwards, overwriting the
+     * text the test had just pushed. That is a race against a real clock, and it failed on CI as
+     * `expected:<00:41> but was:<05:00>`.
+     *
+     * `_announcementTickerLive` is the only thing these tests need out of going live — it is half of
+     * what [PresenterManager.pushAnnouncementTextIfLive] gates on, the other half being a screen on
+     * announcements — and it has its own setter. `goLiveAnnouncementTimer` itself stays covered by
+     * the go-live tests below.
+     */
+    private fun PresenterManager.armLiveTicker() = setAnnouncementTickerLive(true)
 
     @Test
     fun `timer text is not pushed when nothing is showing announcements`() {


### PR DESCRIPTION
`PresenterManagerAnnouncementTimerTest` > `timer text is pushed when a screen lock pins announcements even off the live mode` failed on CI with `expected:<00:41> but was:<05:00>`. It is a race against a real clock, and it predates the current run of PRs.

`armLiveTicker()` went live with a real five-minute countdown and then paused it. `pauseAnnouncementTimer` only cancels the ticker's job, and cancellation is cooperative — a ticker already dispatched can still land its first `pushAnnouncementTextIfLive("05:00")` afterwards, on top of the text the test had just pushed. Hence `05:00` where `00:41` was expected.

These tests are about the *gate* in `pushAnnouncementTextIfLive`, which reads `_announcementTickerLive` plus a screen showing announcements. The flag has its own setter, so the helper now sets it and starts no coroutine at all. `goLiveAnnouncementTimer` keeps its own coverage in the go-live tests further down the same class.

Mutation-checked rather than assumed: dropping `_announcementTickerLive` from the gate still fails the suite, so the tests are not passing vacuously. Run three times with `--rerun-tasks`, green each time.