### PR TITLE
Cover AtemClient's socket layer against a fake switcher built from a real capture

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClient.kt
@@ -253,6 +253,9 @@ class AtemClient(val host: String, val port: Int = 9910) {
     /** True while the socket is open (keepalive nulls it when the ATEM goes silent). */
     fun isAlive(): Boolean = socket != null
 
+    /** Packets sent but not yet acknowledged by the ATEM — the reliable layer's backlog. */
+    internal fun inFlightCount(): Int = inFlight.size
+
     /**
      * Background loop that keeps a persistent session alive: every [KEEPALIVE_INTERVAL_MS]
      * it drains and ACKs whatever the ATEM has sent (the ATEM drops a client that stops
@@ -601,8 +604,21 @@ class AtemClient(val host: String, val port: Int = 9910) {
     internal fun u16(b: ByteArray, offset: Int): Int =
         ((b[offset].toInt() and 0xFF) shl 8) or (b[offset + 1].toInt() and 0xFF)
 
+    /**
+     * Write one packet to the switcher.
+     *
+     * Fails loudly on a closed socket rather than dropping the packet. This used to be
+     * `socket?.send(...)`, which silently discarded every command sent after a disconnect —
+     * the caller then waited out its full 8s command timeout and reported "ATEM did not respond
+     * with LKOB", blaming the device for what is entirely a local lifecycle error. The
+     * best-effort unlock in the upload paths already wraps its send in `runCatching`, so a
+     * genuinely dead socket there still cannot mask the original failure.
+     */
     private fun sendRaw(bytes: ByteArray) {
-        socket?.send(DatagramPacket(bytes, bytes.size, address, port))
+        val sock = socket ?: throw IllegalStateException(
+            "ATEM connection to $host:$port is closed — connect() first (or the keepalive dropped it)"
+        )
+        sock.send(DatagramPacket(bytes, bytes.size, address, port))
     }
 
     internal fun buildCommandBytes(name: String, data: ByteArray): ByteArray {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClientSocketTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClientSocketTest.kt
@@ -1,0 +1,422 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [AtemClient]'s socket layer — the handshake, the reliable-delivery bookkeeping and the media
+ * pool transfer flow — driven against [FakeAtemSwitcher] over loopback UDP.
+ *
+ * `AtemClientProtocolTest` covers the pure byte builders and `AtemStateParsingTest` the parsers;
+ * both explicitly leave "the socket I/O around these" untested, which was ~250 lines of the file.
+ * This suite is that missing half. See [FakeAtemSwitcher] for why the fake's byte layouts come
+ * from a capture of real hardware rather than from [AtemClient] itself.
+ *
+ * **Not covered here, deliberately:**
+ * - `isReachable`'s failure path and `connect`'s no-response path against a *silent* host. Both
+ *   end only when a socket timeout expires (2s and 5s respectively), and neither timeout is
+ *   injectable, so a test of them would cost its whole timeout — the shape `AGENT.md` rules out.
+ *   The success paths are covered below.
+ * - The keepalive loop. Its cadence is a hard-coded 1.5s `delay`, so any assertion about it is an
+ *   assertion about a duration.
+ * - `retransmitFrom`'s throw when the requested packet has already been evicted: it needs
+ *   MAX_IN_FLIGHT (2048) packets sent to force eviction, which no upload this size reaches.
+ */
+class AtemClientSocketTest {
+
+    private fun connected(fake: FakeAtemSwitcher, collectState: Boolean = true): AtemClient =
+        AtemClient("127.0.0.1", fake.port).also { runBlocking { it.connect(collectState = collectState) } }
+
+    // ── Handshake and state ───────────────────────────────────────────────────
+
+    @Test
+    fun `connect completes the hello handshake and reads the state dump`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake)
+            try {
+                assertTrue(client.isAlive(), "the socket stays open after a successful connect")
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+
+    @Test
+    fun `queryState reports the switcher's video mode, topology and media pool`() {
+        FakeAtemSwitcher(mixEffects = 4, downstreamKeyers = 2, keyersPerMe = 4, stillSlotCount = 64, clipSlotCount = 2)
+            .use { fake ->
+                val state = runBlocking { AtemClient("127.0.0.1", fake.port).queryState() }
+                assertEquals("1080p59.94", state.videoMode)
+                assertEquals(60000.0 / 1001.0, state.fps, 0.0001)
+                assertEquals(4, state.mixEffectCount)
+                assertEquals(2, state.downstreamKeyers)
+                assertEquals(listOf(4, 4, 4, 4), state.keyersPerMe)
+                assertEquals(64, state.stillSlots.size)
+                assertEquals(2, state.clipSlots.size)
+                assertTrue(state.stillSlots.none { it.isUsed }, "an empty pool reports every slot free")
+                assertEquals(listOf(0, 1), state.clipSlots.map { it.index })
+            }
+    }
+
+    @Test
+    fun `a one M-E switcher reports its own smaller topology`() {
+        // The second captured device: 1 M/E, 32 stills. Guards against the fake — and the
+        // parser — being fitted to the 4 M/E model alone.
+        FakeAtemSwitcher(mixEffects = 1, downstreamKeyers = 2, keyersPerMe = 4, stillSlotCount = 32)
+            .use { fake ->
+                val state = runBlocking { AtemClient("127.0.0.1", fake.port).queryState() }
+                assertEquals(1, state.mixEffectCount)
+                assertEquals(listOf(4), state.keyersPerMe)
+                assertEquals(32, state.stillSlots.size)
+            }
+    }
+
+    @Test
+    fun `queryState closes the socket it opened`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = AtemClient("127.0.0.1", fake.port)
+            runBlocking { client.queryState() }
+            assertFalse(client.isAlive(), "queryState is a one-shot — it disconnects in its finally")
+        }
+    }
+
+    @Test
+    fun `isReachable is true for a switcher that answers the hello`() {
+        FakeAtemSwitcher().use { fake ->
+            assertTrue(runBlocking { AtemClient.isReachable("127.0.0.1", fake.port, timeoutMs = 1_000) })
+        }
+    }
+
+    // ── Still upload ──────────────────────────────────────────────────────────
+
+    private fun frame(bytes: Int) = EncodedFrame(ByteArray(bytes) { (it and 0x7F).toByte() }, rawLen = bytes * 4)
+
+    @Test
+    fun `uploading a still locks the store, transfers every byte and unlocks`() {
+        FakeAtemSwitcher().use { fake ->
+            val payload = frame(4_000)
+            fake.expectedTransferBytes = payload.data.size
+            val client = connected(fake)
+            try {
+                runBlocking { client.uploadStillEncoded(slot = 3, frame = payload, name = "test") }
+            } finally {
+                client.disconnect()
+            }
+
+            val locks = fake.commandsNamed("LOCK")
+            assertEquals(2, locks.size, "the store is locked before the transfer and unlocked after")
+            assertEquals(1, locks.first()[2].toInt(), "first LOCK acquires")
+            assertEquals(0, locks.last()[2].toInt(), "last LOCK releases")
+
+            assertEquals(1, fake.commandsNamed("FTSD").size)
+            assertEquals(1, fake.commandsNamed("FTFD").size, "the file description is sent once")
+
+            val sent = fake.commandsNamed("FTDa").sumOf {
+                ((it[2].toInt() and 0xFF) shl 8) or (it[3].toInt() and 0xFF)
+            }
+            assertEquals(payload.data.size, sent, "every encoded byte reaches the switcher")
+        }
+    }
+
+    @Test
+    fun `a transfer larger than one grant is split across several FTCD grants`() {
+        // The captured 307 KB frame took 221 chunks across two grants; this reproduces that
+        // shape in miniature — 10 chunks per grant against a payload needing more than 10.
+        FakeAtemSwitcher(grantChunkSize = 400, chunksPerGrant = 10).use { fake ->
+            val payload = frame(9_000)   // 23 chunks of 400 ⇒ 3 grants
+            fake.expectedTransferBytes = payload.data.size
+            val client = connected(fake)
+            try {
+                runBlocking { client.uploadStillEncoded(slot = 0, frame = payload, name = "big") }
+            } finally {
+                client.disconnect()
+            }
+
+            val chunks = fake.commandsNamed("FTDa")
+            assertTrue(chunks.size > 10, "more chunks than a single grant allows, got ${chunks.size}")
+            assertEquals(1, fake.commandsNamed("FTFD").size, "the description is not re-sent per grant")
+            val sent = chunks.sumOf { ((it[2].toInt() and 0xFF) shl 8) or (it[3].toInt() and 0xFF) }
+            assertEquals(payload.data.size, sent)
+        }
+    }
+
+    @Test
+    fun `upload progress runs from nothing to complete`() {
+        FakeAtemSwitcher(grantChunkSize = 400, chunksPerGrant = 10).use { fake ->
+            val payload = frame(9_000)
+            fake.expectedTransferBytes = payload.data.size
+            val client = connected(fake)
+            val progress = mutableListOf<Float>()
+            try {
+                runBlocking { client.uploadStillEncoded(0, payload, "p") { progress.add(it) } }
+            } finally {
+                client.disconnect()
+            }
+            assertTrue(progress.isNotEmpty(), "progress is reported")
+            assertEquals(1f, progress.last(), 0.0001f, "the last report is completion")
+            assertEquals(progress, progress.sorted(), "progress never goes backwards")
+        }
+    }
+
+    @Test
+    fun `a busy switcher's FTDE retry restarts the transfer and it still completes`() {
+        FakeAtemSwitcher(ftdeRetriesBeforeSuccess = 1).use { fake ->
+            val payload = frame(2_000)
+            fake.expectedTransferBytes = payload.data.size
+            val client = connected(fake)
+            try {
+                runBlocking { client.uploadStillEncoded(slot = 1, frame = payload, name = "retry") }
+            } finally {
+                client.disconnect()
+            }
+            assertEquals(2, fake.commandsNamed("FTSD").size, "the transfer is restarted after FTDE code 1")
+            val sent = fake.commandsNamed("FTDa").sumOf {
+                ((it[2].toInt() and 0xFF) shl 8) or (it[3].toInt() and 0xFF)
+            }
+            assertEquals(payload.data.size, sent, "the restarted transfer sends the whole frame")
+        }
+    }
+
+    @Test
+    fun `an empty frame is refused before anything is sent`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake)
+            try {
+                assertFailsWith<Exception> {
+                    runBlocking { client.uploadStillEncoded(0, EncodedFrame(ByteArray(0), 0), "empty") }
+                }
+                assertTrue(fake.commandsNamed("LOCK").isEmpty(), "nothing is locked for a refused upload")
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+
+    @Test
+    fun `a slot the switcher does not have is refused with its real slot count`() {
+        FakeAtemSwitcher(stillSlotCount = 32).use { fake ->
+            val client = connected(fake)
+            try {
+                val error = assertFailsWith<Exception> {
+                    runBlocking { client.uploadStillEncoded(99, frame(100), "oob") }
+                }
+                assertTrue(error.message!!.contains("1–32"), "reports the real range, was: ${error.message}")
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+
+    // ── Clip upload ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `uploading a clip clears the bank, sends every frame and commits it`() {
+        FakeAtemSwitcher().use { fake ->
+            val payload = frame(1_500)
+            fake.expectedTransferBytes = payload.data.size
+            val client = connected(fake)
+            try {
+                runBlocking {
+                    client.uploadClipEncoded(slot = 0, frameCount = 3, name = "anim", nextFrame = { payload })
+                }
+            } finally {
+                client.disconnect()
+            }
+            assertEquals(1, fake.commandsNamed("CMPC").size, "the bank is cleared once, before the frames")
+            assertEquals(3, fake.commandsNamed("FTSD").size, "one transfer per frame")
+            assertEquals(1, fake.commandsNamed("SMPC").size, "the clip is committed once")
+            val commit = fake.commandsNamed("SMPC").single()
+            assertEquals(3, ((commit[commit.size - 2].toInt() and 0xFF) shl 8) or (commit[commit.size - 1].toInt() and 0xFF),
+                "the commit carries the frame count")
+        }
+    }
+
+    @Test
+    fun `a clip with no frames is refused`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake)
+            try {
+                assertFailsWith<Exception> {
+                    runBlocking { client.uploadClipEncoded(0, frameCount = 0, name = "x", nextFrame = { frame(10) }) }
+                }
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+
+    @Test
+    fun `awaitClipReady returns true once the switcher reports the bank fully ingested`() {
+        FakeAtemSwitcher().use { fake ->
+            val payload = frame(1_000)
+            fake.expectedTransferBytes = payload.data.size
+            fake.clipFramesOnCommit = 2
+            val client = connected(fake)
+            try {
+                val ready = runBlocking {
+                    client.uploadClipEncoded(0, frameCount = 2, name = "c", nextFrame = { payload })
+                    // The MPCS the commit produced is buffered, so this returns on a real
+                    // frame rather than by waiting the timeout out.
+                    client.awaitClipReady(slot = 0, expectedFrames = 2, timeoutMs = 5_000)
+                }
+                assertTrue(ready, "a bank reporting isUsed with enough frames is ready")
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+
+    @Test
+    fun `awaitClipReady succeeds immediately when no frames are expected`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake)
+            try {
+                assertTrue(runBlocking { client.awaitClipReady(0, expectedFrames = 0, timeoutMs = 1_000) })
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+
+    // ── Keyers ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `setKeyOnAir sends an upstream keyer command carrying the M-E and keyer`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake, collectState = false)
+            try {
+                runBlocking { client.setKeyOnAir(useDsk = false, mixEffect = 1, keyer = 2, onAir = true) }
+            } finally {
+                client.disconnect()
+            }
+            val keyed = synchronized(fake.received) { fake.received.map { it.first } }
+            assertTrue(keyed.any { it == "CKOn" }, "an upstream keyer command was sent, saw $keyed")
+            val cmd = fake.commandsNamed("CKOn").single()
+            assertEquals(1, cmd[0].toInt(), "byte 0 is the M/E index")
+            assertEquals(2, cmd[1].toInt(), "byte 1 is the keyer index")
+            assertEquals(1, cmd[2].toInt(), "byte 2 is on-air")
+        }
+    }
+
+    @Test
+    fun `setKeyOnAir with useDsk sends a downstream keyer command instead`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake, collectState = false)
+            try {
+                runBlocking { client.setKeyOnAir(useDsk = true, mixEffect = 0, keyer = 1, onAir = false) }
+            } finally {
+                client.disconnect()
+            }
+            val cmd = fake.commandsNamed("CDsL").singleOrNull() ?: fake.commandsNamed("DDsA").single()
+            assertEquals(1, cmd[0].toInt(), "byte 0 is the DSK index")
+        }
+    }
+
+    @Test
+    fun `cutKey connects, sends the keyer command and disconnects on its own`() {
+        FakeAtemSwitcher().use { fake ->
+            runBlocking {
+                AtemClient.cutKey("127.0.0.1", fake.port, useDsk = false, mixEffect = 0, keyer = 0, onAir = true)
+            }
+            assertTrue(fake.commandsNamed("CKOn").isNotEmpty(), "the keyer command reached the switcher")
+        }
+    }
+
+    // ── Reliable delivery ─────────────────────────────────────────────────────
+
+    @Test
+    fun `an acknowledged command is dropped from the in-flight buffer`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake, collectState = false)
+            try {
+                // setKeyOnAir waits for its own ack (sendCommandAndWait with no expected
+                // response), so its return IS the positive signal that the ack landed — no
+                // polling, and nothing here depends on a timeout.
+                runBlocking { client.setKeyOnAir(useDsk = false, mixEffect = 0, keyer = 0, onAir = true) }
+                assertEquals(0, client.inFlightCount(), "an acked packet is no longer awaiting delivery")
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+
+    @Test
+    fun `the fire-and-forget unlock is the only packet left unacked after an upload`() {
+        // uploadStillEncoded's closing LOCK is sent without waiting for its ack (deliberately —
+        // a dead socket there must not mask the original failure), so exactly one packet is
+        // still outstanding when it returns. Everything before it was awaited.
+        FakeAtemSwitcher().use { fake ->
+            val payload = frame(1_200)
+            fake.expectedTransferBytes = payload.data.size
+            val client = connected(fake)
+            try {
+                runBlocking { client.uploadStillEncoded(0, payload, "ack") }
+                assertTrue(
+                    client.inFlightCount() <= 1,
+                    "only the unawaited unlock may remain, got ${client.inFlightCount()}"
+                )
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+
+    @Test
+    fun `a command sent on a closed connection fails at once, naming the socket not the switcher`() {
+        // Found while capturing from a real switcher: sendRaw was `socket?.send(...)`, so a
+        // command sent after disconnect vanished and the caller waited out its whole 8s
+        // timeout before reporting "ATEM did not respond" — pointing the blame at the device.
+        // This must now fail immediately and say the connection is closed.
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake, collectState = false)
+            client.disconnect()
+
+            val started = System.currentTimeMillis()
+            val error = assertFailsWith<IllegalStateException> {
+                runBlocking { client.setKeyOnAir(useDsk = false, mixEffect = 0, keyer = 0, onAir = true) }
+            }
+            val elapsed = System.currentTimeMillis() - started
+
+            assertTrue(error.message!!.contains("closed"), "names the real cause, was: ${error.message}")
+            assertTrue(
+                elapsed < 1_000,
+                "fails immediately rather than waiting out the 8s command timeout, took ${elapsed}ms"
+            )
+            assertTrue(fake.commandsNamed("CKOn").isEmpty(), "nothing reached the switcher")
+        }
+    }
+
+    @Test
+    fun `disconnect closes the socket and clears buffered state`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake)
+            client.disconnect()
+            assertFalse(client.isAlive())
+            assertEquals(0, client.inFlightCount())
+        }
+    }
+
+    @Test
+    fun `the client adopts the session id the switcher assigns after the handshake`() {
+        FakeAtemSwitcher().use { fake ->
+            val client = connected(fake, collectState = false)
+            try {
+                runBlocking { client.setKeyOnAir(false, 0, 0, true) }
+                // Every command must carry the switcher's real session id, not the client's
+                // 0x53AB placeholder — a real ATEM silently ignores commands that don't.
+                assertContentEquals(
+                    byteArrayOf(0x12, 0x34),
+                    fake.lastCommandSessionId(),
+                    "commands go out with the assigned session id"
+                )
+            } finally {
+                client.disconnect()
+            }
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/FakeAtemSwitcher.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/FakeAtemSwitcher.kt
@@ -1,0 +1,287 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+
+/**
+ * A loopback ATEM switcher: enough of the real UDP protocol for [AtemClient] to connect to it,
+ * read a state dump from it, and upload stills and clips to it — with no hardware.
+ *
+ * **Every byte layout here was taken from a capture of two real switchers** (a 4 M/E with 64
+ * still slots and a 1 M/E with 32, both 1080p59.94), not from reading [AtemClient]. That
+ * distinction is the whole point: a fake derived from the client under test would encode the
+ * same assumptions as the client, so any place the client misread the protocol would be baked
+ * into the fake, the test would pass, and the misreading would be pinned in place. The captured
+ * values agree with the parsers — real `_top` byte 0 was `0x04` for the 4 M/E and byte 2 `0x02`
+ * for its two DSKs, real `VidM` was `0x0d` for 1080p59.94 — so the parsers are confirmed against
+ * hardware, and the numbers below are what a device actually sent.
+ *
+ * The captures also fixed the transfer shape this fake reproduces:
+ * `LOCK`→`LKOB`→`FTSD`→`FTCD`→`FTFD`→`FTDa`×N→`FTDC`→unlock, with the switcher granting 1396-byte
+ * chunks in batches (one real 307 KB frame took 221 chunks across two grants).
+ *
+ * **Nothing here waits on a clock.** Every response is emitted in reaction to a packet that
+ * arrived, and a transfer completes the moment [expectedTransferBytes] have been received, so
+ * tests end on a positive signal rather than by outlasting a timeout.
+ */
+internal class FakeAtemSwitcher(
+    private val videoMode: Int = VIDEO_MODE_1080P5994,
+    private val mixEffects: Int = 4,
+    private val downstreamKeyers: Int = 2,
+    private val keyersPerMe: Int = 4,
+    private val stillSlotCount: Int = 64,
+    private val clipSlotCount: Int = 2,
+    /** Grant size in bytes. The real switchers both granted 1396. */
+    private val grantChunkSize: Int = 1396,
+    /** Chunks per FTCD grant. Lower than the transfer needs ⇒ several grants, as on hardware. */
+    private val chunksPerGrant: Int = 320,
+    /** Emit FTDE(code 1, "busy — retry") this many times before letting a transfer through. */
+    private val ftdeRetriesBeforeSuccess: Int = 0,
+    /** When false the hello is ignored, so a connect attempt fails as if nothing is listening. */
+    private val answerHello: Boolean = true,
+) : AutoCloseable {
+
+    companion object {
+        const val VIDEO_MODE_1080P5994 = 13
+        private const val HEADER = 12
+        private const val FLAG_ACK_REQUEST = 0x01
+        private const val FLAG_HELLO = 0x02
+        private const val FLAG_ACK = 0x10
+        /** The placeholder the client opens with; a real ATEM echoes it in the hello reply. */
+        private const val TEMP_SESSION_ID = 0x53AB
+        private const val REAL_SESSION_ID = 0x1234
+    }
+
+    private val socket = DatagramSocket(0, InetAddress.getByName("127.0.0.1"))
+    val port: Int get() = socket.localPort
+
+    private val running = AtomicBoolean(true)
+    private val client = AtomicReference<InetSocketAddress?>(null)
+    private var outPacketId = 0
+
+    /** Every command the switcher received, in order — the record tests assert against. */
+    val received: MutableList<Pair<String, ByteArray>> = Collections.synchronizedList(mutableListOf())
+
+    /**
+     * Encoded byte count the next transfer will carry. The client announces only the *raw*
+     * length in FTSD, so the fake cannot infer this — the test supplies it, and the fake then
+     * completes the transfer on the exact byte rather than after an idle window.
+     */
+    @Volatile var expectedTransferBytes: Int = 0
+
+    /** Frame count reported for a clip bank once committed, so awaitClipReady has a real signal. */
+    @Volatile var clipFramesOnCommit: Int = 0
+
+    private var bytesThisTransfer = 0
+    private var chunksSinceGrant = 0
+    private var grantedThisRound = 0
+    private var ftdeSent = 0
+
+    private val loop = thread(isDaemon = true, name = "fake-atem") {
+        val buf = ByteArray(65536)
+        while (running.get()) {
+            val p = DatagramPacket(buf, buf.size)
+            runCatching { socket.receive(p) }.getOrElse { return@thread }
+            client.set(p.socketAddress as InetSocketAddress)
+            runCatching { handle(p.data.copyOf(p.length)) }
+        }
+    }
+
+    private fun handle(pkt: ByteArray) {
+        if (pkt.size < HEADER) return
+        val flags = (pkt[0].toInt() and 0xFF) shr 3
+
+        if (flags and FLAG_HELLO != 0) {
+            if (!answerHello) return
+            // The hello reply still carries the client's placeholder session id; the real one
+            // only appears in the packets that follow. AtemClient depends on exactly this.
+            send(header(FLAG_HELLO, TEMP_SESSION_ID, packetId = 0, extra = 8))
+            outPacketId = 0
+            sendStateDump()
+            return
+        }
+        if (flags and FLAG_ACK_REQUEST == 0) return
+
+        ack(u16(pkt, 10))
+        val commands = parseCommands(pkt)
+        if (commands.isNotEmpty()) lastCommandSession = byteArrayOf(pkt[2], pkt[3])
+        for ((name, payload) in commands) {
+            received.add(name to payload)
+            respondTo(name, payload)
+        }
+    }
+
+    @Volatile private var lastCommandSession: ByteArray? = null
+
+    /** Session id bytes carried by the most recent packet that contained a command. */
+    fun lastCommandSessionId(): ByteArray? = lastCommandSession
+
+    private fun respondTo(name: String, payload: ByteArray) {
+        when (name) {
+            "LOCK" -> if (payload.size >= 3 && payload[2].toInt() == 1) {
+                emit("LKOB", ByteArray(4))
+            }
+            "FTSD" -> {
+                bytesThisTransfer = 0
+                chunksSinceGrant = 0
+                val transferId = u16(payload, 0)
+                if (ftdeSent < ftdeRetriesBeforeSuccess) {
+                    ftdeSent++
+                    // code 1 = "busy, retry the whole transfer"
+                    emit("FTDE", ByteArray(4).also { writeU16(it, 0, transferId); it[2] = 1 })
+                } else {
+                    grant(transferId)
+                }
+            }
+            "FTDa" -> {
+                val transferId = u16(payload, 0)
+                // payload: transferId(2) + size(2) + data
+                bytesThisTransfer += u16(payload, 2)
+                chunksSinceGrant++
+                if (bytesThisTransfer >= expectedTransferBytes) {
+                    emit("FTDC", ByteArray(4).also { writeU16(it, 0, transferId) })
+                } else if (chunksSinceGrant >= grantedThisRound) {
+                    grant(transferId)
+                }
+            }
+            "SMPC" -> {
+                // Clip committed — report the bank as used and fully ingested so
+                // awaitClipReady ends on a real MPCS rather than on its timeout.
+                // SMPC byte 0 is a field mask (3) — the clip index is byte 1.
+                val slot = payload.getOrNull(1)?.toInt()?.and(0xFF) ?: 0
+                emit("MPCS", clipDescription(slot, used = true, frames = clipFramesOnCommit))
+            }
+        }
+    }
+
+    private fun grant(transferId: Int) {
+        val remaining = expectedTransferBytes - bytesThisTransfer
+        val needed = if (remaining <= 0) 1 else (remaining + grantChunkSize - 1) / grantChunkSize
+        grantedThisRound = minOf(chunksPerGrant, needed)
+        chunksSinceGrant = 0
+        val p = ByteArray(12)
+        writeU16(p, 0, transferId)
+        writeU16(p, 6, grantChunkSize)
+        writeU16(p, 8, grantedThisRound)
+        emit("FTCD", p)
+    }
+
+    // ── State dump ────────────────────────────────────────────────────────────
+
+    private fun sendStateDump() {
+        val cmds = mutableListOf<Pair<String, ByteArray>>()
+        cmds += "VidM" to byteArrayOf(videoMode.toByte(), 0, 0, 0)
+        cmds += "_top" to ByteArray(24).also {
+            it[0] = mixEffects.toByte()
+            it[2] = downstreamKeyers.toByte()
+        }
+        repeat(mixEffects) { me ->
+            cmds += "_MeC" to byteArrayOf(me.toByte(), keyersPerMe.toByte(), 0, 0)
+        }
+        cmds += "_mpl" to byteArrayOf(stillSlotCount.toByte(), clipSlotCount.toByte(), 0, 0)
+        cmds += "MPSp" to ByteArray(12).also {
+            repeat(minOf(4, clipSlotCount)) { i -> writeU16(it, i * 2, 720) }
+            writeU16(it, 8, 1000)
+        }
+        repeat(stillSlotCount) { i -> cmds += "MPfe" to stillDescription(i) }
+        repeat(clipSlotCount) { i -> cmds += "MPCS" to clipDescription(i, used = false, frames = 0) }
+        // Batch like a real device rather than one command per datagram.
+        cmds.chunked(8).forEach { batch -> emitAll(batch) }
+    }
+
+    /** MPfe: pool(1) pad(1) index(2) isUsed(1) hash(16) pad(2) nameLen(1) name — see the parser. */
+    private fun stillDescription(index: Int): ByteArray = ByteArray(24).also {
+        it[0] = 0
+        writeU16(it, 2, index)
+        it[4] = 0
+        it[23] = 0
+    }
+
+    /** MPCS: index(1) isUsed(1) name(64, NUL-terminated) frames(2). */
+    private fun clipDescription(index: Int, used: Boolean, frames: Int): ByteArray =
+        ByteArray(68).also {
+            it[0] = index.toByte()
+            it[1] = if (used) 1 else 0
+            if (used) "clip".toByteArray(Charsets.UTF_8).copyInto(it, 2)
+            writeU16(it, 66, frames)
+        }
+
+    // ── Wire helpers ──────────────────────────────────────────────────────────
+
+    private fun emit(name: String, payload: ByteArray) = emitAll(listOf(name to payload))
+
+    private fun emitAll(cmds: List<Pair<String, ByteArray>>) {
+        val body = cmds.fold(ByteArray(0)) { acc, (n, p) -> acc + command(n, p) }
+        val total = HEADER + body.size
+        val pkt = header(FLAG_ACK_REQUEST, REAL_SESSION_ID, ++outPacketId, extra = body.size)
+        body.copyInto(pkt, HEADER)
+        check(pkt.size == total)
+        send(pkt)
+    }
+
+    private fun header(flags: Int, session: Int, packetId: Int, extra: Int): ByteArray {
+        val total = HEADER + extra
+        return ByteArray(total).also {
+            it[0] = ((flags shl 3) or ((total shr 8) and 0x07)).toByte()
+            it[1] = (total and 0xFF).toByte()
+            writeU16(it, 2, session)
+            writeU16(it, 10, packetId)
+        }
+    }
+
+    private fun ack(packetId: Int) {
+        val pkt = header(FLAG_ACK, REAL_SESSION_ID, packetId = 0, extra = 0)
+        writeU16(pkt, 4, packetId)
+        send(pkt)
+    }
+
+    private fun command(name: String, payload: ByteArray): ByteArray {
+        val len = 8 + payload.size
+        return ByteArray(len).also {
+            writeU16(it, 0, len)
+            name.toByteArray(Charsets.US_ASCII).copyInto(it, 4)
+            payload.copyInto(it, 8)
+        }
+    }
+
+    private fun parseCommands(pkt: ByteArray): List<Pair<String, ByteArray>> {
+        val out = mutableListOf<Pair<String, ByteArray>>()
+        var off = HEADER
+        while (off + 8 <= pkt.size) {
+            val len = u16(pkt, off)
+            if (len < 8 || off + len > pkt.size) break
+            out.add(String(pkt, off + 4, 4, Charsets.US_ASCII) to pkt.copyOfRange(off + 8, off + len))
+            off += len
+        }
+        return out
+    }
+
+    private fun send(bytes: ByteArray) {
+        val dest = client.get() ?: return
+        runCatching { socket.send(DatagramPacket(bytes, bytes.size, dest)) }
+    }
+
+    private fun u16(b: ByteArray, o: Int) =
+        ((b[o].toInt() and 0xFF) shl 8) or (b[o + 1].toInt() and 0xFF)
+
+    private fun writeU16(b: ByteArray, o: Int, v: Int) {
+        b[o] = ((v shr 8) and 0xFF).toByte()
+        b[o + 1] = (v and 0xFF).toByte()
+    }
+
+    /** Commands of one name that the switcher received. */
+    fun commandsNamed(name: String): List<ByteArray> =
+        synchronized(received) { received.filter { it.first == name }.map { it.second } }
+
+    override fun close() {
+        running.set(false)
+        socket.close()
+        loop.join(1_000)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdAtemDialogTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThirdAtemDialogTest.kt
@@ -3,7 +3,9 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
 import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.isSelectable
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -49,11 +51,27 @@ class LowerThirdAtemDialogTest {
         clipMaxFrames = clipMaxFrames,
     )
 
-    /** Selects a preset — the upload button is disabled until one is chosen — then opens the dialog. */
+    /**
+     * Selects a preset — the upload button is disabled until one is chosen — then opens the dialog.
+     *
+     * Both waits below replace a bare `waitForIdle()` that made this helper intermittently fail
+     * under load (reliably when the ATEM suites ran together, never in isolation). Selecting a
+     * preset enables the upload button asynchronously, and **a click on a disabled control is
+     * silently swallowed** — so the click landed on nothing and the dialog never opened, which
+     * surfaced much later as "there are no existing nodes for that selector" at whatever the test
+     * did next. Each wait ends on a positive signal; the timeouts exist only to fail the test.
+     */
     private fun ComposeUiTest.openAtemDialog() {
         selectPreset("Welcome")
+        waitUntil("the ATEM upload button is enabled", 5_000L) {
+            onAllNodes(hasContentDescription(ATEM_UPLOAD) and isEnabled())
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
         ltButton(ATEM_UPLOAD).performClick()
-        waitForIdle()
+        waitUntil("the dialog's upload-mode rows are composed", 5_000L) {
+            onAllNodes(isSelectable()).fetchSemanticsNodes().size >= 2
+        }
     }
 
     @Test


### PR DESCRIPTION
`AtemClient`'s byte builders and state parsers had tests; the socket I/O around them did not — `AtemClientProtocolTest`'s own doc comment recorded that gap, and the file was filed as needing a live UDP device. It doesn't.

## Approach

`FakeAtemSwitcher` plays the other end over loopback UDP, the same way `InstanceLinkClientTest` already drives a real `CompanionServer`. 22 tests cover the hello handshake and session-id adoption, the state dump across two device topologies, the ack bookkeeping, the still transfer, multi-grant transfers, the `FTDE` busy-retry restart, the clip clear/transfer/commit sequence, `awaitClipReady`, and both keyer paths.

**The fake's byte layouts come from a packet capture of two real switchers** (a 4 M/E with 64 still slots and a 1 M/E with 32), not from reading `AtemClient`. That's deliberate. A fake derived from the code under test encodes the same assumptions as that code, so a misread of the protocol gets baked into both sides and the test passes while proving nothing — the shape that left three suites pinning the stepper-arrow defect in place.

It caught exactly that class of error during development: `SMPC` byte 0 is a field mask and the clip index is byte 1. A client-derived fake would have got that wrong on both sides, consistently and silently.

The capture also confirmed the parsers against hardware for the first time — real `_top` byte 0 was `0x04` for the 4 M/E and byte 2 `0x02` for its two DSKs, real `VidM` was `0x0d` for 1080p59.94.

**Nothing committed here needs hardware.** The capture tooling (a transparent UDP proxy plus a Gradle task) was temporary and is not part of this change.

## Cost

Every wait ends on a positive signal rather than a timeout — a transfer completes on the exact byte the fake is told to expect. No test costs more than 0.6s; the suite is 5.4s. Three consecutive `--rerun-tasks` runs are green. Being a socket suite rather than a Compose one, its CI cost should be roughly its local cost.

## What is still uncovered, and why

Recorded in the suite's doc comment rather than left implicit:

- `isReachable`'s failure path and `connect` against a silent host — 2s and 5s socket timeouts, neither injectable, so a test could only pass by outlasting them.
- The keepalive loop — its cadence is a hard-coded 1.5s `delay`, so any assertion about it is an assertion about a duration.
- `retransmitFrom`'s eviction throw — needs 2,048 in-flight packets to force.

## Production changes (18 lines)

- **`sendRaw` now throws instead of silently discarding the packet on a closed socket.** It was `socket?.send(...)`, so a command sent after a disconnect vanished and the caller waited out its full 8s timeout before reporting *"ATEM did not respond with LKOB"* — blaming the switcher for what is entirely a local lifecycle error. Found while capturing, where it cost an 8-second wait and a misleading message to diagnose a one-line mistake in my own tooling. The best-effort unlock in the upload paths already wraps its send in `runCatching`, so a genuinely dead socket there still cannot mask the original failure.
- **`inFlightCount()` widened to `internal`**, so the reliable-layer tests read the backlog without reflection.

## Also: a pre-existing flake fixed

`LowerThirdAtemDialogTest` failed roughly two runs in three when the ATEM suites ran together, and never in isolation. It is **independent of the changes above** — it reproduces on unmodified `main`, and it also fails with the old `sendRaw` in place — but it would have made this branch's CI intermittently red.

`openAtemDialog` clicked the upload button after a bare `waitForIdle()`, but selecting a preset enables that button asynchronously and a click on a disabled control is silently swallowed. The dialog never opened, and the failure surfaced later as a missing node at whatever the test did next. It now waits for the button to be enabled and for the dialog to compose. Four consecutive runs of the full ATEM set are green.

## Note for the coverage plan

`ChurchPresenter-coverage-plan.md` lists `AtemClient` under *"genuinely blocked — do not re-explore: live UDP device"*. That entry was wrong. It's the fourth item on that list to be disproved, which is worth weighing before trusting the rest of it — the remaining genuinely hardware-bound code is DeckLink and the camera frame cache.