### PR TITLE
Fix unlabelled song import, and cover the Q&A history view

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabHistoryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabHistoryTest.kt
@@ -1,0 +1,129 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Q&A history view — where questions go when a session ends.
+ *
+ * Ending a session moves every question out of the queue and into history rather than deleting
+ * them, so the next service starts clean without losing what was asked. History is the one view
+ * reached by its own button rather than the filter dropdown (`selectedFilter = 6`), which is why
+ * it had no coverage: every existing test drives the dropdown.
+ *
+ * The restore path is the one worth defending most. A session ended by accident mid-service is
+ * recoverable only if history keeps the questions *and* can hand them back.
+ */
+class QATabHistoryTest {
+
+    private fun ComposeUiTest.openHistory() {
+        // The button carries its own count, so it cannot be addressed by a bare label.
+        onNodeWithText(QALabel.HISTORY, substring = true).performClick()
+        waitForIdle()
+    }
+
+    @Test
+    fun `the history button reports how many questions are held`() =
+        qaTab(seed = { askAll("First question", "Second question") }) { qa, _, _ ->
+            onNodeWithText("${QALabel.HISTORY} (0)", substring = true).assertExists("empty to start with")
+
+            qa.toggleSession()
+            waitForIdle()
+
+            onNodeWithText("${QALabel.HISTORY} (2)", substring = true)
+                .assertExists("both questions moved into history: ${renderedText().take(200)}")
+        }
+
+    @Test
+    fun `ending a session moves questions to history rather than deleting them`() =
+        qaTab(seed = { askAll("Asked before the break") }) { qa, _, _ ->
+            qa.toggleSession()
+            waitForIdle()
+
+            assertFalse(showsQuestion("Asked before the break"), "the queue is clear for the next session")
+
+            openHistory()
+            assertTrue(showsQuestion("Asked before the break"), "but it is still on record")
+        }
+
+    @Test
+    fun `the history view offers to export what it holds`() =
+        qaTab(seed = { askAll("Something asked") }) { qa, _, _ ->
+            qa.toggleSession()
+            waitForIdle()
+            openHistory()
+
+            // The actions bar only appears once there is history to act on.
+            assertTrue(
+                renderedText().any { it.contains("Export", ignoreCase = true) },
+                "an export action is offered: ${renderedText().take(200)}",
+            )
+        }
+
+    @Test
+    fun `an empty history offers no actions to take`() =
+        qaTab(seed = { askAll("Still in the queue") }) { _, _, _ ->
+            openHistory()
+
+            assertFalse(
+                renderedText().any { it.contains("Export", ignoreCase = true) },
+                "nothing to export yet: ${renderedText().take(200)}",
+            )
+        }
+
+    @Test
+    fun `restoring puts the questions back in the queue and empties history`() =
+        qaTab(seed = { askAll("Asked before the break", "And another") }) { qa, _, _ ->
+            qa.toggleSession()
+            waitForIdle()
+            assertEquals(2, qa.history.size)
+
+            qa.restoreFromHistory()
+            waitForIdle()
+
+            assertTrue(qa.history.isEmpty(), "history handed them back rather than copying them")
+            assertTrue(qa.sessionActive, "and the session is running again")
+            assertTrue(showsQuestion("Asked before the break"), "they are answerable again")
+            assertTrue(showsQuestion("And another"))
+        }
+
+    @Test
+    fun `clearing history empties it without touching the live queue`() =
+        qaTab(seed = { askAll("From the first session") }) { qa, _, _ ->
+            qa.toggleSession()
+            waitForIdle()
+            qa.toggleSession()          // start a new session
+            qa.addQuestion("From the second session")
+            waitForIdle()
+
+            qa.clearHistory()
+            waitForIdle()
+
+            assertTrue(qa.history.isEmpty())
+            assertTrue(showsQuestion("From the second session"), "the current queue is untouched")
+        }
+
+    @Test
+    fun `history survives a second session ending, accumulating both`() =
+        qaTab(seed = { askAll("Session one question") }) { qa, _, _ ->
+            qa.toggleSession()
+            waitForIdle()
+
+            qa.toggleSession()
+            qa.addQuestion("Session two question")
+            waitForIdle()
+            qa.toggleSession()
+            waitForIdle()
+
+            openHistory()
+            assertTrue(showsQuestion("Session one question"), "the first session is still there")
+            assertTrue(showsQuestion("Session two question"), "and the second joined it")
+        }
+}


### PR DESCRIPTION
Two pieces: a real import bug fixed in the Converter submodule, and a slice of the app tab coverage work.

Branched off `main`, so it is **independent of #134** — the two can merge in either order.

## The Converter fix — the substantial part

A document with **no section markers** imported as ONE section holding the entire song, which the app then shows as a single unreadable slide.

`parseSections` always meant to split those (on a blank line, on a bare `1.` marker, and by relabelling a repeated block as the chorus), but none of the three branches could run: they were guarded on `currentLabel == null`, while the fall-through that collects a lyric line assigns `"Verse N"` to the first content line. The guard is now on whether the label came from a real section marker.

Three consequences:

- unlabelled documents import as **one verse per paragraph**
- **chorus detection works for the first time** — a refrain written out after every verse is now recognised and written once, which was unreachable while everything collapsed into one section
- **labelled documents are unaffected**, pinned by a test: under an explicit label a blank line stays inside the section, so a verse with a stanza break is not torn in two

`MarkdownToSongConverter` 83.0% → **91.5%**. Details in the paired submodule PR, whose pointer this bumps.

I had left this unfixed deliberately during the earlier coverage work and deleted the failing tests rather than assert broken output — a test that pins a defect is what keeps it. They are restored here alongside the fix.

## Q&A history view

`QATab` 73.2% → **76.5%**. History is the one view reached by its own button rather than the filter dropdown, which is why it had no coverage — every existing test drives the dropdown.

The restore path is the one worth defending: a session ended by accident mid-service is only recoverable if history keeps the questions *and* can hand them back. That is asserted directly — history empties, the session restarts, the questions are answerable again. Also covered: the export action appears only once there is history to act on, clearing history leaves the current queue untouched, and a second session's questions accumulate alongside the first's.

The import/export file dialogs stay uncovered — they go through `FileChooser`, on this repo's established untestable list.

## An honest note on the remaining tab work

This is a slice of Phase 3, not the whole of it, and I stopped deliberately. The QA suite bought **22 lines**, and the rest looks similar or worse:

- `PresentationTab` (345) mostly needs a loaded deck through `DeckRasterizer`
- `SourcePropertiesPanel` (236), `BibleTab` (263), `SongsTab` (221) are long tails already at 82–85%
- `MediaTab`'s seek bar is a private composable reachable only via a loaded media file
- QATab's remaining 160 are the `FileChooser` paths

The app-wide figure is unchanged at 79.0% as a result. Roughly 1,900 lines spread across ten tabs is a genuine grind at 20–40 lines per suite, so I would rather flag the ratio than keep going and report motion. Happy to grind it out if the headline number is worth it to you.

## Verification

App suite **7,151 tests, 0 failures**. Every new suite green on three consecutive `--rerun-tasks` runs, nothing over 1s, and `compileKotlinJvm` passes against the changed submodule source.