### PR TITLE
Stop a faked os.name from killing every later Compose test in the JVM

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -204,6 +204,16 @@ When writing tests here:
   construction and then write or delete there. `CrashReporter`, `InstanceLinkLogger` and
   `TrainingDataLogger` resolve theirs once per JVM, so touch them before any swap or they latch
   onto a temp dir that gets deleted.
+- **Isolate `os.name` the same way** — skiko maps it onto a known OS in a JVM-wide `by lazy` and
+  throws `Error: Unknown OS <name>` on anything else, from `org.jetbrains.skia.Surface`'s static
+  initializer. So a Compose test composed inside a faked `os.name` permanently breaks every later
+  Compose test in that JVM with `NoClassDefFoundError: Could not initialize class
+  org.jetbrains.skia.Surface`, blamed on whichever class ran next. Call
+  `TestSingletons.latchSkikoHostOs()` before the swap; `withOsName` already does.
 - Tests run headless (`java.awt.headless=true`); anything reaching `GraphicsEnvironment` throws.
   `BibleBookAbbreviations.resolveBookId` does so indirectly (Compose string resources) — stub it.
 - Assert invariants over exact pixel values — font metrics differ across the three target platforms.
+- **Build paths from real directories, not POSIX literals.** `Path("/tmp/x.png").parent` is `\tmp`
+  on Windows and does not exist, so `FileChooser` silently falls back to the home directory; and a
+  chosen path stored via `absolutePathString()` gains a drive letter. Create a temp dir and derive
+  the expectation from it rather than asserting a `/`-rooted string.

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -377,6 +377,52 @@ Submit crash logs by opening a GitHub Issue and attaching the file.
 3. Run `./gradlew :composeApp:run` to verify the build works
 4. Read this entire guide before making changes
 
+### Running the tests, per platform
+
+The app's own suite is `./gradlew :composeApp:check`. It needs **JDK 21** and the submodules
+checked out (`git clone --recurse-submodules`, or `git submodule update --init --recursive`) —
+`composeApp` mounts their sources via `kotlin.srcDir` and will not compile without them.
+
+Beyond that there is nothing platform-specific to install:
+
+| Platform | Status |
+|----------|--------|
+| **Linux** | What CI runs (`ubuntu-latest`), fully headless. |
+| **Windows** | Runs the full suite, including the Compose UI tests. |
+| **macOS** | Unverified — no one has run the suite on it. Treat a failure there as unknown territory rather than a regression. |
+
+**If Compose UI tests fail with `NoClassDefFoundError: Could not initialize class
+org.jetbrains.skia.Surface`**, that is not a stale build and `--rerun-tasks` will not clear it.
+Skiko resolves its host OS from `os.name` in a JVM-wide `by lazy` and throws on a name it does not
+know, so a test that fakes `os.name` and is the first to touch Compose kills every Compose test
+after it in that JVM. `TestSingletons.latchSkikoHostOs()` exists to prevent exactly this and must
+be called *before* any `os.name` swap — `withOsName` already does. Whether it bites depends on test
+execution order, so it can appear on one machine and not another.
+
+### The six sub-builds
+
+`:composeApp:check` does **not** reach them — each is its own Gradle build with its own wrapper,
+under `composeApp/src/jvmMain/appResources/common/`. CI runs them as separate steps. To run one
+yourself, from its directory:
+
+```bash
+./gradlew test        # macOS/Linux — jvmTest for ChurchPresenter-Cross, which is Multiplatform
+```
+```shell
+.\gradlew.bat test    # Windows — .\gradlew.bat jvmTest for ChurchPresenter-Cross
+```
+
+### DeckLink hardware tests
+
+`DeckLinkHardwareTest` drives a real Blackmagic card and is **opt-in**, because opening the output
+pushes a frame to whatever that card is wired to — a visible glitch on the program feed if it were
+to run mid-service — and installs a JVM shutdown hook. It is inert in every ordinary run. To do a
+deliberate hardware pass on a machine with a card fitted:
+
+```bash
+./gradlew :composeApp:jvmTest -PdecklinkHardware=true --tests '*DeckLinkHardwareTest*'
+```
+
 ### Pull Request Guidelines
 
 - Keep PRs focused on a single feature or fix

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/TestSingletons.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/TestSingletons.kt
@@ -4,8 +4,14 @@ import org.churchpresenter.app.churchpresenter.utils.InstanceLinkLogSide
 import org.churchpresenter.app.churchpresenter.utils.InstanceLinkLogger
 
 /**
- * Pins the JVM-wide singletons that resolve a path from `user.home` to the real test home
- * (`build/test-home`) before any test swaps that property.
+ * Pins JVM-wide lazies that read a system property, forcing them to resolve against the real value
+ * before any test swaps that property.
+ *
+ * Two properties are covered — `user.home` ([latchToTestHome]) and `os.name` ([latchSkikoHostOs]).
+ * The failure mode is the same for both: a `by lazy` that resolves once per JVM keeps whatever the
+ * property said at the moment it was first touched, so a test that swaps the property and happens
+ * to be the one that triggers the lazy poisons every later test in that JVM — and which test that
+ * is depends on execution order, so it passes on one machine and fails on another.
  *
  * [InstanceLinkLogger] resolves its log directory in a `by lazy`, so it keeps whatever `user.home`
  * pointed at the *first* time anything logged, for the rest of the JVM. A test class that swaps
@@ -29,6 +35,37 @@ object TestSingletons {
             // The only public entry point that forces the logger's lazy path resolution.
             InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "test_home_latch")
             latched = true
+        }
+    }
+
+    @Volatile private var skikoLatched = false
+
+    /**
+     * Forces skiko to resolve its host OS against the real `os.name`, before any test fakes it.
+     *
+     * `org.jetbrains.skiko.hostOs` is a `by lazy` that maps `os.name` onto a known OS and throws
+     * `Error: Unknown OS <name>` for anything it does not recognise. `org.jetbrains.skia.Surface`
+     * resolves it in its static initializer, on the way to loading the native library, and every
+     * `runComposeUiTest` touches `Surface`. So a Compose test composed inside a fake `os.name` — as
+     * every [org.churchpresenter.app.churchpresenter.composables.withOsName] caller does, naming an
+     * OS no enumerator matches precisely so the panel spawns no processes — makes that the *first*
+     * touch, and skiko throws. `Surface` is then permanently uninitialisable and every later Compose
+     * test in the JVM dies with `NoClassDefFoundError: Could not initialize class
+     * org.jetbrains.skia.Surface`, pointing at whichever innocent class ran next.
+     *
+     * Whether it bites is pure execution order: if any Compose test runs before the first faking
+     * one, the lazy is already resolved and the fake is harmless. That is why CI stayed green while
+     * running a single faking class on its own reproduces it every time.
+     *
+     * Loading `Surface` is what a Compose test does anyway, so this only moves that cost earlier.
+     */
+    fun latchSkikoHostOs() {
+        if (skikoLatched) return
+        synchronized(this) {
+            if (skikoLatched) return
+            // Initialising the class runs the static load that resolves skiko's hostOs lazy.
+            Class.forName("org.jetbrains.skia.Surface")
+            skikoLatched = true
         }
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/DeckLinkHardwareTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/DeckLinkHardwareTest.kt
@@ -33,9 +33,10 @@ import kotlin.test.assertTrue
  * With the flag on: the `available` field is a private memoizing `Boolean?`, so once the
  * guard-clause tests in [DeckLinkManagerTest] latch it to `false` it stays false for the rest of
  * the JVM. This class resets it to `null` and sets `compose.application.resources.dir` to the
- * directory holding `decklink_jni.dll`, giving `isAvailable()` a fresh chance to load the native
- * library; both are restored afterwards so [DeckLinkManagerTest]'s assumptions still hold if it
- * runs later in the same JVM.
+ * directory holding the platform's DeckLink JNI library — chosen by the same `os.name` split
+ * `isAvailable()` itself uses, so a card fitted to a Linux or macOS box is reachable too — giving
+ * `isAvailable()` a fresh chance to load it; both are restored afterwards so
+ * [DeckLinkManagerTest]'s assumptions still hold if it runs later in the same JVM.
  *
  * The `println`s below are the point of a manual harness rather than stray debug output — what a
  * card reported is the result you run this for — and are the same exemption the PresentationEngine's
@@ -64,19 +65,28 @@ class DeckLinkHardwareTest {
         savedAvailable = availableField.get(DeckLinkManager)
         savedResDir = System.getProperty("compose.application.resources.dir")
 
-        // Reset the memoized availability and point at the DLL's directory.
+        // Reset the memoized availability and point at the native library's directory.
         // Gradle's test working dir may differ from the project root, so walk up to find it.
         availableField.set(DeckLinkManager, null)
+        // The same os.name split DeckLinkManager.isAvailable() uses to choose the library name,
+        // kept in step with it so the harness looks for the file the loader will actually load.
+        // The repo ships all three, so a card on Linux or macOS is reachable too.
+        val osName = System.getProperty("os.name").lowercase()
+        val (platformDir, libName) = when {
+            osName.contains("win") -> "windows" to "decklink_jni.dll"
+            osName.contains("mac") -> "macos" to "libdecklink_jni.dylib"
+            else -> "linux" to "libdecklink_jni.so"
+        }
         val candidates = listOf(
-            File("composeApp/src/jvmMain/appResources/windows"),
-            File("src/jvmMain/appResources/windows"),
-            File("../composeApp/src/jvmMain/appResources/windows"),
+            File("composeApp/src/jvmMain/appResources/$platformDir"),
+            File("src/jvmMain/appResources/$platformDir"),
+            File("../composeApp/src/jvmMain/appResources/$platformDir"),
         )
-        val dllDir = candidates.firstOrNull { File(it, "decklink_jni.dll").exists() }
-        if (dllDir != null) {
-            System.setProperty("compose.application.resources.dir", dllDir.absolutePath)
+        val libDir = candidates.firstOrNull { File(it, libName).exists() }
+        if (libDir != null) {
+            System.setProperty("compose.application.resources.dir", libDir.absolutePath)
         } else {
-            println("[DeckLinkHardwareTest] Could not find decklink_jni.dll; cwd=${File(".").absolutePath}")
+            println("[DeckLinkHardwareTest] Could not find $libName; cwd=${File(".").absolutePath}")
         }
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesImageTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesImageTest.kt
@@ -10,8 +10,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.app.churchpresenter.models.SceneSource
+import java.nio.file.Files
 import java.nio.file.Path
 import javax.swing.filechooser.FileNameExtensionFilter
+import kotlin.io.path.absolutePathString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -89,28 +91,38 @@ class SourcePropertiesImageTest {
 
     @Test
     fun `clicking Browse opens the chooser with an image filter, at the stored path's directory`() {
+        // A real directory, not a literal "/tmp": FileChooser falls back to the home directory for
+        // a start path that does not exist, and "/tmp" is not one on Windows.
+        val dir = Files.createTempDirectory("cp-image-browse")
         val chooser = FakeFileChooser(answer = null)
-        sourcePanel(Fixture.image(), fileChooser = chooser) { _ ->
-            onNodeWithContentDescription("Browse").performClick()
-            waitForIdle()
+        try {
+            sourcePanel(Fixture.image(filePath = dir.resolve("logo.png").toString()), fileChooser = chooser) { _ ->
+                onNodeWithContentDescription("Browse").performClick()
+                waitForIdle()
 
-            assertEquals(1, chooser.callCount)
-            assertEquals(Path.of("/tmp"), chooser.lastPath, "the chooser must open at the stored file's parent directory")
-            assertEquals(
-                listOf("png", "jpg", "jpeg", "gif", "bmp", "webp", "heic", "heif", "svg"),
-                chooser.lastFilters?.single()?.extensions?.toList(),
-            )
+                assertEquals(1, chooser.callCount)
+                assertEquals(dir, chooser.lastPath, "the chooser must open at the stored file's parent directory")
+                assertEquals(
+                    listOf("png", "jpg", "jpeg", "gif", "bmp", "webp", "heic", "heif", "svg"),
+                    chooser.lastFilters?.single()?.extensions?.toList(),
+                )
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
         }
     }
 
     @Test
     fun `choosing a file from Browse stores its path`() {
-        val chooser = FakeFileChooser(answer = Path.of("/media/backdrops/sunset.jpg"))
+        val chosen = Path.of("/media/backdrops/sunset.jpg")
+        val chooser = FakeFileChooser(answer = chosen)
         sourcePanel(Fixture.image(), fileChooser = chooser) { get ->
             onNodeWithContentDescription("Browse").performClick()
             waitForIdle()
 
-            assertEquals("/media/backdrops/sunset.jpg", (get() as SceneSource.ImageSource).filePath)
+            // The panel stores what the chooser answered, absolutised — which on Windows gains a
+            // drive letter, so the expectation is derived rather than spelled out.
+            assertEquals(chosen.absolutePathString(), (get() as SceneSource.ImageSource).filePath)
         }
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanelTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesPanelTestSupport.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
+import org.churchpresenter.app.churchpresenter.TestSingletons
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.app.churchpresenter.models.SceneSource
@@ -151,8 +152,13 @@ internal fun redrawablePanel(
  * the panel has no enumerator for sends it down its own empty-list path with no process spawned at
  * all, which is what makes the surrounding controls — the mode dropdown, the Refresh button, the
  * "nothing found" message — testable at all.
+ *
+ * Skiko reads `os.name` through a JVM-wide `by lazy` and throws on a name it does not know, so the
+ * latch below has to happen before the swap — see [TestSingletons.latchSkikoHostOs] for what breaks
+ * without it, and why it breaks only on some machines.
  */
 internal fun <T> withOsName(name: String, block: () -> T): T {
+    TestSingletons.latchSkikoHostOs()
     val previous = System.getProperty("os.name")
     System.setProperty("os.name", name)
     return try {
@@ -174,10 +180,12 @@ internal const val OS_WITHOUT_ENUMERATOR = "TestOS"
  * singleton — sharing one id across tests would leak a running timer between them.
  */
 internal object Fixture {
-    fun image(id: String = "img-1") = SceneSource.ImageSource(id = id, name = "Logo", filePath = "/tmp/logo.png")
+    fun image(id: String = "img-1", filePath: String = "/tmp/logo.png") =
+        SceneSource.ImageSource(id = id, name = "Logo", filePath = filePath)
     fun text(id: String = "txt-1") = SceneSource.TextSource(id = id, name = "Title")
     fun color(id: String = "col-1") = SceneSource.ColorSource(id = id, name = "Backdrop")
-    fun video(id: String = "vid-1") = SceneSource.VideoSource(id = id, name = "Bumper", filePath = "/tmp/bumper.mp4")
+    fun video(id: String = "vid-1", filePath: String = "/tmp/bumper.mp4") =
+        SceneSource.VideoSource(id = id, name = "Bumper", filePath = filePath)
     fun browser(id: String = "web-1") = SceneSource.BrowserSource(id = id, name = "Feed", url = "https://example.org")
     fun shape(id: String = "shp-1") = SceneSource.ShapeSource(id = id, name = "Box")
     fun clock(id: String = "clk-1") = SceneSource.ClockSource(id = id, name = "Service timer")

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesVideoTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesVideoTest.kt
@@ -12,8 +12,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.app.churchpresenter.models.SceneSource
+import java.nio.file.Files
 import java.nio.file.Path
 import javax.swing.filechooser.FileNameExtensionFilter
+import kotlin.io.path.absolutePathString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -94,28 +96,38 @@ class SourcePropertiesVideoTest {
 
     @Test
     fun `clicking Browse opens the chooser with a video filter, at the stored path's directory`() {
+        // A real directory, not a literal "/tmp": FileChooser falls back to the home directory for
+        // a start path that does not exist, and "/tmp" is not one on Windows.
+        val dir = Files.createTempDirectory("cp-video-browse")
         val chooser = FakeFileChooser(answer = null)
-        sourcePanel(Fixture.video(), fileChooser = chooser) { _ ->
-            onNodeWithContentDescription("Browse").performClick()
-            waitForIdle()
+        try {
+            sourcePanel(Fixture.video(filePath = dir.resolve("bumper.mp4").toString()), fileChooser = chooser) { _ ->
+                onNodeWithContentDescription("Browse").performClick()
+                waitForIdle()
 
-            assertEquals(1, chooser.callCount)
-            assertEquals(Path.of("/tmp"), chooser.lastPath, "the chooser must open at the stored file's parent directory")
-            assertEquals(
-                listOf("mp4", "mov", "avi", "mkv", "wmv", "flv", "webm", "m4v"),
-                chooser.lastFilters?.single()?.extensions?.toList(),
-            )
+                assertEquals(1, chooser.callCount)
+                assertEquals(dir, chooser.lastPath, "the chooser must open at the stored file's parent directory")
+                assertEquals(
+                    listOf("mp4", "mov", "avi", "mkv", "wmv", "flv", "webm", "m4v"),
+                    chooser.lastFilters?.single()?.extensions?.toList(),
+                )
+            }
+        } finally {
+            dir.toFile().deleteRecursively()
         }
     }
 
     @Test
     fun `choosing a file from Browse stores its path`() {
-        val chooser = FakeFileChooser(answer = Path.of("/media/clips/outro.mov"))
+        val chosen = Path.of("/media/clips/outro.mov")
+        val chooser = FakeFileChooser(answer = chosen)
         sourcePanel(Fixture.video(), fileChooser = chooser) { get ->
             onNodeWithContentDescription("Browse").performClick()
             waitForIdle()
 
-            assertEquals("/media/clips/outro.mov", (get() as SceneSource.VideoSource).filePath)
+            // The panel stores what the chooser answered, absolutised — which on Windows gains a
+            // drive letter, so the expectation is derived rather than spelled out.
+            assertEquals(chosen.absolutePathString(), (get() as SceneSource.VideoSource).filePath)
         }
     }
 


### PR DESCRIPTION
﻿Running any one of the four test classes that fake `os.name` on its own fails, and takes the rest of the JVM's Compose tests down with it:

```
java.lang.Error: Unknown OS TestOS
  at org.jetbrains.skiko.OsArch_jvmKt.hostOs_delegate$lambda$0(OsArch.jvm.kt:10)
  at org.jetbrains.skiko.Library.findAndLoad(Library.kt:107)
  at org.jetbrains.skia.Surface.<clinit>(Surface.kt:539)
  at androidx.compose.ui.test.SkikoComposeUiTest.<init>(ComposeUiTest.skiko.kt:222)
```

## What is happening

`withOsName` names an OS no enumerator matches, and that is deliberate — it is what stops the camera and screen-capture panels shelling out to `/dev/video*`, DirectShow, `xprop` or `osascript`, or raising a macOS accessibility prompt that would block the run. But `runComposeUiTest` is called *inside* that window, and skiko maps `os.name` onto a known OS in a JVM-wide `by lazy` that throws on anything else — from `org.jetbrains.skia.Surface`'s static initializer, which every Compose test touches.

So whichever test touches Compose first while the name is faked poisons `Surface` for the entire JVM. Every later Compose test then fails with `NoClassDefFoundError: Could not initialize class org.jetbrains.skia.Surface`, reported against whatever class happened to run next rather than the one that caused it.

**Whether it bites is pure execution order.** If any Compose test runs before the first faking one, the lazy is already resolved and the fake is harmless. That is the only reason CI has been green — and why on a Windows machine, which orders the suite differently, the Compose tests could not run at all. 145 test files use `runComposeUiTest`.

## The fix

`TestSingletons.latchSkikoHostOs()` forces the lazy to resolve against the real `os.name` before anything fakes it — the same shape as the existing `latchToTestHome()` for `user.home`, and for the same underlying reason. `withOsName` calls it before the swap, so all four callers are covered. Loading `Surface` is what a Compose test does anyway, so this only moves that cost earlier.

## Four assertions that had never actually run

With the JVM no longer poisoned, `SourcePropertiesImageTest` and `SourcePropertiesVideoTest` turned out to assume POSIX paths:

- `Path("/tmp/logo.png").parent` is `\tmp` on Windows and does not exist, so `FileChooser.choose`'s `path?.takeIf { it.exists() } ?: home` (`FileChooser.kt:80`) silently opened at the home directory instead.
- A chosen path stored through `absolutePathString()` gains a drive letter, so `/media/backdrops/sunset.jpg` came back as `C:\media\backdrops\sunset.jpg`.

Both now derive their expectation — from a real `Files.createTempDirectory`, and from the same `absolutePathString()` the panel applies — rather than asserting a `/`-rooted literal. `Fixture.image`/`video` gained an optional `filePath` so the defaults every other test relies on are unchanged.

## Also

`DeckLinkHardwareTest` now picks its native library with the same `os.name` split `DeckLinkManager.isAvailable()` uses, so a card fitted to a Linux or macOS box is reachable. The repo ships all three natives (`decklink_jni.dll`, `libdecklink_jni.so`, `libdecklink_jni.dylib`) but the harness only ever looked for the DLL. Still inert unless `-PdecklinkHardware=true`.

Docs: per-platform test instructions and the sub-build commands (`gradlew.bat` on Windows) in `DEVELOPMENT_GUIDE.md`; both traps added to AGENT.md's test rules so the next person meets them as a rule rather than as a mystery.

## Verification

- The isolated run that reproduced it, `--tests '*SourcePropertiesCameraTest*'`, went from erroring entirely to 9/9 green.
- All `*SourceProperties*` and `*DeckLink*` classes together: **462 tests, 0 failures** (previously 4 failures plus a class that could not run).
- No production code is touched — the diff is test sources and documentation only.
- A full local `jvmTest` run was still in flight when this was opened; CI is the arbiter and covers Linux, where the ordering has always happened to be benign.

## Note on scope

The `-Dskiko.renderApi` setting the `Test` tasks lack, unlike the `run` task and the packaged distributions, turned out to be a red herring — the native library loads fine. No build configuration was changed.
