### PR TITLE
test: wait for the dictionary load to settle, not just to produce a Bible

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/DictionaryViewModelBiblePickerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/DictionaryViewModelBiblePickerTest.kt
@@ -209,13 +209,19 @@ class DictionaryViewModelBiblePickerTest {
         val file = writeBible("kjv.spb")
         val d = vm()
         d.setDictBible(file.absolutePath)
-        awaitUntil("the bible to load") { d.dictBible != null }
+        // Both, not just the Bible: `setDictBible` assigns `dictBible` inside the coroutine and only
+        // clears `isDictBibleLoading` in its `finally`, so waiting on the Bible alone can return
+        // between the two. This test then asserts the flag, and on a loaded CI runner it lost that
+        // race — the failure it produced was a bare "Expected value to be true".
+        awaitUntil("the bible to load and the loading flag to clear") {
+            d.dictBible != null && !d.isDictBibleLoading
+        }
         val loaded = d.dictBible
 
         d.setDictBible(file.absolutePath)
 
         assertTrue(d.dictBible === loaded, "re-picking the current entry must not re-parse the whole module")
-        assertTrue(!d.isDictBibleLoading)
+        assertTrue(!d.isDictBibleLoading, "re-picking must not put the picker back into a loading state")
     }
 
     /**


### PR DESCRIPTION
A CI-only flake, seen on #161's run: `DictionaryViewModelBiblePickerTest > re-choosing the module already loaded does not reload it` failed with a bare **"Expected value to be true"**. That is the unmessaged assertion — `assertTrue(!d.isDictBibleLoading)`.

## Cause

`setDictBible` assigns `dictBible` inside its coroutine and only clears `isDictBibleLoading` in the `finally` that follows:

```kotlin
dictBible = withContext(Dispatchers.IO) { Bible().apply { loadFromSpb(filePath) } }
...
} finally {
    isDictBibleLoading = false
}
```

The test waited on `dictBible != null` and then asserted the flag, so it could land in the gap between the two. And because the second `setDictBible` returns early for a path already selected, nothing clears the flag afterwards — once the race is lost the assertion fails outright rather than eventually passing.

**The sibling test one line up already waits on both conditions.** Same corroboration as #157: the file knew the shape, and one test missed it.

## Pattern, not an incident

Third instance of what #142 and #153 both were — *a state change and the detail that goes with it, written separately, with the test waiting on the wrong one of the two.* I swept the rest of the `viewmodel` test package for it; this was the only remaining case, and the others already wait on the flag.

The second assertion also gains a message. A bare "Expected value to be true" is what made this cost a CI cycle to identify at all.

## Still open, and not addressed here

The `BibleViewModelChapterTest` intermittent recorded in the plan is a different shape (`expected:<[1-3]> but was:<[]>`) and remains unexplained — I ruled out the obvious causes last iteration and did not want to bundle a speculative change with a proven one.

## Verification

`--tests '*DictionaryViewModel*' --rerun-tasks` three consecutive times, green. The race is CI-timing-dependent, so local green is necessary but not sufficient — the argument is the ordering itself.
