### PR TITLE
Show folder scans in progress, and follow the Bible folder when it changes

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -2111,7 +2111,7 @@
     <string name="bible_stt_src_chapter_history">Matched an earlier chapter</string>
     <string name="bible_stt_track_transcription">Heard in transcription</string>
     <string name="bible_stt_track_translation">Heard in translation</string>
-    <string name="bible_stt_detected_version_tooltip">The translation the speaker appears to be reading from, matched against every Bible in your folder. Informational only — the verse text shown still comes from your own Bible.</string>
+    <string name="bible_stt_detected_version_tooltip">The translation the speaker appears to be reading from, matched against the Bibles in your folder that are in the same language. Informational only — the verse text shown still comes from your own Bible.\n\nIf this looks wrong, the translation being read is probably not installed. Add it under Bible Storage Directory in Settings — "Download Bibles…" installs one in a click. The more translations you have in that language, the more certain this can be; with only one installed it can never be checked against anything.</string>
     <string name="bible_stt_flag_needs_live">Available once a verse is live — this flag describes the passage on screen</string>
     <string name="bible_stt_match_label">Text match</string>
     <string name="bible_stt_text_match_hint">Also affects overall detection confidence and how long a spoken book/chapter stays active — not just quoted-text matches</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -287,6 +287,7 @@
     <string name="set_all_directories">Set All</string>
     <string name="no_directory_selected">No directory selected</string>
     <string name="no_files_detected">No files detected</string>
+    <string name="scanning_directory">Scanning folder…</string>
     <string name="detected_files_label">Detected:</string>
     <string name="files_in_directory">Files in Directory</string>
     <string name="import_song_file">Import Song File</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
@@ -590,9 +590,14 @@ fun MainDesktop(
     val engineBibles = remember(appSettings.bibleSettings.translationList()) {
         appSettings.bibleSettings.translationList().map { it.fileName }.sorted()
     }
+    // storageDirectory is a key because it is READ below as bibleRoot: without it, changing the
+    // Bible folder mid-service leaves the engine on the old root — old verse index, and a version
+    // corpus that is built once at start and never rebuilt. engineBibles does not cover it, being
+    // file NAMES: move to another folder holding the same names and the set never changes.
     LaunchedEffect(
         sttConnected, bibleEngineSettings.enabled, bibleEngineSettings.runLocal,
         bibleEngineSettings.host, bibleEngineSettings.port, engineBibles,
+        appSettings.bibleSettings.storageDirectory,
     ) {
         if (sttConnected && bibleEngineSettings.enabled && engineBibles.isNotEmpty()) {
             bibleEngineClient.start(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SystemSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SystemSettingsTab.kt
@@ -69,6 +69,7 @@ import churchpresenter.composeapp.generated.resources.lower_third_storage_direct
 import churchpresenter.composeapp.generated.resources.media_storage_directory
 import churchpresenter.composeapp.generated.resources.no_directory_selected
 import churchpresenter.composeapp.generated.resources.no_files_detected
+import churchpresenter.composeapp.generated.resources.scanning_directory
 import churchpresenter.composeapp.generated.resources.pictures_storage_directory
 import churchpresenter.composeapp.generated.resources.presentation_storage_directory
 import churchpresenter.composeapp.generated.resources.reset_settings
@@ -168,7 +169,8 @@ fun SystemSettingsTab(
     ) {
         // Bible Storage Directory
         SettingsSection(title = stringResource(Res.string.bible_storage_directory)) {
-        var bibleFiles by remember(settings.bibleSettings.storageDirectory) { mutableStateOf(emptyList<String>()) }
+        // null until the scan lands — see DetectedFilesList.
+        var bibleFiles by remember(settings.bibleSettings.storageDirectory) { mutableStateOf<List<String>?>(null) }
         LaunchedEffect(settings.bibleSettings.storageDirectory) {
             bibleFiles = withContext(Dispatchers.IO) {
                 fileManager.getBibleFilesInDirectory(settings.bibleSettings.storageDirectory)
@@ -192,7 +194,8 @@ fun SystemSettingsTab(
             files = bibleFiles,
             directorySet = settings.bibleSettings.storageDirectory.isNotEmpty(),
             detectedLabel = stringResource(Res.string.detected_files_label),
-            noFilesText = stringResource(Res.string.no_files_detected)
+            noFilesText = stringResource(Res.string.no_files_detected),
+            scanningText = stringResource(Res.string.scanning_directory)
         )
         // Sits beside the folder picker because that is where someone with no Bibles ends up.
         // Offered only once a real folder is in place: downloads are written the moment they
@@ -218,7 +221,7 @@ fun SystemSettingsTab(
                     onDismiss = { showBibleCatalog = false },
                     onBibleInstalled = { fileName ->
                         onSettingsChange { s -> s.withInstalledBible(fileName) }
-                        bibleFiles = bibleFiles + fileName
+                        bibleFiles = bibleFiles.orEmpty() + fileName
                     }
                 )
             }
@@ -246,10 +249,19 @@ fun SystemSettingsTab(
             val coroutineScope = rememberCoroutineScope()
             var spsFiles by remember(settings.songSettings.storageDirectory) { mutableStateOf(emptyList<String>()) }
             var songFolders by remember(settings.songSettings.storageDirectory) { mutableStateOf(emptyList<Pair<String, Int>>()) }
+            // Two scans, one verdict: "no songs here" is only true once BOTH have landed, so this
+            // stays true across the pair rather than flickering between them.
+            var scanningSongs by remember(settings.songSettings.storageDirectory) { mutableStateOf(true) }
             LaunchedEffect(settings.songSettings.storageDirectory) {
                 val dir = settings.songSettings.storageDirectory
-                spsFiles = withContext(Dispatchers.IO) { fileManager.getSongFilesInDirectory(dir) }
-                songFolders = withContext(Dispatchers.IO) { fileManager.getSongFoldersInDirectory(dir) }
+                scanningSongs = true
+                try {
+                    spsFiles = withContext(Dispatchers.IO) { fileManager.getSongFilesInDirectory(dir) }
+                    songFolders = withContext(Dispatchers.IO) { fileManager.getSongFoldersInDirectory(dir) }
+                } finally {
+                    // finally, so a cancelled or failed scan does not leave the spinner up forever.
+                    scanningSongs = false
+                }
             }
 
             // Add Song Samples button
@@ -260,7 +272,9 @@ fun SystemSettingsTab(
                 modifier = Modifier.padding(top = 2.dp, start = 2.dp).height(24.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                if (spsFiles.isEmpty() && songFolders.isEmpty()) {
+                if (scanningSongs) {
+                    ScanningRow(stringResource(Res.string.scanning_directory))
+                } else if (spsFiles.isEmpty() && songFolders.isEmpty()) {
                     Text(
                         text = stringResource(Res.string.no_files_detected),
                         style = MaterialTheme.typography.bodySmall,
@@ -888,14 +902,27 @@ private fun DirectoryPicker(
     }
 }
 
+/**
+ * Detected files under a chosen folder, or a spinner while the scan is still running.
+ *
+ * [files] is null until the scan finishes. That distinction is the whole point: the scan runs on
+ * Dispatchers.IO and takes seconds against a network share, and rendering "no files detected" for
+ * that whole time reads as a verdict rather than a wait — someone who has just picked the right
+ * folder is told, in red, that it is empty.
+ */
 @Composable
 private fun DetectedFilesList(
-    files: List<String>,
+    files: List<String>?,
     directorySet: Boolean,
     detectedLabel: String,
-    noFilesText: String
+    noFilesText: String,
+    scanningText: String
 ) {
     if (!directorySet) return
+    if (files == null) {
+        ScanningRow(scanningText)
+        return
+    }
     Text(
         text = if (files.isNotEmpty()) "$detectedLabel ${files.joinToString(", ")}"
                else noFilesText,
@@ -904,6 +931,33 @@ private fun DetectedFilesList(
                 else MaterialTheme.colorScheme.error.copy(alpha = 0.7f),
         modifier = Modifier.padding(top = 4.dp, start = 2.dp)
     )
+}
+
+/**
+ * Spinner plus label, sized to sit inline with the body-small text it replaces.
+ *
+ * `internal` so it can be composed directly in a test: the state it represents is transient by
+ * nature, and `SystemSettingsTab` builds its own `FileManager`, so there is no seam to hold a scan
+ * open long enough to catch this on screen without racing it.
+ */
+@Composable
+internal fun ScanningRow(scanningText: String) {
+    Row(
+        modifier = Modifier.padding(top = 4.dp, start = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(12.dp),
+            strokeWidth = 1.5.dp,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = scanningText,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
 }
 
 private suspend fun copySongSamples(storageDirectory: String): Int {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SystemSettingsTabScanningTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/SystemSettingsTabScanningTest.kt
@@ -1,0 +1,36 @@
+package org.churchpresenter.app.churchpresenter.dialogs.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+
+/**
+ * The folder-scan progress row in the directory settings.
+ *
+ * Why this exists: both the Bible and Songs folder scans run on `Dispatchers.IO` and take seconds
+ * against a network share, and until this row landed the UI rendered "No files detected" in red for
+ * the whole wait. Someone who had just picked the correct folder was told it was empty.
+ *
+ * **Not covered:** that `SystemSettingsTab` actually shows this row *while* a scan is in flight.
+ * The tab constructs its own `FileManager`, so a test cannot hold a scan open, and asserting on a
+ * state that resolves in microseconds would mean racing it — the flake shape `AGENT.md` rules out.
+ * Making it reachable needs a production seam (an injectable `FileManager`), which is a change to
+ * flag rather than to smuggle into a UI fix. What is covered here is the row itself, and the
+ * scanned-to-completion outcomes are covered by `SystemSettingsTabTest`.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SystemSettingsTabScanningTest {
+
+    @Test
+    fun `the scanning row shows the label it is given`() = runComposeUiTest {
+        setContent {
+            MaterialTheme { ScanningRow("Scanning folder…") }
+        }
+        // The label is the whole point: a bare spinner says "busy" without saying at what, and this
+        // sits exactly where the "No files detected" verdict would otherwise be.
+        onNodeWithText("Scanning folder…").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
Three fixes to variations of the same complaint: the app looking like it found nothing, when it had not yet looked — or was still pointed at the old folder.

## Folder settings show the scan

The Bible and Songs scans in `SystemSettingsTab` run on `Dispatchers.IO`, and both lists were initialised to `emptyList()`. Until the scan landed the UI rendered **"No files detected"** in red — against a network share, several seconds of telling someone their correct folder is empty.

Both now hold `null` (Bible) / `scanning = true` (Songs) until the scan finishes, and show a spinner with a "Scanning folder…" label meanwhile. "No files" is only claimed once something has actually looked. The Songs side runs two scans and stays in the scanning state across the pair, so it does not flicker to a false verdict between them; its flag is cleared in a `finally` so a cancelled scan cannot leave the spinner up.

## The engine follows the Bible folder

`MainDesktop`'s engine `LaunchedEffect` **read** `storageDirectory` as `bibleRoot` but did not key on it. Changing the Bible folder mid-service left the engine on the old root — stale verse index, and a version corpus that is built once at startup and never rebuilt.

`engineBibles` did not cover this: it is file *names*, so moving to a different folder holding the same filenames leaves the set identical and nothing restarts. `start()` already does a full stop/restart, so the key is the whole fix.

## Submodule

`ChurchPresenter-BLE` → `5bd9fb5` ([BLE #3](https://github.com/ChurchPresenter/ChurchPresenter-BLE/pull/3)):

- **Says why a bible is missing from the version corpus.** A live install had 24 `.spb` files and a corpus of 3; the loader discarded the other 21 inside `runCatching { }.getOrNull()` without a word. Each drop is now reported with a reason, separated by what the operator would have to do about it.
- **Names the only installed translation instead of nothing.** Scoring weighs each token by how rare it is among renderings of a verse, so one bible in the language being read produced no answer at all — the ordinary case for a Russian-only library. The single-candidate path now makes the weaker, honest claim ("the only translation installed, and the words match"), held to a higher coverage bar and a capped confidence because nothing was ruled out.

> Note: the gitlink points at the PR branch, since BLE #3 is not merged yet. Re-point it to `master` after that merges, before this lands.

## Not covered

That `SystemSettingsTab` shows the spinner *while* a scan is in flight. The tab constructs its own `FileManager`, so a test cannot hold a scan open, and asserting on a state that resolves in microseconds means racing it. `ScanningRow` is widened to `internal` and tested directly; the reason and the production seam it would need (an injectable `FileManager`) are recorded on the test class.

The `MainDesktop` key change is in an excluded file — no test reaches it.

## Detected-version tooltip

The hover text said what the label *was* but not what to do when it is wrong, and the answer is rarely obvious: a wrong version almost always means the translation being read is not installed, because detection can only ever name something already in the folder.

It also claimed to match against "every Bible in your folder", which overstates it — candidates in another language are filtered out before scoring. The tooltip now says which Bibles it actually compares, points at **Download Bibles…** in the settings, and states the part that explains an unhelpful answer on a small library: with one translation installed there is nothing to check the reading against.

No new test — this is a wording change to an existing string resource on an existing `TooltipArea`, and a hover-driven assertion on tooltip text is exactly the flake shape `AGENT.md` rules out.

## Verify

- `./gradlew :composeApp:jvmTest --tests '*SystemSettingsTab*'` — run three consecutive times with `--rerun-tasks`, green each time.
- BLE: `./gradlew test` in the module, also three consecutive `--rerun-tasks` runs.
- By hand: point the Bible folder at a network share and watch the spinner instead of the red verdict; change the Bible folder while the engine is running and confirm it re-indexes.
