### PR TITLE
Give release notes one bullet per pull request

### DIFF
--- a/generate_release_notes.py
+++ b/generate_release_notes.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """
-Generates categorized release notes from commits since the last GitHub release.
+Generates categorized release notes for everything that landed since the last GitHub release.
+
+One bullet per pull request, titled the way the PR was titled, plus anything pushed straight to the
+branch. Not one bullet per commit: a release is read by people deciding whether to upgrade, and the
+steps a branch took to get where it got are not that.
+
 Usage: python3 generate_release_notes.py [from_tag [version [windows macos_arm64 macos_x64 linux]]]
 Platform args are 'true'/'false' strings; omit to include all platforms.
 """
@@ -49,6 +54,63 @@ def categorize(msg):
             return name
     return "UI / General"
 
+# GitHub's merge commits carry the PR title as the first line of the commit body, so the whole
+# changelog is computable from git alone — no API calls, nothing to rate-limit in CI.
+PR_MERGE = re.compile(r"^Merge pull request #(\d+) from (\S+)")
+
+# Bodies are multi-line, so records and fields need separators a commit message cannot contain.
+FIELD, RECORD = "\x1f", "\x1e"
+
+def landed_entries(from_tag, end_ref):
+    """
+    What actually landed on the release branch, as (title, pr_number) pairs.
+
+    Walks --first-parent, which is the whole point: it never descends into a merged branch, so a
+    pull request contributes its own title once instead of every internal step it took to get
+    there. Without it, twelve PRs whose commits were each called "Added unit tests" printed
+    twenty-one identical bullets.
+    """
+    fmt = f"--pretty=format:%P{FIELD}%s{FIELD}%b{RECORD}"
+    raw = run(["git", "log", f"{from_tag}..{end_ref}", "--first-parent", fmt])
+    for record in raw.split(RECORD):
+        if not record.strip():
+            continue
+        parents, subject, body = (record.strip("\n").split(FIELD) + ["", ""])[:3]
+        merged = PR_MERGE.match(subject.strip())
+        if merged:
+            number, branch = merged.group(1), merged.group(2)
+            title = next((line.strip() for line in body.splitlines() if line.strip()), "")
+            # An empty body would otherwise yield a blank bullet; the branch name still says
+            # something about the work.
+            yield (title or branch.rsplit("/", 1)[-1], number)
+        elif len(parents.split()) > 1:
+            # A sync merge ("Merge branch 'main' into ...") — carries no content of its own.
+            continue
+        else:
+            # Pushed straight to the branch, never went through a PR. Keep it, or this is where
+            # work silently disappears from the notes.
+            yield (subject.strip(), None)
+
+def combine_duplicates(entries):
+    """
+    One bullet per distinct title, carrying every PR that used it.
+
+    Separate pull requests share a title often enough to matter ("Added unit tests" was twelve of
+    them), and listing it twelve times is what made these notes unreadable. Collapsing to one
+    bullet while keeping all the numbers means nothing becomes unfindable.
+    """
+    order, numbers = [], {}
+    for title, number in entries:
+        key = title.lower()
+        if key not in numbers:
+            order.append((key, title))
+            numbers[key] = []
+        if number and number not in numbers[key]:
+            numbers[key].append(number)
+    for key, title in order:
+        refs = numbers[key]
+        yield f"{title} ({', '.join('#' + n for n in refs)})" if refs else title
+
 def main():
     from_tag = last_release_tag()
     latest_tag = run(["git", "describe", "--tags", "--abbrev=0"])
@@ -60,8 +122,8 @@ def main():
     else:
         version = latest_tag.lstrip("v") if end_ref != "HEAD" else "unreleased"
 
-    raw = run(["git", "log", f"{from_tag}..{end_ref}", "--pretty=format:%s"])
-    commits = [line for line in raw.splitlines() if line and not NOISE.match(line.strip())]
+    entries = [(t, n) for t, n in landed_entries(from_tag, end_ref) if t and not NOISE.match(t)]
+    commits = list(combine_duplicates(entries))
 
     buckets = {name: [] for name, _ in CATEGORIES}
     for msg in commits:


### PR DESCRIPTION
The v26.6.143 notes are 481 lines, and **46% of them are merge commits** — 113 `Merge pull request #N from …` subjects and 97 `Merge branch 'main' into …` ones. `Added unit tests` appears twelve times. It reads like a raw `git log` because that is what it was: `git log {from}..{to} --pretty=format:%s`, walking *inside* every merged branch.

## One entry per merge request

The walk is now `--first-parent`, so it never descends into a branch and a pull request contributes **its own title, once**, instead of every step it took to get there. The title needs no API call — GitHub already stores it as the first line of the merge commit's body:

```
subject: Merge pull request #132 from ChurchPresenter/test/submodule-coverage
body:    Cover every submodule, measure them all, and run them all in CI
```

Every PR merge in the range has a non-empty body, and there is a branch-name fallback for one that does not, so a bullet can never come out blank.

Three cases, and the third is the one that is easy to get wrong:

- **a PR merge** → its title, tagged `(#N)`
- **any other merge** → dropped; a sync merge carries no content of its own
- **anything else** → a commit pushed straight to `main`. Kept. There were **18** of them in this range, and both obvious shortcuts lose them: `--no-merges` alone keeps 240 internal commits instead, and taking PR titles only drops these silently.

## Duplicate titles combine, references survive

Twelve separate PRs were titled `Added unit tests`. They collapse to one bullet that still carries all of them, rather than twelve bullets or one that quietly loses eleven references:

```
- Added unit tests (#120, #111, #103, #93, #87, #82, #79, #75, #60)
```

## Result

**454 bullets → 118**, no line starting `- Merge`. Categories, the `NOISE` filter and the download-links trailer are untouched.

Verified on the real range `v26.4.203..v26.6.143`, and both call shapes CI uses still work: no arguments (resolves its own range) and `<prev-tag> <version> …` where the tag does not exist yet and the range ends at `HEAD`.

v26.6.143's published body is being regenerated with this and updated separately.