### PR TITLE
test: wait for the QA file dialog instead of assuming it ran

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabFileChooserTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATabFileChooserTest.kt
@@ -29,6 +29,18 @@ import java.nio.file.Path as NioPath
  * None of the three report success or failure on screen, so what a test can observe is the
  * resulting file and the manager's own state, not a status message.
  *
+ * Every flow runs in `coroutineScope.launch` around a *suspend* chooser call, so a click is not a
+ * barrier and `waitForIdle()` does not await it. Tests that expect something to appear wait for that
+ * thing; tests that expect nothing to change wait for [FakeChooser.answered] instead, which is a
+ * positive signal that the handler ran rather than an assumption that it had time to.
+ *
+ * That signal is exact for a **cancelled** dialog — the handler's remaining work is
+ * `if (path != null)`, so a null answer ends it. For the three cases where the dialog succeeds and
+ * the *write or read* then fails there is no such signal: the failure is swallowed into
+ * `CrashReporter` inside `withContext(Dispatchers.IO)` and changes nothing observable. Those tests
+ * therefore assert at the last point the test can see rather than at true completion, which is
+ * weaker than the rest of this file and is why it is written down here.
+ *
  * See `QATabTestSupport.kt` for the harness.
  */
 class QATabFileChooserTest {
@@ -39,26 +51,43 @@ class QATabFileChooserTest {
     }
 
     private class FakeChooser(private val picked: String?) : FileChooser() {
+        /**
+         * Bumped as the dialog answers. Every one of these flows runs in `coroutineScope.launch`
+         * around a *suspend* chooser call, and `waitForIdle()` does not await an arbitrary
+         * coroutine — so this is the signal a test waits on before reading the result.
+         */
+        @Volatile
+        var answered: Int = 0
+            private set
+
         override suspend fun chooseImpl(
             path: NioPath,
             filters: List<FileNameExtensionFilter>,
             title: String,
             selectDirectory: Boolean,
             multiple: Boolean
-        ): List<NioPath>? = picked?.let { listOf(Path(it)) }
+        ): List<NioPath>? = picked?.let { listOf(Path(it)) }.also { answered++ }
 
         override suspend fun saveImpl(
             location: NioPath,
             suggestedName: String,
             filters: List<FileNameExtensionFilter>,
             title: String
-        ): NioPath? = picked?.let { Path(it) }
+        ): NioPath? = picked?.let { Path(it) }.also { answered++ }
     }
 
-    private fun givenChooserReturns(picked: String?) {
+    private fun givenChooserReturns(picked: String?): FakeChooser {
         mockkObject(FileChooser.Companion)
-        every { FileChooser.platformInstance } returns FakeChooser(picked)
+        return FakeChooser(picked).also { every { FileChooser.platformInstance } returns it }
     }
+
+    /**
+     * Waits for the dialog to have answered. For a **cancelled** dialog this is the whole story: the
+     * handler's remaining work is `if (path != null) { … }`, so once the chooser has returned null
+     * the flow is finished and what follows is a settled assertion rather than a race.
+     */
+    private fun ComposeUiTest.awaitDialogAnswered(chooser: FakeChooser) =
+        waitUntil("the file dialog to have been answered", 2_000) { chooser.answered == 1 }
 
     private fun ComposeUiTest.openHistory() {
         onNodeWithText(QALabel.HISTORY, substring = true).performClick()
@@ -84,12 +113,12 @@ class QATabFileChooserTest {
 
     @Test
     fun `cancelling the export dialog leaves history untouched`() {
-        givenChooserReturns(null)
+        val chooser = givenChooserReturns(null)
 
         qaTab(seed = { askAll("stays in history"); toggleSession() }) { qa, _, _ ->
             openHistory()
             clickQaLabel(QALabel.EXPORT_TO_FILE)
-            waitForIdle()
+            awaitDialogAnswered(chooser)
 
             assertEquals(1, qa.history.size, "cancelling the save dialog must not touch history")
         }
@@ -132,12 +161,12 @@ class QATabFileChooserTest {
 
     @Test
     fun `cancelling the import dialog adds nothing`() {
-        givenChooserReturns(null)
+        val chooser = givenChooserReturns(null)
 
         qaTab(seed = { askAll("prior session question"); toggleSession() }) { qa, _, _ ->
             openHistory()
             clickQaLabel(QALabel.IMPORT_FROM_FILE)
-            waitForIdle()
+            awaitDialogAnswered(chooser)
 
             assertTrue(qa.questions.isEmpty())
         }
@@ -146,12 +175,12 @@ class QATabFileChooserTest {
     @Test
     fun `importing a file that cannot be read adds nothing and does not crash`() {
         val missing = File(Files.createTempDirectory("cp-qa-import-missing").toFile(), "gone.txt")
-        givenChooserReturns(missing.absolutePath)
+        val chooser = givenChooserReturns(missing.absolutePath)
 
         qaTab(seed = { askAll("prior session question"); toggleSession() }) { qa, _, _ ->
             openHistory()
             clickQaLabel(QALabel.IMPORT_FROM_FILE)
-            waitForIdle()
+            awaitDialogAnswered(chooser)
 
             assertTrue(qa.questions.isEmpty(), "a failed read must add nothing")
         }
@@ -160,12 +189,12 @@ class QATabFileChooserTest {
     @Test
     fun `exporting to a folder that does not exist does not crash`() {
         val dest = File(Files.createTempDirectory("cp-qa-export-bad").toFile(), "no/such/folder/questions.txt")
-        givenChooserReturns(dest.absolutePath)
+        val chooser = givenChooserReturns(dest.absolutePath)
 
         qaTab(seed = { askAll("Exported question"); toggleSession() }) { qa, _, _ ->
             openHistory()
             clickQaLabel(QALabel.EXPORT_TO_FILE)
-            waitForIdle()
+            awaitDialogAnswered(chooser)
 
             assertFalse(dest.exists())
             assertEquals(1, qa.history.size, "the failed export must not touch history")
@@ -194,12 +223,12 @@ class QATabFileChooserTest {
 
     @Test
     fun `cancelling the export-and-clear save dialog leaves the questions untouched`() {
-        givenChooserReturns(null)
+        val chooser = givenChooserReturns(null)
 
         qaTab(seed = { askAll("must survive") }) { qa, _, _ ->
             clickQaLabel(QALabel.CLEAR_ALL)
             clickQaLabel(QALabel.EXPORT_AND_CLEAR)
-            waitForIdle()
+            awaitDialogAnswered(chooser)
 
             assertEquals(1, qa.questions.size, "cancelling the save dialog must abort the clear")
         }
@@ -208,12 +237,12 @@ class QATabFileChooserTest {
     @Test
     fun `export and clear aborts when the save fails, leaving the queue intact`() {
         val dest = File(Files.createTempDirectory("cp-qa-exportclear-bad").toFile(), "no/such/folder/questions.txt")
-        givenChooserReturns(dest.absolutePath)
+        val chooser = givenChooserReturns(dest.absolutePath)
 
         qaTab(seed = { askAll("must survive a failed export") }) { qa, _, _ ->
             clickQaLabel(QALabel.CLEAR_ALL)
             clickQaLabel(QALabel.EXPORT_AND_CLEAR)
-            waitForIdle()
+            awaitDialogAnswered(chooser)
 
             assertFalse(dest.exists())
             assertEquals(1, qa.questions.size, "a failed export must abort the clear rather than lose questions")


### PR DESCRIPTION
Follow-up to the [#154 review](https://github.com/ChurchPresenter/ChurchPresenter/pull/154#issuecomment-5166475036), as promised there rather than pushed to that branch.

Six tests in `QATabFileChooserTest` asserted that **nothing had changed** immediately after a bare `waitForIdle()`. Each flow runs in `coroutineScope.launch` around a *suspend* chooser call, and `waitForIdle()` does not await an arbitrary coroutine. The same file already knew this — its positive tests wait on `waitUntil { dest.exists() }` / `waitUntil { qa.questions.size == 2 }`.

**These were not flaky**, and that is the point: the asserted state is the state you start in, so they could never fail spuriously. The cost is the reverse — had cancelling ever started clearing questions, the assertion would only have caught it when the coroutine happened to win the race. A regression detector that works most of the time.

## What changed

`FakeChooser` counts answered dialogs; the tests wait on that before reading the result. For a **cancelled** dialog this is exact: the handler's remaining work is `if (path != null) { … }`, so a null answer ends the flow and what follows is settled rather than raced. The wait completing is also, in itself, proof the handler ran — which none of these tests previously established.

## What is still weaker, and why it is written down

For the three cases where the dialog *succeeds* and the write or read then **fails**, there is no positive signal at all: the failure is swallowed into `CrashReporter` inside `withContext(Dispatchers.IO)` and changes nothing observable. Those tests now assert at the last point a test can see rather than at true completion. That is weaker than the rest of the file, so it is stated in the class doc rather than left for someone to rediscover.

## Verification

`--tests 'org.churchpresenter.app.churchpresenter.tabs.*' --rerun-tasks` three consecutive times, green — the whole tabs package, since this touches a shared support pattern.