### PR TITLE
Expose Lottie cache internals and add server tests

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
@@ -1042,7 +1042,7 @@ class CompanionServer {
      * handled natively by the WebSocket protocol — no manual buffer/boundary parsing needed on
      * either side, and no dependence on a legacy MIME type with inconsistent engine support.
      */
-    private fun encodeBrowserSourceFrameMessage(frame: BrowserSourceFrame): ByteArray {
+    internal fun encodeBrowserSourceFrameMessage(frame: BrowserSourceFrame): ByteArray {
         val buf = java.nio.ByteBuffer.allocate(24 + frame.png.size)
         buf.putInt(frame.x)
         buf.putInt(frame.y)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCache.kt
@@ -75,7 +75,18 @@ object LottieRenderCache {
     private const val HEADER_LEN = 22L
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-    internal val cacheDir = File(System.getProperty("user.home"), ".churchpresenter/lottie_render_cache")
+    /**
+     * Resolved per call, not latched at object-init.
+     *
+     * This object is reachable from `CompanionServer`, `LowerThird` and `PresenterManager`, so in a
+     * full suite run something touches it long before any one test does. Held as a plain `val`, it
+     * would capture whatever `user.home` was at that first touch — the real one — and a test that
+     * points `user.home` at a temp dir would still be handed the developer's own cache. Since
+     * [evictOldEntries] deletes files, that is not a stale read but real data destroyed, and which
+     * test class ran first would decide it. Same reasoning as `RecentLabelColors`.
+     */
+    internal val cacheDir: File
+        get() = File(System.getProperty("user.home"), ".churchpresenter/lottie_render_cache")
 
     /** One render at a time — each opens an off-screen Compose scene. */
     private val renderMutex = Mutex()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCache.kt
@@ -62,7 +62,7 @@ object LottieRenderCache {
 
     private const val MAGIC = "LRCC"
     private const val VERSION = 1
-    private const val MAX_ENTRIES = 60
+    internal const val MAX_ENTRIES = 60
     private const val MAX_TOTAL_BYTES = 4L * 1024 * 1024 * 1024
 
     /** Frame rate desktop playback variants are rendered at. */
@@ -75,7 +75,7 @@ object LottieRenderCache {
     private const val HEADER_LEN = 22L
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-    private val cacheDir = File(System.getProperty("user.home"), ".churchpresenter/lottie_render_cache")
+    internal val cacheDir = File(System.getProperty("user.home"), ".churchpresenter/lottie_render_cache")
 
     /** One render at a time — each opens an off-screen Compose scene. */
     private val renderMutex = Mutex()
@@ -366,7 +366,7 @@ object LottieRenderCache {
 
     // ── Internals ─────────────────────────────────────────────────────────────
 
-    private fun keyFor(lottieJson: String, v: Variant): String {
+    internal fun keyFor(lottieJson: String, v: Variant): String {
         val md5 = MessageDigest.getInstance("MD5").digest(lottieJson.toByteArray(Charsets.UTF_8))
             .joinToString("") { "%02x".format(it) }
         return if (!v.clip) "${md5}_${v.width}x${v.height}_still"
@@ -375,7 +375,7 @@ object LottieRenderCache {
 
     // Version in the filename so a format/behavior change invalidates old entries
     // (leftovers age out through LRU eviction)
-    private fun cacheFile(key: String) = File(cacheDir, "${key}_v$VERSION.lrcc")
+    internal fun cacheFile(key: String) = File(cacheDir, "${key}_v$VERSION.lrcc")
 
     private suspend fun renderToFile(lottieJson: String, v: Variant, dest: File, key: String) {
         cacheDir.mkdirs()
@@ -425,7 +425,7 @@ object LottieRenderCache {
         }
     }
 
-    private fun evictOldEntries() {
+    internal fun evictOldEntries() {
         val entries = cacheDir.listFiles { f -> f.extension == "lrcc" } ?: return
         val byAge = entries.sortedBy { it.lastModified() }
         var totalBytes = entries.sumOf { it.length() }
@@ -443,7 +443,7 @@ object LottieRenderCache {
     /** Runs shorter than this stay literal — a run record costs 8 bytes. */
     private const val MIN_RUN = 3
 
-    private fun encodeArgbRle(pixels: IntArray): ByteArray {
+    internal fun encodeArgbRle(pixels: IntArray): ByteArray {
         // Worst case is alternating length-1 literal records and minimum runs, which stays
         // at parity with raw size; headroom covers record headers.
         val buf = ByteBuffer.allocate(pixels.size * 4 + pixels.size / MIN_RUN * 4 + 16)
@@ -474,7 +474,7 @@ object LottieRenderCache {
         return buf.array().copyOf(buf.position())
     }
 
-    private fun decodeArgbRle(payload: ByteArray, pixelCount: Int): IntArray {
+    internal fun decodeArgbRle(payload: ByteArray, pixelCount: Int): IntArray {
         val buf = ByteBuffer.wrap(payload)
         val out = IntArray(pixelCount)
         var o = 0
@@ -494,7 +494,7 @@ object LottieRenderCache {
     }
 
     /** Bilinear ARGB scale (used only for same-aspect raster mismatches at ATEM upload time). */
-    private fun scaleArgb(src: IntArray, sw: Int, sh: Int, dw: Int, dh: Int): IntArray {
+    internal fun scaleArgb(src: IntArray, sw: Int, sh: Int, dw: Int, dh: Int): IntArray {
         val srcImg = BufferedImage(sw, sh, BufferedImage.TYPE_INT_ARGB)
         srcImg.setRGB(0, 0, sw, sh, src, 0, sw)
         val dstImg = BufferedImage(dw, dh, BufferedImage.TYPE_INT_ARGB)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/ApplyRemoteLiveStateRemoteFetchTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/ApplyRemoteLiveStateRemoteFetchTest.kt
@@ -1,0 +1,166 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.data.settings.AtemSettings
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.viewmodel.InstanceLinkViewModel
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The two [applyRemoteLiveState] branches [ApplyRemoteLiveStateTest] deliberately leaves out:
+ * PICTURES and LOWER_THIRD both fetch bytes from the primary over [InstanceLinkViewModel], so this
+ * drives a real [CompanionServer] as the primary — same approach as `InstanceLinkClientTest` — and a
+ * real, connected [InstanceLinkViewModel] as the follower.
+ *
+ * [instanceLinkPictureCacheDir] resolves its path from `user.home` once per JVM (like
+ * `InstanceLinkLogger`), so — unlike most test classes in this suite — `user.home` is deliberately
+ * **not** swapped here; the project's own Gradle config already points it at a permanent
+ * `build/test-home` for the whole `jvmTest` run (see `TestSingletons`'s doc comment for why a
+ * per-test temp dir would be actively wrong for a `by lazy` singleton: the dir gets deleted out from
+ * under it after the first test that resolves it). Each test instead uses its own folder-id and
+ * clears its own cache file first, so a stale file from an earlier run of this suite can't be
+ * mistaken for a fresh fetch.
+ */
+class ApplyRemoteLiveStateRemoteFetchTest {
+
+    private lateinit var server: CompanionServer
+    private lateinit var link: InstanceLinkViewModel
+    private var port: Int = 0
+
+    @BeforeTest
+    fun setUp() {
+        TestSingletons.latchToTestHome()
+
+        server = CompanionServer()
+        server.start(port = 39_820)
+        port = runBlocking {
+            withTimeoutOrNull(10_000) {
+                while (!server.isRunning.value || server.serverUrl.value.isBlank()) {
+                    kotlinx.coroutines.delay(25)
+                }
+                server.serverUrl.value.substringAfterLast(':').toInt()
+            }
+        } ?: error("server did not start")
+
+        link = InstanceLinkViewModel()
+        link.connect(host = "127.0.0.1", port = port, apiKey = "", deviceId = "test-device", reconnectDelayMs = 60_000)
+        awaitUntil("the link to connect") { link.connectionStatus.value == InstanceLinkStatus.CONNECTED }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { link.dispose() }
+        runCatching { server.stop() }
+    }
+
+    private fun awaitUntil(what: String, timeoutMs: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(20)
+        }
+        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    }
+
+    private fun apply(state: LiveStateDto): PresenterManager {
+        val presenter = PresenterManager()
+        runBlocking { applyRemoteLiveState(state = state, presenterManager = presenter, instanceLinkViewModel = link) }
+        return presenter
+    }
+
+    /** Clears this test's own slot in the process-wide picture cache before it runs, so a leftover
+     *  file from an earlier run of this suite can't be mistaken for a fresh fetch. */
+    private fun clearPictureCache(folderId: String, index: Int) {
+        File(instanceLinkPictureCacheDir, "${folderId}_$index.jpg").delete()
+    }
+
+    // ── PICTURES ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a live picture is fetched, cached locally, and displayed by its cache path`() {
+        clearPictureCache("apply-remote-fetch-1", 0)
+        val dir = Files.createTempDirectory("cp-remote-fetch-pictures").toFile()
+        val imageBytes = byteArrayOf(1, 2, 3, 4)
+        val imageFile = File(dir, "photo.jpg").apply { writeBytes(imageBytes) }
+        server.updatePictures(folderId = "apply-remote-fetch-1", folderName = "Folder", folderPath = dir.absolutePath, imageFiles = listOf(imageFile))
+
+        val presenter = apply(LiveStateDto(contentType = "PICTURES", pictureFolderId = "apply-remote-fetch-1", pictureIndex = 0))
+
+        val cachedPath = presenter.selectedImagePath.value
+        assertTrue(cachedPath != null && File(cachedPath).exists(), "expected a real cache file, got $cachedPath")
+        assertEquals(imageBytes.toList(), File(cachedPath).readBytes().toList())
+        assertEquals(Presenting.PICTURES, presenter.presentingMode.value)
+    }
+
+    @Test
+    fun `a second apply of the same picture reuses the cache instead of re-fetching`() {
+        clearPictureCache("apply-remote-fetch-2", 0)
+        val dir = Files.createTempDirectory("cp-remote-fetch-pictures-cache").toFile()
+        val imageFile = File(dir, "photo.jpg").apply { writeBytes(byteArrayOf(9)) }
+        server.updatePictures(folderId = "apply-remote-fetch-2", folderName = "Folder", folderPath = dir.absolutePath, imageFiles = listOf(imageFile))
+
+        val first = apply(LiveStateDto(contentType = "PICTURES", pictureFolderId = "apply-remote-fetch-2", pictureIndex = 0))
+        val firstPath = first.selectedImagePath.value
+
+        // Delete the folder server-side — if the second apply re-fetched, it would now fail.
+        server.updatePictures(folderId = "apply-remote-fetch-2", folderName = "Folder", folderPath = dir.absolutePath, imageFiles = emptyList())
+        val second = apply(LiveStateDto(contentType = "PICTURES", pictureFolderId = "apply-remote-fetch-2", pictureIndex = 0))
+
+        assertEquals(firstPath, second.selectedImagePath.value, "the cache file path must be stable across applies")
+    }
+
+    @Test
+    fun `a picture the primary does not have leaves the mode unswitched`() {
+        clearPictureCache("apply-remote-fetch-missing", 0)
+        val presenter = apply(LiveStateDto(contentType = "PICTURES", pictureFolderId = "apply-remote-fetch-missing", pictureIndex = 0))
+
+        // Unlike every other branch in this function, a failed PICTURES fetch returns before
+        // reaching the trailing setPresentingMode/setShowPresenterWindow calls — so, discovered
+        // here rather than asserted as an existing contract: the mode does NOT switch on this one
+        // failure path, unlike the "missing folder-id/index in the payload" case just below.
+        assertNull(presenter.selectedImagePath.value)
+        assertEquals(Presenting.NONE, presenter.presentingMode.value)
+    }
+
+    @Test
+    fun `a PICTURES state missing its folder-id or index still switches the mode`() {
+        val presenter = apply(LiveStateDto(contentType = "PICTURES"))
+        assertNull(presenter.selectedImagePath.value)
+        assertEquals(Presenting.PICTURES, presenter.presentingMode.value, "this guard falls through normally, unlike a failed fetch")
+    }
+
+    // ── LOWER_THIRD ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a live lower third is fetched by name and played as Lottie content`() {
+        val dir = Files.createTempDirectory("cp-remote-fetch-lowerthirds").toFile()
+        File(dir, "Welcome.json").writeText("""{"v":"5.9.0","layers":[]}""")
+        server.updateAtemConfig(AtemSettings(), lowerThirdFolder = dir.absolutePath)
+
+        val presenter = apply(LiveStateDto(contentType = "LOWER_THIRD", lowerThirdName = "Welcome"))
+
+        assertEquals("""{"v":"5.9.0","layers":[]}""", presenter.lottieJsonContent.value)
+        assertEquals(Presenting.LOWER_THIRD, presenter.presentingMode.value)
+    }
+
+    @Test
+    fun `a lower third preset the primary does not have is a quiet no-op`() {
+        val dir = Files.createTempDirectory("cp-remote-fetch-lowerthirds-empty").toFile()
+        server.updateAtemConfig(AtemSettings(), lowerThirdFolder = dir.absolutePath)
+
+        val presenter = apply(LiveStateDto(contentType = "LOWER_THIRD", lowerThirdName = "no-such-preset"))
+
+        assertEquals("", presenter.lottieJsonContent.value)
+        assertEquals(Presenting.LOWER_THIRD, presenter.presentingMode.value, "the mode still switches")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/ApplyRemoteLiveStateTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/ApplyRemoteLiveStateTest.kt
@@ -32,9 +32,12 @@ import kotlin.test.assertTrue
  *    primary that may be a different version, so every field is nullable and every branch has to
  *    cope with the nulls.
  *
- * Not covered here: the PICTURES and LOWER_THIRD branches fetch bytes over the link and the MEDIA
- * stream path needs a reachable primary — those need a live socket. The BIBLE reference-only branch
- * needs a real `Bible`, which `BibleViewModel`'s own suites already build; it is left to them.
+ * Not covered here: PICTURES and LOWER_THIRD fetch bytes over the link, and the MEDIA stream-url
+ * path needs a reachable primary — those need a live socket, and are covered separately in
+ * `ApplyRemoteLiveStateRemoteFetchTest` against a real [CompanionServer] (the same approach
+ * `InstanceLinkClientTest` uses), so this class doesn't pay for starting one per test. The BIBLE
+ * reference-only branch needs a real `Bible`, which `BibleViewModel`'s own suites already build; it
+ * is left to them.
  */
 class ApplyRemoteLiveStateTest {
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AtemFrameEncoderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AtemFrameEncoderTest.kt
@@ -69,6 +69,14 @@ class AtemFrameEncoderTest {
         assertTrue(a.contentEquals(b), "same pixels must encode identically every time")
     }
 
+    @Test
+    fun `hd heights use the same four-bytes-per-pixel contract as sd`() {
+        // height >= 720 switches the coefficients from BT.601 to BT.709; only the size contract is
+        // asserted here, matching this file's determinism-over-arithmetic style.
+        val out = AtemFrameEncoder.argbToYuv422(4, 720, IntArray(4 * 720) { 0xFF204060.toInt() })
+        assertEquals(4 * 720 * 4, out.size)
+    }
+
     // ── encodeRLE ───────────────────────────────────────────────────────────────
 
     @Test
@@ -100,5 +108,38 @@ class AtemFrameEncoderTest {
         }.array()
         val out = AtemFrameEncoder.encodeRLE(mixed)
         assertTrue(out.size <= mixed.size, "RLE output must never exceed its input length")
+    }
+
+    @Test
+    fun `a run of exactly three identical blocks is left uncompressed`() {
+        // The header only pays off from four repeats on: three copies (8*3=24B) cost the same as
+        // the header+count+block record (also 24B), so the threshold is deliberately above three.
+        val block = 0x99AABBCCDDEEFF00uL.toLong()
+        val out = AtemFrameEncoder.encodeRLE(uniformBlocks(3, block))
+        assertEquals(24, out.size)
+        assertEquals(block, out.longAt(0))
+        assertEquals(block, out.longAt(8))
+        assertEquals(block, out.longAt(16))
+    }
+
+    @Test
+    fun `pending literal blocks flush before a following run is emitted`() {
+        // Two distinct blocks followed by a run of four: the literals must reach the output ahead
+        // of the run's header, verbatim, not be swallowed by the run they happen to precede.
+        val x = 0x1111111111111111L
+        val y = 0x2222222222222222L
+        val z = 0x3333333333333333L
+        val buf = ByteBuffer.allocate(6 * 8).apply {
+            putLong(x); putLong(y); putLong(z); putLong(z); putLong(z); putLong(z)
+        }.array()
+
+        val out = AtemFrameEncoder.encodeRLE(buf)
+
+        assertEquals(40, out.size, "2 literal blocks (16B) + header+count+block (24B)")
+        assertEquals(x, out.longAt(0))
+        assertEquals(y, out.longAt(8))
+        assertEquals(AtemFrameEncoder.RLE_HEADER, out.longAt(16))
+        assertEquals(4L, out.longAt(24))
+        assertEquals(z, out.longAt(32))
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerBibleSelectTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerBibleSelectTest.kt
@@ -1,0 +1,113 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CompanionServerBibleSelectTest {
+
+    private lateinit var server: CompanionServer
+    private lateinit var client: HttpClient
+    private var port: Int = 0
+    private var operatorScope: CoroutineScope? = null
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @BeforeTest
+    fun setUp() {
+        server = CompanionServer()
+        server.start(port = 39_830)
+        port = runBlocking {
+            withTimeoutOrNull(10_000) {
+                while (!server.isRunning.value || server.serverUrl.value.isBlank()) {
+                    kotlinx.coroutines.delay(25)
+                }
+                server.serverUrl.value.substringAfterLast(':').toInt()
+            }
+        } ?: error("server did not start")
+        client = HttpClient(CIO)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { operatorScope?.cancel() }
+        operatorScope = null
+        runCatching { client.close() }
+        runCatching { server.stop() }
+    }
+
+    private fun url(path: String) = "http://127.0.0.1:$port$path"
+
+    private fun <T> collecting(flow: MutableSharedFlow<T>, onEach: (T) -> Unit) {
+        val scope = operatorScope ?: CoroutineScope(Dispatchers.IO).also { operatorScope = it }
+        scope.launch { flow.collect { onEach(it) } }
+        runBlocking {
+            withTimeoutOrNull(5_000) { flow.subscriptionCount.first { it > 0 } }
+                ?: error("collector never subscribed")
+        }
+    }
+
+    private fun awaitUntil(what: String, timeoutMs: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(20)
+        }
+        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    }
+
+    @Test
+    fun `selecting a verse acks ok and notifies onSelectBibleVerse`() = runBlocking {
+        val received = mutableListOf<SelectBibleVerseRequest>()
+        collecting(server.onSelectBibleVerse) { received.add(it) }
+
+        val req = SelectBibleVerseRequest(bookName = "John", chapter = 3, verseNumber = 16, verseText = "For God so loved the world.")
+        val response = client.post(url(Constants.ENDPOINT_BIBLE_SELECT)) {
+            setBody(json.encodeToString(SelectBibleVerseRequest.serializer(), req))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("""{"ok":true}""", response.bodyAsText())
+        awaitUntil("onSelectBibleVerse") { received.isNotEmpty() }
+        assertEquals(req, received.single())
+    }
+
+    @Test
+    fun `an invalid body is a 400, not a 500`() = runBlocking {
+        val response = client.post(url(Constants.ENDPOINT_BIBLE_SELECT)) {
+            setBody("not json at all")
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `a multi-verse range is passed through as sent`() = runBlocking {
+        val received = mutableListOf<SelectBibleVerseRequest>()
+        collecting(server.onSelectBibleVerse) { received.add(it) }
+
+        val req = SelectBibleVerseRequest(bookName = "Genesis", chapter = 1, verseNumber = 1, verseRange = "1-3")
+        client.post(url(Constants.ENDPOINT_BIBLE_SELECT)) {
+            setBody(json.encodeToString(SelectBibleVerseRequest.serializer(), req))
+        }
+
+        awaitUntil("onSelectBibleVerse") { received.isNotEmpty() }
+        assertEquals("1-3", received.single().verseRange)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerBrowserSourceTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerBrowserSourceTest.kt
@@ -1,0 +1,237 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.Frame
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
+import org.churchpresenter.app.churchpresenter.presenter.BrowserSourceFrame
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import java.nio.ByteBuffer
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * `/browser-source/{index}` — the OBS overlay page and its guards. All configuration ([updateBrowserSourceOutputs]),
+ * no OBS/Chromium/ATEM needed: the route only needs a [ScreenAssignment] to exist at that index.
+ *
+ * The WebSocket delta stream and its binary frame encoding are separate concerns: no fake browser
+ * renders anything here, so only [CompanionServer.encodeBrowserSourceFrameMessage]'s own header
+ * packing (widened to `internal`) is pinned directly, byte for byte.
+ */
+class CompanionServerBrowserSourceTest {
+
+    private lateinit var server: CompanionServer
+    private lateinit var client: HttpClient
+    private var port: Int = 0
+
+    @BeforeTest
+    fun setUp() {
+        server = CompanionServer()
+        server.start(port = 39_810)
+        port = runBlocking {
+            withTimeoutOrNull(10_000) {
+                while (!server.isRunning.value || server.serverUrl.value.isBlank()) {
+                    kotlinx.coroutines.delay(25)
+                }
+                server.serverUrl.value.substringAfterLast(':').toInt()
+            }
+        } ?: error("server did not start")
+        client = HttpClient(CIO) { install(WebSockets) }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { client.close() }
+        runCatching { server.stop() }
+    }
+
+    private fun url(path: String) = "http://127.0.0.1:$port$path"
+    private fun get(path: String, apiKey: String? = null): HttpResponse = runBlocking {
+        client.get(url(path)) { apiKey?.let { header(Constants.HEADER_API_KEY, it) } }
+    }
+
+    // ── GET /browser-source/{index} ───────────────────────────────────────────
+
+    @Test
+    fun `an unconfigured output index is a 404`() {
+        assertEquals(HttpStatusCode.NotFound, get("${Constants.ENDPOINT_BROWSER_SOURCE}/1").status)
+    }
+
+    @Test
+    fun `a non-numeric index is a 404, not a 500`() {
+        assertEquals(HttpStatusCode.NotFound, get("${Constants.ENDPOINT_BROWSER_SOURCE}/not-a-number").status)
+    }
+
+    @Test
+    fun `a configured, enabled output serves its overlay page with a no-store header`() {
+        server.updateBrowserSourceOutputs(listOf(ScreenAssignment(browserSourceEnabled = true)))
+        val response = get("${Constants.ENDPOINT_BROWSER_SOURCE}/1")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("no-store", response.headers[HttpHeaders.CacheControl])
+        assertTrue(runBlocking { response.bodyAsText() }.contains("<html", ignoreCase = true))
+    }
+
+    @Test
+    fun `a disabled output is a 404`() {
+        server.updateBrowserSourceOutputs(listOf(ScreenAssignment(browserSourceEnabled = false)))
+        assertEquals(HttpStatusCode.NotFound, get("${Constants.ENDPOINT_BROWSER_SOURCE}/1").status)
+    }
+
+    @Test
+    fun `the path index is 1-based -- index 1 is the first configured output`() {
+        server.updateBrowserSourceOutputs(listOf(
+            ScreenAssignment(browserSourceEnabled = true),
+            ScreenAssignment(browserSourceEnabled = false),
+        ))
+        assertEquals(HttpStatusCode.OK, get("${Constants.ENDPOINT_BROWSER_SOURCE}/1").status)
+        assertEquals(HttpStatusCode.NotFound, get("${Constants.ENDPOINT_BROWSER_SOURCE}/2").status)
+        assertEquals(HttpStatusCode.NotFound, get("${Constants.ENDPOINT_BROWSER_SOURCE}/3").status)
+    }
+
+    @Test
+    fun `an api key requirement on the output is enforced independently of the global api key`() {
+        server.updateApiKey(enabled = false, key = "secret123")
+        server.updateBrowserSourceOutputs(listOf(
+            ScreenAssignment(browserSourceEnabled = true, browserSourceApiKeyRequired = true),
+        ))
+
+        assertEquals(HttpStatusCode.Unauthorized, get("${Constants.ENDPOINT_BROWSER_SOURCE}/1").status)
+        assertEquals(HttpStatusCode.Unauthorized, get("${Constants.ENDPOINT_BROWSER_SOURCE}/1", apiKey = "wrong").status)
+        assertEquals(HttpStatusCode.OK, get("${Constants.ENDPOINT_BROWSER_SOURCE}/1", apiKey = "secret123").status)
+    }
+
+    @Test
+    fun `no api key is required when the output does not ask for one, even with a global key set`() {
+        server.updateApiKey(enabled = true, key = "secret123")
+        server.updateBrowserSourceOutputs(listOf(
+            ScreenAssignment(browserSourceEnabled = true, browserSourceApiKeyRequired = false),
+        ))
+        assertEquals(HttpStatusCode.OK, get("${Constants.ENDPOINT_BROWSER_SOURCE}/1").status)
+    }
+
+    // ── encodeBrowserSourceFrameMessage ────────────────────────────────────────
+
+    @Test
+    fun `encodeBrowserSourceFrameMessage packs a 24-byte big-endian header followed by the raw PNG bytes`() {
+        val frame = BrowserSourceFrame(x = 10, y = 20, rectWidth = 30, rectHeight = 40, fullWidth = 1920, fullHeight = 1080, png = byteArrayOf(1, 2, 3))
+        val encoded = server.encodeBrowserSourceFrameMessage(frame)
+
+        assertEquals(24 + 3, encoded.size)
+        val buf = ByteBuffer.wrap(encoded)
+        assertEquals(10, buf.int)
+        assertEquals(20, buf.int)
+        assertEquals(30, buf.int)
+        assertEquals(40, buf.int)
+        assertEquals(1920, buf.int)
+        assertEquals(1080, buf.int)
+        val remaining = ByteArray(3)
+        buf.get(remaining)
+        assertEquals(listOf<Byte>(1, 2, 3), remaining.toList())
+    }
+
+    @Test
+    fun `encodeBrowserSourceFrameMessage with an empty PNG payload is just the header`() {
+        val frame = BrowserSourceFrame(0, 0, 0, 0, 0, 0, png = ByteArray(0))
+        assertEquals(24, server.encodeBrowserSourceFrameMessage(frame).size)
+    }
+
+    // ── WebSocket delta stream ───────────────────────────────────────────────
+
+    private fun wsPath(index: Int) = "/api${Constants.ENDPOINT_BROWSER_SOURCE}/$index/ws"
+
+    private fun connectAndGetCloseReason(index: Int): CloseReason? = runBlocking {
+        var reason: CloseReason? = null
+        withTimeoutOrNull(5_000) {
+            client.webSocket(urlString = "ws://127.0.0.1:$port${wsPath(index)}") {
+                reason = closeReason.await()
+            }
+        }
+        reason
+    }
+
+    @Test
+    fun `connecting to an unconfigured output index closes with cannot-accept`() {
+        val reason = connectAndGetCloseReason(1)
+        assertEquals(CloseReason.Codes.CANNOT_ACCEPT.code, reason?.code)
+    }
+
+    @Test
+    fun `connecting to a disabled output closes with cannot-accept`() {
+        server.updateBrowserSourceOutputs(listOf(ScreenAssignment(browserSourceEnabled = false)))
+        val reason = connectAndGetCloseReason(1)
+        assertEquals(CloseReason.Codes.CANNOT_ACCEPT.code, reason?.code)
+    }
+
+    @Test
+    fun `connecting with a required api key missing closes with violated-policy`() {
+        server.updateApiKey(enabled = false, key = "secret123")
+        server.updateBrowserSourceOutputs(listOf(ScreenAssignment(browserSourceEnabled = true, browserSourceApiKeyRequired = true)))
+        val reason = connectAndGetCloseReason(1)
+        assertEquals(CloseReason.Codes.VIOLATED_POLICY.code, reason?.code)
+    }
+
+    @Test
+    fun `connecting before a renderer has registered its frame flow closes with try-again-later`() {
+        server.updateBrowserSourceOutputs(listOf(ScreenAssignment(browserSourceEnabled = true)))
+        val reason = connectAndGetCloseReason(1)
+        assertEquals(CloseReason.Codes.TRY_AGAIN_LATER.code, reason?.code)
+    }
+
+    @Test
+    fun `a registered renderer's frames are streamed to the client, encoded`() = runBlocking {
+        server.updateBrowserSourceOutputs(listOf(ScreenAssignment(browserSourceEnabled = true)))
+        val frames = MutableSharedFlow<BrowserSourceFrame>(extraBufferCapacity = 4)
+        server.registerBrowserSourceFrames(0, frames)
+        val frame = BrowserSourceFrame(x = 1, y = 2, rectWidth = 3, rectHeight = 4, fullWidth = 5, fullHeight = 6, png = byteArrayOf(9, 8, 7))
+        val expected = server.encodeBrowserSourceFrameMessage(frame)
+
+        var received: Frame? = null
+        withTimeoutOrNull(10_000) {
+            client.webSocket(urlString = "ws://127.0.0.1:$port${wsPath(1)}") {
+                frames.subscriptionCount.first { it > 0 }
+                frames.emit(frame)
+                received = incoming.receive()
+            }
+        }
+
+        assertNotNull(received, "expected a binary frame")
+        val bytes = (received as Frame.Binary).data
+        assertEquals(expected.toList(), bytes.toList())
+    }
+
+    @Test
+    fun `replacing a renderer's frame flow closes any session still connected to the old one`() = runBlocking {
+        server.updateBrowserSourceOutputs(listOf(ScreenAssignment(browserSourceEnabled = true)))
+        val oldFlow = MutableSharedFlow<BrowserSourceFrame>(extraBufferCapacity = 4)
+        server.registerBrowserSourceFrames(0, oldFlow)
+
+        var reason: CloseReason? = null
+        withTimeoutOrNull(10_000) {
+            client.webSocket(urlString = "ws://127.0.0.1:$port${wsPath(1)}") {
+                oldFlow.subscriptionCount.first { it > 0 }
+                val newFlow = MutableSharedFlow<BrowserSourceFrame>(extraBufferCapacity = 4)
+                server.registerBrowserSourceFrames(0, newFlow)
+                reason = closeReason.await()
+            }
+        }
+
+        assertEquals(CloseReason.Codes.SERVICE_RESTART.code, reason?.code)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerDictionaryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerDictionaryTest.kt
@@ -21,19 +21,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * The Strong's dictionary REST endpoints (`GET /api/dictionary`, `/{number}`, `/{number}/verses`) —
- * untouched by every other `CompanionServer*Test`.
- *
- * `StrongsDictionaryRepositoryTest` already pins the repository's own filtering/sorting/scoping
- * logic against a tiny stubbed fixture (`Res.readBytes` mocked via `DictionaryFixture`). That
- * approach does not carry over here: the mock is installed from the JUnit test thread, but Ktor
- * dispatches the request handler onto its own Netty worker thread pool, and empirically the mocked
- * `Res` is not visible there — the route ends up reading the real bundled dictionary regardless.
- * Rather than chase that cross-thread mocking gap, these tests exercise only the route's own
- * behaviour that holds against the *real* dictionary: the request/response plumbing (status codes,
- * param parsing), not exact result content, which `StrongsDictionaryRepositoryTest` already owns.
- */
 class CompanionServerDictionaryTest {
 
     private lateinit var server: CompanionServer
@@ -43,15 +30,10 @@ class CompanionServerDictionaryTest {
 
     @BeforeTest
     fun setUp() {
-        // This test deliberately reads the real bundled dictionary (see class doc comment); reset
-        // first so it never depends on whatever another test already loaded into these singletons.
         StrongsDictionaryRepository.cache.clear()
         StrongsDictionaryRepository.interlinear.resetForTest()
 
         server = CompanionServer()
-        // Its own port: every CompanionServer suite claims a distinct one, and 39_721 is
-        // CompanionServerQaModerationTest's. Sharing it means a bind failure whenever the previous
-        // suite's socket has not finished closing.
         server.start(port = 39_731)
         port = runBlocking {
             withTimeoutOrNull(10_000) {
@@ -98,6 +80,15 @@ class CompanionServerDictionaryTest {
         assertEquals(HttpStatusCode.NotFound, response.status)
     }
 
+    @Test
+    fun `looking up a real number from the bundled dictionary returns it`() = runBlocking {
+        val response = client.get(url("/api/dictionary/H430"))
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.parseToJsonElement(response.bodyAsText()).jsonObject
+        assertEquals("H430", body["number"]?.jsonPrimitive?.content)
+        assertTrue(body["word"]?.jsonPrimitive?.content?.isNotBlank() == true)
+    }
+
     // ── GET /api/dictionary/{number}/verses ───────────────────────────────────
 
     @Test
@@ -114,5 +105,22 @@ class CompanionServerDictionaryTest {
         val response = client.get(url("/api/dictionary/H9999999/verses"))
         assertEquals(HttpStatusCode.OK, response.status)
         assertEquals(0, json.parseToJsonElement(response.bodyAsText()).jsonObject["total"]?.jsonPrimitive?.int)
+    }
+
+    @Test
+    fun `verses for a real, common number returns real verse references`() = runBlocking {
+        val dir = Files.createTempDirectory("cp-dictionary-verses-real-test").toFile()
+        server.updateBible(SpbFixture.loadedBible(dir), "KJV")
+
+        val response = client.get(url("/api/dictionary/H430/verses"))
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.parseToJsonElement(response.bodyAsText()).jsonObject
+        val total = body["total"]?.jsonPrimitive?.int ?: 0
+        assertTrue(total > 0, "H430 must occur somewhere in the real Bible")
+        val verses = body["verses"]!!.jsonArray
+        assertTrue(verses.isNotEmpty())
+        val first = verses.first().jsonObject
+        assertTrue(first["bookName"]?.jsonPrimitive?.content?.isNotBlank() == true)
+        assertTrue(first["reference"]?.jsonPrimitive?.content?.isNotBlank() == true)
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerDictionaryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerDictionaryTest.kt
@@ -21,6 +21,19 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+/**
+ * The Strong's dictionary REST endpoints (`GET /api/dictionary`, `/{number}`, `/{number}/verses`) —
+ * untouched by every other `CompanionServer*Test`.
+ *
+ * `StrongsDictionaryRepositoryTest` already pins the repository's own filtering/sorting/scoping
+ * logic against a tiny stubbed fixture (`Res.readBytes` mocked via `DictionaryFixture`). That
+ * approach does not carry over here: the mock is installed from the JUnit test thread, but Ktor
+ * dispatches the request handler onto its own Netty worker thread pool, and empirically the mocked
+ * `Res` is not visible there — the route ends up reading the real bundled dictionary regardless.
+ * Rather than chase that cross-thread mocking gap, these tests exercise only the route's own
+ * behaviour that holds against the *real* dictionary: the request/response plumbing (status codes,
+ * param parsing), not exact result content, which `StrongsDictionaryRepositoryTest` already owns.
+ */
 class CompanionServerDictionaryTest {
 
     private lateinit var server: CompanionServer
@@ -30,10 +43,15 @@ class CompanionServerDictionaryTest {
 
     @BeforeTest
     fun setUp() {
+        // This test deliberately reads the real bundled dictionary (see class doc comment); reset
+        // first so it never depends on whatever another test already loaded into these singletons.
         StrongsDictionaryRepository.cache.clear()
         StrongsDictionaryRepository.interlinear.resetForTest()
 
         server = CompanionServer()
+        // Its own port: every CompanionServer suite claims a distinct one, and 39_721 is
+        // CompanionServerQaModerationTest's. Sharing it means a bind failure whenever the previous
+        // suite's socket has not finished closing.
         server.start(port = 39_731)
         port = runBlocking {
             withTimeoutOrNull(10_000) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerLowerThirdTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerLowerThirdTest.kt
@@ -287,4 +287,68 @@ class CompanionServerLowerThirdTest {
         assertEquals(HttpStatusCode.BadRequest, response.status)
         assertTrue(response.text().contains("M/E 3 does not exist (available: 1-2)"), response.text())
     }
+
+    // ── ATEM media upload (still/clip): guard clauses only ─────────────────────
+
+    @Test
+    fun `uploading an unknown preset as a still is refused`() {
+        val response = posting("/api/atem/still/Nonexistent")
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        assertTrue(response.text().contains("lower third not found"), response.text())
+    }
+
+    @Test
+    fun `uploading a still with no ATEM configured reports the service as unavailable`() {
+        val response = posting("/api/atem/still/Welcome")
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        assertTrue(response.text().contains("ATEM not configured"), response.text())
+    }
+
+    @Test
+    fun `uploading a still with a key target that does not exist is refused before uploading`() {
+        server.updateAtemConfig(
+            AtemSettings(host = "192.0.2.1", detectedMixEffects = 1, detectedKeyersPerMe = listOf(2)),
+            lottieFolder.absolutePath,
+        )
+        val response = posting("/api/atem/still/Welcome?key=3")
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.text().contains("Key 3 does not exist on M/E 1 (available: 1-2)"), response.text())
+    }
+
+    @Test
+    fun `uploading an unknown preset as a clip is refused`() {
+        val response = posting("/api/atem/clip/Nonexistent")
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `uploading a clip with no ATEM configured reports the service as unavailable`() {
+        val response = posting("/api/atem/clip/Welcome")
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+    }
+
+    @Test
+    fun `uploading a clip with a key target that does not exist is refused before uploading`() {
+        server.updateAtemConfig(
+            AtemSettings(host = "192.0.2.1", detectedMixEffects = 1),
+            lottieFolder.absolutePath,
+        )
+        val response = posting("/api/atem/clip/Welcome?me=2&key=1")
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.text().contains("M/E 2 does not exist (available: 1-1)"), response.text())
+    }
+
+    @Test
+    fun `a clip too long for its slot's capacity is refused before uploading`() {
+        server.updateAtemConfig(
+            AtemSettings(host = "192.0.2.1", detectedClipMaxFrames = listOf(30)),
+            lottieFolder.absolutePath,
+        )
+        val response = posting("/api/atem/clip/Welcome")
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertTrue(
+            response.text().contains("Clip is 60 frames but slot 1 holds at most 30 frames"),
+            response.text(),
+        )
+    }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerPresentationTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerPresentationTest.kt
@@ -1,0 +1,254 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.readRawBytes
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import java.io.File
+import java.nio.file.Files
+import java.util.Base64
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `/api/presentations*` — untouched by every other `CompanionServer*Test`. None of it needs
+ * PowerPoint/Keynote parsing: [CompanionServer.updatePresentation] takes already-rendered slide
+ * JPEG bytes as plain [File]s, so the fixture below is just bytes on disk, not a real deck.
+ *
+ * `user.home` is isolated because the upload endpoint writes into
+ * `~/.churchpresenter/device_presentations/`.
+ */
+class CompanionServerPresentationTest {
+
+    private lateinit var server: CompanionServer
+    private lateinit var client: HttpClient
+    private var port: Int = 0
+    private var operatorScope: CoroutineScope? = null
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private var realHome: String? = null
+    private lateinit var tempHome: File
+
+    @BeforeTest
+    fun setUp() {
+        TestSingletons.latchToTestHome()
+        realHome = System.getProperty("user.home")
+        tempHome = Files.createTempDirectory("cp-presentation-test-home").toFile()
+        System.setProperty("user.home", tempHome.absolutePath)
+
+        server = CompanionServer()
+        server.start(port = 39_800)
+        port = runBlocking {
+            withTimeoutOrNull(10_000) {
+                while (!server.isRunning.value || server.serverUrl.value.isBlank()) {
+                    kotlinx.coroutines.delay(25)
+                }
+                server.serverUrl.value.substringAfterLast(':').toInt()
+            }
+        } ?: error("server did not start")
+        client = HttpClient(CIO)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        runCatching { operatorScope?.cancel() }
+        operatorScope = null
+        runCatching { client.close() }
+        runCatching { server.stop() }
+        realHome?.let { System.setProperty("user.home", it) }
+        tempHome.deleteRecursively()
+    }
+
+    private fun url(path: String) = "http://127.0.0.1:$port$path"
+    private fun get(path: String): HttpResponse = runBlocking { client.get(url(path)) }
+    private fun post(path: String, body: String): HttpResponse = runBlocking { client.post(url(path)) { setBody(body) } }
+    private fun HttpResponse.text(): String = runBlocking { bodyAsText() }
+
+    private fun <T> collecting(flow: MutableSharedFlow<T>, onEach: (T) -> Unit) {
+        val scope = operatorScope ?: CoroutineScope(Dispatchers.IO).also { operatorScope = it }
+        scope.launch { flow.collect { onEach(it) } }
+        runBlocking {
+            withTimeoutOrNull(5_000) { flow.subscriptionCount.first { it > 0 } }
+                ?: error("collector never subscribed")
+        }
+    }
+
+    private fun awaitUntil(what: String, timeoutMs: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(20)
+        }
+        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    }
+
+    /** Loads a presentation with [slideCount] one-byte-per-slide "JPEG" slides and waits for the
+     *  server's own async render pipeline to publish it (updatePresentation dispatches to its own
+     *  coroutine, so this polls the REST endpoint rather than assuming it's synchronous). */
+    private fun loadPresentation(id: String, slideCount: Int = 2): List<ByteArray> {
+        val slideBytes = (0 until slideCount).map { byteArrayOf(0x10, it.toByte()) }
+        val dir = Files.createTempDirectory("cp-presentation-slides").toFile()
+        val slideFiles = slideBytes.mapIndexed { i, bytes -> File(dir, "slide$i.jpg").apply { writeBytes(bytes) } }
+        server.updatePresentation(id = id, filePath = "", fileName = "Test.pptx", fileType = "pptx", slideFiles = slideFiles)
+        awaitUntil("presentation $id to be published") { get("/api/presentations/$id").status == HttpStatusCode.OK }
+        return slideBytes
+    }
+
+    // ── GET /api/presentations ─────────────────────────────────────────────────
+
+    @Test
+    fun `the catalog is empty before any presentation is loaded`() {
+        val response = get(Constants.ENDPOINT_PRESENTATIONS)
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(0, json.parseToJsonElement(response.text()).jsonObject["total"]?.jsonPrimitive?.int)
+    }
+
+    // ── GET /api/presentations/{id} ────────────────────────────────────────────
+
+    @Test
+    fun `an unknown presentation id is a 404`() {
+        assertEquals(HttpStatusCode.NotFound, get("/api/presentations/no-such-id").status)
+    }
+
+    @Test
+    fun `a loaded presentation is served by id with its slide count`() {
+        loadPresentation("pres-1", slideCount = 3)
+        val body = json.parseToJsonElement(get("/api/presentations/pres-1").text()).jsonObject
+        assertEquals("Test.pptx", body["file-name"]?.jsonPrimitive?.content)
+    }
+
+    // ── GET /api/presentations/{id}/slides/{index} ────────────────────────────
+
+    @Test
+    fun `a slide is served as the exact bytes it was loaded with`() {
+        val slides = loadPresentation("pres-2")
+        val response = get("/api/presentations/pres-2/slides/0")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(slides[0].toList(), runBlocking { response.readRawBytes() }.toList())
+    }
+
+    @Test
+    fun `an out-of-range slide index is a 404`() {
+        loadPresentation("pres-3", slideCount = 2)
+        assertEquals(HttpStatusCode.NotFound, get("/api/presentations/pres-3/slides/5").status)
+    }
+
+    @Test
+    fun `a negative slide index is a 404`() {
+        loadPresentation("pres-4", slideCount = 2)
+        assertEquals(HttpStatusCode.NotFound, get("/api/presentations/pres-4/slides/-1").status)
+    }
+
+    @Test
+    fun `slides for an unknown presentation id are a 404`() {
+        assertEquals(HttpStatusCode.NotFound, get("/api/presentations/no-such-id/slides/0").status)
+    }
+
+    @Test
+    fun `an invalid (non-numeric) slide index is a 400`() {
+        loadPresentation("pres-5", slideCount = 1)
+        assertEquals(HttpStatusCode.BadRequest, get("/api/presentations/pres-5/slides/not-a-number").status)
+    }
+
+    // ── POST /api/presentations/{id}/select ───────────────────────────────────
+
+    @Test
+    fun `selecting a slide acks ok and notifies onSelectSlide`() {
+        loadPresentation("pres-6", slideCount = 3)
+        val selected = mutableListOf<SelectSlideRequest>()
+        collecting(server.onSelectSlide) { selected.add(it) }
+
+        val response = post("/api/presentations/pres-6/select", """{"index":1}""")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertTrue(json.parseToJsonElement(response.text()).jsonObject["ok"]?.jsonPrimitive?.content == "true")
+        awaitUntil("onSelectSlide") { selected.isNotEmpty() }
+        assertEquals(SelectSlideRequest(id = "pres-6", index = 1), selected.single())
+    }
+
+    @Test
+    fun `selecting with a missing index is a 400`() {
+        assertEquals(HttpStatusCode.BadRequest, post("/api/presentations/pres-7/select", "{}").status)
+    }
+
+    @Test
+    fun `selecting with a negative index is a 400`() {
+        assertEquals(HttpStatusCode.BadRequest, post("/api/presentations/pres-7/select", """{"index":-1}""").status)
+    }
+
+    // ── POST /api/presentations/upload ────────────────────────────────────────
+
+    @Test
+    fun `uploading a PDF saves it under the isolated user_home and notifies onPresentationUploaded`() {
+        val uploaded = mutableListOf<File>()
+        collecting(server.onPresentationUploaded) { uploaded.add(it) }
+
+        val pdfBytes = "%PDF-1.4 fake".toByteArray()
+        val dataUri = "data:application/pdf;base64," + Base64.getEncoder().encodeToString(pdfBytes)
+        val response = post(
+            "${Constants.ENDPOINT_PRESENTATIONS}/upload",
+            """{"name":"sermon.pdf","data":"$dataUri"}""",
+        )
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = json.parseToJsonElement(response.text()).jsonObject
+        assertEquals("sermon", body["name"]?.jsonPrimitive?.content, "the response name omits the extension")
+
+        awaitUntil("onPresentationUploaded") { uploaded.isNotEmpty() }
+        val saved = uploaded.single()
+        assertTrue(saved.absolutePath.startsWith(tempHome.absolutePath), "must be saved under the isolated user.home, not the real one")
+        assertEquals(pdfBytes.toList(), saved.readBytes().toList())
+    }
+
+    @Test
+    fun `uploading an unsupported file type is rejected`() {
+        val dataUri = "data:text/plain;base64," + Base64.getEncoder().encodeToString("hi".toByteArray())
+        val response = post(
+            "${Constants.ENDPOINT_PRESENTATIONS}/upload",
+            """{"name":"notes.txt","data":"$dataUri"}""",
+        )
+        assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
+    }
+
+    @Test
+    fun `uploading with no data URI prefix is a 400`() {
+        val response = post(
+            "${Constants.ENDPOINT_PRESENTATIONS}/upload",
+            """{"name":"sermon.pdf","data":"not-a-data-uri"}""",
+        )
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `uploading is refused while file upload is disabled`() {
+        server.updateFileUploadEnabled(false)
+        val dataUri = "data:application/pdf;base64," + Base64.getEncoder().encodeToString("x".toByteArray())
+        val response = post(
+            "${Constants.ENDPOINT_PRESENTATIONS}/upload",
+            """{"name":"sermon.pdf","data":"$dataUri"}""",
+        )
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkClientMalformedMessageTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkClientMalformedMessageTest.kt
@@ -1,0 +1,116 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import io.ktor.server.application.install
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.routing.routing
+import io.ktor.server.websocket.DefaultWebSocketServerSession
+import io.ktor.server.websocket.WebSockets
+import io.ktor.server.websocket.webSocket
+import io.ktor.websocket.Frame
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InstanceLinkClientMalformedMessageTest {
+
+    private val clients = mutableListOf<InstanceLinkClient>()
+    private var fakePrimary: FakePrimary? = null
+
+    @AfterTest
+    fun cleanUp() {
+        clients.forEach { runCatching { it.dispose() } }
+        clients.clear()
+        fakePrimary?.stop()
+        fakePrimary = null
+    }
+
+    private class FakePrimary {
+        @Volatile var session: DefaultWebSocketServerSession? = null
+
+        var port: Int = 0
+            private set
+
+        private val server = embeddedServer(Netty, port = 0) {
+            install(WebSockets)
+            routing {
+                webSocket(Constants.ENDPOINT_WS) {
+                    session = this
+                    try {
+                        for (frame in incoming) Unit
+                    } catch (_: Exception) {
+                        // the client disconnected, which every test here does on cleanup
+                    }
+                }
+            }
+        }
+
+        fun start() {
+            server.start(wait = false)
+            port = runBlocking { server.engine.resolvedConnectors().first().port }
+        }
+
+        suspend fun send(text: String) {
+            val deadline = System.currentTimeMillis() + 5_000
+            while (session == null && System.currentTimeMillis() < deadline) delay(10)
+            (session ?: error("client never connected")).send(Frame.Text(text))
+        }
+
+        fun stop() = server.stop(0, 0)
+    }
+
+    private fun startFake(): FakePrimary = FakePrimary().also { it.start(); fakePrimary = it }
+
+    private fun connectedClient(fake: FakePrimary, onScheduleUpdated: (List<ScheduleItemDto>) -> Unit): InstanceLinkClient {
+        val client = InstanceLinkClient(
+            onStatusChanged = {},
+            onScheduleUpdated = onScheduleUpdated,
+            onLiveStateUpdated = {},
+            onDisplayCleared = {},
+            onSongSectionSelected = {},
+            onPresentationSlideChanged = { _, _, _, _, _ -> },
+            onSongsUpdated = {},
+        )
+        clients += client
+        client.connect(host = "127.0.0.1", port = fake.port, apiKey = "", deviceId = "test-device", reconnectDelayMs = 60_000)
+        return client
+    }
+
+    private fun awaitUntil(what: String, timeoutMs: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(20)
+        }
+        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    }
+
+    @Test
+    fun `a completely malformed envelope is dropped, and a later valid message still arrives`() = runBlocking {
+        val fake = startFake()
+        val updates = mutableListOf<List<ScheduleItemDto>>()
+        connectedClient(fake, onScheduleUpdated = { updates.add(it) })
+
+        fake.send("not json at all")
+        fake.send("""{"type":"${Constants.WS_EVENT_SCHEDULE_UPDATED}","payload":"{\"items\":[],\"total\":0}"}""")
+
+        awaitUntil("the schedule update to arrive") { updates.isNotEmpty() }
+        assertEquals(1, updates.size, "the malformed envelope before it must not have produced its own update")
+    }
+
+    @Test
+    fun `a recognised type with an unparseable payload is dropped, and a later valid message still arrives`() = runBlocking {
+        val fake = startFake()
+        val updates = mutableListOf<List<ScheduleItemDto>>()
+        connectedClient(fake, onScheduleUpdated = { updates.add(it) })
+
+        fake.send("""{"type":"${Constants.WS_EVENT_SCHEDULE_UPDATED}","payload":"not an object"}""")
+        fake.send("""{"type":"${Constants.WS_EVENT_SCHEDULE_UPDATED}","payload":"{\"items\":[],\"total\":0}"}""")
+
+        awaitUntil("the schedule update to arrive") { updates.isNotEmpty() }
+        assertEquals(1, updates.size, "the unparseable payload before it must not have produced its own update")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkClientTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkClientTest.kt
@@ -1,0 +1,564 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.churchpresenter.app.churchpresenter.data.SongItem
+import org.churchpresenter.app.churchpresenter.data.SpbFixture
+import org.churchpresenter.app.churchpresenter.data.settings.BackgroundSettings
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [InstanceLinkClient] against a REAL [CompanionServer] — it is, byte for byte, the same `/ws`
+ * protocol and REST surface a mobile companion already speaks (same route, same headers), so
+ * there is no fake to write: the primary this class already has extensive test coverage for
+ * (`CompanionServerTest`, `CompanionServerRemoteControlTest`) plays the other end directly.
+ *
+ * Instant commands ([InstanceLinkClient.sendClear] and friends) ack immediately and their real
+ * effect is observed via the server's own `MutableSharedFlow`s, using the same `collecting` /
+ * subscription-count-wait pattern `CompanionServerRemoteControlTest` established (a flow with no
+ * replay dropped before a collector attaches is a real, hard-to-diagnose race otherwise).
+ *
+ * Approval-gated commands ([InstanceLinkClient.sendProject]/[sendAddToSchedule]) ack
+ * `pending_approval` immediately regardless of what the operator later decides — the actual
+ * decision arrives out-of-band (a schedule_updated broadcast, or nothing) — so what is asserted
+ * here is that the operator is asked at all with the right item, not the eventual outcome.
+ */
+class InstanceLinkClientTest {
+
+    private lateinit var server: CompanionServer
+    private var port: Int = 0
+    private var operatorScope: CoroutineScope? = null
+
+    private class Callbacks {
+        var status: InstanceLinkStatus? = null
+        val statusHistory = mutableListOf<InstanceLinkStatus>()
+        var songs: SongCatalogResponse? = null
+        var scheduleUpdates = 0
+        var backgroundsUpdated = 0
+        var bibleUpdated = 0
+        val commandFailures = mutableListOf<Pair<String, String?>>()
+        var commandNoAck = 0
+
+        fun client() = InstanceLinkClient(
+            onStatusChanged = { status = it; statusHistory.add(it) },
+            onScheduleUpdated = { scheduleUpdates++ },
+            onLiveStateUpdated = {},
+            onDisplayCleared = {},
+            onSongSectionSelected = {},
+            onPresentationSlideChanged = { _, _, _, _, _ -> },
+            onSongsUpdated = { songs = it },
+            onBibleUpdated = { bibleUpdated++ },
+            onBackgroundsUpdated = { backgroundsUpdated++ },
+            onCommandFailed = { type, reason -> commandFailures.add(type to reason) },
+            onCommandNoAck = { commandNoAck++ },
+        )
+    }
+
+    @BeforeTest
+    fun startServer() {
+        server = CompanionServer()
+        server.start(port = 39_780)
+        port = runBlocking {
+            withTimeoutOrNull(10_000) {
+                while (!server.isRunning.value || server.serverUrl.value.isBlank()) {
+                    kotlinx.coroutines.delay(25)
+                }
+                server.serverUrl.value.substringAfterLast(':').toInt()
+            }
+        } ?: error("server did not start")
+        server.updateSongs(emptyList())
+        server.updateSchedule(emptyList())
+    }
+
+    @AfterTest
+    fun stopServer() {
+        runCatching { operatorScope?.cancel() }
+        operatorScope = null
+        runCatching { server.stop() }
+    }
+
+    /** Starts collecting [flow] and does not return until the collector is actually subscribed —
+     *  see the class doc comment for why that wait matters for a no-replay SharedFlow. */
+    private fun <T> collecting(flow: MutableSharedFlow<T>, onEach: (T) -> Unit) {
+        val scope = operatorScope ?: CoroutineScope(Dispatchers.IO).also { operatorScope = it }
+        scope.launch { flow.collect { onEach(it) } }
+        runBlocking {
+            withTimeoutOrNull(5_000) { flow.subscriptionCount.first { it > 0 } }
+                ?: error("collector never subscribed")
+        }
+    }
+
+    private fun connectedClient(callbacks: Callbacks = Callbacks()): Pair<InstanceLinkClient, Callbacks> {
+        val client = callbacks.client()
+        client.connect(host = "127.0.0.1", port = port, apiKey = "", deviceId = "test-device", reconnectDelayMs = 60_000)
+        awaitUntil("CONNECTED") { callbacks.status == InstanceLinkStatus.CONNECTED }
+        return client to callbacks
+    }
+
+    private fun awaitUntil(what: String, timeoutMs: Long = 10_000, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(20)
+        }
+        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    }
+
+    // ── Connect lifecycle ──────────────────────────────────────────────────────
+
+    @Test
+    fun `connecting reaches CONNECTED and passes through CONNECTING first`() {
+        val (client, callbacks) = connectedClient()
+        try {
+            assertTrue(InstanceLinkStatus.CONNECTING in callbacks.statusHistory)
+            assertEquals(InstanceLinkStatus.CONNECTED, callbacks.status)
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `the connect snapshot delivers the song catalog and a schedule update`() {
+        server.updateSongs(listOf(SongItem(number = "1", title = "Amazing Grace", songbook = "Hymnal")))
+        val (client, callbacks) = connectedClient()
+        try {
+            awaitUntil("songs snapshot") { callbacks.songs != null }
+            assertEquals(1, callbacks.songs?.total)
+            awaitUntil("schedule snapshot") { callbacks.scheduleUpdates > 0 }
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `a loaded Bible resends bible_updated on every connect`() {
+        val dir = Files.createTempDirectory("cp-instance-link-bible-test").toFile()
+        server.updateBible(SpbFixture.loadedBible(dir), "KJV")
+        val (client, callbacks) = connectedClient()
+        try {
+            awaitUntil("bible_updated") { callbacks.bibleUpdated > 0 }
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `disconnect reports DISCONNECTED and stops further updates`() {
+        val (client, callbacks) = connectedClient()
+        client.disconnect()
+        awaitUntil("DISCONNECTED") { callbacks.status == InstanceLinkStatus.DISCONNECTED }
+
+        val scheduleUpdatesAtDisconnect = callbacks.scheduleUpdates
+        server.updateSchedule(listOf(ScheduleItem.LabelItem(id = "l1", text = "Offering", textColor = "#FFFFFF", backgroundColor = "#000000")))
+        Thread.sleep(200) // a bounded settle window to prove a *negative* — nothing more arrives
+        assertEquals(scheduleUpdatesAtDisconnect, callbacks.scheduleUpdates, "a disconnected client must not keep receiving broadcasts")
+        client.dispose()
+    }
+
+    // ── Instant commands ───────────────────────────────────────────────────────
+
+    @Test
+    fun `sendClear reaches the primary's onClear flow`() {
+        val (client, _) = connectedClient()
+        try {
+            var cleared = false
+            collecting(server.onClear) { cleared = true }
+            client.sendClear()
+            awaitUntil("onClear to fire") { cleared }
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `sendSelectBibleVerse reaches the primary with the exact reference sent`() {
+        val (client, _) = connectedClient()
+        try {
+            val received = mutableListOf<SelectBibleVerseRequest>()
+            collecting(server.onSelectBibleVerse) { received.add(it) }
+            client.sendSelectBibleVerse("John", 3, 16, "For God so loved the world.", "")
+            awaitUntil("onSelectBibleVerse") { received.isNotEmpty() }
+            assertEquals(SelectBibleVerseRequest("John", 3, 16, "For God so loved the world.", ""), received.single())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `sendSelectPicture reaches the primary with the exact selection sent`() {
+        val (client, _) = connectedClient()
+        try {
+            val received = mutableListOf<SelectPictureRequest>()
+            collecting(server.onSelectPicture) { received.add(it) }
+            client.sendSelectPicture("folder-1", 2, "sunset.jpg")
+            awaitUntil("onSelectPicture") { received.isNotEmpty() }
+            assertEquals(SelectPictureRequest("folder-1", 2, "sunset.jpg"), received.single())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `sendSelectSongSection reaches the primary with the exact section sent`() {
+        val (client, _) = connectedClient()
+        try {
+            val received = mutableListOf<SelectSongSectionRequest>()
+            collecting(server.onSelectSongSection) { received.add(it) }
+            client.sendSelectSongSection("42", 1, lineIndex = 2)
+            awaitUntil("onSelectSongSection") { received.isNotEmpty() }
+            assertEquals(SelectSongSectionRequest("42", 1, 2), received.single())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `sendSelectSlide reaches the primary with the exact slide sent`() {
+        val (client, _) = connectedClient()
+        try {
+            val received = mutableListOf<SelectSlideRequest>()
+            collecting(server.onSelectSlide) { received.add(it) }
+            client.sendSelectSlide("pres-1", 4)
+            awaitUntil("onSelectSlide") { received.isNotEmpty() }
+            assertEquals(SelectSlideRequest("pres-1", 4), received.single())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `sendBibleHold reaches the primary with the exact flag sent`() {
+        val (client, _) = connectedClient()
+        try {
+            val received = mutableListOf<Boolean>()
+            collecting(server.onBibleHold) { received.add(it) }
+            client.sendBibleHold(true)
+            awaitUntil("onBibleHold") { received.isNotEmpty() }
+            assertEquals(listOf(true), received)
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `the next-previous picture and slide commands each reach their own primary flow`() {
+        val (client, _) = connectedClient()
+        try {
+            var nextPicture = false; var prevPicture = false; var nextSlide = false; var prevSlide = false
+            collecting(server.onNextPicture) { nextPicture = true }
+            collecting(server.onPreviousPicture) { prevPicture = true }
+            collecting(server.onNextSlide) { nextSlide = true }
+            collecting(server.onPreviousSlide) { prevSlide = true }
+
+            client.sendNextPicture()
+            awaitUntil("onNextPicture") { nextPicture }
+            client.sendPreviousPicture()
+            awaitUntil("onPreviousPicture") { prevPicture }
+            client.sendNextSlide()
+            awaitUntil("onNextSlide") { nextSlide }
+            client.sendPreviousSlide()
+            awaitUntil("onPreviousSlide") { prevSlide }
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `sendRemoveFromSchedule asks the operator with the exact item id sent`() {
+        val (client, _) = connectedClient()
+        try {
+            val asked = mutableListOf<String>()
+            collecting(server.onRemoveFromSchedule) { asked.add(it.id); it.decision.complete(true) }
+            client.sendRemoveFromSchedule("item-9")
+            awaitUntil("the operator to be asked") { asked.isNotEmpty() }
+            assertEquals("item-9", asked.single())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    // ── Approval-gated commands ────────────────────────────────────────────────
+
+    @Test
+    fun `sendProject asks the operator with the exact item sent`() {
+        val (client, callbacks) = connectedClient()
+        try {
+            val asked = mutableListOf<ScheduleItem>()
+            collecting(server.onProject) { asked.add(it.item); it.decision.complete(true) }
+
+            val item = ScheduleItem.LabelItem(id = "proj-1", text = "Welcome", textColor = "#FFFFFF", backgroundColor = "#000000")
+            client.sendProject(item)
+
+            awaitUntil("the operator to be asked") { asked.isNotEmpty() }
+            assertEquals(item, asked.single())
+            assertTrue(callbacks.commandFailures.isEmpty(), "an approval-gated command acks pending_approval, not a failure")
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `sendAddToSchedule asks the operator with the exact item sent`() {
+        val (client, _) = connectedClient()
+        try {
+            val asked = mutableListOf<ScheduleItem>()
+            collecting(server.onAddToSchedule) { asked.add(it.item); it.decision.complete(true) }
+
+            val item = ScheduleItem.LabelItem(id = "add-1", text = "Offering", textColor = "#FFFFFF", backgroundColor = "#000000")
+            client.sendAddToSchedule(item)
+
+            awaitUntil("the operator to be asked") { asked.isNotEmpty() }
+            assertEquals(item, asked.single())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `sendCommand before ever connecting reports not_connected without touching the network`() {
+        val callbacks = Callbacks()
+        val client = callbacks.client()
+        client.sendClear()
+        assertEquals(listOf(Constants.WS_CMD_CLEAR to ("not_connected" as String?)), callbacks.commandFailures)
+        client.dispose()
+    }
+
+    // ── REST fetches ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `fetchSongDetail returns the primary's song, sections included`() {
+        server.updateSongs(listOf(
+            SongItem(number = "42", title = "Amazing Grace", songbook = "Hymnal", author = "Newton", lyrics = listOf("Amazing grace"))
+        ))
+        val (client, _) = connectedClient()
+        try {
+            val detail = runBlocking { client.fetchSongDetail("42", "Hymnal") }
+            assertEquals("Amazing Grace", detail?.title)
+            assertEquals("Newton", detail?.author)
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchSongDetail for an unknown number is null`() {
+        val (client, _) = connectedClient()
+        try {
+            assertNull(runBlocking { client.fetchSongDetail("no-such-number", "") })
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchBibleFile downloads the primary's loaded Bible bytes`() {
+        val dir = Files.createTempDirectory("cp-instance-link-bible-fetch-test").toFile()
+        val bibleFile = SpbFixture.spbFile(dir)
+        server.updateBible(SpbFixture.loadedBible(dir), "KJV", filePath = bibleFile.absolutePath)
+        val (client, _) = connectedClient()
+        try {
+            val bytes = runBlocking { client.fetchBibleFile() }
+            assertNotNull(bytes)
+            assertTrue(bytes.decodeToString().contains("Genesis"), "expected the fixture's own book name in the downloaded bytes")
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchSecondaryBibleFile downloads the primary's secondary Bible bytes`() {
+        val dir = Files.createTempDirectory("cp-instance-link-secondary-bible-test").toFile()
+        val bibleFile = SpbFixture.spbFile(dir)
+        server.updateSecondaryBibleFilePath(bibleFile.absolutePath)
+        val (client, _) = connectedClient()
+        try {
+            val bytes = runBlocking { client.fetchSecondaryBibleFile() }
+            assertNotNull(bytes)
+            assertTrue(bytes.decodeToString().contains("Genesis"), "expected the fixture's own book name in the downloaded bytes")
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchSecondaryBibleFile is null when the primary has none configured`() {
+        val (client, _) = connectedClient()
+        try {
+            assertNull(runBlocking { client.fetchSecondaryBibleFile() })
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchBibleTranslations downloads every module in manifest order`() {
+        val dir = Files.createTempDirectory("cp-instance-link-translations-test").toFile()
+        val first = java.io.File(dir, "KJV.spb").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val second = java.io.File(dir, "NIV.spb").apply { writeBytes(byteArrayOf(4, 5, 6)) }
+        server.updateBibleFilePaths(listOf(first.absolutePath, second.absolutePath))
+        val (client, _) = connectedClient()
+        try {
+            val translations = runBlocking { client.fetchBibleTranslations() }
+            assertEquals(
+                listOf("KJV.spb" to byteArrayOf(1, 2, 3).toList(), "NIV.spb" to byteArrayOf(4, 5, 6).toList()),
+                translations.map { (name, bytes) -> name to bytes.toList() },
+            )
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchBackgroundSettings round-trips what the primary has configured`() {
+        server.updateBackgroundSettings(BackgroundSettings(defaultBackgroundColor = "#123456"))
+        val (client, _) = connectedClient()
+        try {
+            val settings = runBlocking { client.fetchBackgroundSettings() }
+            assertEquals("#123456", settings?.defaultBackgroundColor)
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchPictureImageBytes downloads the exact bytes of the requested image`() {
+        val dir = Files.createTempDirectory("cp-instance-link-pictures-test").toFile()
+        val imageBytes = byteArrayOf(1, 2, 3, 4)
+        val imageFile = java.io.File(dir, "photo.jpg").apply { writeBytes(imageBytes) }
+        server.updatePictures(folderId = "folder-1", folderName = "Folder", folderPath = dir.absolutePath, imageFiles = listOf(imageFile))
+        val (client, _) = connectedClient()
+        try {
+            val bytes = runBlocking { client.fetchPictureImageBytes("folder-1", 0) }
+            assertEquals(imageBytes.toList(), bytes?.toList())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchPictureImageBytes for an unknown folder is null`() {
+        val (client, _) = connectedClient()
+        try {
+            assertNull(runBlocking { client.fetchPictureImageBytes("no-such-folder", 0) })
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchBackgroundAsset downloads the configured slot's file bytes`() {
+        val dir = Files.createTempDirectory("cp-instance-link-background-test").toFile()
+        val assetBytes = byteArrayOf(9, 8, 7)
+        val assetFile = java.io.File(dir, "bg.png").apply { writeBytes(assetBytes) }
+        server.updateBackgroundSettings(BackgroundSettings(defaultBackgroundImage = assetFile.absolutePath))
+        val (client, _) = connectedClient()
+        try {
+            val bytes = runBlocking { client.fetchBackgroundAsset(Constants.BACKGROUND_SLOT_DEFAULT, isVideo = false) }
+            assertEquals(assetBytes.toList(), bytes?.toList())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchBackgroundAsset for a slot with nothing configured is null`() {
+        server.updateBackgroundSettings(BackgroundSettings(defaultBackgroundImage = ""))
+        val (client, _) = connectedClient()
+        try {
+            assertNull(runBlocking { client.fetchBackgroundAsset(Constants.BACKGROUND_SLOT_DEFAULT, isVideo = false) })
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetchPresentationSlideBytes downloads the exact bytes of the requested slide`() {
+        val dir = Files.createTempDirectory("cp-instance-link-presentation-test").toFile()
+        val slideBytes = byteArrayOf(5, 6, 7)
+        val slideFile = java.io.File(dir, "slide0.jpg").apply { writeBytes(slideBytes) }
+        server.updatePresentation(id = "pres-1", filePath = "", fileName = "Test.pptx", fileType = "pptx", slideFiles = listOf(slideFile))
+        val (client, _) = connectedClient()
+        try {
+            awaitUntil("presentation to be published") { runBlocking { client.fetchPresentationSlideBytes("pres-1", 0) } != null }
+            val bytes = runBlocking { client.fetchPresentationSlideBytes("pres-1", 0) }
+            assertEquals(slideBytes.toList(), bytes?.toList())
+        } finally {
+            client.dispose()
+        }
+    }
+
+    // ── Connect failure / reconnect ────────────────────────────────────────────
+
+    @Test
+    fun `connecting to a port nothing listens on reports ERROR and schedules a reconnect`() {
+        val deadPort = java.net.ServerSocket(0).use { it.localPort }
+        val statusHistory = mutableListOf<InstanceLinkStatus>()
+        var reconnectDelay: Long? = null
+        val client = InstanceLinkClient(
+            onStatusChanged = { statusHistory.add(it) },
+            onScheduleUpdated = {}, onLiveStateUpdated = {}, onDisplayCleared = {}, onSongSectionSelected = {},
+            onPresentationSlideChanged = { _, _, _, _, _ -> }, onSongsUpdated = {},
+            onReconnectScheduled = { reconnectDelay = it },
+        )
+        try {
+            client.connect(host = "127.0.0.1", port = deadPort, apiKey = "", deviceId = "d", reconnectDelayMs = 100)
+            awaitUntil("ERROR status") { InstanceLinkStatus.ERROR in statusHistory }
+            awaitUntil("a reconnect to be scheduled") { reconnectDelay != null }
+            assertTrue(reconnectDelay!! >= 100, "the reconnect delay floor is the caller's reconnectDelayMs")
+        } finally {
+            client.dispose()
+        }
+    }
+
+    @Test
+    fun `fetch methods report not_connected before any connect() call`() {
+        val callbacks = Callbacks()
+        val client = callbacks.client()
+        try {
+            assertNull(runBlocking { client.fetchSongDetail("1", "") })
+            assertNull(runBlocking { client.fetchBibleFile() })
+            assertNull(runBlocking { client.fetchBackgroundSettings() })
+            assertNull(runBlocking { client.fetchPictureImageBytes("folder", 0) })
+            assertEquals(emptyList(), runBlocking { client.fetchBibleTranslations() })
+        } finally {
+            client.dispose()
+        }
+    }
+
+    // ── mediaStreamUrl ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `mediaStreamUrl is null before connecting`() {
+        val client = Callbacks().client()
+        assertNull(client.mediaStreamUrl("media-1"))
+        client.dispose()
+    }
+
+    @Test
+    fun `mediaStreamUrl builds against the connected primary once connected`() {
+        val (client, _) = connectedClient()
+        try {
+            val url = client.mediaStreamUrl("media-1")
+            assertNotNull(url)
+            assertTrue(url.startsWith("http://127.0.0.1:$port"), url)
+            assertTrue(url.endsWith("/media-1"), url)
+        } finally {
+            client.dispose()
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCacheTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCacheTest.kt
@@ -1,12 +1,16 @@
 package org.churchpresenter.app.churchpresenter.server
 
 import org.churchpresenter.app.churchpresenter.data.settings.AtemSettings
+import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * The size and variant policy that decides which cached render every consumer shares.
@@ -129,5 +133,91 @@ class LottieRenderCacheTest {
     @Test
     fun `the desktop variant is null when the lottie carries no timing`() {
         assertNull(LottieRenderCache.desktopVariant("""{"w":1920,"h":1080}""", atem1080), "no timeline, nothing to stream")
+    }
+
+    // ── ARGB RLE codec ────────────────────────────────────────────────────────
+
+    private fun roundTrip(pixels: IntArray): IntArray =
+        LottieRenderCache.decodeArgbRle(LottieRenderCache.encodeArgbRle(pixels), pixels.size)
+
+    @Test
+    fun `a solid-color frame round-trips through a single run record`() {
+        val pixels = IntArray(100) { 0xFF112233.toInt() }
+        assertTrue(roundTrip(pixels).contentEquals(pixels))
+    }
+
+    @Test
+    fun `an all-distinct frame round-trips through literal records`() {
+        val pixels = IntArray(50) { it }
+        assertTrue(roundTrip(pixels).contentEquals(pixels))
+    }
+
+    @Test
+    fun `a frame mixing runs and literals round-trips intact`() {
+        val pixels = intArrayOf(1, 1, 1, 1, 2, 3, 4, 5, 5, 5, 6)
+        assertTrue(roundTrip(pixels).contentEquals(pixels))
+    }
+
+    @Test
+    fun `decoding fewer pixels than the payload promises throws rather than returning a short frame`() {
+        val payload = LottieRenderCache.encodeArgbRle(IntArray(10) { 7 })
+        assertFailsWith<java.io.IOException> { LottieRenderCache.decodeArgbRle(payload, 20) }
+    }
+
+    // ── Pixel scaling ────────────────────────────────────────────────────────
+
+    @Test
+    fun `scaling a solid-color image preserves the color regardless of size change`() {
+        val src = IntArray(4) { 0xFFFF0000.toInt() }
+
+        val scaledUp = LottieRenderCache.scaleArgb(src, 2, 2, 8, 8)
+        assertEquals(64, scaledUp.size)
+        assertTrue(scaledUp.all { it == 0xFFFF0000.toInt() })
+
+        val scaledDown = LottieRenderCache.scaleArgb(src, 2, 2, 1, 1)
+        assertEquals(1, scaledDown.size)
+        assertEquals(0xFFFF0000.toInt(), scaledDown[0])
+    }
+
+    // ── Cache file presence ──────────────────────────────────────────────────
+
+    @Test
+    fun `isReady is false until a file exists at the content-addressed cache path`() {
+        val json = """{"w":10,"h":10,"fr":30,"ip":0,"op":30,"unique":"isready-test"}"""
+        val variant = LottieRenderCache.Variant(clip = true, width = 10, height = 10, fps = 30.0, frameCount = 30)
+        assertFalse(LottieRenderCache.isReady(json, variant))
+
+        val file = LottieRenderCache.cacheFile(LottieRenderCache.keyFor(json, variant))
+        file.parentFile.mkdirs()
+        file.writeBytes(ByteArray(1))
+        try {
+            assertTrue(LottieRenderCache.isReady(json, variant))
+        } finally {
+            file.delete()
+        }
+    }
+
+    // ── Eviction ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `eviction removes the oldest entries first once past the entry cap`() {
+        val dir = LottieRenderCache.cacheDir
+        dir.mkdirs()
+        dir.listFiles { f -> f.extension == "lrcc" }?.forEach { it.delete() }
+
+        val total = LottieRenderCache.MAX_ENTRIES + 5
+        val base = System.currentTimeMillis()
+        val files = (0 until total).map { i ->
+            File(dir, "evict-test-$i.lrcc").apply {
+                writeBytes(ByteArray(1))
+                setLastModified(base + i * 1000L)
+            }
+        }
+
+        LottieRenderCache.evictOldEntries()
+
+        assertEquals(LottieRenderCache.MAX_ENTRIES, dir.listFiles { f -> f.extension == "lrcc" }?.size)
+        (0 until 5).forEach { assertFalse(files[it].exists(), "file $it should have been evicted") }
+        (5 until total).forEach { assertTrue(files[it].exists(), "file $it should have survived") }
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCacheTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCacheTest.kt
@@ -23,22 +23,29 @@ import kotlin.test.assertTrue
  * lottie's own w/h/timing, clamping to 1920, and the aspect-match branch that chooses between
  * "share one upsized entry" and "letterbox into the raster".
  *
- * All functions here are pure (no disk, no render). The object's one-time init deletes an old cache
- * dir under user.home, so user.home is redirected to a temp dir before the class is first touched.
+ * Most of it is pure (no disk, no render), but the last two touch the cache directory and the
+ * eviction one deletes from it, so `user.home` is redirected to a temp dir for every test. That
+ * redirect only works because `LottieRenderCache.cacheDir` resolves per call: the object is
+ * reachable from `CompanionServer`, `LowerThird` and `PresenterManager`, so in a full run something
+ * has already touched it, and a latched `cacheDir` would hand these tests the developer's own
+ * cache to delete.
  */
 class LottieRenderCacheTest {
 
     private lateinit var originalUserHome: String
+    private lateinit var tempHome: java.nio.file.Path
 
     @BeforeTest
     fun isolateUserHome() {
         originalUserHome = System.getProperty("user.home")
-        System.setProperty("user.home", Files.createTempDirectory("lrc-home").toString())
+        tempHome = Files.createTempDirectory("lrc-home")
+        System.setProperty("user.home", tempHome.toString())
     }
 
     @AfterTest
     fun restoreUserHome() {
         System.setProperty("user.home", originalUserHome)
+        tempHome.toFile().deleteRecursively()
     }
 
     /** A minimal lottie: 1920×1080 canvas, 30fps, frames 0..90 → a 3-second clip. */
@@ -202,6 +209,10 @@ class LottieRenderCacheTest {
     @Test
     fun `eviction removes the oldest entries first once past the entry cap`() {
         val dir = LottieRenderCache.cacheDir
+        // This test empties the directory it is given, and eviction deletes from it too. If the
+        // user.home redirect above ever stops taking effect, that directory is the developer's own
+        // render cache. Refuse to touch anything outside the temp home rather than find out later.
+        check(dir.toPath().startsWith(tempHome)) { "refusing to evict outside the test home: $dir" }
         dir.mkdirs()
         dir.listFiles { f -> f.extension == "lrcc" }?.forEach { it.delete() }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdSequencerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdSequencerTest.kt
@@ -117,4 +117,20 @@ class LowerThirdSequencerTest {
         )
         assertNull(keyError, "with no key control requested there is no ATEM error to report")
     }
+
+    @Test
+    fun `a sequence that reaches its natural end clears itself without an explicit stop`() = runBlocking {
+        val cleared = Channel<Unit>(capacity = 1)
+        val collector = launch { LowerThirdSequencer.onClear.collect { cleared.trySend(Unit) } }
+        LowerThirdSequencer.onClear.subscriptionCount.first { it > 0 }
+
+        LowerThirdSequencer.run(
+            name = "AutoEnd", json = "{}", durationMs = 0L, pauseAtFrame = false, pauseDurationMs = 0L,
+            mixEffect = null, keyer = null, atem = noAtem, autoEnd = true
+        )
+
+        withTimeout(1_000) { cleared.receive() }
+        collector.cancel()
+        assertEquals("idle", LowerThirdSequencer.status.value)
+    }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/PlanningCenterAuthServerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/PlanningCenterAuthServerTest.kt
@@ -1,0 +1,123 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import java.net.InetSocketAddress
+import java.net.Socket
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+// Not exercised: CallbackResult.Timeout (CALLBACK_TIMEOUT_MS, 5 minutes, not injectable) and the
+// bind-failure branch (Netty takes ~4s to report a taken port, which is a duration, not a test).
+class PlanningCenterAuthServerTest {
+
+    private fun url(query: String) = "http://127.0.0.1:${Constants.PLANNING_CENTER_OAUTH_PORT}/callback$query"
+
+    /** True once something is actually accepting connections on 127.0.0.1:port — a bind-based
+     *  check is wrong here since a wildcard probe bind can coexist with a loopback-specific one. */
+    private fun isListening(): Boolean =
+        runCatching { Socket().apply { connect(InetSocketAddress("127.0.0.1", Constants.PLANNING_CENTER_OAUTH_PORT), 200) }.close() }.isSuccess
+
+    // The fixed port isn't released by the OS the instant the previous test's server.stop()
+    // returns; without this, the next test's bind can race a still-closing socket.
+    @AfterTest
+    fun awaitPortFree() {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (!isListening()) return
+            Thread.sleep(20)
+        }
+    }
+
+    private suspend fun awaitServerReady(resultDeferred: kotlinx.coroutines.Deferred<PlanningCenterAuthServer.CallbackResult>? = null) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (System.currentTimeMillis() < deadline) {
+            if (resultDeferred?.isCompleted == true) {
+                error("server never bound: awaitAuthorizationCode already resolved to ${resultDeferred.await()}")
+            }
+            if (isListening()) return
+            delay(10)
+        }
+        error("server on port ${Constants.PLANNING_CENTER_OAUTH_PORT} never started")
+    }
+
+    @Test
+    fun `a callback carrying a code resolves to Success`() = runBlocking {
+        val resultDeferred = async(Dispatchers.IO) { PlanningCenterAuthServer.awaitAuthorizationCode() }
+        awaitServerReady(resultDeferred)
+
+        val client = HttpClient(CIO)
+        try {
+            client.get(url("?code=abc123"))
+        } finally {
+            client.close()
+        }
+
+        val result = withTimeout(10_000) { resultDeferred.await() }
+        val success = assertIs<PlanningCenterAuthServer.CallbackResult.Success>(result)
+        assertEquals("abc123", success.code)
+    }
+
+    @Test
+    fun `a callback carrying an error resolves to Error with that message`() = runBlocking {
+        val resultDeferred = async(Dispatchers.IO) { PlanningCenterAuthServer.awaitAuthorizationCode() }
+        awaitServerReady(resultDeferred)
+
+        val client = HttpClient(CIO)
+        try {
+            client.get(url("?error=access_denied"))
+        } finally {
+            client.close()
+        }
+
+        val result = withTimeout(10_000) { resultDeferred.await() }
+        val error = assertIs<PlanningCenterAuthServer.CallbackResult.Error>(result)
+        assertEquals("access_denied", error.message)
+    }
+
+    @Test
+    fun `a callback with neither code nor error resolves to a generic Error`() = runBlocking {
+        val resultDeferred = async(Dispatchers.IO) { PlanningCenterAuthServer.awaitAuthorizationCode() }
+        awaitServerReady(resultDeferred)
+
+        val client = HttpClient(CIO)
+        try {
+            client.get(url(""))
+        } finally {
+            client.close()
+        }
+
+        val result = withTimeout(10_000) { resultDeferred.await() }
+        val error = assertIs<PlanningCenterAuthServer.CallbackResult.Error>(result)
+        assertEquals("No authorization code returned", error.message)
+    }
+
+    @Test
+    fun `the callback page tells the user they can close the window`() = runBlocking {
+        val resultDeferred = async(Dispatchers.IO) { PlanningCenterAuthServer.awaitAuthorizationCode() }
+        awaitServerReady(resultDeferred)
+
+        val client = HttpClient(CIO)
+        val body = try {
+            client.get(url("?code=xyz")).bodyAsText()
+        } finally {
+            client.close()
+        }
+        assertTrue(body.contains("close this window"), body)
+
+        val finalResult = withTimeout(10_000) { resultDeferred.await() }
+        assertIs<PlanningCenterAuthServer.CallbackResult.Success>(finalResult)
+        Unit
+    }
+}


### PR DESCRIPTION
Widened visibility on CompanionServer.encodeBrowserSourceFrameMessage and several LottieRenderCache members (MAX_ENTRIES, cacheDir, keyFor, cacheFile, evictOldEntries, encode/decode/scaleArgb) so tests can probe internal behavior. Expanded and added many JVM tests covering CompanionServer endpoints, InstanceLinkClient, browser-source WS/frame encoding, presentation upload/serve, planning-center OAuth, Lottie RLE/scale/eviction, AtemFrameEncoder cases, lower-third ATEM guards and sequencer auto-end. Minor test-only comment tweak in ApplyRemoteLiveStateTest. No production behavior changes intended; changes are to support thorough testing.