### PR TITLE
test: stop racing the ATEM unlock datagram

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClientSocketTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClientSocketTest.kt
@@ -108,7 +108,9 @@ class AtemClientSocketTest {
                 client.disconnect()
             }
 
-            val locks = fake.commandsNamed("LOCK")
+            // The closing unlock is sent without waiting for its ack, so the upload returning
+            // does not mean it has arrived — wait for the datagram itself.
+            val locks = fake.awaitCommandsNamed("LOCK", 2)
             assertEquals(2, locks.size, "the store is locked before the transfer and unlocked after")
             assertEquals(1, locks.first()[2].toInt(), "first LOCK acquires")
             assertEquals(0, locks.last()[2].toInt(), "last LOCK releases")

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/FakeAtemSwitcher.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/FakeAtemSwitcher.kt
@@ -279,6 +279,29 @@ internal class FakeAtemSwitcher(
     fun commandsNamed(name: String): List<ByteArray> =
         synchronized(received) { received.filter { it.first == name }.map { it.second } }
 
+    /**
+     * Waits until [count] commands named [name] have arrived, then returns them.
+     *
+     * Needed for the one command the client sends without awaiting its ack — the closing
+     * `LOCK` release, deliberately fire-and-forget so a dead socket there cannot mask the
+     * failure that preceded it. The upload returning is therefore *not* a signal that the
+     * unlock has landed, and asserting on it directly races the datagram: it passes on a
+     * quiet machine and fails on a loaded two-core CI runner.
+     *
+     * The arrival is the positive signal; the timeout exists only to fail the test.
+     */
+    fun awaitCommandsNamed(name: String, count: Int, timeoutMs: Long = 5_000): List<ByteArray> {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            val got = commandsNamed(name)
+            if (got.size >= count) return got
+            Thread.sleep(5)
+        }
+        throw AssertionError(
+            "timed out after ${timeoutMs}ms waiting for $count $name commands, got ${commandsNamed(name).size}"
+        )
+    }
+
     override fun close() {
         running.set(false)
         socket.close()


### PR DESCRIPTION
`AtemClientSocketTest > uploading a still locks the store, transfers every byte and unlocks` failed on CI (PR #140's run) with `expected:<2> but was:<1>`. It is not caused by that PR — it is a race the assertion has had since #130.

## What was wrong

`uploadStillEncoded` releases the still-store lock in a `finally` with `sendCommand`, **not** `sendCommandAndWait` — deliberately, so a dead socket during the unlock cannot mask the failure that preceded it. The upload returning therefore does not mean the unlock datagram has arrived at the switcher. The test asserted `commandsNamed("LOCK").size == 2` immediately after the call: on a quiet machine the loopback delivery always won, on a loaded two-core runner it did not.

The suite already knows this — `the fire-and-forget unlock is the only packet left unacked after an upload` exists precisely to pin that behaviour. This one assertion just did not honour it.

## Fix

`FakeAtemSwitcher.awaitCommandsNamed(name, count)` waits for the commands to actually arrive and returns them. The arrival is the positive signal; the timeout only fails the test. No production change, no widened timeout, no loosened assertion.

Audited the other 18 `commandsNamed` call sites: every one follows a `sendCommandAndWait` (or asserts a command was never sent at all), so this was the only racing assertion.

## Verification

Three consecutive `--rerun-tasks` runs of all `*Atem*` suites plus `LowerThirdAtemDialogTest`: green 3/3. The race is timing-dependent and does not reproduce locally, so the argument for the fix is structural rather than a reproduction.

## Also seen in that run

The `Coverage floor` step timed out at 10 minutes after `jvmTest` failed — with no usable execution data it appears to re-run the tests rather than reuse them. Worth a look separately; not touched here.