### PR TITLE
fix: make Instance Link honour every setting in both roles

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -118,6 +118,8 @@
     <string name="instance_link_host_hint">e.g. 192.168.1.10</string>
     <string name="instance_link_port">Port</string>
     <string name="instance_link_autoconnect">Connect automatically on launch</string>
+    <string name="instance_link_reconnect_delay">Minimum reconnect delay</string>
+    <string name="instance_link_reconnect_delay_hint">Shortest wait before retrying a dropped link. Repeated failures back off further on their own.</string>
     <string name="instance_link_allow_push_to_schedule">Allow adding items to the primary's schedule</string>
     <string name="instance_link_mirror_backgrounds">Also mirror the primary's backgrounds</string>
     <string name="instance_link_role">Connection role</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/InstanceLinkDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/InstanceLinkDialog.kt
@@ -47,6 +47,8 @@ import churchpresenter.composeapp.generated.resources.instance_link_last_receive
 import churchpresenter.composeapp.generated.resources.instance_link_last_update_age
 import churchpresenter.composeapp.generated.resources.instance_link_mirror_backgrounds
 import churchpresenter.composeapp.generated.resources.instance_link_port
+import churchpresenter.composeapp.generated.resources.instance_link_reconnect_delay
+import churchpresenter.composeapp.generated.resources.instance_link_reconnect_delay_hint
 import churchpresenter.composeapp.generated.resources.instance_link_role
 import churchpresenter.composeapp.generated.resources.instance_link_role_controlled
 import churchpresenter.composeapp.generated.resources.instance_link_role_controller
@@ -64,7 +66,9 @@ import churchpresenter.composeapp.generated.resources.obs_mode_presentation
 import churchpresenter.composeapp.generated.resources.obs_mode_qa
 import churchpresenter.composeapp.generated.resources.obs_mode_songs
 import churchpresenter.composeapp.generated.resources.obs_mode_website
+import churchpresenter.composeapp.generated.resources.save
 import churchpresenter.composeapp.generated.resources.tab_dictionary
+import churchpresenter.composeapp.generated.resources.unit_ms
 import org.churchpresenter.app.churchpresenter.LocalMainWindowState
 import org.churchpresenter.app.churchpresenter.centeredOnMainWindow
 import kotlinx.coroutines.delay
@@ -89,7 +93,9 @@ fun InstanceLinkDialog(
     remoteScheduleCount: Int,
     /** Wall-clock ms of the last WS message from the primary, null while not connected. */
     lastMessageAtMs: Long? = null,
-    onConnect: (host: String, port: Int, apiKey: String, autoConnect: Boolean, allowPushToSchedule: Boolean, bibleSyncMode: BibleSyncMode, mirrorBackgrounds: Boolean, role: InstanceLinkRole) -> Unit,
+    onConnect: (InstanceLinkSettings) -> Unit,
+    /** Persists the edited settings without touching the connection — see [InstanceLinkDialogContent]. */
+    onSave: (InstanceLinkSettings) -> Unit,
     onDisconnect: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -116,11 +122,30 @@ fun InstanceLinkDialog(
             remoteScheduleCount = remoteScheduleCount,
             lastMessageAtMs = lastMessageAtMs,
             onConnect = onConnect,
+            onSave = onSave,
             onDisconnect = onDisconnect,
             onDismiss = onDismiss,
         )
     }
 }
+
+/**
+ * Lower bound on the reconnect delay: the setting is the *floor* of the client's exponential
+ * backoff, so a zero (or a stray "1") would have a dropped link retry in a tight loop against a
+ * primary that is probably still restarting. The upper bound keeps a mistyped extra digit from
+ * silently turning a link into one that looks dead for the rest of a service.
+ */
+internal const val INSTANCE_LINK_MIN_RECONNECT_DELAY_MS = 250
+internal const val INSTANCE_LINK_MAX_RECONNECT_DELAY_MS = 60_000
+
+/**
+ * Reads the reconnect-delay field, falling back to [fallback] for anything unusable — an empty
+ * field, or a number too long to be an Int — and clamping the rest into the supported range.
+ * Never throws: this runs on the operator's keystrokes during a service.
+ */
+internal fun parseReconnectDelayMs(text: String, fallback: Int): Int =
+    text.trim().toIntOrNull()?.coerceIn(INSTANCE_LINK_MIN_RECONNECT_DELAY_MS, INSTANCE_LINK_MAX_RECONNECT_DELAY_MS)
+        ?: fallback
 
 @Composable
 internal fun InstanceLinkDialogContent(
@@ -130,7 +155,13 @@ internal fun InstanceLinkDialogContent(
     remoteLiveState: LiveStateDto?,
     remoteScheduleCount: Int,
     lastMessageAtMs: Long? = null,
-    onConnect: (host: String, port: Int, apiKey: String, autoConnect: Boolean, allowPushToSchedule: Boolean, bibleSyncMode: BibleSyncMode, mirrorBackgrounds: Boolean, role: InstanceLinkRole) -> Unit,
+    onConnect: (InstanceLinkSettings) -> Unit,
+    /**
+     * Persists the edited settings and leaves the connection alone. Connect used to be the only way
+     * to save, so changing a setting that is consumed reactively — the role, Bible sync mode,
+     * background mirroring — forced a reconnect that nothing about the change required.
+     */
+    onSave: (InstanceLinkSettings) -> Unit,
     onDisconnect: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -138,10 +169,25 @@ internal fun InstanceLinkDialogContent(
     var portText by remember(isVisible) { mutableStateOf(if (settings.primaryPort > 0) settings.primaryPort.toString() else "") }
     var apiKey by remember(isVisible) { mutableStateOf(settings.apiKey) }
     var autoConnect by remember(isVisible) { mutableStateOf(settings.autoConnect) }
+    var reconnectDelayText by remember(isVisible) { mutableStateOf(settings.reconnectDelayMs.toString()) }
     var allowPushToSchedule by remember(isVisible) { mutableStateOf(settings.allowPushToSchedule) }
     var bibleSyncMode by remember(isVisible) { mutableStateOf(settings.bibleSyncMode) }
     var mirrorBackgrounds by remember(isVisible) { mutableStateOf(settings.mirrorBackgrounds) }
     var role by remember(isVisible) { mutableStateOf(settings.role) }
+
+    // Everything the operator has edited, folded back onto the settings this dialog was opened with
+    // so the fields it does not show (deviceId, enabled) are carried through untouched.
+    fun edited(): InstanceLinkSettings = settings.copy(
+        primaryHost = host.trim(),
+        primaryPort = portText.toIntOrNull() ?: settings.primaryPort,
+        apiKey = apiKey.trim(),
+        autoConnect = autoConnect,
+        reconnectDelayMs = parseReconnectDelayMs(reconnectDelayText, settings.reconnectDelayMs),
+        allowPushToSchedule = allowPushToSchedule,
+        bibleSyncMode = bibleSyncMode,
+        mirrorBackgrounds = mirrorBackgrounds,
+        role = role
+    )
 
         Surface(
             modifier = Modifier.fillMaxWidth(),
@@ -251,13 +297,19 @@ internal fun InstanceLinkDialogContent(
                             spacing = 12.dp,
                         )
 
-                        LabeledSwitch(
-                            checked = allowPushToSchedule,
-                            onCheckedChange = { allowPushToSchedule = it },
-                            label = stringResource(Res.string.instance_link_allow_push_to_schedule),
-                            modifier = Modifier.fillMaxWidth(),
-                            style = MaterialTheme.typography.bodyMedium,
-                            spacing = 12.dp,
+                        SettingRow(label = stringResource(Res.string.instance_link_reconnect_delay)) {
+                            SettingsTextField(
+                                value = reconnectDelayText,
+                                onValueChange = { new -> if (new.all(Char::isDigit)) reconnectDelayText = new },
+                                placeholder = { Text(stringResource(Res.string.unit_ms)) },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true
+                            )
+                        }
+                        Text(
+                            text = stringResource(Res.string.instance_link_reconnect_delay_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
 
@@ -293,10 +345,20 @@ internal fun InstanceLinkDialogContent(
                             spacing = 12.dp,
                         )
 
-                        // Bible sync mode / background mirroring only matter in Controlled mode — a
-                        // Controller keeps its own local content entirely, so these settings would
-                        // have no effect there.
+                        // Pushing to the schedule, the Bible sync mode and background mirroring only
+                        // matter in Controlled mode — a Controller keeps its own local content
+                        // entirely, and its schedule is never the primary's, so a push has nothing
+                        // to push to. Shown only where they do something.
                         if (role == InstanceLinkRole.CONTROLLED) {
+                            LabeledSwitch(
+                                checked = allowPushToSchedule,
+                                onCheckedChange = { allowPushToSchedule = it },
+                                label = stringResource(Res.string.instance_link_allow_push_to_schedule),
+                                modifier = Modifier.fillMaxWidth(),
+                                style = MaterialTheme.typography.bodyMedium,
+                                spacing = 12.dp,
+                            )
+
                             Text(
                                 stringResource(Res.string.instance_link_bible_sync_mode),
                                 style = MaterialTheme.typography.labelLarge,
@@ -361,11 +423,29 @@ internal fun InstanceLinkDialogContent(
 
                     Spacer(modifier = Modifier.width(8.dp))
 
+                    // Always available, including with no host yet: turning autoConnect back off, or
+                    // switching role, is a legitimate edit on its own and must not require a live
+                    // connection to persist.
+                    TextButton(
+                        shape = RoundedCornerShape(6.dp),
+                        onClick = {
+                            onSave(edited())
+                            onDismiss()
+                        }
+                    ) {
+                        Text(
+                            stringResource(Res.string.save),
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
                     Button(
                         shape = RoundedCornerShape(6.dp),
                         onClick = {
-                            val port = portText.toIntOrNull() ?: return@Button
-                            onConnect(host.trim(), port, apiKey.trim(), autoConnect, allowPushToSchedule, bibleSyncMode, mirrorBackgrounds, role)
+                            if (portText.toIntOrNull() == null) return@Button
+                            onConnect(edited())
                             onDismiss()
                         },
                         enabled = host.isNotBlank() && portText.toIntOrNull() != null,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -184,6 +184,9 @@ import org.churchpresenter.app.churchpresenter.server.instanceLinkBackgroundCach
 import org.churchpresenter.app.churchpresenter.server.instanceLinkPictureCacheDir
 import org.churchpresenter.app.churchpresenter.server.qaActionType
 import org.churchpresenter.app.churchpresenter.server.remoteEventLabel
+import org.churchpresenter.app.churchpresenter.server.shouldMirrorRemoteBackgrounds
+import org.churchpresenter.app.churchpresenter.server.shouldMirrorRemoteOutput
+import org.churchpresenter.app.churchpresenter.server.shouldUseRemoteContent
 import org.churchpresenter.app.churchpresenter.server.withAnnouncement
 
 
@@ -479,6 +482,14 @@ fun main() {
         // only the plain Scene list crosses here) — used to resolve a mirrored CANVAS live state
         // by scene id.
         var scenesForInstanceLink by remember { mutableStateOf<List<Scene>>(emptyList()) }
+        // Records the operator's connect/disconnect intent so it survives a restart: without this,
+        // `enabled` was only ever written as true and Disconnect was silently undone by the next
+        // launch's auto-connect, with no way to turn the link off short of editing settings.json.
+        fun setInstanceLinkEnabled(enabled: Boolean) {
+            if (appSettings.instanceLink.enabled == enabled) return
+            appSettings = appSettings.copy(instanceLink = appSettings.instanceLink.copy(enabled = enabled))
+            settingsManager.saveSettings(appSettings)
+        }
         // Auto-connect on launch (and reconnect if the saved connection details change while
         // enabled). Keys are the CONNECTION parameters only — role/bibleSyncMode/mirrorBackgrounds
         // are consumed reactively elsewhere and must not force a spurious reconnect when toggled.
@@ -506,7 +517,9 @@ fun main() {
         // collectLatest: applying a state does suspend network fetches (pictures, lottie JSON), so
         // a newer state must cancel an in-flight apply instead of queueing behind it — otherwise a
         // slow fetch can finish late and clobber content the operator has already moved past.
-        LaunchedEffect(instanceLinkViewModel) {
+        // Controlled mode only — see shouldMirrorRemoteOutput for why a Controller must not mirror.
+        LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
+            if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
             instanceLinkViewModel.remoteLiveState.collectLatest { state ->
                 if (state == null) return@collectLatest
                 applyRemoteLiveState(
@@ -523,9 +536,14 @@ fun main() {
         }
         // Presentations have their own dedicated broadcast (richer than LiveStateDto's mode-only
         // PRESENTATION entry) — fetch and mirror whichever slide the primary is currently showing.
-        LaunchedEffect(instanceLinkViewModel) {
+        // Controlled mode only, same reasoning as the live-state mirror above.
+        LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
+            if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
             instanceLinkViewModel.remotePresentationSlide.collectLatest { slide ->
                 if (slide == null) return@collectLatest
+                // The connect snapshot always sends this event, with an empty id when the primary
+                // has no presentation loaded — nothing to fetch, and the request would 404.
+                if (slide.id.isBlank()) return@collectLatest
                 val bytes = instanceLinkViewModel.fetchPresentationSlideBytes(slide.id, slide.index)
                 if (bytes == null) {
                     InstanceLinkLogger.log(
@@ -555,8 +573,16 @@ fun main() {
                 )
             }
         }
-        LaunchedEffect(instanceLinkViewModel) {
-            instanceLinkViewModel.displayClearedSignal.collect {
+        // Controlled mode only — a Controller sending Clear must not have its own display cleared by
+        // the echo of the primary acting on that command.
+        LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
+            if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
+            // Skip the value the StateFlow replays on subscribe (and on any re-subscribe when the
+            // role changes) — only an actual increment past the count seen here is a fresh clear.
+            var lastSeen = instanceLinkViewModel.displayClearedSignal.value
+            instanceLinkViewModel.displayClearedSignal.collect { signal ->
+                if (signal == lastSeen) return@collect
+                lastSeen = signal
                 presenterManager.requestClearDisplay()
             }
         }
@@ -592,11 +618,11 @@ fun main() {
         // the asset cache is cleared first so the per-file exists() gate re-downloads fresh bytes.
         val instanceLinkBackgroundsSignal by instanceLinkViewModel.backgroundsUpdatedSignal.collectAsState()
         LaunchedEffect(instanceLinkConnectionStatusForBackgrounds, appSettings.instanceLink.mirrorBackgrounds, appSettings.instanceLink.role, instanceLinkBackgroundsSignal) {
-            // Only in Controlled mode — a Controller keeps its own local backgrounds, same reasoning
-            // as the Bible/Songs/Schedule mirror gating in MainDesktop.kt.
-            if (instanceLinkConnectionStatusForBackgrounds != InstanceLinkStatus.CONNECTED ||
-                !appSettings.instanceLink.mirrorBackgrounds ||
-                appSettings.instanceLink.role != InstanceLinkRole.CONTROLLED
+            if (!shouldMirrorRemoteBackgrounds(
+                    status = instanceLinkConnectionStatusForBackgrounds,
+                    role = appSettings.instanceLink.role,
+                    mirrorBackgrounds = appSettings.instanceLink.mirrorBackgrounds
+                )
             ) {
                 mirroredBackgroundSettings = null
                 return@LaunchedEffect
@@ -990,6 +1016,15 @@ fun main() {
                                 // Activity toasts for already-allowed clients (auto-approved actions)
                                 val remoteActivityNotifications =
                                     remember { mutableStateListOf<RemoteActivityNotification>() }
+
+                                // Both block lists reach the server itself, so a blocked device is
+                                // refused at the socket instead of only at the approval-gated
+                                // commands — see CompanionServer.blockedClientIds for what that
+                                // used to leave open.
+                                LaunchedEffect(remoteClientManager.blockedClients, sessionBlockedClients.toList()) {
+                                    companionServer.blockedClientIds =
+                                        remoteClientManager.blockedClients + sessionBlockedClients
+                                }
 
                                 // ── Remote add-to-schedule requests ──────────────────────────────────────────
                                 LaunchedEffect(Unit) {
@@ -1754,9 +1789,14 @@ fun main() {
                                     }
                                 }
 
+                                val instanceLinkStatus = instanceLinkViewModel.connectionStatus.collectAsState().value
                                 val instanceLinkIsControllerConnected =
-                                    instanceLinkViewModel.connectionStatus.collectAsState().value == InstanceLinkStatus.CONNECTED &&
+                                    instanceLinkStatus == InstanceLinkStatus.CONNECTED &&
                                         appSettings.instanceLink.role == InstanceLinkRole.CONTROLLER
+                                // See shouldUseRemoteContent — the remote-asset fallbacks belong to a
+                                // mirrored schedule, so they are Controlled-only.
+                                val instanceLinkUsesRemoteContent =
+                                    shouldUseRemoteContent(instanceLinkStatus, appSettings.instanceLink.role)
                                 MainDesktop(
                                     hostWindow = window,
                                     instanceLinkConnectionStatus = instanceLinkViewModel.connectionStatus.collectAsState().value,
@@ -1767,12 +1807,16 @@ fun main() {
                                     connectedInstanceLinkFollowerCount = companionServer.connectedInstanceLinkFollowers.collectAsState().value.size,
                                     onInstanceLinkConnect = {
                                         val link = appSettings.instanceLink
+                                        setInstanceLinkEnabled(true)
                                         instanceLinkViewModel.connect(
                                             link.primaryHost, link.primaryPort, link.apiKey, link.deviceId,
                                             link.reconnectDelayMs.toLong()
                                         )
                                     },
-                                    onInstanceLinkDisconnect = { instanceLinkViewModel.disconnect() },
+                                    onInstanceLinkDisconnect = {
+                                        setInstanceLinkEnabled(false)
+                                        instanceLinkViewModel.disconnect()
+                                    },
                                     instanceLinkRemoteSchedule = instanceLinkViewModel.remoteSchedule.collectAsState().value,
                                     instanceLinkRemoteSongCatalog = instanceLinkViewModel.remoteSongCatalog.collectAsState().value,
                                     instanceLinkFetchSongDetail = { number, songbook -> instanceLinkViewModel.fetchSongDetail(number, songbook) },
@@ -1824,15 +1868,15 @@ fun main() {
                                     instanceLinkSendPreviousSlide = if (instanceLinkIsControllerConnected) {
                                         { instanceLinkViewModel.sendPreviousSlide() }
                                     } else null,
-                                    instanceLinkFetchPictureImageBytes = if (instanceLinkViewModel.connectionStatus.collectAsState().value == InstanceLinkStatus.CONNECTED) {
+                                    instanceLinkFetchPictureImageBytes = if (instanceLinkUsesRemoteContent) {
                                         { folderId, index -> instanceLinkViewModel.fetchPictureImageBytes(folderId, index) }
                                     } else null,
-                                    instanceLinkFetchPresentationSlideBytes = if (instanceLinkViewModel.connectionStatus.collectAsState().value == InstanceLinkStatus.CONNECTED) {
+                                    instanceLinkFetchPresentationSlideBytes = if (instanceLinkUsesRemoteContent) {
                                         { id, index -> instanceLinkViewModel.fetchPresentationSlideBytes(id, index) }
                                     } else null,
                                     instanceLinkMediaStreamUrl = run {
                                         val link = appSettings.instanceLink
-                                        if (instanceLinkViewModel.connectionStatus.collectAsState().value == InstanceLinkStatus.CONNECTED) {
+                                        if (instanceLinkUsesRemoteContent) {
                                             ({ itemId: String ->
                                                 val keyParam = if (link.apiKey.isNotEmpty()) "?${Constants.QUERY_PARAM_API_KEY}=${link.apiKey}" else ""
                                                 "http://${link.primaryHost}:${link.primaryPort}${Constants.ENDPOINT_MEDIA_STREAM}/$itemId$keyParam"
@@ -2056,27 +2100,26 @@ fun main() {
                                     remoteLiveState = instanceLinkViewModel.remoteLiveState.collectAsState().value,
                                     remoteScheduleCount = instanceLinkViewModel.remoteSchedule.collectAsState().value.size,
                                     lastMessageAtMs = instanceLinkViewModel.lastMessageAtMs.collectAsState().value,
-                                    onConnect = { host, port, apiKey, autoConnect, allowPushToSchedule, bibleSyncMode, mirrorBackgrounds, role ->
-                                        appSettings = appSettings.copy(
-                                            instanceLink = appSettings.instanceLink.copy(
-                                                enabled = true,
-                                                primaryHost = host,
-                                                primaryPort = port,
-                                                apiKey = apiKey,
-                                                autoConnect = autoConnect,
-                                                allowPushToSchedule = allowPushToSchedule,
-                                                bibleSyncMode = bibleSyncMode,
-                                                mirrorBackgrounds = mirrorBackgrounds,
-                                                role = role
-                                            )
-                                        )
+                                    onConnect = { edited ->
+                                        val link = edited.copy(enabled = true)
+                                        appSettings = appSettings.copy(instanceLink = link)
                                         settingsManager.saveSettings(appSettings)
                                         instanceLinkViewModel.connect(
-                                            host, port, apiKey, appSettings.instanceLink.deviceId,
-                                            appSettings.instanceLink.reconnectDelayMs.toLong()
+                                            link.primaryHost, link.primaryPort, link.apiKey, link.deviceId,
+                                            link.reconnectDelayMs.toLong()
                                         )
                                     },
-                                    onDisconnect = { instanceLinkViewModel.disconnect() },
+                                    // Persist only — the connection is left exactly as it is, and the
+                                    // reactive settings (role, Bible sync, backgrounds) take effect
+                                    // from appSettings without one.
+                                    onSave = { edited ->
+                                        appSettings = appSettings.copy(instanceLink = edited)
+                                        settingsManager.saveSettings(appSettings)
+                                    },
+                                    onDisconnect = {
+                                        setInstanceLinkEnabled(false)
+                                        instanceLinkViewModel.disconnect()
+                                    },
                                     onDismiss = { showInstanceLinkDialog = false; dialogDismissSignal++ }
                                 )
                                 AboutDialog(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
@@ -1221,6 +1221,23 @@ class CompanionServer {
      *  (as opposed to a regular mobile/browser companion client) — see [Constants.HEADER_CLIENT_ROLE]. */
     private val _connectedInstanceLinkFollowers = MutableStateFlow<Set<String>>(emptySet())
     val connectedInstanceLinkFollowers: StateFlow<Set<String>> = _connectedInstanceLinkFollowers.asStateFlow()
+
+    /**
+     * Device ids the operator has permanently blocked (mirrored from `RemoteClientManager`, which
+     * owns the list and its persistence).
+     *
+     * Blocking used to stop only the requests that ask for approval — adding to the schedule,
+     * projecting, removing. Everything instant went straight through: a blocked phone or linked
+     * instance could still put a verse, a picture or a slide on the main screen, and still received
+     * the whole live feed. Enforced here rather than at each of the ~15 command branches so a new
+     * command cannot be added without it.
+     */
+    @Volatile
+    var blockedClientIds: Set<String> = emptySet()
+
+    /** Blank ids are anonymous clients, which cannot be blocked (there is nothing to block). */
+    internal fun isClientBlocked(clientId: String): Boolean =
+        clientId.isNotBlank() && clientId in blockedClientIds
     /** schedule item UUID → absolute local media file path — populated by updateSchedule, serves /api/media/stream */
     private val _scheduleItemToMediaPath = ConcurrentHashMap<String, String>()
 
@@ -3398,6 +3415,17 @@ class CompanionServer {
                     val wsClientId = call.request.headers[Constants.HEADER_DEVICE_ID]
                         ?: call.request.queryParameters[Constants.HEADER_DEVICE_ID]
                         ?: ""
+                    // A blocked device gets no session at all: no live feed to watch, and no socket
+                    // to send commands down. Checked before the follower registration below so a
+                    // blocked instance never appears in the connected-followers count either.
+                    if (isClientBlocked(wsClientId)) {
+                        InstanceLinkLogger.log(
+                            InstanceLinkLogSide.PRIMARY, "follower_unauthorized",
+                            mapOf("reason" to "blocked", "deviceId" to wsClientId)
+                        )
+                        send(Frame.Text("{\"error\":\"Blocked\"}"))
+                        return@webSocket
+                    }
                     val isInstanceLinkFollower = call.request.headers[Constants.HEADER_CLIENT_ROLE] ==
                         Constants.CLIENT_ROLE_INSTANCE_LINK
                     if (isInstanceLinkFollower && wsClientId.isNotEmpty()) {
@@ -3515,6 +3543,16 @@ class CompanionServer {
                                     InstanceLinkLogSide.PRIMARY, "ws_command_received",
                                     mapOf("type" to msg.type, "deviceId" to wsClientId)
                                 )
+                                // Blocked *during* this session — the handshake check above cannot
+                                // see a decision the operator makes while the socket is already open.
+                                if (isClientBlocked(wsClientId)) {
+                                    InstanceLinkLogger.log(
+                                        InstanceLinkLogSide.PRIMARY, "ws_command_refused",
+                                        mapOf("type" to msg.type, "deviceId" to wsClientId, "reason" to "blocked")
+                                    )
+                                    sendCommandAck(msg.commandId, ok = false, reason = "blocked")
+                                    continue
+                                }
                                 when (msg.type) {
                                     Constants.WS_CMD_SELECT_SONG -> {
                                         val song = json.decodeFromString(ScheduleSongDto.serializer(), msg.payload)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
@@ -12,6 +12,7 @@ import org.churchpresenter.app.churchpresenter.ScheduleActions
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.BackgroundSettings
 import org.churchpresenter.app.churchpresenter.data.settings.BibleSyncMode
+import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkRole
 import org.churchpresenter.app.churchpresenter.dialogs.RemoteEventType
 import org.churchpresenter.app.churchpresenter.models.LyricSection
 import org.churchpresenter.app.churchpresenter.models.Question
@@ -52,6 +53,59 @@ internal val instanceLinkPictureCacheDir: File by lazy {
 internal val instanceLinkBackgroundCacheDir: File by lazy {
     File(System.getProperty("user.home"), ".churchpresenter/instance-link/cache/backgrounds").apply { mkdirs() }
 }
+
+/**
+ * Whether this instance mirrors the primary's live output onto its own presenter — the single
+ * decision behind every "does the follower follow?" gate in `main.kt` (live state, the dedicated
+ * presentation-slide broadcast, and display_cleared).
+ *
+ * Only [InstanceLinkRole.CONTROLLED] mirrors. A [InstanceLinkRole.CONTROLLER] drives the primary
+ * and keeps its own output: it goes live locally *and* sends the command, so mirroring the primary
+ * as well would echo that command straight back and overwrite the content it had just put up — with
+ * the primary's version of it, refetched over the network. The primary's connect snapshot replays
+ * its current live state to every client, so an ungated Controller is clobbered the moment it
+ * connects, before the operator does anything at all.
+ */
+internal fun shouldMirrorRemoteOutput(role: InstanceLinkRole): Boolean =
+    role == InstanceLinkRole.CONTROLLED
+
+/**
+ * Whether content should be sourced from the primary rather than from this machine — the same
+ * decision as [shouldMirrorRemoteOutput], plus a live connection to source it over.
+ *
+ * Gates the remote-asset fallbacks (picture bytes, presentation slides, the media stream URL). Those
+ * exist for a *mirrored* schedule item, whose file only lives on the primary's disk. A Controller's
+ * schedule is its own local one, so routing it through the primary streams the wrong bytes — or none
+ * at all, for an item id the primary has never seen.
+ */
+internal fun shouldUseRemoteContent(status: InstanceLinkStatus, role: InstanceLinkRole): Boolean =
+    status == InstanceLinkStatus.CONNECTED && shouldMirrorRemoteOutput(role)
+
+/**
+ * Whether to replace this instance's backgrounds with the primary's — [shouldUseRemoteContent] plus
+ * the explicit opt-in, which is off by default because backgrounds are usually venue-specific.
+ */
+internal fun shouldMirrorRemoteBackgrounds(
+    status: InstanceLinkStatus,
+    role: InstanceLinkRole,
+    mirrorBackgrounds: Boolean
+): Boolean = mirrorBackgrounds && shouldUseRemoteContent(status, role)
+
+/**
+ * Which URL a follower actually plays for a schedule item's media.
+ *
+ * A mirrored item's path usually only exists on the primary's disk, so it is streamed from there
+ * ([remoteStreamUrl], null when there is nothing to stream from). A path that *does* resolve here —
+ * a shared network drive, or the same layout on both machines — is played from disk instead: no
+ * network in the path, and seeking a local file beats seeking an HTTP stream. A URL-type item is
+ * already reachable from anywhere and is never rewritten.
+ */
+internal fun followerMediaUrl(mediaType: String, localUrl: String, remoteStreamUrl: String?): String =
+    if (mediaType == Constants.MEDIA_TYPE_LOCAL && remoteStreamUrl != null && !File(localUrl).exists()) {
+        remoteStreamUrl
+    } else {
+        localUrl
+    }
 
 /**
  * Downloads the primary's configured background image/video assets (only for slots it actually has

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
@@ -136,6 +136,7 @@ import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.server.followerMediaUrl
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.utils.presenterAspectRatio
 import org.churchpresenter.app.churchpresenter.viewmodel.LocalMediaViewModel
@@ -267,13 +268,13 @@ fun MediaTab(
                 Constants.MEDIA_TYPE_URL -> { selectedSourceType = Constants.MEDIA_TYPE_URL; urlInput = it.mediaUrl }
                 else -> selectedSourceType = Constants.MEDIA_TYPE_LOCAL
             }
-            // A mirrored schedule item's local path only exists on the primary's disk — stream it
-            // over HTTP from there instead when following via Instance Link.
-            val effectiveUrl = if (it.mediaType == Constants.MEDIA_TYPE_LOCAL && instanceLinkMediaStreamUrl != null) {
-                instanceLinkMediaStreamUrl(it.id)
-            } else {
-                it.mediaUrl
-            }
+            // Local file when it resolves here, the primary's stream when it doesn't — see
+            // followerMediaUrl.
+            val effectiveUrl = followerMediaUrl(
+                mediaType = it.mediaType,
+                localUrl = it.mediaUrl,
+                remoteStreamUrl = instanceLinkMediaStreamUrl?.invoke(it.id)
+            )
             viewModel.loadMediaFromSchedule(url = effectiveUrl, title = it.mediaTitle, type = it.mediaType)
             focusRequester.requestFocus()
         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/InstanceLinkContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/InstanceLinkContentTest.kt
@@ -29,19 +29,9 @@ import kotlin.test.assertNull
 
 class InstanceLinkContentTest {
 
-    private data class Connected(
-        val host: String,
-        val port: Int,
-        val apiKey: String,
-        val autoConnect: Boolean,
-        val allowPushToSchedule: Boolean,
-        val bibleSyncMode: BibleSyncMode,
-        val mirrorBackgrounds: Boolean,
-        val role: InstanceLinkRole,
-    )
-
     private class Result {
-        var connected: Connected? = null
+        var connected: InstanceLinkSettings? = null
+        var saved: InstanceLinkSettings? = null
         var disconnectCalls = 0
         var dismissed = 0
     }
@@ -65,9 +55,8 @@ class InstanceLinkContentTest {
                         remoteLiveState = remoteLiveState,
                         remoteScheduleCount = remoteScheduleCount,
                         lastMessageAtMs = lastMessageAtMs,
-                        onConnect = { host, port, apiKey, autoConnect, allowPushToSchedule, bibleSyncMode, mirrorBackgrounds, role ->
-                            result.connected = Connected(host, port, apiKey, autoConnect, allowPushToSchedule, bibleSyncMode, mirrorBackgrounds, role)
-                        },
+                        onConnect = { result.connected = it },
+                        onSave = { result.saved = it },
                         onDisconnect = { result.disconnectCalls++ },
                         onDismiss = { result.dismissed++ },
                     )
@@ -80,6 +69,7 @@ class InstanceLinkContentTest {
     private fun ComposeUiTest.hostField(): SemanticsNodeInteraction = onAllNodes(hasSetTextAction())[0]
     private fun ComposeUiTest.portField(): SemanticsNodeInteraction = onAllNodes(hasSetTextAction())[1]
     private fun ComposeUiTest.apiKeyField(): SemanticsNodeInteraction = onAllNodes(hasSetTextAction())[2]
+    private fun ComposeUiTest.reconnectDelayField(): SemanticsNodeInteraction = onAllNodes(hasSetTextAction())[3]
 
     // ── Connect's enabled state ─────────────────────────────────────────────────
 
@@ -139,8 +129,8 @@ class InstanceLinkContentTest {
         apiKeyField().performTextInput("  secret  ")
         onNodeWithText("Connect").performClick()
 
-        assertEquals("192.168.1.10", result.connected?.host)
-        assertEquals(8080, result.connected?.port)
+        assertEquals("192.168.1.10", result.connected?.primaryHost)
+        assertEquals(8080, result.connected?.primaryPort)
         assertEquals("secret", result.connected?.apiKey)
     }
 
@@ -168,9 +158,108 @@ class InstanceLinkContentTest {
     ) { result ->
         onNodeWithText("Connect").performClick()
 
-        assertEquals("10.0.0.5", result.connected?.host)
-        assertEquals(9090, result.connected?.port)
+        assertEquals("10.0.0.5", result.connected?.primaryHost)
+        assertEquals(9090, result.connected?.primaryPort)
         assertEquals("existing-key", result.connected?.apiKey)
+    }
+
+    // ── Saving without connecting ────────────────────────────────────────────────
+    //
+    // Connect used to be the only button that persisted anything, so every settings edit — including
+    // the ones consumed reactively and needing no handshake at all — cost a reconnect.
+
+    @Test
+    fun `Save persists the edits without connecting`() = dialog { result ->
+        hostField().performTextInput("192.168.1.10")
+        portField().performTextInput("8080")
+        onNodeWithText("Save").performClick()
+
+        assertEquals("192.168.1.10", result.saved?.primaryHost)
+        assertEquals(8080, result.saved?.primaryPort)
+        assertNull(result.connected, "Save must not open a connection")
+        assertEquals(1, result.dismissed)
+    }
+
+    @Test
+    fun `Save is available with no host, unlike Connect`() = dialog { result ->
+        // Turning autoConnect back off is a legitimate edit on its own; requiring a reachable
+        // primary to record it would make the setting impossible to undo from here.
+        onNodeWithText("Connect").assertIsNotEnabled()
+        onAllNodes(isToggleable())[0].performClick()
+        onNodeWithText("Save").assertIsEnabled().performClick()
+
+        assertEquals(true, result.saved?.autoConnect)
+    }
+
+    @Test
+    fun `Save keeps the fields the dialog never shows`() = dialog(
+        settings = InstanceLinkSettings(deviceId = "device-abc", enabled = true),
+    ) { result ->
+        onNodeWithText("Save").performClick()
+
+        assertEquals("device-abc", result.saved?.deviceId)
+        assertEquals(true, result.saved?.enabled)
+    }
+
+    // ── Reconnect delay ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `the reconnect delay is pre-filled and editable`() = dialog(
+        settings = InstanceLinkSettings(reconnectDelayMs = 3000),
+    ) { result ->
+        reconnectDelayField().performTextReplacement("5000")
+        onNodeWithText("Save").performClick()
+
+        assertEquals(5000, result.saved?.reconnectDelayMs)
+    }
+
+    @Test
+    fun `a non-digit reconnect delay edit is rejected outright`() = dialog(
+        settings = InstanceLinkSettings(reconnectDelayMs = 2000),
+    ) { result ->
+        reconnectDelayField().performTextInput("x")
+        onNodeWithText("Save").performClick()
+
+        assertEquals(2000, result.saved?.reconnectDelayMs)
+    }
+
+    @Test
+    fun `an emptied reconnect delay falls back to the saved value`() = dialog(
+        settings = InstanceLinkSettings(reconnectDelayMs = 2000),
+    ) { result ->
+        reconnectDelayField().performTextReplacement("")
+        onNodeWithText("Save").performClick()
+
+        assertEquals(2000, result.saved?.reconnectDelayMs)
+    }
+
+    @Test
+    fun `a reconnect delay of zero is clamped to the floor`() = dialog { result ->
+        // The setting is the floor of the client's backoff, so 0 would retry in a tight loop
+        // against a primary that is most likely still restarting.
+        reconnectDelayField().performTextReplacement("0")
+        onNodeWithText("Save").performClick()
+
+        assertEquals(INSTANCE_LINK_MIN_RECONNECT_DELAY_MS, result.saved?.reconnectDelayMs)
+    }
+
+    @Test
+    fun `a mistyped extra digit is clamped to the ceiling`() = dialog { result ->
+        reconnectDelayField().performTextReplacement("600000")
+        onNodeWithText("Save").performClick()
+
+        assertEquals(INSTANCE_LINK_MAX_RECONNECT_DELAY_MS, result.saved?.reconnectDelayMs)
+    }
+
+    @Test
+    fun `parseReconnectDelayMs falls back rather than throwing on unusable input`() {
+        assertEquals(2000, parseReconnectDelayMs("", fallback = 2000))
+        assertEquals(2000, parseReconnectDelayMs("   ", fallback = 2000))
+        // Longer than an Int can hold — toIntOrNull is null, not an exception.
+        assertEquals(2000, parseReconnectDelayMs("99999999999999", fallback = 2000))
+        assertEquals(3000, parseReconnectDelayMs(" 3000 ", fallback = 2000))
+        assertEquals(INSTANCE_LINK_MIN_RECONNECT_DELAY_MS, parseReconnectDelayMs("0", fallback = 2000))
+        assertEquals(INSTANCE_LINK_MAX_RECONNECT_DELAY_MS, parseReconnectDelayMs("999999", fallback = 2000))
     }
 
     // ── Disconnect ───────────────────────────────────────────────────────────────
@@ -242,6 +331,26 @@ class InstanceLinkContentTest {
     @Test
     fun `Controlled-only settings are shown for the default role`() = dialog {
         onNodeWithText("Bible sync").assertExists()
+        onNodeWithText("Allow adding items to the primary's schedule").assertExists()
+    }
+
+    @Test
+    fun `pushing to the schedule is hidden for a Controller`() = dialog {
+        // A Controller's schedule is its own local one — ScheduleViewModel is not following the
+        // primary, so nothing it adds is ever pushed and the switch would be inert.
+        onAllNodes(isSelectable())[1].performClick()
+        onNodeWithText("Allow adding items to the primary's schedule").assertDoesNotExist()
+    }
+
+    @Test
+    fun `switching to Controller and back keeps the push setting that was saved`() = dialog(
+        settings = InstanceLinkSettings(allowPushToSchedule = true),
+    ) { result ->
+        onAllNodes(isSelectable())[1].performClick()
+        onAllNodes(isSelectable())[0].performClick()
+
+        onNodeWithText("Save").performClick()
+        assertEquals(true, result.saved?.allowPushToSchedule)
     }
 
     // ── Bible sync (Controlled only) ─────────────────────────────────────────────
@@ -508,7 +617,8 @@ class InstanceLinkContentTest {
                     connectionStatus = InstanceLinkStatus.DISCONNECTED,
                     remoteLiveState = null,
                     remoteScheduleCount = 0,
-                    onConnect = { _, _, _, _, _, _, _, _ -> },
+                    onConnect = {},
+                    onSave = {},
                     onDisconnect = {},
                     onDismiss = {},
                 )

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerRemoteControlTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerRemoteControlTest.kt
@@ -43,6 +43,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -107,6 +108,7 @@ class CompanionServerRemoteControlTest {
         server.clearPresentationState()
         server.updateSongs(emptyList())
         server.updateSchedule(emptyList())
+        server.blockedClientIds = emptySet()
     }
 
     @AfterTest
@@ -572,6 +574,43 @@ class CompanionServerRemoteControlTest {
                 while (true) {
                     val frame = withTimeoutOrNull(quietMs) { incoming.receive() } ?: break
                     if (frame is Frame.Text) received.add(frame.readText())
+                }
+            }
+        }
+        received
+    }
+
+    /**
+     * [sendOverWebSocket] with a device identity, and a hook that runs once the session is open.
+     *
+     * Blocking is per-device, so these tests need a client the server can tell apart; [beforeSend]
+     * exists for the case the operator blocks a device that is *already* connected, which the
+     * handshake check cannot see. Tolerates the server closing the session, which is the whole
+     * point of one of the tests below.
+     */
+    private fun sendAsDevice(
+        deviceId: String,
+        vararg frames: String,
+        quietMs: Long = 250,
+        beforeSend: () -> Unit = {},
+    ): List<String> = runBlocking {
+        val received = mutableListOf<String>()
+        withTimeoutOrNull(quietMs + 10_000) {
+            runCatching {
+                client.webSocket(
+                    urlString = "ws://127.0.0.1:$port${Constants.ENDPOINT_WS}",
+                    request = { header(Constants.HEADER_DEVICE_ID, deviceId) },
+                ) {
+                    while (true) {
+                        val frame = withTimeoutOrNull(quietMs) { incoming.receive() } ?: break
+                        if (frame is Frame.Text) received.add(frame.readText())
+                    }
+                    beforeSend()
+                    frames.forEach { send(Frame.Text(it)) }
+                    while (true) {
+                        val frame = withTimeoutOrNull(quietMs) { incoming.receive() } ?: break
+                        if (frame is Frame.Text) received.add(frame.readText())
+                    }
                 }
             }
         }
@@ -1379,5 +1418,92 @@ class CompanionServerRemoteControlTest {
         } finally {
             dir.deleteRecursively()
         }
+    }
+
+    // ── Blocking a device ───────────────────────────────────────────────────────
+    //
+    // Blocking used to reach only the approval-gated requests. Everything instant — a verse, a
+    // picture, a slide, Clear — went straight through, and the blocked device still received the
+    // whole live feed. "Blocked" has to mean blocked, or the button is decoration.
+
+    @Test
+    fun `a blocked device is refused the socket outright`() {
+        server.updateSongs(listOf(song("42", "Amazing Grace")))
+        server.blockedClientIds = setOf("phone-9")
+
+        val received = sendAsDevice("phone-9")
+
+        assertTrue(
+            received.none { Constants.WS_EVENT_SONGS_UPDATED in it },
+            "a blocked device must not be handed the live feed either: $received",
+        )
+        assertTrue(received.any { "Blocked" in it }, "it should be told why: $received")
+    }
+
+    @Test
+    fun `a blocked device's instant command never reaches the app`() {
+        val cleared = CompletableDeferred<Unit>()
+        collecting(server.onClear) { cleared.complete(Unit) }
+        server.blockedClientIds = setOf("phone-9")
+
+        val received = sendAsDevice("phone-9", command(Constants.WS_CMD_CLEAR, commandId = "cmd-blocked"))
+
+        // The refusal frame is the positive signal that the handler returned before reading any
+        // command at all, so nothing can still be in flight behind this assertion.
+        assertTrue(received.any { "Blocked" in it }, "expected the refusal frame: $received")
+        assertFalse(
+            cleared.isCompleted,
+            "Clear is instant and ungated by approval — blocking is the only thing standing in front of it",
+        )
+    }
+
+    @Test
+    fun `blocking a device that is already connected refuses its next command by name`() {
+        // The handshake check cannot see a decision the operator makes mid-session, so the command
+        // path re-checks. Until it did, blocking someone only took effect on their next reconnect.
+        val cleared = CompletableDeferred<Unit>()
+        collecting(server.onClear) { cleared.complete(Unit) }
+
+        val ack = sendAsDevice(
+            "phone-9",
+            command(Constants.WS_CMD_CLEAR, commandId = "cmd-mid"),
+            beforeSend = { server.blockedClientIds = setOf("phone-9") },
+        ).ackFor("cmd-mid")
+
+        // The ack is the positive signal: the refusal branch sends it and then skips the dispatch
+        // outright, so once it is in hand no emission can still be pending behind it.
+        assertEquals(false, assertNotNull(ack).ok)
+        assertEquals("blocked", ack.reason)
+        assertFalse(
+            cleared.isCompleted,
+            "refusing it in the ack while still acting on it would be worse than not refusing at all",
+        )
+    }
+
+    @Test
+    fun `a device that is not blocked is unaffected`() {
+        val cleared = CompletableDeferred<Unit>()
+        collecting(server.onClear) { cleared.complete(Unit) }
+        server.blockedClientIds = setOf("some-other-phone")
+
+        val ack = sendAsDevice("phone-9", command(Constants.WS_CMD_CLEAR, commandId = "cmd-ok")).ackFor("cmd-ok")
+
+        assertEquals(true, assertNotNull(ack).ok)
+        assertNotNull(runBlocking { withTimeoutOrNull(2_000) { cleared.await() } })
+    }
+
+    @Test
+    fun `an anonymous client is not blocked by a blank entry in the list`() {
+        // A device id is optional on this socket. A blank one identifies nobody, so it can never be
+        // the id the operator blocked — and treating it as a match would lock out every client that
+        // does not send the header.
+        val cleared = CompletableDeferred<Unit>()
+        collecting(server.onClear) { cleared.complete(Unit) }
+        server.blockedClientIds = setOf("")
+
+        val ack = sendAsDevice("", command(Constants.WS_CMD_CLEAR, commandId = "cmd-anon")).ackFor("cmd-anon")
+
+        assertEquals(true, assertNotNull(ack).ok)
+        assertNotNull(runBlocking { withTimeoutOrNull(2_000) { cleared.await() } })
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkRoleGatingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkRoleGatingTest.kt
@@ -1,0 +1,158 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkRole
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The four decisions that separate the two Instance Link roles: whether this instance mirrors the
+ * primary's output, sources content from it, replaces its backgrounds with it, and where it plays a
+ * schedule item's media from.
+ *
+ * These used to be conditions inlined in `main.kt`'s root composable, unreachable from any test, and
+ * they were wrong: everything that drives the *presenter* was gated on the connection alone, so a
+ * Controller — which is defined as staying independent — mirrored the primary anyway. That is a
+ * feedback loop rather than a cosmetic slip. A Controller going live sets its own presenter *and*
+ * sends the command; the primary then broadcasts the resulting state back, and the Controller
+ * overwrote what it had just put up with the primary's version of it. The primary's connect snapshot
+ * replays its live state to every client, so it happened at connect time too, before the operator
+ * touched anything.
+ *
+ * Hence the shape of this suite: every predicate is asserted over the **whole** status × role
+ * product rather than at the one or two points a bug was found, because the property that matters is
+ * the negative one — a Controller never follows, under any status.
+ */
+class InstanceLinkRoleGatingTest {
+
+    private val tempDir: File = Files.createTempDirectory("cp-instance-link-role").toFile()
+
+    @AfterTest
+    fun tearDown() {
+        tempDir.deleteRecursively()
+    }
+
+    @Test
+    fun `only a Controlled instance mirrors the primary's output`() {
+        assertTrue(shouldMirrorRemoteOutput(InstanceLinkRole.CONTROLLED))
+        assertFalse(shouldMirrorRemoteOutput(InstanceLinkRole.CONTROLLER))
+    }
+
+    @Test
+    fun `remote content is sourced only while a Controlled instance is connected`() {
+        for (status in InstanceLinkStatus.entries) {
+            for (role in InstanceLinkRole.entries) {
+                val expected = status == InstanceLinkStatus.CONNECTED && role == InstanceLinkRole.CONTROLLED
+                assertEquals(
+                    expected,
+                    shouldUseRemoteContent(status, role),
+                    "shouldUseRemoteContent($status, $role)"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a Controller never sources remote content, whatever the connection is doing`() {
+        for (status in InstanceLinkStatus.entries) {
+            assertFalse(
+                shouldUseRemoteContent(status, InstanceLinkRole.CONTROLLER),
+                "a Controller must keep its own content while $status"
+            )
+        }
+    }
+
+    @Test
+    fun `backgrounds are mirrored only on an explicit opt-in`() {
+        assertTrue(
+            shouldMirrorRemoteBackgrounds(
+                InstanceLinkStatus.CONNECTED, InstanceLinkRole.CONTROLLED, mirrorBackgrounds = true
+            )
+        )
+        // Off by default — backgrounds are usually venue-specific, so a follower keeps its own.
+        assertFalse(
+            shouldMirrorRemoteBackgrounds(
+                InstanceLinkStatus.CONNECTED, InstanceLinkRole.CONTROLLED, mirrorBackgrounds = false
+            )
+        )
+    }
+
+    @Test
+    fun `the backgrounds opt-in cannot override the role or the connection`() {
+        for (status in InstanceLinkStatus.entries) {
+            for (role in InstanceLinkRole.entries) {
+                val expected = status == InstanceLinkStatus.CONNECTED && role == InstanceLinkRole.CONTROLLED
+                assertEquals(
+                    expected,
+                    shouldMirrorRemoteBackgrounds(status, role, mirrorBackgrounds = true),
+                    "shouldMirrorRemoteBackgrounds($status, $role, opted in)"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `media that exists on this machine is played from disk, not streamed from the primary`() {
+        // Built from the real temp dir rather than a POSIX literal: a "/tmp/..." string is not a
+        // path on Windows, so exists() would answer false there for the wrong reason and the test
+        // would pass while asserting nothing.
+        val local = File(tempDir, "sermon-bumper.mp4").apply { writeBytes(ByteArray(1)) }
+        assertEquals(
+            local.absolutePath,
+            followerMediaUrl(
+                mediaType = Constants.MEDIA_TYPE_LOCAL,
+                localUrl = local.absolutePath,
+                remoteStreamUrl = "http://primary:8080/media/abc"
+            )
+        )
+    }
+
+    @Test
+    fun `media that exists only on the primary's disk is streamed from there`() {
+        val missing = File(tempDir, "not-mounted-here.mp4")
+        assertFalse(missing.exists(), "fixture must not exist for this branch to be the one under test")
+        assertEquals(
+            "http://primary:8080/media/abc",
+            followerMediaUrl(
+                mediaType = Constants.MEDIA_TYPE_LOCAL,
+                localUrl = missing.absolutePath,
+                remoteStreamUrl = "http://primary:8080/media/abc"
+            )
+        )
+    }
+
+    @Test
+    fun `a missing file with nowhere to stream from keeps its own path`() {
+        // No link (or a Controller, which is handed no stream URL at all): the player must fail on
+        // the real path the operator configured, not on a silently substituted one.
+        val missing = File(tempDir, "gone.mp4")
+        assertEquals(
+            missing.absolutePath,
+            followerMediaUrl(
+                mediaType = Constants.MEDIA_TYPE_LOCAL,
+                localUrl = missing.absolutePath,
+                remoteStreamUrl = null
+            )
+        )
+    }
+
+    @Test
+    fun `a URL media item is never rewritten to the primary's stream`() {
+        // Already reachable from anywhere — routing it through the primary would add a hop and pin
+        // the follower's playback to the primary staying up.
+        val url = "rtsp://camera.local/stream1"
+        assertEquals(
+            url,
+            followerMediaUrl(
+                mediaType = Constants.MEDIA_TYPE_URL,
+                localUrl = url,
+                remoteStreamUrl = "http://primary:8080/media/abc"
+            )
+        )
+    }
+}


### PR DESCRIPTION
Audit of all eleven `InstanceLinkSettings` fields end to end — follower (Controlled) path, Controller path, and the primary side — and the fixes for what was not doing what it said.

## The main one: `role` was ignored by everything that drives the presenter

Songs, Bible, Schedule and backgrounds were correctly gated on `InstanceLinkRole.CONTROLLED`. The three collectors that drive the *presenter* were gated on connection status alone, so a Controller — defined as staying independent — mirrored the primary anyway.

That is a feedback loop rather than a cosmetic slip. A Controller going live sets its own presenter **and** sends the command; the primary then broadcasts the resulting state back, and the Controller overwrote what it had just put up, with the primary's version of it, refetched over the network. The primary's connect snapshot replays its live state to every client, so it also happened the moment a Controller connected, before the operator touched anything.

Same root cause in two more places:

- **Media.** A Controller's schedule is its own local one, but every `MEDIA_TYPE_LOCAL` item was rewritten to a stream URL keyed by an item id the primary has never seen. Remote picture and slide bytes were reached for on the same basis.
- **Even while Controlled**, a local media file that *does* resolve here — shared drive, same layout on both machines — was streamed from the primary anyway. It now plays from disk when the path exists: no network in the path, and seeking a local file beats seeking an HTTP stream.

## The rest of the audit

- **`enabled` could never be turned off.** It was only ever written `true`. Disconnect dropped the session but left `enabled`/`autoConnect` set, so the next launch silently reconnected and the only way to turn the link off was editing `settings.json`. Both Connect/Disconnect pairs now record the operator's intent.
- **`reconnectDelayMs` had no UI at all** — persisted, defaulting to 2000ms, reachable only by hand-editing. It has a field now, clamped so the backoff *floor* cannot be set to a tight retry loop against a primary that is probably still restarting, nor to a value that makes a link look dead for the rest of a service.
- **Connect was the only button that saved.** Changing the role, Bible sync mode or background mirroring — all consumed reactively, none needing a handshake — forced a reconnect that nothing about the change required. Added Save.
- **`allowPushToSchedule` was offered to a Controller**, whose `ScheduleViewModel` is not following the primary, so nothing it adds is ever pushed and the switch was inert. Hidden alongside the other Controlled-only settings.
- **Blocking a device stopped only the approval-gated requests.** `add_to_schedule`, `project` and `remove_from_schedule` checked the block list; everything instant — a verse, a picture, a slide, Clear — went straight through, and the blocked device still received the whole live feed. Enforced on the socket itself: refused at the handshake, and re-checked per command so blocking someone mid-service takes effect immediately rather than on their next reconnect.
- Two smaller ones found alongside: the connect snapshot always sends `presentation_slide_changed` with an empty id when nothing is loaded, causing a guaranteed 404 fetch per connection; and `displayClearedSignal.collect` fired on the `StateFlow`'s replayed value, clearing the display once at startup.

Verified correct and left alone: `primaryHost`/`primaryPort`/`apiKey` (WS headers plus every REST fetch and the media stream URL), `deviceId`, `autoConnect`, `bibleSyncMode`, `mirrorBackgrounds`.

## Approach

The role and connection decisions move out of `main.kt`'s root composable — unreachable from any test, which is why these were invisible — into named predicates in `RemoteApply.kt`, the file that already owns "what a follower does with what a remote instance sends". `shouldMirrorRemoteBackgrounds` is defined in terms of `shouldUseRemoteContent`, which is defined in terms of `shouldMirrorRemoteOutput`, so the "a Controller never follows" invariant is stated once and inherited rather than repeated as independent conditions that can drift apart again. Call sites are single predicate calls; no lambda parameters were introduced.

`InstanceLinkDialog`'s eight-positional-argument `onConnect` becomes `(InstanceLinkSettings) -> Unit`, with the edited settings folded back onto the ones the dialog opened with so the fields it does not show (`deviceId`, `enabled`) carry through untouched.

## Tests

- `InstanceLinkRoleGatingTest` — the four extracted decisions. The predicates are asserted over the **whole** status × role product rather than at the points a bug was found, because the property that matters is the negative one: a Controller never follows, under any status. `followerMediaUrl` covers all four branches, including that a missing file with nowhere to stream from keeps its own path so playback fails on what the operator configured rather than a silent substitute.
- `CompanionServerRemoteControlTest` — five tests against the real server for device blocking: refused at the handshake with no live feed, instant commands never reaching the app, mid-session blocking refused by name, an unblocked device unaffected, and a blank id not matching a blank list entry. Both "must not happen" assertions end on a positive signal (the refusal frame, the ack) rather than on a timeout expiring.
- `InstanceLinkContentTest` — Save persists without connecting and is available with no host; the reconnect-delay field including clamping and fallback; `allowPushToSchedule` hidden for a Controller and preserved across a role round-trip.

Full suite: 7406 tests, 0 failed. New and changed suites pass three consecutive `--rerun-tasks` runs, all tests under the 1s bar.

## Not changed

An **unknown** device can still present instantly without approval. That is deliberate and shared with mobile companions — the design is that schedule mutations need approval while presenting actions are instant with a toast, and an approval prompt per slide would make a remote useless. The API key already gates entry. Only the block list was broken, and only that was fixed.