### PR TITLE
refactor: one dispatch for remote add-to-schedule, fixing the batch path

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -179,6 +179,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import org.churchpresenter.app.churchpresenter.models.SelectedVerse
 import org.churchpresenter.app.churchpresenter.server.applyRemoteLiveState
 import org.churchpresenter.app.churchpresenter.server.downloadMirroredBackgroundSettings
+import org.churchpresenter.app.churchpresenter.server.addScheduleItem
 import org.churchpresenter.app.churchpresenter.server.executeProjectItem
 import org.churchpresenter.app.churchpresenter.server.instanceLinkBackgroundCacheDir
 import org.churchpresenter.app.churchpresenter.server.instanceLinkPictureCacheDir
@@ -1045,64 +1046,8 @@ fun main() {
                                             (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
                                         ) {
                                             val item = pending.item
-                                            when (item) {
-                                                is ScheduleItem.SongItem -> {
-                                                    currentScheduleActions.addSong(
-                                                        item.songNumber,
-                                                        item.title,
-                                                        item.songbook,
-                                                        item.songId
-                                                    )
-                                                    coroutineScope.launch { remoteSelectSongFlow.emit(item) }
-                                                }
-
-                                                is ScheduleItem.BibleVerseItem ->
-                                                    currentScheduleActions.addBibleVerse(
-                                                        item.bookName,
-                                                        item.chapter,
-                                                        item.verseNumber,
-                                                        item.verseText,
-                                                        item.verseRange,
-                                                        item.bookId
-                                                    )
-
-                                                is ScheduleItem.PresentationItem ->
-                                                    currentScheduleActions.addPresentation(
-                                                        item.filePath,
-                                                        item.fileName,
-                                                        item.slideCount,
-                                                        item.fileType
-                                                    )
-
-                                                is ScheduleItem.PictureItem ->
-                                                    currentScheduleActions.addPicture(
-                                                        item.folderPath,
-                                                        item.folderName,
-                                                        item.imageCount
-                                                    )
-
-                                                is ScheduleItem.MediaItem ->
-                                                    currentScheduleActions.addMedia(
-                                                        item.mediaUrl,
-                                                        item.mediaTitle,
-                                                        item.mediaType
-                                                    )
-
-                                                is ScheduleItem.DictionaryItem ->
-                                                    currentScheduleActions.addDictionary(
-                                                        item.number,
-                                                        item.word,
-                                                        item.transliteration,
-                                                        item.definition
-                                                    )
-
-                                                is ScheduleItem.AnnouncementItem ->
-                                                    currentScheduleActions.addAnnouncement(item)
-
-                                                is ScheduleItem.WebsiteItem ->
-                                                    currentScheduleActions.addWebsite(item.url, item.title)
-
-                                                else -> Unit
+                                            addScheduleItem(item, currentScheduleActions) { song ->
+                                                coroutineScope.launch { remoteSelectSongFlow.emit(song) }
                                             }
                                             pending.decision.complete(true)
                                             // Show activity toast so operator is aware
@@ -1126,64 +1071,8 @@ fun main() {
                                             clientLabel = remoteClientManager.getLabel(clientId)
                                         )
                                         val allow: () -> Unit = {
-                                            when (item) {
-                                                is ScheduleItem.SongItem -> {
-                                                    currentScheduleActions.addSong(
-                                                        item.songNumber,
-                                                        item.title,
-                                                        item.songbook,
-                                                        item.songId
-                                                    )
-                                                    coroutineScope.launch { remoteSelectSongFlow.emit(item) }
-                                                }
-
-                                                is ScheduleItem.BibleVerseItem ->
-                                                    currentScheduleActions.addBibleVerse(
-                                                        item.bookName,
-                                                        item.chapter,
-                                                        item.verseNumber,
-                                                        item.verseText,
-                                                        item.verseRange,
-                                                        item.bookId
-                                                    )
-
-                                                is ScheduleItem.PresentationItem ->
-                                                    currentScheduleActions.addPresentation(
-                                                        item.filePath,
-                                                        item.fileName,
-                                                        item.slideCount,
-                                                        item.fileType
-                                                    )
-
-                                                is ScheduleItem.PictureItem ->
-                                                    currentScheduleActions.addPicture(
-                                                        item.folderPath,
-                                                        item.folderName,
-                                                        item.imageCount
-                                                    )
-
-                                                is ScheduleItem.MediaItem ->
-                                                    currentScheduleActions.addMedia(
-                                                        item.mediaUrl,
-                                                        item.mediaTitle,
-                                                        item.mediaType
-                                                    )
-
-                                                is ScheduleItem.DictionaryItem ->
-                                                    currentScheduleActions.addDictionary(
-                                                        item.number,
-                                                        item.word,
-                                                        item.transliteration,
-                                                        item.definition
-                                                    )
-
-                                                is ScheduleItem.AnnouncementItem ->
-                                                    currentScheduleActions.addAnnouncement(item)
-
-                                                is ScheduleItem.WebsiteItem ->
-                                                    currentScheduleActions.addWebsite(item.url, item.title)
-
-                                                else -> Unit
+                                            addScheduleItem(item, currentScheduleActions) { song ->
+                                                coroutineScope.launch { remoteSelectSongFlow.emit(song) }
                                             }
                                             pending.decision.complete(true)
                                         }
@@ -1252,50 +1141,8 @@ fun main() {
                                             (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
                                         ) {
                                             for (item in pending.items) {
-                                                when (item) {
-                                                    is ScheduleItem.SongItem -> {
-                                                        currentScheduleActions.addSong(
-                                                            item.songNumber,
-                                                            item.title,
-                                                            item.songbook,
-                                                            item.songId
-                                                        )
-                                                        coroutineScope.launch { remoteSelectSongFlow.emit(item) }
-                                                    }
-
-                                                    is ScheduleItem.BibleVerseItem ->
-                                                        currentScheduleActions.addBibleVerse(
-                                                            item.bookName,
-                                                            item.chapter,
-                                                            item.verseNumber,
-                                                            item.verseText,
-                                                            item.verseRange,
-                                                            item.bookId
-                                                        )
-
-                                                    is ScheduleItem.PresentationItem ->
-                                                        currentScheduleActions.addPresentation(
-                                                            item.filePath,
-                                                            item.fileName,
-                                                            item.slideCount,
-                                                            item.fileType
-                                                        )
-
-                                                    is ScheduleItem.PictureItem ->
-                                                        currentScheduleActions.addPicture(
-                                                            item.folderPath,
-                                                            item.folderName,
-                                                            item.imageCount
-                                                        )
-
-                                                    is ScheduleItem.MediaItem ->
-                                                        currentScheduleActions.addMedia(
-                                                            item.mediaUrl,
-                                                            item.mediaTitle,
-                                                            item.mediaType
-                                                        )
-
-                                                    else -> Unit
+                                                addScheduleItem(item, currentScheduleActions) { song ->
+                                                    coroutineScope.launch { remoteSelectSongFlow.emit(song) }
                                                 }
                                             }
                                             pending.decision.complete(true)
@@ -1347,50 +1194,8 @@ fun main() {
                                         )
                                         val allow: () -> Unit = {
                                             for (item in pending.items) {
-                                                when (item) {
-                                                    is ScheduleItem.SongItem -> {
-                                                        currentScheduleActions.addSong(
-                                                            item.songNumber,
-                                                            item.title,
-                                                            item.songbook,
-                                                            item.songId
-                                                        )
-                                                        coroutineScope.launch { remoteSelectSongFlow.emit(item) }
-                                                    }
-
-                                                    is ScheduleItem.BibleVerseItem ->
-                                                        currentScheduleActions.addBibleVerse(
-                                                            item.bookName,
-                                                            item.chapter,
-                                                            item.verseNumber,
-                                                            item.verseText,
-                                                            item.verseRange,
-                                                            item.bookId
-                                                        )
-
-                                                    is ScheduleItem.PresentationItem ->
-                                                        currentScheduleActions.addPresentation(
-                                                            item.filePath,
-                                                            item.fileName,
-                                                            item.slideCount,
-                                                            item.fileType
-                                                        )
-
-                                                    is ScheduleItem.PictureItem ->
-                                                        currentScheduleActions.addPicture(
-                                                            item.folderPath,
-                                                            item.folderName,
-                                                            item.imageCount
-                                                        )
-
-                                                    is ScheduleItem.MediaItem ->
-                                                        currentScheduleActions.addMedia(
-                                                            item.mediaUrl,
-                                                            item.mediaTitle,
-                                                            item.mediaType
-                                                        )
-
-                                                    else -> Unit
+                                                addScheduleItem(item, currentScheduleActions) { song ->
+                                                    coroutineScope.launch { remoteSelectSongFlow.emit(song) }
                                                 }
                                             }
                                             pending.decision.complete(true)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
@@ -655,3 +655,78 @@ internal fun executeProjectItem(
         else -> Unit
     }
 }
+
+/**
+ * Adds a remotely-requested [item] to the schedule, reporting whether anything was added.
+ *
+ * The same eight-way dispatch was written out four times in `main.kt` — twice for the single-add
+ * path and twice for the batch path — and the batch copies were missing the dictionary,
+ * announcement and website branches. `RemoteItemDto.toScheduleItem` produces all three and
+ * `POST /api/schedule/add-batch` answers `{"ok":true,"added":N}` counting every item it parsed, so
+ * a batch containing one of them told the phone it had been added while nothing reached the
+ * schedule. Having one dispatch is what stops the two paths drifting again.
+ *
+ * [onSongAdded] is how the Songs tab is told to navigate to the song it just received; the caller
+ * supplies it because the flow it emits on is scoped to the composable.
+ *
+ * Deliberately **not** shared with [executeProjectItem]: that path drives dictionary and
+ * announcement items onto the presenter *without* adding them to the schedule, so routing it
+ * through here would start adding a row every time one is projected.
+ *
+ * @return true when a schedule action fired; false for the types that are not schedule content
+ *         (label, lower third — and scene, which has an `addScene` action no remote path uses).
+ */
+internal fun addScheduleItem(
+    item: ScheduleItem,
+    scheduleActions: ScheduleActions,
+    onSongAdded: (ScheduleItem.SongItem) -> Unit = {}
+): Boolean {
+    when (item) {
+        is ScheduleItem.SongItem -> {
+            scheduleActions.addSong(item.songNumber, item.title, item.songbook, item.songId)
+            onSongAdded(item)
+        }
+
+        is ScheduleItem.BibleVerseItem -> scheduleActions.addBibleVerse(
+            item.bookName,
+            item.chapter,
+            item.verseNumber,
+            item.verseText,
+            item.verseRange,
+            item.bookId
+        )
+
+        is ScheduleItem.PresentationItem -> scheduleActions.addPresentation(
+            item.filePath,
+            item.fileName,
+            item.slideCount,
+            item.fileType
+        )
+
+        is ScheduleItem.PictureItem -> scheduleActions.addPicture(
+            item.folderPath,
+            item.folderName,
+            item.imageCount
+        )
+
+        is ScheduleItem.MediaItem -> scheduleActions.addMedia(
+            item.mediaUrl,
+            item.mediaTitle,
+            item.mediaType
+        )
+
+        is ScheduleItem.DictionaryItem -> scheduleActions.addDictionary(
+            item.number,
+            item.word,
+            item.transliteration,
+            item.definition
+        )
+
+        is ScheduleItem.AnnouncementItem -> scheduleActions.addAnnouncement(item)
+
+        is ScheduleItem.WebsiteItem -> scheduleActions.addWebsite(item.url, item.title)
+
+        else -> return false
+    }
+    return true
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AddScheduleItemTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AddScheduleItemTest.kt
@@ -1,0 +1,163 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * What an approved remote "add this to the schedule" request actually adds.
+ *
+ * This dispatch was written out four times in `main.kt` — twice for a single item, twice inside the
+ * batch loop — and the two batch copies had drifted: they were missing the dictionary, announcement
+ * and website branches, so those types fell to `else -> Unit`. `RemoteItemDto.toScheduleItem`
+ * produces all three and `POST /api/schedule/add-batch` answers `{"ok":true,"added":N}` counting
+ * every item it parsed, so a batch containing one told the phone it had been added while nothing
+ * reached the schedule. `a mixed batch adds every item` below is the pin for that.
+ *
+ * Driven with a [ScheduleActionsRecorder] — `ScheduleActions` is a data class of lambdas, so
+ * recording what it was asked to add needs no mock and the assertions are the real argument lists.
+ *
+ * Lived in `main.kt` until the extraction that added this file, in the same way
+ * [ExecuteProjectItemTest] did for the project path.
+ */
+class AddScheduleItemTest {
+
+    private fun song(number: Int = 42) =
+        ScheduleItem.SongItem(id = "s", songNumber = number, title = "Amazing Grace", songbook = "Hymnal", songId = "sid")
+
+    private fun bibleVerse() = ScheduleItem.BibleVerseItem(
+        id = "b", bookName = "John", chapter = 3, verseNumber = 16,
+        verseText = "For God so loved", verseRange = "16", bookId = 43,
+    )
+
+    private fun presentation() = ScheduleItem.PresentationItem(
+        id = "p", filePath = "/decks/sunday.pdf", fileName = "sunday", slideCount = 4, fileType = "pdf",
+    )
+
+    private fun picture() =
+        ScheduleItem.PictureItem(id = "pic", folderPath = "/photos/advent", folderName = "advent", imageCount = 12)
+
+    private fun media() =
+        ScheduleItem.MediaItem(id = "m", mediaUrl = "/clips/welcome.mp4", mediaTitle = "Welcome", mediaType = "local")
+
+    private fun dictionary() = ScheduleItem.DictionaryItem(
+        id = "d", number = "G5485", word = "χάρις", transliteration = "charis", definition = "grace",
+    )
+
+    private fun announcement() = ScheduleItem.AnnouncementItem(id = "a", text = "Service starts at 10")
+
+    private fun website() = ScheduleItem.WebsiteItem(id = "w", url = "https://example.org", title = "Notices")
+
+    private fun add(item: ScheduleItem): Pair<ScheduleActionsRecorder, Boolean> {
+        val recorder = ScheduleActionsRecorder()
+        val added = addScheduleItem(item, recorder.actions())
+        return recorder to added
+    }
+
+    // ── One of each ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `each kind of content reaches its own schedule action`() {
+        // One test rather than eight: what this pins is that no branch calls a neighbour's action —
+        // a picture added as a presentation is the copy-paste slip this shape invites.
+        assertEquals(listOf("song:42:Amazing Grace:Hymnal:sid"), add(song()).first.added)
+        assertEquals(listOf("bible:John:3:16:For God so loved:16:43"), add(bibleVerse()).first.added)
+        assertEquals(listOf("presentation:/decks/sunday.pdf:sunday:4:pdf"), add(presentation()).first.added)
+        assertEquals(listOf("picture:/photos/advent:advent:12"), add(picture()).first.added)
+        assertEquals(listOf("media:/clips/welcome.mp4:Welcome:local"), add(media()).first.added)
+        assertEquals(listOf("dictionary:G5485:χάρις:charis:grace"), add(dictionary()).first.added)
+        assertEquals(listOf("announcement:a"), add(announcement()).first.added)
+        assertEquals(listOf("website:https://example.org:Notices"), add(website()).first.added)
+    }
+
+    @Test
+    fun `every kind of content reports that it was added`() {
+        listOf(song(), bibleVerse(), presentation(), picture(), media(), dictionary(), announcement(), website())
+            .forEach { assertTrue(add(it).second, "${it::class.simpleName} is schedule content") }
+    }
+
+    @Test
+    fun `an announcement is handed over whole`() {
+        // Its colour, font and timer fields ride on the item itself, so passing anything but the
+        // original instance would quietly drop the styling the operator set up.
+        val item = announcement()
+        val recorder = ScheduleActionsRecorder()
+
+        addScheduleItem(item, recorder.actions())
+
+        assertSame(item, recorder.announcements.single())
+    }
+
+    // ── The song's extra half ───────────────────────────────────────────────────
+
+    @Test
+    fun `a song also asks the Songs tab to navigate to it`() {
+        val item = song()
+        val navigated = mutableListOf<ScheduleItem.SongItem>()
+
+        addScheduleItem(item, ScheduleActionsRecorder().actions()) { navigated += it }
+
+        assertSame(item, navigated.single(), "the tab needs the item itself to select the right song")
+    }
+
+    @Test
+    fun `nothing but a song asks the Songs tab to navigate`() {
+        var navigations = 0
+
+        listOf(song(), bibleVerse(), presentation(), picture(), media(), dictionary(), announcement(), website())
+            .forEach { addScheduleItem(it, ScheduleActionsRecorder().actions()) { navigations++ } }
+
+        assertEquals(1, navigations, "only the song branch may pull the Songs tab away from what it is showing")
+    }
+
+    // ── Things that are not schedule content ────────────────────────────────────
+
+    @Test
+    fun `a label, a lower third and a scene add nothing`() {
+        // A scene has an addScene action, but no remote path has ever called it — recorded here so
+        // the gap is visible rather than looking like an oversight in this function.
+        val notContent = listOf(
+            ScheduleItem.LabelItem(id = "l", text = "Part 2", textColor = "#fff", backgroundColor = "#000"),
+            ScheduleItem.LowerThirdItem(
+                id = "lt", presetId = "welcome", presetLabel = "Welcome",
+                pauseAtFrame = false, pauseDurationMs = 0,
+            ),
+            ScheduleItem.SceneItem(id = "sc", sceneId = "scene-1", sceneName = "Opening"),
+        )
+
+        notContent.forEach { item ->
+            val (recorder, added) = add(item)
+            assertFalse(added, "${item::class.simpleName} is not schedule content")
+            assertTrue(recorder.added.isEmpty(), "${item::class.simpleName} must not add anything")
+        }
+    }
+
+    // ── The bug this extraction fixed ───────────────────────────────────────────
+
+    @Test
+    fun `a mixed batch adds every item, in order`() {
+        // The batch copies of this dispatch handled only song/bible/presentation/picture/media, so a
+        // batch carrying a dictionary entry, an announcement or a website was answered
+        // {"ok":true,"added":5} with three of them silently dropped. One dispatch is what stops the
+        // single and batch paths drifting apart again.
+        val batch = listOf(song(), bibleVerse(), dictionary(), announcement(), website())
+        val recorder = ScheduleActionsRecorder()
+
+        batch.forEach { addScheduleItem(it, recorder.actions()) }
+
+        assertEquals(
+            listOf(
+                "song:42:Amazing Grace:Hymnal:sid",
+                "bible:John:3:16:For God so loved:16:43",
+                "dictionary:G5485:χάρις:charis:grace",
+                "announcement:a",
+                "website:https://example.org:Notices",
+            ),
+            recorder.added,
+            "every item the endpoint counted in its `added` response has to actually be added",
+        )
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/ScheduleActionsRecorder.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/ScheduleActionsRecorder.kt
@@ -1,0 +1,46 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import org.churchpresenter.app.churchpresenter.ScheduleActions
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+
+/**
+ * Records what the schedule was asked to do, as a stand-in for the real actions.
+ *
+ * `ScheduleActions` is a data class of lambdas with no-op defaults, so the "fake" is a constructor
+ * call — no mocking library, and every recorded string is the real argument list the production code
+ * passed. Supplying only the lambdas a test cares about leaves the rest as no-ops.
+ *
+ * Supersedes the private `Recorder` in [ExecuteProjectItemTest], which predates this file and covers
+ * fewer actions; that copy can be deleted once something needs to touch that suite anyway.
+ */
+internal class ScheduleActionsRecorder {
+
+    /** Every add, in the order it was requested. */
+    val added = mutableListOf<String>()
+
+    /** Items handed over whole, so a test can assert on identity rather than on a formatted string. */
+    val announcements = mutableListOf<ScheduleItem.AnnouncementItem>()
+
+    /** Ids passed to `removeById`. */
+    val removed = mutableListOf<String>()
+
+    fun actions() = ScheduleActions(
+        removeById = { id -> removed += id },
+        addSong = { number, title, songbook, id -> added += "song:$number:$title:$songbook:$id" },
+        addBibleVerse = { book, chapter, verse, text, range, bookId ->
+            added += "bible:$book:$chapter:$verse:$text:$range:$bookId"
+        },
+        addPicture = { path, name, count -> added += "picture:$path:$name:$count" },
+        addPresentation = { path, name, slides, type -> added += "presentation:$path:$name:$slides:$type" },
+        addMedia = { url, title, type -> added += "media:$url:$title:$type" },
+        addScene = { id, name -> added += "scene:$id:$name" },
+        addDictionary = { number, word, translit, definition ->
+            added += "dictionary:$number:$word:$translit:$definition"
+        },
+        addAnnouncement = { item ->
+            added += "announcement:${item.id}"
+            announcements += item
+        },
+        addWebsite = { url, title -> added += "website:$url:$title" },
+    )
+}


### PR DESCRIPTION
The `when (item) -> scheduleActions.addX(...)` dispatch was written out **four times** in `main.kt`: twice for the single-add path and twice inside the batch loop. The two batch copies had drifted — **5 branches where the single-add copies had 8**.

## This is a live bug, not just duplication

`RemoteItemDto.toScheduleItem` produces `DictionaryItem`, `AnnouncementItem` and `WebsiteItem`, and `POST /api/schedule/add-batch` answers `{"ok":true,"added":N}` counting every item it parsed — while those three fell to `else -> Unit`.

**So a phone adding a website as part of a batch was told it had been added, and nothing reached the schedule.** Adding the same website on its own always worked. It is a false success response, not merely a missing feature.

Evidence from the pre-change file: batch site had 5 `is ScheduleItem.` branches, single-add site had 8.

## The change

Extracts `addScheduleItem(item, scheduleActions, onSongAdded)` into `RemoteApply.kt` — where #110 put `executeProjectItem` — and calls it from all four sites. **Deduplicating is the fix**: the batch path gains the three branches by construction, which is also what stops the two paths drifting again.

**Deliberately not shared with `executeProjectItem`.** Its dictionary and announcement branches drive the presenter *without* adding to the schedule, so routing it through here would start adding a row every time one is projected. That reasoning is on the function so nobody merges them later.

## Coverage

204 lines leave `main.kt` — which is excluded from the coverage gate — and land in `RemoteApply.kt`, which is not.

- `main.kt`: 2,855 → **2,715** missed lines
- `RemoteApply.kt`: **90.8%**
- project: 82.04% → **82.57%**, with a *smaller* denominator, since the gain is deleted duplication rather than added code.

## On the batch test

`a mixed batch adds every item, in order` pins that all five types survive the round trip. To be precise about what it does and does not prove: it exercises the new shared function, so it cannot be run red against the old code — the function did not exist there. What establishes the bug is the old file itself (5 branches vs 8), and what prevents its return is that there is now one dispatch instead of four.

## Test helper

`ScheduleActionsRecorder` is promoted from `ExecuteProjectItemTest`'s private `Recorder` and extended to cover `addDictionary`, `addAnnouncement`, `addWebsite`, `addScene` and `removeById`. `ScheduleActions` is a data class of no-op-default lambdas, so the fake is a constructor call — no mocking library. **That suite is left untouched here**; adding files never conflicts, editing them does, so its private copy can go whenever something else needs to touch it.

## Recorded, not fixed

`SceneItem` falls through at all four sites despite `addScene` existing. Unlike the batch case, both add paths *agree*, so it is a separate question rather than drift — noted in a test so it stays visible.

## Verification

- `./gradlew :composeApp:check` — full suite plus the 75% gate, green.
- `--tests '*AddScheduleItem*' --tests '*ExecuteProjectItem*' --tests '*RemoteEventLabel*' --tests '*ScheduleActions*' --rerun-tasks` three consecutive times, green. 7 tests, 0.09s, no coroutines or waits.
- Still worth a manual smoke before release, since none of the endpoint wiring runs headless: connect a phone and add a website **via a batch**.
