### PR TITLE
Add UI tests for Pictures, QA and Web tabs

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabExtraTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabExtraTest.kt
@@ -1,0 +1,168 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.models.AnimationType
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The rest of the Pictures tab: going live, the animation dropdown reflecting a previously-saved
+ * choice, an unhandled key, Instance Link Controller navigation with an empty list, loading a
+ * schedule item's folder, and the tab's own bare defaults.
+ *
+ * Left uncovered: the shift+drag reorder gesture (a test cannot set `keyboardModifiers` on an
+ * injected pointer event — see `ScheduleTabReorderDragTest`'s doc comment, which records this same
+ * tab as one of the two places that blocks); the loop toggle button, whose icon carries neither text
+ * nor a content description to address it by; and anything that reaches `RecentPictureFolders` — see
+ * `PicturesTabTestSupport.kt`'s doc comment for why.
+ *
+ * See `PicturesTabTestSupport.kt` for the harness.
+ */
+class PicturesTabExtraTest {
+
+    // ── Going live ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `the go live button pushes the selected image to the presenter`() {
+        val presenter = PresenterManager()
+        picturesTab(presenterManager = presenter) { vm, _ ->
+            pictureButton(PictureLabel.NEXT).performClick()
+            waitForIdle()
+            val selected = vm.images[vm.selectedImageIndex]
+
+            pictureButton(PictureLabel.GO_LIVE).performClick()
+            waitForIdle()
+
+            assertEquals(Presenting.PICTURES, presenter.presentingMode.value)
+            assertEquals(selected.absolutePath, presenter.selectedImagePath.value)
+        }
+    }
+
+    @Test
+    fun `there is nowhere to go live without a presenter manager`() = picturesTab { _, _ ->
+        assertFalse(hasPictureButton(PictureLabel.GO_LIVE))
+    }
+
+    // ── The animation dropdown reflects a previously-saved choice ──────────────────
+
+    @Test
+    fun `a saved fade setting is shown as Fade`() =
+        picturesTab(settings = { it.copy(pictureSettings = it.pictureSettings.copy(animationType = Constants.ANIMATION_FADE)) }) { _, _ ->
+            assertTrue(showsContainingText("ANIMATION TYPE:Fade"), renderedText().toString())
+        }
+
+    @Test
+    fun `a saved slide-right setting is shown as Slide Right`() =
+        picturesTab(settings = { it.copy(pictureSettings = it.pictureSettings.copy(animationType = Constants.ANIMATION_SLIDE_RIGHT)) }) { _, _ ->
+            assertTrue(showsContainingText("ANIMATION TYPE:Slide Right"), renderedText().toString())
+        }
+
+    @Test
+    fun `a saved none setting is shown as None`() =
+        picturesTab(settings = { it.copy(pictureSettings = it.pictureSettings.copy(animationType = Constants.ANIMATION_NONE)) }) { _, _ ->
+            assertTrue(showsContainingText("ANIMATION TYPE:None"), renderedText().toString())
+        }
+
+    @Test
+    fun `re-choosing Crossfade from the dropdown is a real choice, not a no-op`() =
+        picturesTab(settings = { it.copy(pictureSettings = it.pictureSettings.copy(animationType = Constants.ANIMATION_SLIDE_LEFT)) }) { vm, reports ->
+            openAnimationDropdown()
+            onNodeWithText("Crossfade").performClick()
+            waitForIdle()
+
+            assertEquals(AnimationType.CROSSFADE, vm.animationType)
+            assertEquals(Constants.ANIMATION_CROSSFADE, reports.settingsAfterChange?.pictureSettings?.animationType)
+        }
+
+    // ── An unhandled key ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `a key with no meaning here changes nothing`() = picturesTab { vm, _ ->
+        onRoot().performKeyInput { pressKey(Key.A) }
+        waitForIdle()
+
+        assertEquals(0, vm.selectedImageIndex)
+        assertFalse(vm.isPlaying)
+    }
+
+    // ── Instance Link Controller navigation with nothing of its own loaded ─────────
+
+    @Test
+    fun `next and previous still reach the primary when this Controller has no images`() {
+        var nextCalls = 0
+        var previousCalls = 0
+        picturesTab(
+            folder = null,
+            onInstanceLinkSendNextPicture = { nextCalls++ },
+            onInstanceLinkSendPreviousPicture = { previousCalls++ },
+        ) { vm, _ ->
+            onRoot().performKeyInput { pressKey(Key.DirectionRight) }
+            waitForIdle()
+            onRoot().performKeyInput { pressKey(Key.DirectionLeft) }
+            waitForIdle()
+
+            assertEquals(1, nextCalls)
+            assertEquals(1, previousCalls)
+            assertEquals(0, vm.selectedImageIndex, "there is nothing of this Controller's own to move")
+        }
+    }
+
+    @Test
+    fun `an unhandled key with Instance Link navigation available still does nothing`() {
+        var nextCalls = 0
+        picturesTab(folder = null, onInstanceLinkSendNextPicture = { nextCalls++ }) { vm, _ ->
+            onRoot().performKeyInput { pressKey(Key.A) }
+            waitForIdle()
+
+            assertEquals(0, nextCalls)
+            assertEquals(0, vm.selectedImageIndex)
+        }
+    }
+
+    // ── Loading a schedule item ──────────────────────────────────────────────────
+
+    @Test
+    fun `selecting a picture schedule item loads its folder`() {
+        val folder = pictureFolder()
+        try {
+            val item = ScheduleItem.PictureItem(
+                id = "p1",
+                folderPath = folder.absolutePath,
+                folderName = folder.name,
+                imageCount = 3,
+            )
+            picturesTab(folder = null, selectedPictureItem = item) { vm, _ ->
+                waitForIdle()
+
+                assertEquals(folder.absolutePath, vm.selectedFolder?.absolutePath)
+                assertEquals(3, vm.images.size)
+            }
+        } finally {
+            folder.deleteRecursively()
+        }
+    }
+
+    // ── Bare defaults ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `PicturesTab with no overrides builds its own view model`() = runComposeUiTest {
+        setContent { MaterialTheme { PicturesTab() } }
+
+        onNodeWithText(PictureLabel.NO_FOLDER).assertExists()
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabSettingsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabSettingsTest.kt
@@ -111,6 +111,17 @@ class PicturesTabSettingsTest {
         }
 
     @Test
+    fun `cancelling the transition editor changes nothing`() = picturesTab { vm, reports ->
+        openTransitionEditor()
+        editorField().performTextReplacement("900")
+        onNodeWithText("Cancel").performClick()
+        waitForIdle()
+
+        assertEquals(500f, vm.transitionDuration, "the slideshow is untouched")
+        assertEquals(0, reports.settingsChanges, "and nothing was persisted")
+    }
+
+    @Test
     fun `choosing an animation applies it and asks for it to be remembered`() =
         picturesTab { vm, reports ->
             openAnimationDropdown()

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTestSupport.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.runComposeUiTest
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.PictureSettings
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.viewmodel.PicturesViewModel
+import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
 import java.awt.image.BufferedImage
 import java.io.File
 import java.nio.file.Files
@@ -67,11 +69,30 @@ internal class PictureReports {
  *
  * `storageDirectory` points at the folder so nothing resolves under the real `user.home`. Pass
  * `folder = null` for the no-folder-selected state.
+ *
+ * [presenterManager] is left null in most tests — passing one renders the Go Live button and turns
+ * on the presenter-sync effects. [selectedPictureItem] and the Instance Link callbacks are also left
+ * out of most tests; each is exercised on its own where it matters.
+ *
+ * Deliberately never touches `RecentPictureFolders` — that object is a JVM-wide singleton private to
+ * `PicturesTab.kt` that persists to real JSON files under the real `~/.churchpresenter` directory on
+ * first touch, with no test seam to redirect it. Every existing test already reads it (composing the
+ * tab evaluates the recent-folders row unconditionally), which is harmless; nothing here calls
+ * `add`/`togglePin`/`clear`, which
+ * would write, because JVM-wide latching means an isolated `user.home` in this file could not
+ * guarantee it wins the race to be first (see `TestSingletons`'s own doc comment for the same failure
+ * mode on `CrashReporter`/`InstanceLinkLogger`). The "Select Folder" button and the recent-folder
+ * chips are left untested for the same reason — both call `RecentPictureFolders.add` in the same
+ * click handler as the part that would otherwise be worth testing.
  */
 @OptIn(ExperimentalTestApi::class)
 internal fun picturesTab(
     folder: File? = pictureFolder(),
     settings: (AppSettings) -> AppSettings = { it },
+    presenterManager: PresenterManager? = null,
+    selectedPictureItem: ScheduleItem.PictureItem? = null,
+    onInstanceLinkSendNextPicture: (() -> Unit)? = null,
+    onInstanceLinkSendPreviousPicture: (() -> Unit)? = null,
     block: ComposeUiTest.(vm: PicturesViewModel, reports: PictureReports) -> Unit,
 ) {
     val appSettings = settings(
@@ -89,6 +110,10 @@ internal fun picturesTab(
                     PicturesTab(
                         viewModel = vm,
                         appSettings = appSettings,
+                        presenterManager = presenterManager,
+                        selectedPictureItem = selectedPictureItem,
+                        onInstanceLinkSendNextPicture = onInstanceLinkSendNextPicture,
+                        onInstanceLinkSendPreviousPicture = onInstanceLinkSendPreviousPicture,
                         onAddToSchedule = { path, name, count ->
                             reports.scheduled += Triple(path, name, count)
                         },

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabDisplayAndControlsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabDisplayAndControlsTest.kt
@@ -1,0 +1,445 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.QASettings
+import org.churchpresenter.app.churchpresenter.models.QuestionStatus
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The header controls (QR toggle, voting toggle, sort), the filters beyond approved/denied, the
+ * clear-display bar, and what happens to a question that is on screen when it is finished, edited
+ * or deleted from underneath itself.
+ *
+ * See `QATabTestSupport.kt` for the harness.
+ */
+class QATabDisplayAndControlsTest {
+
+    private fun voting() = AppSettings(qaSettings = QASettings(votingEnabled = true))
+
+    // ── Server state ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a stopped server tells the moderator why there is no session`() =
+        qaTab(serverUrl = "") { _, _, _ ->
+            assertTrue(showsContainingText("Server not running"), renderedText().toString())
+            assertFalse(showsExactly(QALabel.NEW_SESSION), "no way to start a session without a server")
+        }
+
+    // ── Displaying an approved question ────────────────────────────────────────
+
+    @Test
+    fun `going live on an approved question puts it on screen`() =
+        qaTab(seed = { askAll("ready to show") }) { qa, presenter, reports ->
+            qaButton(QALabel.APPROVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+
+            assertEquals(qa.questions.single().id, presenter.displayedQuestion.value?.id)
+            assertEquals(Presenting.QA, reports.presenting.last())
+            assertTrue(showsContainingText("Displaying:"), renderedText().toString())
+        }
+
+    @Test
+    fun `the clear display bar blanks the output without touching the queue`() =
+        qaTab(seed = { askAll("ready to show") }) { qa, presenter, reports ->
+            qaButton(QALabel.APPROVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+
+            clickQaLabel(QALabel.CLEAR_DISPLAY)
+
+            assertEquals(1, qa.questions.size, "the queue is untouched")
+            assertEquals(QuestionStatus.APPROVED, qa.questions.single().status)
+            assertEquals(null, presenter.displayedQuestion.value)
+            assertEquals(Presenting.NONE, reports.presenting.last())
+            assertFalse(showsContainingText("Displaying:"), renderedText().toString())
+        }
+
+    @Test
+    fun `marking a displayed question done clears what is on screen`() =
+        qaTab(seed = { askAll("live now") }) { qa, presenter, reports ->
+            qaButton(QALabel.APPROVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+            assertTrue(presenter.displayedQuestion.value != null)
+
+            qaButton(QALabel.DONE_CLEAR).performClick()
+            waitForIdle()
+
+            assertEquals(QuestionStatus.DONE, qa.questions.single().status)
+            assertEquals(null, presenter.displayedQuestion.value)
+            assertEquals(Presenting.NONE, reports.presenting.last())
+        }
+
+    @Test
+    fun `deleting a displayed question clears what is on screen`() =
+        qaTab(seed = { askAll("live now") }) { qa, presenter, reports ->
+            qaButton(QALabel.APPROVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+
+            qaButton(QALabel.DELETE).performClick()
+            waitForIdle()
+            qaButton2(QALabel.DELETE, 0).performClick()
+            waitForIdle()
+
+            assertTrue(qa.questions.isEmpty())
+            assertEquals(null, presenter.displayedQuestion.value)
+            assertEquals(Presenting.NONE, reports.presenting.last())
+        }
+
+    @Test
+    fun `editing a displayed question updates what is on screen`() =
+        qaTab(seed = { askAll("live now") }) { qa, presenter, _ ->
+            qaButton(QALabel.APPROVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+
+            qaButton(QALabel.EDIT).performClick()
+            waitForIdle()
+            editField().performTextClearance()
+            editField().performTextInput("live now, edited")
+            qaButton(QALabel.SAVE).performClick()
+            waitForIdle()
+
+            assertEquals("live now, edited", presenter.displayedQuestion.value?.text)
+        }
+
+    // ── QR code on screen ───────────────────────────────────────────────────────
+
+    @Test
+    fun `showing the QR code puts it on screen`() =
+        qaTab(seed = { askAll("q") }) { qa, presenter, reports ->
+            qaButton(QALabel.SHOW_QR).performClick()
+            waitForIdle()
+
+            assertTrue(qa.showQRCodeOnDisplay)
+            assertTrue(presenter.showQRCodeOnDisplay.value)
+            assertEquals(Presenting.QA, reports.presenting.last())
+            assertTrue(hasQaButton(QALabel.HIDE_QR))
+        }
+
+    @Test
+    fun `hiding the QR code with nothing else displayed clears the output`() =
+        qaTab(seed = { askAll("q") }) { qa, presenter, reports ->
+            qaButton(QALabel.SHOW_QR).performClick()
+            waitForIdle()
+            qaButton(QALabel.HIDE_QR).performClick()
+            waitForIdle()
+
+            assertFalse(qa.showQRCodeOnDisplay)
+            assertFalse(presenter.showQRCodeOnDisplay.value)
+            assertEquals(Presenting.NONE, reports.presenting.last())
+        }
+
+    @Test
+    fun `the QR toggle is locked while a locked screen is showing it`() =
+        qaTab(seed = { askAll("q") }) { qa, presenter, _ ->
+            qaButton(QALabel.SHOW_QR).performClick()
+            waitForIdle()
+            presenter.setScreenLock(0, Presenting.QA)
+
+            qaButton(QALabel.HIDE_QR).assertIsNotEnabled()
+            assertTrue(qa.showQRCodeOnDisplay, "still showing, the button is just locked")
+        }
+
+    // ── Voting toggle ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `voting can be turned on from the header`() =
+        qaTab { _, _, reports ->
+            qaButton(QALabel.VOTING_DISABLED).performClick()
+            waitForIdle()
+
+            assertEquals(1, reports.settingsChanges)
+            assertEquals(true, reports.settingsAfterChange?.qaSettings?.votingEnabled)
+        }
+
+    @Test
+    fun `voting can be turned off again from the header`() =
+        qaTab(settings = voting()) { _, _, reports ->
+            qaButton(QALabel.VOTING_ENABLED).performClick()
+            waitForIdle()
+
+            assertEquals(false, reports.settingsAfterChange?.qaSettings?.votingEnabled)
+        }
+
+    // ── Sorting ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `most votes sorts approved questions with the highest count first`() =
+        qaTab(
+            settings = voting(),
+            seed = {
+                askAll("Low votes", "High votes")
+                val low = questions.first { it.text == "Low votes" }.id
+                val high = questions.first { it.text == "High votes" }.id
+                approveQuestion(low)
+                approveQuestion(high)
+                voteForQuestion(high, clientIp = "10.2.0.1", direction = "up")
+                voteForQuestion(high, clientIp = "10.2.0.2", direction = "up")
+                voteForQuestion(low, clientIp = "10.2.0.3", direction = "up")
+            },
+        ) { _, _, _ ->
+            selectSort(QALabel.SORT_MOST_VOTES)
+            assertEquals(listOf("High votes", "Low votes"), orderOfQuestions("High votes", "Low votes"))
+        }
+
+    @Test
+    fun `least votes sorts approved questions with the lowest count first`() =
+        qaTab(
+            settings = voting(),
+            seed = {
+                askAll("Low votes", "High votes")
+                val low = questions.first { it.text == "Low votes" }.id
+                val high = questions.first { it.text == "High votes" }.id
+                approveQuestion(low)
+                approveQuestion(high)
+                voteForQuestion(high, clientIp = "10.2.0.1", direction = "up")
+                voteForQuestion(high, clientIp = "10.2.0.2", direction = "up")
+                voteForQuestion(low, clientIp = "10.2.0.3", direction = "up")
+            },
+        ) { _, _, _ ->
+            selectSort(QALabel.SORT_LEAST_VOTES)
+            assertEquals(listOf("Low votes", "High votes"), orderOfQuestions("Low votes", "High votes"))
+        }
+
+    @Test
+    fun `oldest first keeps every question on screen`() =
+        qaTab(seed = { askAll("One", "Two", "Three") }) { _, _, _ ->
+            selectSort(QALabel.SORT_OLDEST)
+
+            assertTrue(showsQuestion("One"))
+            assertTrue(showsQuestion("Two"))
+            assertTrue(showsQuestion("Three"))
+        }
+
+    // ── Filters not covered elsewhere ──────────────────────────────────────────
+
+    @Test
+    fun `the all filter shows every question regardless of status`() =
+        qaTab(seed = { askAll("pending", "approved", "denied") }) { qa, _, _ ->
+            qa.approveQuestion(qa.questions.first { it.text == "approved" }.id)
+            qa.denyQuestion(qa.questions.first { it.text == "denied" }.id)
+            waitForIdle()
+
+            selectFilter(QALabel.ALL)
+
+            assertTrue(showsQuestion("pending"))
+            assertTrue(showsQuestion("approved"))
+            assertTrue(showsQuestion("denied"))
+        }
+
+    @Test
+    fun `the incoming and approved filter combines both statuses`() =
+        qaTab(seed = { askAll("still pending", "cleared", "finished") }) { qa, _, _ ->
+            qa.approveQuestion(qa.questions.first { it.text == "cleared" }.id)
+            qa.approveQuestion(qa.questions.first { it.text == "finished" }.id)
+            qa.markDone(qa.questions.first { it.text == "finished" }.id)
+            waitForIdle()
+
+            selectFilter(QALabel.INCOMING_APPROVED)
+
+            assertTrue(showsQuestion("still pending"))
+            assertTrue(showsQuestion("cleared"))
+            assertFalse(showsQuestion("finished"), "done questions are not incoming or approved")
+        }
+
+    @Test
+    fun `the done filter shows only finished questions`() =
+        qaTab(seed = { askAll("finished one", "still pending") }) { qa, _, _ ->
+            val id = qa.questions.first { it.text == "finished one" }.id
+            qa.approveQuestion(id)
+            qa.markDone(id)
+            waitForIdle()
+
+            selectFilter(QALabel.DONE)
+
+            assertTrue(showsQuestion("finished one"))
+            assertFalse(showsQuestion("still pending"))
+        }
+
+    @Test
+    fun `the done filter says so when nothing has finished yet`() =
+        qaTab(seed = { askAll("still pending") }) { _, _, _ ->
+            selectFilter(QALabel.DONE)
+
+            assertTrue(showsExactly(QALabel.NO_FINISHED), renderedText().toString())
+        }
+
+    @Test
+    fun `the denied filter says so when nothing has been refused yet`() =
+        qaTab(seed = { askAll("still pending") }) { _, _, _ ->
+            selectFilter(QALabel.DENIED)
+
+            assertTrue(showsExactly(QALabel.NO_DENIED), renderedText().toString())
+        }
+
+    // ── Resuming a stopped session ──────────────────────────────────────────────
+
+    @Test
+    fun `resume brings history back into the live queue`() =
+        qaTab(seed = { askAll("kept") }) { qa, _, _ ->
+            qa.toggleSession()
+            waitForIdle()
+            assertFalse(qa.sessionActive)
+
+            onNodeWithText("Resume (", substring = true).performClick()
+            waitForIdle()
+
+            assertTrue(qa.sessionActive)
+            assertTrue(qa.history.isEmpty())
+            assertTrue(showsQuestion("kept"))
+        }
+
+    // ── Denied questions can also go live, after confirming ─────────────────────
+
+    @Test
+    fun `going live on a denied question also asks first`() =
+        qaTab(seed = { askAll("denied one") }) { qa, presenter, _ ->
+            qaButton(QALabel.DENY).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+
+            assertTrue(showsContainingText("Go Live?"), renderedText().toString())
+            assertNull(presenter.displayedQuestion.value)
+        }
+
+    @Test
+    fun `confirming go live on a denied question approves and displays it`() =
+        qaTab(seed = { askAll("denied one") }) { qa, presenter, _ ->
+            qaButton(QALabel.DENY).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.CONFIRM_GO_LIVE).performClick()
+            waitForIdle()
+
+            assertEquals(QuestionStatus.APPROVED, qa.questions.single().status)
+            assertEquals(qa.questions.single().id, presenter.displayedQuestion.value?.id)
+        }
+
+    @Test
+    fun `cancelling go live on a denied question leaves it denied`() =
+        qaTab(seed = { askAll("denied one") }) { qa, presenter, _ ->
+            qaButton(QALabel.DENY).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.CANCEL).performClick()
+            waitForIdle()
+
+            assertEquals(QuestionStatus.DENIED, qa.questions.single().status)
+            assertNull(presenter.displayedQuestion.value)
+            assertFalse(showsContainingText("Go Live?"), renderedText().toString())
+        }
+
+    // ── Delete confirmation can be cancelled ─────────────────────────────────────
+
+    @Test
+    fun `cancelling delete leaves the question in place`() =
+        qaTab(seed = { askAll("keep me") }) { qa, _, _ ->
+            qaButton(QALabel.DELETE).performClick()
+            waitForIdle()
+            qaButton(QALabel.CANCEL).performClick()
+            waitForIdle()
+
+            assertEquals(1, qa.questions.size)
+            assertFalse(showsExactly("Delete?"), renderedText().toString())
+        }
+
+    // ── Clearing history from the button, not the view model directly ───────────
+
+    @Test
+    fun `the delete all history button empties history`() =
+        qaTab(seed = { askAll("old question") }) { qa, _, _ ->
+            qa.toggleSession()
+            waitForIdle()
+            onNodeWithText(QALabel.HISTORY, substring = true).performClick()
+            waitForIdle()
+
+            clickQaLabel(QALabel.DELETE_ALL_HISTORY)
+
+            assertTrue(qa.history.isEmpty())
+        }
+
+    // ── Who asked ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a question shows who submitted it`() =
+        qaTab(seed = {
+            toggleSession()
+            submitQuestion("Asked by name", name = "Jane", clientIp = "10.9.0.1")
+        }) { _, _, _ ->
+            assertTrue(showsQuestion("Jane"))
+        }
+
+    // ── Statistic badges ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `the finished badge counts done and denied together`() =
+        qaTab(seed = { askAll("done one", "denied one", "still pending") }) { qa, _, _ ->
+            qa.approveQuestion(qa.questions.first { it.text == "done one" }.id)
+            qa.markDone(qa.questions.first { it.text == "done one" }.id)
+            qa.denyQuestion(qa.questions.first { it.text == "denied one" }.id)
+            waitForIdle()
+
+            assertTrue(showsExactly("2"), "one done + one denied: ${renderedText().take(12)}")
+            assertTrue(showsExactly(QALabel.FINISHED))
+        }
+
+    // ── The tab follows the display back to empty ────────────────────────────────
+
+    @Test
+    fun `clearing the display externally resets the QA tab`() =
+        qaTab(seed = { askAll("on screen") }) { qa, presenter, _ ->
+            qaButton(QALabel.APPROVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+            assertTrue(qa.displayedQuestion != null)
+
+            presenter.setPresentingMode(Presenting.QA)
+            waitForIdle()
+            presenter.setPresentingMode(Presenting.NONE)
+            waitForIdle()
+
+            assertEquals(null, qa.displayedQuestion, "the tab followed the display back to empty")
+            assertFalse(showsContainingText("Displaying:"), renderedText().toString())
+        }
+
+    @Test
+    fun `a locked QA screen keeps its content when the display clears`() =
+        qaTab(seed = { askAll("on screen") }) { qa, presenter, _ ->
+            qaButton(QALabel.APPROVE).performClick()
+            waitForIdle()
+            qaButton(QALabel.GO_LIVE).performClick()
+            waitForIdle()
+            presenter.setScreenLock(0, Presenting.QA)
+
+            presenter.setPresentingMode(Presenting.QA)
+            waitForIdle()
+            presenter.setPresentingMode(Presenting.NONE)
+            waitForIdle()
+
+            assertEquals(qa.questions.single().id, qa.displayedQuestion?.id, "locked screen keeps its content")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabFileChooserTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabFileChooserTest.kt
@@ -1,0 +1,222 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import java.io.File
+import java.nio.file.Files
+import javax.swing.filechooser.FileNameExtensionFilter
+import kotlin.io.path.Path
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import java.nio.file.Path as NioPath
+
+/**
+ * Export/import in the History view, and Export & Clear in the clear-all dialog — all three drive
+ * `FileChooser.platformInstance`, a real native save/open dialog with nothing to click in a headless
+ * test. Stood in for the same way `StatisticsContentTest` does for its own save dialog.
+ *
+ * None of the three report success or failure on screen, so what a test can observe is the
+ * resulting file and the manager's own state, not a status message.
+ *
+ * See `QATabTestSupport.kt` for the harness.
+ */
+class QATabFileChooserTest {
+
+    @AfterTest
+    fun cleanUp() {
+        unmockkObject(FileChooser.Companion)
+    }
+
+    private class FakeChooser(private val picked: String?) : FileChooser() {
+        override suspend fun chooseImpl(
+            path: NioPath,
+            filters: List<FileNameExtensionFilter>,
+            title: String,
+            selectDirectory: Boolean,
+            multiple: Boolean
+        ): List<NioPath>? = picked?.let { listOf(Path(it)) }
+
+        override suspend fun saveImpl(
+            location: NioPath,
+            suggestedName: String,
+            filters: List<FileNameExtensionFilter>,
+            title: String
+        ): NioPath? = picked?.let { Path(it) }
+    }
+
+    private fun givenChooserReturns(picked: String?) {
+        mockkObject(FileChooser.Companion)
+        every { FileChooser.platformInstance } returns FakeChooser(picked)
+    }
+
+    private fun ComposeUiTest.openHistory() {
+        onNodeWithText(QALabel.HISTORY, substring = true).performClick()
+        waitForIdle()
+    }
+
+    // ── Export from History ──────────────────────────────────────────────────────
+
+    @Test
+    fun `exporting history writes every question to the chosen file`() {
+        val dest = File(Files.createTempDirectory("cp-qa-export").toFile(), "questions.txt")
+        givenChooserReturns(dest.absolutePath)
+
+        qaTab(seed = { askAll("Exported question"); toggleSession() }) { _, _, _ ->
+            openHistory()
+            clickQaLabel(QALabel.EXPORT_TO_FILE)
+            waitForIdle()
+            waitUntil(timeoutMillis = 2_000) { dest.exists() }
+
+            assertTrue(dest.readText().contains("Exported question"), dest.readText())
+        }
+    }
+
+    @Test
+    fun `cancelling the export dialog leaves history untouched`() {
+        givenChooserReturns(null)
+
+        qaTab(seed = { askAll("stays in history"); toggleSession() }) { qa, _, _ ->
+            openHistory()
+            clickQaLabel(QALabel.EXPORT_TO_FILE)
+            waitForIdle()
+
+            assertEquals(1, qa.history.size, "cancelling the save dialog must not touch history")
+        }
+    }
+
+    // ── Import into the live queue ───────────────────────────────────────────────
+
+    @Test
+    fun `importing a file adds each line as a new question`() {
+        val src = File(Files.createTempDirectory("cp-qa-import").toFile(), "import.txt")
+        src.writeText("[2024-01-01 10:00] [Pending] Imported one\n[2024-01-01 10:01] [Approved] Imported two\n")
+        givenChooserReturns(src.absolutePath)
+
+        qaTab(seed = { askAll("prior session question"); toggleSession() }) { qa, _, _ ->
+            openHistory()
+            clickQaLabel(QALabel.IMPORT_FROM_FILE)
+            waitForIdle()
+            waitUntil(timeoutMillis = 2_000) { qa.questions.size == 2 }
+
+            assertTrue(qa.questions.any { it.text == "Imported one" }, "${qa.questions.map { it.text }}")
+            assertTrue(qa.questions.any { it.text == "Imported two" })
+        }
+    }
+
+    @Test
+    fun `importing skips blank lines`() {
+        val src = File(Files.createTempDirectory("cp-qa-import-blank").toFile(), "import.txt")
+        src.writeText("[2024-01-01 10:00] [Pending] Kept line\n\n   \n")
+        givenChooserReturns(src.absolutePath)
+
+        qaTab(seed = { askAll("prior session question"); toggleSession() }) { qa, _, _ ->
+            openHistory()
+            clickQaLabel(QALabel.IMPORT_FROM_FILE)
+            waitForIdle()
+            waitUntil(timeoutMillis = 2_000) { qa.questions.size == 1 }
+
+            assertEquals("Kept line", qa.questions.single().text)
+        }
+    }
+
+    @Test
+    fun `cancelling the import dialog adds nothing`() {
+        givenChooserReturns(null)
+
+        qaTab(seed = { askAll("prior session question"); toggleSession() }) { qa, _, _ ->
+            openHistory()
+            clickQaLabel(QALabel.IMPORT_FROM_FILE)
+            waitForIdle()
+
+            assertTrue(qa.questions.isEmpty())
+        }
+    }
+
+    @Test
+    fun `importing a file that cannot be read adds nothing and does not crash`() {
+        val missing = File(Files.createTempDirectory("cp-qa-import-missing").toFile(), "gone.txt")
+        givenChooserReturns(missing.absolutePath)
+
+        qaTab(seed = { askAll("prior session question"); toggleSession() }) { qa, _, _ ->
+            openHistory()
+            clickQaLabel(QALabel.IMPORT_FROM_FILE)
+            waitForIdle()
+
+            assertTrue(qa.questions.isEmpty(), "a failed read must add nothing")
+        }
+    }
+
+    @Test
+    fun `exporting to a folder that does not exist does not crash`() {
+        val dest = File(Files.createTempDirectory("cp-qa-export-bad").toFile(), "no/such/folder/questions.txt")
+        givenChooserReturns(dest.absolutePath)
+
+        qaTab(seed = { askAll("Exported question"); toggleSession() }) { qa, _, _ ->
+            openHistory()
+            clickQaLabel(QALabel.EXPORT_TO_FILE)
+            waitForIdle()
+
+            assertFalse(dest.exists())
+            assertEquals(1, qa.history.size, "the failed export must not touch history")
+        }
+    }
+
+    // ── Export & Clear from the clear-all dialog ────────────────────────────────
+
+    @Test
+    fun `export and clear writes the live queue then clears it`() {
+        val dest = File(Files.createTempDirectory("cp-qa-exportclear").toFile(), "questions.txt")
+        givenChooserReturns(dest.absolutePath)
+
+        qaTab(seed = { askAll("about to be cleared") }) { qa, presenter, reports ->
+            clickQaLabel(QALabel.CLEAR_ALL)
+            clickQaLabel(QALabel.EXPORT_AND_CLEAR)
+            waitForIdle()
+            waitUntil(timeoutMillis = 2_000) { qa.questions.isEmpty() }
+
+            assertTrue(dest.readText().contains("about to be cleared"), dest.readText())
+            assertEquals(null, presenter.displayedQuestion.value)
+            assertFalse(presenter.showQRCodeOnDisplay.value)
+            assertEquals(Presenting.NONE, reports.presenting.last())
+        }
+    }
+
+    @Test
+    fun `cancelling the export-and-clear save dialog leaves the questions untouched`() {
+        givenChooserReturns(null)
+
+        qaTab(seed = { askAll("must survive") }) { qa, _, _ ->
+            clickQaLabel(QALabel.CLEAR_ALL)
+            clickQaLabel(QALabel.EXPORT_AND_CLEAR)
+            waitForIdle()
+
+            assertEquals(1, qa.questions.size, "cancelling the save dialog must abort the clear")
+        }
+    }
+
+    @Test
+    fun `export and clear aborts when the save fails, leaving the queue intact`() {
+        val dest = File(Files.createTempDirectory("cp-qa-exportclear-bad").toFile(), "no/such/folder/questions.txt")
+        givenChooserReturns(dest.absolutePath)
+
+        qaTab(seed = { askAll("must survive a failed export") }) { qa, _, _ ->
+            clickQaLabel(QALabel.CLEAR_ALL)
+            clickQaLabel(QALabel.EXPORT_AND_CLEAR)
+            waitForIdle()
+
+            assertFalse(dest.exists())
+            assertEquals(1, qa.questions.size, "a failed export must abort the clear rather than lose questions")
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabTestSupport.kt
@@ -101,6 +101,7 @@ internal fun QAManager.askAll(vararg texts: String) {
 internal object QALabel {
     const val ALL = "All"
     const val INCOMING = "Incoming"
+    const val FINISHED = "Finished"
     const val APPROVED = "Approved"
     const val DONE = "Done"
     const val DENIED = "Denied"
@@ -125,6 +126,21 @@ internal object QALabel {
     const val CLEAR = "Clear"
     const val BACK_TO_INCOMING = "Back to Incoming"
     const val CONFIRM_GO_LIVE = "Confirm Go Live"
+    const val INCOMING_APPROVED = "Incoming + Approved"
+    const val NO_FINISHED = "No finished questions"
+    const val NO_DENIED = "No denied questions"
+    const val SHOW_QR = "Show QR on Display"
+    const val HIDE_QR = "Hide QR from Display"
+    const val VOTING_ENABLED = "Voting Enabled"
+    const val VOTING_DISABLED = "Voting Disabled"
+    const val SORT_OLDEST = "Oldest First"
+    const val SORT_MOST_VOTES = "Most Votes"
+    const val SORT_LEAST_VOTES = "Least Votes"
+    const val DONE_CLEAR = "Done & Clear"
+    const val DELETE_ALL_HISTORY = "Delete All History"
+    const val EXPORT_TO_FILE = "Export to File"
+    const val IMPORT_FROM_FILE = "Import from File"
+    const val EXPORT_AND_CLEAR = "Export & Clear"
 }
 
 // ── Reading and driving what was rendered ───────────────────────────────────────────────────────
@@ -170,6 +186,14 @@ internal fun ComposeUiTest.selectFilter(name: String) {
     onAllNodes(hasText("FILTER", substring = true))[0].performClick()
     waitForIdle()
     onAllNodes(hasText("$name (", substring = true))[0].performClick()
+    waitForIdle()
+}
+
+/** Chooses an ordering from the SORT dropdown — its options carry no count, unlike FILTER's. */
+internal fun ComposeUiTest.selectSort(name: String) {
+    onAllNodes(hasText("SORT", substring = true))[0].performClick()
+    waitForIdle()
+    onAllNodes(hasText(name))[0].performClick()
     waitForIdle()
 }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabBrowserBridgeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabBrowserBridgeTest.kt
@@ -1,0 +1,189 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import io.mockk.mockk
+import io.mockk.verify
+import org.cef.browser.CefBrowser
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The pieces of `WebTab` that only run once a live `CefBrowser` is attached, plus the narrow-width
+ * layout `BoxWithConstraints` picks between. `CefBrowser` is JCEF's native browser handle — nothing
+ * a test can construct for real — so it stands in as `mockk<CefBrowser>(relaxed = true)`, matching
+ * `WebNavControllerTest`. There is no other observable effect of these branches (they exist to talk
+ * to a real page that is not present here), so a `verify` on the mock is the only assertion available.
+ *
+ * See `WebTabTestSupport.kt` for the harness.
+ */
+class WebTabBrowserBridgeTest {
+
+    // ── The URL bar's Enter key ─────────────────────────────────────────────────
+
+    @Test
+    fun `pressing Enter in the URL bar normalises it and updates the presenter`() = webTab { presenter, _ ->
+        onNodeWithText(WebLabel.URL_PLACEHOLDER_DEFAULT).performTextReplacement("example.com")
+        onNodeWithText("example.com").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        onNodeWithText("https://example.com").assertExists()
+        assertEquals("https://example.com", presenter.websiteUrl.value)
+    }
+
+    @Test
+    fun `pressing Enter in the URL bar while live also navigates the live browser`() = webTab { presenter, _ ->
+        val browser = mockk<CefBrowser>(relaxed = true)
+        presenter.setPresentingMode(Presenting.WEBSITE)
+        presenter.setLiveBrowser(browser)
+        waitForIdle()
+
+        onNodeWithText(WebLabel.URL_PLACEHOLDER_DEFAULT).performTextReplacement("example.com")
+        onNodeWithText("example.com").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        verify { browser.loadURL("https://example.com") }
+    }
+
+    // ── Attaching a live browser ─────────────────────────────────────────────────
+
+    @Test
+    fun `attaching a live browser applies the current zoom level`() = webTab { presenter, _ ->
+        val browser = mockk<CefBrowser>(relaxed = true)
+        presenter.setPresentingMode(Presenting.WEBSITE)
+
+        presenter.setLiveBrowser(browser)
+        waitForIdle()
+
+        verify { browser.setZoomLevel(0.0) }
+    }
+
+    @Test
+    fun `toggling desktop-mobile while live reloads the live browser`() = webTab { presenter, _ ->
+        val browser = mockk<CefBrowser>(relaxed = true)
+        presenter.setPresentingMode(Presenting.WEBSITE)
+        presenter.setLiveBrowser(browser)
+        waitForIdle()
+
+        onNodeWithText(WebLabel.DESKTOP).performClick()
+        waitForIdle()
+
+        verify { browser.reload() }
+    }
+
+    // ── The "type to page" field with a live browser attached ───────────────────
+
+    @Test
+    fun `typing into the type-to-page field with a live browser injects JavaScript per character`() = webTab { presenter, _ ->
+        val browser = mockk<CefBrowser>(relaxed = true)
+        presenter.setPresentingMode(Presenting.WEBSITE)
+        presenter.setLiveBrowser(browser)
+        waitForIdle()
+
+        onNodeWithText(WebLabel.TYPE_TO_PAGE_PLACEHOLDER).performTextInput("hi")
+        waitForIdle()
+
+        onNodeWithText("hi").assertExists()
+        verify(exactly = 2) { browser.executeJavaScript(any(), "", 0) }
+    }
+
+    @Test
+    fun `typing a quote and a backslash escapes them for JavaScript`() = webTab { presenter, _ ->
+        val browser = mockk<CefBrowser>(relaxed = true)
+        presenter.setPresentingMode(Presenting.WEBSITE)
+        presenter.setLiveBrowser(browser)
+        waitForIdle()
+
+        onNodeWithText(WebLabel.TYPE_TO_PAGE_PLACEHOLDER).performTextInput("a\"\\")
+        waitForIdle()
+
+        onNodeWithText("a\"\\").assertExists()
+        verify(exactly = 3) { browser.executeJavaScript(any(), "", 0) }
+    }
+
+    @Test
+    fun `pressing Enter in the type-to-page field submits and clears it`() = webTab { presenter, _ ->
+        val browser = mockk<CefBrowser>(relaxed = true)
+        presenter.setPresentingMode(Presenting.WEBSITE)
+        presenter.setLiveBrowser(browser)
+        waitForIdle()
+
+        onNodeWithText(WebLabel.TYPE_TO_PAGE_PLACEHOLDER).performTextInput("hi")
+        onNodeWithText("hi").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        onNodeWithText(WebLabel.TYPE_TO_PAGE_PLACEHOLDER).assertExists()
+    }
+
+    @Test
+    fun `clicking Focus first input with a live browser attached executes the focus script`() = webTab { presenter, _ ->
+        val browser = mockk<CefBrowser>(relaxed = true)
+        presenter.setPresentingMode(Presenting.WEBSITE)
+        presenter.setLiveBrowser(browser)
+        waitForIdle()
+
+        webButton(WebLabel.FOCUS_FIRST_INPUT).performClick()
+        waitForIdle()
+
+        verify { browser.executeJavaScript(any(), "", 0) }
+    }
+
+    // ── Narrow layout ─────────────────────────────────────────────────────────────
+
+    /** Comfortably under the 960dp (440+200+320) single-row threshold. */
+    private val narrow = 700.dp
+
+    @Test
+    fun `the narrow layout still offers every toolbar control`() = webTab(width = narrow) { _, _ ->
+        webButton(WebLabel.BACK).assertExists()
+        webButton(WebLabel.FORWARD).assertExists()
+        webButton(WebLabel.REFRESH).assertExists()
+        webButton(WebLabel.CLEAR_CACHE).assertExists()
+        webButton(WebLabel.ZOOM_IN).assertExists()
+        webButton(WebLabel.ZOOM_OUT).assertExists()
+        webButton(WebLabel.BOOKMARK_ADD).assertExists()
+        webButton(WebLabel.GO_LIVE).assertExists()
+        onNodeWithText(WebLabel.URL_PLACEHOLDER_DEFAULT).assertExists()
+    }
+
+    @Test
+    fun `the narrow layout stacks the URL bar below the toolbar`() = webTab(width = narrow) { _, _ ->
+        val back = webButton(WebLabel.BACK).fetchSemanticsNode().boundsInRoot
+        val urlField = onAllNodes(hasSetTextAction())[0].fetchSemanticsNode().boundsInRoot
+
+        assertTrue(
+            urlField.top >= back.bottom,
+            "URL bar (top=${urlField.top}) must sit below the toolbar (bottom=${back.bottom})",
+        )
+    }
+
+    @Test
+    fun `the wide layout keeps the toolbar and URL bar on one line`() = webTab { _, _ ->
+        val back = webButton(WebLabel.BACK).fetchSemanticsNode().boundsInRoot
+        val urlField = onAllNodes(hasSetTextAction())[0].fetchSemanticsNode().boundsInRoot
+
+        assertTrue(urlField.top < back.bottom, "the URL bar shares the row with the toolbar at full width")
+    }
+
+    // ── Real defaults ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `WebTab with no overrides falls back to the real CefManager state`() = runComposeUiTest {
+        setContent { MaterialTheme { WebTab() } }
+
+        onNodeWithText(WebLabel.ENGINE_UNAVAILABLE_TITLE).assertExists()
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabTest.kt
@@ -49,6 +49,17 @@ class WebTabTest {
     }
 
     @Test
+    fun `clicking the star again removes an already-bookmarked URL`() = webTab(
+        settings = { it.copy(webBookmarks = listOf(WebBookmark(url = "https://example.com", title = "Example"))) },
+    ) { _, reports ->
+        onNodeWithText(WebLabel.URL_PLACEHOLDER_DEFAULT).performTextReplacement("example.com")
+        webButton(WebLabel.BOOKMARK_REMOVE).performClick()
+
+        assertEquals(1, reports.settingsChanges)
+        assertEquals(emptyList(), reports.settingsAfterChange?.webBookmarks)
+    }
+
+    @Test
     fun `clicking Add to Schedule reports the normalised URL and a title falling back to the URL`() = webTab { _, reports ->
         onNodeWithText(WebLabel.URL_PLACEHOLDER_DEFAULT).performTextReplacement("example.com")
         webButton(WebLabel.ADD_TO_SCHEDULE).performClick()

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabTestSupport.kt
@@ -2,13 +2,17 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Dp
 import org.churchpresenter.app.churchpresenter.TestSingletons
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.models.ScheduleItem
@@ -29,6 +33,15 @@ internal fun webTab(
     cefInitialized: Boolean = true,
     cefMacOsUnsupported: Boolean = false,
     includeAddToSchedule: Boolean = true,
+    /**
+     * Constrains the tab's width.
+     *
+     * The toolbar lays itself out from `BoxWithConstraints`, sitting in one row above
+     * navButtonsWidth(440dp) + minUrlWidth(200dp) + actionButtonsWidth(320dp) and stacking into two
+     * rows below it. Left null everywhere else, which gives the tab the whole test window — the
+     * single-row branch.
+     */
+    width: Dp? = null,
     block: ComposeUiTest.(presenter: PresenterManager, reports: WebReports) -> Unit,
 ) {
     TestSingletons.latchToTestHome()
@@ -37,19 +50,21 @@ internal fun webTab(
     runComposeUiTest {
         setContent {
             MaterialTheme {
-                WebTab(
-                    presenterManager = presenterManager,
-                    selectedWebsiteItem = selectedWebsiteItem,
-                    appSettings = appSettings,
-                    onSettingsChange = { transform ->
-                        reports.settingsChanges++
-                        reports.settingsAfterChange = transform(reports.settingsAfterChange ?: appSettings)
-                    },
-                    onAddToSchedule = if (includeAddToSchedule) { url, title -> reports.scheduled += url to title } else null,
-                    onUpdateScheduleTitle = { url, title -> reports.titleUpdates += url to title },
-                    cefInitialized = cefInitialized,
-                    cefMacOsUnsupported = cefMacOsUnsupported,
-                )
+                Box(modifier = width?.let { Modifier.width(it) } ?: Modifier) {
+                    WebTab(
+                        presenterManager = presenterManager,
+                        selectedWebsiteItem = selectedWebsiteItem,
+                        appSettings = appSettings,
+                        onSettingsChange = { transform ->
+                            reports.settingsChanges++
+                            reports.settingsAfterChange = transform(reports.settingsAfterChange ?: appSettings)
+                        },
+                        onAddToSchedule = if (includeAddToSchedule) { url, title -> reports.scheduled += url to title } else null,
+                        onUpdateScheduleTitle = { url, title -> reports.titleUpdates += url to title },
+                        cefInitialized = cefInitialized,
+                        cefMacOsUnsupported = cefMacOsUnsupported,
+                    )
+                }
             }
         }
         block(presenterManager, reports)


### PR DESCRIPTION
Add comprehensive JVM UI tests and test-support updates: new PicturesTabExtraTest, QATabDisplayAndControlsTest, QATabFileChooserTest, and WebTabBrowserBridgeTest. Extend PicturesTabTestSupport to accept PresenterManager/InstanceLink callbacks and schedule items; add a cancel case in PicturesTabSettingsTest. Enhance QATabTestSupport with labels and helpers for export/import/sort, and add narrow-layout support to WebTabTestSupport (width-constrained Box). Also add a WebTab bookmark-remove test. All changes are test-only to improve coverage of presenter interactions, file-chooser flows, and browser bridge behavior.