### PR TITLE
fix: write the OBS error message before the error status

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/OBSWebSocketManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/OBSWebSocketManager.kt
@@ -78,8 +78,12 @@ class OBSWebSocketManager {
                 throw e
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) {
-                    _status.value = ConnectionStatus.ERROR
+                    // Order is load-bearing: the message is written first so that ERROR is never
+                    // observable beside an empty or stale one. Anything watching the status — the
+                    // settings chip, a test — reads both, and the two writes are separate, so
+                    // setting the status first leaves a window showing "failed" with no reason.
                     _errorMessage.value = e.message ?: "Connection failed"
+                    _status.value = ConnectionStatus.ERROR
                 }
             } finally {
                 activeSession = null

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/OBSWebSocketManagerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/OBSWebSocketManagerTest.kt
@@ -238,8 +238,8 @@ class OBSWebSocketManagerTest {
 
         obs.connect("127.0.0.1", server.port, "")
 
-        awaitUntil("the bad greeting to be reported") {
-            obs.status.value == OBSWebSocketManager.ConnectionStatus.ERROR
+        awaitUntil("the bad greeting to be reported, with a reason") {
+            obs.status.value == OBSWebSocketManager.ConnectionStatus.ERROR && obs.errorMessage.value.isNotEmpty()
         }
         assertTrue(obs.errorMessage.value.isNotEmpty(), "the operator needs to know why it will not connect")
     }
@@ -251,8 +251,8 @@ class OBSWebSocketManagerTest {
 
         obs.connect("127.0.0.1", server.port, "wrong-password")
 
-        awaitUntil("the rejection to be reported") {
-            obs.status.value == OBSWebSocketManager.ConnectionStatus.ERROR
+        awaitUntil("the rejection to be reported, with a reason") {
+            obs.status.value == OBSWebSocketManager.ConnectionStatus.ERROR && obs.errorMessage.value.isNotEmpty()
         }
         assertTrue(
             obs.errorMessage.value.contains("password", ignoreCase = true),
@@ -266,8 +266,8 @@ class OBSWebSocketManagerTest {
 
         obs.connect("127.0.0.1", unusedPort(), "") // nothing listening there
 
-        awaitUntil("the failed connection to be reported") {
-            obs.status.value == OBSWebSocketManager.ConnectionStatus.ERROR
+        awaitUntil("the failed connection to be reported, with a reason") {
+            obs.status.value == OBSWebSocketManager.ConnectionStatus.ERROR && obs.errorMessage.value.isNotEmpty()
         }
         assertTrue(obs.errorMessage.value.isNotEmpty())
     }


### PR DESCRIPTION
A CI-only flake, surfaced by **#152's red run**: `OBSWebSocketManagerTest > a greeting that is not Hello is refused` failed on *"the operator needs to know why it will not connect"*.

**It predates that PR.** #152 changes no production code and adds a single new server test file; the test file involved here has been in the tree for many commits. Checked before touching anything — the temptation to fix the innocent new code is what the plan warns about.

## Cause

The connect path wrote the two pieces of state separately:

```kotlin
_status.value = ConnectionStatus.ERROR
_errorMessage.value = e.message ?: "Connection failed"
```

Three tests wait for `status == ERROR` and then assert on `errorMessage`, so a loaded two-core runner can read between the two writes. Loopback always won locally, which is why it only ever appeared on CI.

## Fix

At the cause, not at the three call sites: the **message is written first**, so `ERROR` is never observable beside an empty or stale one. That matters beyond the tests — the settings chip reads both, and the old order left a real window showing "failed" with no reason. The ordering is commented so it does not get tidied back.

The three waits now include the message in their condition as well, so a future reordering cannot silently reintroduce the flake and the timeout message names what was missing.

Same shape as #142: a state change and the detail explaining it, written separately, with the test waiting on the wrong one of the two.

## Verification

`--tests '*OBSWebSocketManagerTest*' --rerun-tasks` three consecutive times, green (18 tests, 1.4s). The race is timing-dependent on CI, so local green is necessary but not sufficient — the argument for the fix is the ordering itself.