### PR TITLE
test: cover the recent-folders bar in Pictures

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
@@ -147,7 +147,15 @@ import androidx.compose.foundation.lazy.items as lazyItems
 import androidx.compose.ui.text.style.TextOverflow
 import kotlinx.coroutines.delay
 
-private object RecentPictureFolders {
+/**
+ * Recent picture folders, mirroring `data/RecentPresentationFiles` for the Pictures tab.
+ *
+ * `internal` rather than private so the bar it feeds can be driven from a test by seeding [folders]
+ * and [pinned] — they are the state the bar renders from, and the sibling object this copies is
+ * public for the same reason. Nothing else is widened: the JSON paths stay private and are still
+ * resolved once per JVM at class-init.
+ */
+internal object RecentPictureFolders {
     private const val MAX = 10
     private val file = File(System.getProperty("user.home"), ".churchpresenter/recent_picture_folders.json")
     private val pinnedFile = File(System.getProperty("user.home"), ".churchpresenter/pinned_picture_folders.json")

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabRecentFoldersTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabRecentFoldersTest.kt
@@ -1,0 +1,126 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The recent-folders bar in the Pictures tab: which folders it offers and in what order.
+ *
+ * Same shape as [PresentationTabRecentFilesTest], and the same reasoning. [RecentPictureFolders]
+ * renders the bar straight off two `mutableStateListOf`s, so seeding those drives it with no file
+ * I/O, no `user.home` swap and no new seam — the object was only ever `private`, which is the single
+ * production change here.
+ *
+ * As there, nothing clicks a chip, a star or the clear button. The two JSON paths are resolved at
+ * class-init, so whichever test touches the object first decides where the whole JVM writes, and
+ * `clear` against a real home would rewrite the developer's own recent-folders list. Those lines
+ * stay uncovered on purpose.
+ *
+ * One difference from the presentation bar is worth pinning: `clear` here **keeps pinned folders**.
+ * That is not covered for the reason above, but it is why the ordering tests treat pinned and recent
+ * as overlapping sets rather than as two disjoint lists.
+ */
+class PicturesTabRecentFoldersTest {
+
+    private lateinit var savedFolders: List<String>
+    private lateinit var savedPinned: List<String>
+
+    @BeforeTest
+    fun snapshotRecents() {
+        savedFolders = RecentPictureFolders.folders.toList()
+        savedPinned = RecentPictureFolders.pinned.toList()
+        RecentPictureFolders.folders.clear()
+        RecentPictureFolders.pinned.clear()
+    }
+
+    @AfterTest
+    fun restoreRecents() {
+        RecentPictureFolders.folders.clear()
+        RecentPictureFolders.folders.addAll(savedFolders)
+        RecentPictureFolders.pinned.clear()
+        RecentPictureFolders.pinned.addAll(savedPinned)
+    }
+
+    private fun seed(folders: List<String> = emptyList(), pinned: List<String> = emptyList()) {
+        RecentPictureFolders.folders.addAll(folders)
+        RecentPictureFolders.pinned.addAll(pinned)
+    }
+
+    /** Chips are labelled with the folder name, so the paths differ but the leaf name is the label. */
+    private fun path(name: String) = "/Volumes/Services/photos/$name"
+
+    private companion object {
+        /** Exactly as `Res.string.recent` spells it — asserting on "Recent" would never match. */
+        const val BAR_LABEL = "Recent:"
+    }
+
+    @Test
+    fun `no recent folders means no bar at all`() {
+        picturesTab { _, _ ->
+            waitForIdle()
+            assertFalse(
+                showsExactly(BAR_LABEL),
+                "an empty bar would take a strip of height from the thumbnail grid for nothing"
+            )
+        }
+    }
+
+    @Test
+    fun `recent folders are offered by folder name`() {
+        seed(folders = listOf(path("Advent 2026"), path("Baptism")))
+
+        picturesTab { _, _ ->
+            waitForIdle()
+            assertTrue(showsExactly("Advent 2026"), renderedText().toString())
+            assertTrue(showsExactly("Baptism"), renderedText().toString())
+        }
+    }
+
+    @Test
+    fun `pinned folders come before the merely recent ones`() {
+        seed(
+            folders = listOf(path("Opened Today"), path("Opened Yesterday")),
+            pinned = listOf(path("Every Week")),
+        )
+
+        picturesTab { _, _ ->
+            waitForIdle()
+            val shown = renderedText()
+            val pinnedAt = shown.indexOf("Every Week")
+            val recentAt = shown.indexOf("Opened Today")
+            assertTrue(pinnedAt >= 0 && recentAt >= 0, "both should be on screen: $shown")
+            assertTrue(pinnedAt < recentAt, "the pinned folder leads the bar: $shown")
+        }
+    }
+
+    @Test
+    fun `a folder that is both pinned and recent is offered once`() {
+        val both = path("Every Week")
+        seed(folders = listOf(both, path("Baptism")), pinned = listOf(both))
+
+        picturesTab { _, _ ->
+            waitForIdle()
+            assertEquals(
+                1, renderedText().count { it == "Every Week" },
+                "the same folder twice in the bar is two chips that do the same thing"
+            )
+        }
+    }
+
+    @Test
+    fun `a pinned folder is still offered when it is the only one`() {
+        seed(pinned = listOf(path("Every Week")))
+
+        picturesTab { _, _ ->
+            waitForIdle()
+            assertTrue(showsExactly("Every Week"), renderedText().toString())
+            assertTrue(showsExactly(BAR_LABEL), "the bar's own label is part of it being there")
+        }
+    }
+}


### PR DESCRIPTION
The companion to #161. `RecentPictureFolders` renders its bar straight off two `mutableStateListOf` lists, so seeding those drives it with no file I/O, no `user.home` swap and no new test seam.

## Production change: one word

The object was `private object`, now `internal object` — which is what its sibling `data/RecentPresentationFiles` already is. **Nothing else is widened**: the two JSON paths stay private and are still resolved once per JVM at class-init. This brings the two recents objects in line rather than inventing a seam for the test.

## §5 was half right

The plan's "recent-folder/file bars are unreachable" entry lumped both tabs together. It was **accurate about this tab** — the object really was private — and **wrong about `PresentationTab`**, where the equivalent has always been public. #161 corrected the second half; this corrects the first, at the cost of one keyword.

## What is deliberately not covered

Nothing clicks a chip, a star or the clear button. `add`, `togglePin` and `clear` all save, and `clear` against a real home would rewrite the developer's own recent-folders list. Those lines stay uncovered on purpose, and the class doc says so.

## What is covered

- pinned folders lead, so the folder used every week does not drift behind whatever was opened most recently;
- a folder that is both pinned and recent appears **once** — pinning does not remove it from recents, so the two overlap constantly;
- an empty list produces no bar, rather than a strip of height taken from the thumbnail grid;
- chips are labelled by leaf folder name.

The empty-bar assertion is paired with a positive one that asserts the same label, which is what caught the vacuous version of this assertion in #161 (the resource is `Recent:`, not `Recent`).

## Worth knowing for later

`clear()` here **keeps pinned folders**, unlike the presentation bar. Not covered for the reason above, but noted in the class doc so the difference is not later mistaken for a bug.

## Verification

`--tests 'org.churchpresenter.app.churchpresenter.tabs.*' --rerun-tasks` three consecutive times, green — the whole tabs package, since this manipulates a process-wide object and restores it in teardown.
