### PR TITLE
refactor: one function for the remote allow/block/prompt gate

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -179,6 +179,8 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import org.churchpresenter.app.churchpresenter.models.SelectedVerse
 import org.churchpresenter.app.churchpresenter.server.applyRemoteLiveState
 import org.churchpresenter.app.churchpresenter.server.downloadMirroredBackgroundSettings
+import org.churchpresenter.app.churchpresenter.server.RemoteAccess
+import org.churchpresenter.app.churchpresenter.server.remoteAccessDecision
 import org.churchpresenter.app.churchpresenter.server.addScheduleItem
 import org.churchpresenter.app.churchpresenter.server.executeProjectItem
 import org.churchpresenter.app.churchpresenter.server.instanceLinkBackgroundCacheDir
@@ -1031,20 +1033,16 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     companionServer.onAddToSchedule.collect { pending ->
                                         val clientId = pending.clientId
-                                        // Permanent block → auto-reject
-                                        if (remoteClientManager.isBlocked(clientId)) {
+                                        val access = remoteAccessDecision(
+                                            clientId,
+                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                            sessionAllowedClients, sessionBlockedClients,
+                                        )
+                                        if (access == RemoteAccess.AUTO_REJECT) {
                                             pending.decision.complete(false)
                                             return@collect
                                         }
-                                        // Session block → auto-reject
-                                        if (clientId.isNotBlank() && sessionBlockedClients.contains(clientId)) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        // Permanent allow or session allow → auto-approve
-                                        if (remoteClientManager.isAllowed(clientId) ||
-                                            (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
-                                        ) {
+                                        if (access == RemoteAccess.AUTO_APPROVE) {
                                             val item = pending.item
                                             addScheduleItem(item, currentScheduleActions) { song ->
                                                 coroutineScope.launch { remoteSelectSongFlow.emit(song) }
@@ -1085,20 +1083,16 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     companionServer.onRemoveFromSchedule.collect { pending ->
                                         val clientId = pending.clientId
-                                        // Permanent block → auto-reject
-                                        if (remoteClientManager.isBlocked(clientId)) {
+                                        val access = remoteAccessDecision(
+                                            clientId,
+                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                            sessionAllowedClients, sessionBlockedClients,
+                                        )
+                                        if (access == RemoteAccess.AUTO_REJECT) {
                                             pending.decision.complete(false)
                                             return@collect
                                         }
-                                        // Session block → auto-reject
-                                        if (clientId.isNotBlank() && sessionBlockedClients.contains(clientId)) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        // Permanent allow or session allow → auto-approve
-                                        if (remoteClientManager.isAllowed(clientId) ||
-                                            (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
-                                        ) {
+                                        if (access == RemoteAccess.AUTO_APPROVE) {
                                             currentScheduleActions.removeById(pending.id)
                                             pending.decision.complete(true)
                                             // Show activity toast so operator is aware
@@ -1129,17 +1123,16 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     companionServer.onAddBatchToSchedule.collect { pending ->
                                         val clientId = pending.clientId
-                                        // Permanent block or session block → auto-reject
-                                        if (remoteClientManager.isBlocked(clientId) ||
-                                            (clientId.isNotBlank() && sessionBlockedClients.contains(clientId))
-                                        ) {
+                                        val access = remoteAccessDecision(
+                                            clientId,
+                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                            sessionAllowedClients, sessionBlockedClients,
+                                        )
+                                        if (access == RemoteAccess.AUTO_REJECT) {
                                             pending.decision.complete(false)
                                             return@collect
                                         }
-                                        // Permanent allow or session allow → auto-approve
-                                        if (remoteClientManager.isAllowed(clientId) ||
-                                            (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
-                                        ) {
+                                        if (access == RemoteAccess.AUTO_APPROVE) {
                                             for (item in pending.items) {
                                                 addScheduleItem(item, currentScheduleActions) { song ->
                                                     coroutineScope.launch { remoteSelectSongFlow.emit(song) }
@@ -1209,17 +1202,16 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     companionServer.onProject.collect { pending ->
                                         val clientId = pending.clientId
-                                        // Permanent block or session block → auto-reject
-                                        if (remoteClientManager.isBlocked(clientId) ||
-                                            (clientId.isNotBlank() && sessionBlockedClients.contains(clientId))
-                                        ) {
+                                        val access = remoteAccessDecision(
+                                            clientId,
+                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                            sessionAllowedClients, sessionBlockedClients,
+                                        )
+                                        if (access == RemoteAccess.AUTO_REJECT) {
                                             pending.decision.complete(false)
                                             return@collect
                                         }
-                                        // Permanent allow or session allow → auto-approve
-                                        if (remoteClientManager.isAllowed(clientId) ||
-                                            (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
-                                        ) {
+                                        if (access == RemoteAccess.AUTO_APPROVE) {
                                             val item = pending.item
                                             if (item is ScheduleItem.AnnouncementItem) {
                                                 appSettings = appSettings.withAnnouncement(item)
@@ -1350,15 +1342,16 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     companionServer.onQAAdminRequest.collect { pending ->
                                         val clientId = pending.clientId
-                                        if (remoteClientManager.isBlocked(clientId) ||
-                                            (clientId.isNotBlank() && sessionBlockedClients.contains(clientId))
-                                        ) {
+                                        val access = remoteAccessDecision(
+                                            clientId,
+                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                            sessionAllowedClients, sessionBlockedClients,
+                                        )
+                                        if (access == RemoteAccess.AUTO_REJECT) {
                                             pending.decision.complete(false)
                                             return@collect
                                         }
-                                        if (remoteClientManager.isAllowed(clientId) ||
-                                            (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
-                                        ) {
+                                        if (access == RemoteAccess.AUTO_APPROVE) {
                                             pending.decision.complete(true)
                                             remoteActivityNotifications.add(RemoteActivityNotification(
                                                 type = qaActionType(pending.action),
@@ -1385,15 +1378,16 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     companionServer.onPresentationRemoteConnect.collect { pending ->
                                         val clientId = pending.clientId
-                                        if (remoteClientManager.isBlocked(clientId) ||
-                                            (clientId.isNotBlank() && sessionBlockedClients.contains(clientId))
-                                        ) {
+                                        val access = remoteAccessDecision(
+                                            clientId,
+                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                            sessionAllowedClients, sessionBlockedClients,
+                                        )
+                                        if (access == RemoteAccess.AUTO_REJECT) {
                                             pending.decision.complete(false)
                                             return@collect
                                         }
-                                        if (remoteClientManager.isAllowed(clientId) ||
-                                            (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
-                                        ) {
+                                        if (access == RemoteAccess.AUTO_APPROVE) {
                                             pending.decision.complete(true)
                                             remoteActivityNotifications.add(RemoteActivityNotification(
                                                 type = RemoteEventType.PRESENTATION_CONNECT,
@@ -1419,15 +1413,16 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     companionServer.onQaAdminConnect.collect { pending ->
                                         val clientId = pending.clientId
-                                        if (remoteClientManager.isBlocked(clientId) ||
-                                            (clientId.isNotBlank() && sessionBlockedClients.contains(clientId))
-                                        ) {
+                                        val access = remoteAccessDecision(
+                                            clientId,
+                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                            sessionAllowedClients, sessionBlockedClients,
+                                        )
+                                        if (access == RemoteAccess.AUTO_REJECT) {
                                             pending.decision.complete(false)
                                             return@collect
                                         }
-                                        if (remoteClientManager.isAllowed(clientId) ||
-                                            (clientId.isNotBlank() && sessionAllowedClients.contains(clientId))
-                                        ) {
+                                        if (access == RemoteAccess.AUTO_APPROVE) {
                                             pending.decision.complete(true)
                                             remoteActivityNotifications.add(RemoteActivityNotification(
                                                 type = RemoteEventType.QA_ADMIN_CONNECT,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteAccess.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteAccess.kt
@@ -1,0 +1,46 @@
+package org.churchpresenter.app.churchpresenter.server
+
+/** What should happen to a remote request before it is applied. */
+internal enum class RemoteAccess {
+    /** The device is trusted — run the request without interrupting the operator. */
+    AUTO_APPROVE,
+
+    /** The device is blocked — refuse without interrupting the operator. */
+    AUTO_REJECT,
+
+    /** Unknown device — the operator decides. */
+    PROMPT,
+}
+
+/**
+ * Decides whether a remote request runs, is refused, or goes to the operator.
+ *
+ * This is what stands between any phone on the church WiFi and the live output, and it was written
+ * out seven times across `main.kt`'s request collectors — in two different spellings, since some
+ * copies split the two block checks and others fused them. Same outcome each way, but a rule that
+ * important is worth having in one place with tests on it.
+ *
+ * Two properties carry the weight:
+ *  - **A block beats an allow.** A device on both lists is refused. Inverting these two checks would
+ *    hand a blocked phone the schedule.
+ *  - **A blank device id is never auto-anything.** Clients that never identified themselves all
+ *    share the empty id, so auto-approving one would approve every anonymous client at once, and
+ *    auto-rejecting one would make their requests vanish without the operator ever seeing them.
+ *    Either way the operator is asked.
+ *
+ * Takes plain collections rather than `RemoteClientManager` on purpose: that class reads and writes
+ * `~/.churchpresenter/remote_clients.json` in its constructor, so a test that built one would touch
+ * the developer's real home directory.
+ */
+internal fun remoteAccessDecision(
+    clientId: String,
+    permanentlyAllowed: Set<String>,
+    permanentlyBlocked: Set<String>,
+    sessionAllowed: Collection<String>,
+    sessionBlocked: Collection<String>,
+): RemoteAccess {
+    if (clientId.isBlank()) return RemoteAccess.PROMPT
+    if (clientId in permanentlyBlocked || clientId in sessionBlocked) return RemoteAccess.AUTO_REJECT
+    if (clientId in permanentlyAllowed || clientId in sessionAllowed) return RemoteAccess.AUTO_APPROVE
+    return RemoteAccess.PROMPT
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteAccessDecisionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteAccessDecisionTest.kt
@@ -1,0 +1,93 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Whether a remote request runs, is refused, or goes to the operator.
+ *
+ * This is the gate between any phone on the church WiFi and the live output. It was written out
+ * seven times across `main.kt`'s request collectors — in two spellings, since some copies split the
+ * block checks and others fused them — with no tests on any of them.
+ *
+ * The two properties worth pinning are both about what happens when the lists disagree or the device
+ * is unknown, which is exactly where seven hand-written copies were free to drift.
+ *
+ * Plain sets, no fixtures: the function takes collections rather than `RemoteClientManager`
+ * precisely so a test never touches `~/.churchpresenter/remote_clients.json`.
+ */
+class RemoteAccessDecisionTest {
+
+    private fun decide(
+        clientId: String,
+        allowed: Set<String> = emptySet(),
+        blocked: Set<String> = emptySet(),
+        sessionAllowed: List<String> = emptyList(),
+        sessionBlocked: List<String> = emptyList(),
+    ) = remoteAccessDecision(clientId, allowed, blocked, sessionAllowed, sessionBlocked)
+
+    // ── Blocks beat allows ──────────────────────────────────────────────────────
+
+    @Test
+    fun `a device on both lists is refused`() {
+        // The ordering is the security property. Swapping these two checks would hand a device the
+        // operator had explicitly blocked the run of the schedule.
+        assertEquals(
+            RemoteAccess.AUTO_REJECT,
+            decide("phone-1", allowed = setOf("phone-1"), blocked = setOf("phone-1")),
+        )
+    }
+
+    @Test
+    fun `blocking for the session overrides a permanent allow`() {
+        // How an operator shuts up a device mid-service without editing its permanent entry.
+        assertEquals(
+            RemoteAccess.AUTO_REJECT,
+            decide("phone-1", allowed = setOf("phone-1"), sessionBlocked = listOf("phone-1")),
+        )
+    }
+
+    // ── The ordinary cases ──────────────────────────────────────────────────────
+
+    @Test
+    fun `a permanently allowed device runs without interrupting the operator`() {
+        assertEquals(RemoteAccess.AUTO_APPROVE, decide("phone-1", allowed = setOf("phone-1")))
+    }
+
+    @Test
+    fun `a device allowed for the session runs too`() {
+        assertEquals(RemoteAccess.AUTO_APPROVE, decide("phone-1", sessionAllowed = listOf("phone-1")))
+    }
+
+    @Test
+    fun `a permanently blocked device is refused without interrupting the operator`() {
+        assertEquals(RemoteAccess.AUTO_REJECT, decide("phone-1", blocked = setOf("phone-1")))
+    }
+
+    @Test
+    fun `an unknown device is put to the operator`() {
+        assertEquals(RemoteAccess.PROMPT, decide("phone-1"))
+    }
+
+    // ── The anonymous client ────────────────────────────────────────────────────
+
+    @Test
+    fun `a device that never identified itself is never auto-approved`() {
+        // Every client that did not send an id shares the blank one, so auto-approving on a blank id
+        // would approve all of them at once off a single earlier decision.
+        assertEquals(
+            RemoteAccess.PROMPT,
+            decide("", allowed = setOf(""), sessionAllowed = listOf("")),
+        )
+    }
+
+    @Test
+    fun `a device that never identified itself is not silently refused either`() {
+        // The other half: a blank id must not vanish into an auto-reject, or an anonymous request
+        // disappears without the operator ever being given the chance to allow it.
+        assertEquals(
+            RemoteAccess.PROMPT,
+            decide("", blocked = setOf(""), sessionBlocked = listOf("")),
+        )
+    }
+}


### PR DESCRIPTION
PR 2 of the extraction plan, now that #165 has landed and `main.kt` has settled.

The gate deciding whether a remote request **runs, is refused, or goes to the operator** was written out **seven times** across `main.kt`'s request collectors — in three spellings: two split the permanent- and session-block checks, two fused them with explanatory comments, three fused them with no comments at all. Same outcome from each, and **no tests on any of them**.

This is what stands between any phone on the church WiFi and the live output.

## The two properties worth pinning

- **A block beats an allow.** A device on both lists is refused. Inverting the two checks would hand a device the operator had explicitly blocked the run of the schedule.
- **A blank device id is never auto-anything.** Every client that did not identify itself shares the empty id — so auto-approving on a blank id would approve all of them off a single earlier decision, and auto-rejecting would make anonymous requests vanish before the operator ever saw them. Either way it prompts.

Both were implicit in fourteen hand-written conditions before; now each is one line with a test on it.

## Design note

`remoteAccessDecision` takes **plain collections rather than `RemoteClientManager`** on purpose: that class reads and writes `~/.churchpresenter/remote_clients.json` in its constructor, so a test that built one would touch the developer's real home directory — the `user.home` leak `AGENT.md` rules out.

Hoisting the blank check to the top is equivalent to the old code, where `isAllowed`/`isBlocked` each guard on `isNotBlank()` internally.

**No behaviour change** — all three spellings produced the same outcome, which is exactly why they were able to drift apart without anyone noticing.

## Coverage

`main.kt` loses another 56 lines from a file excluded from the coverage gate; `RemoteAccess.kt` lands at **100%**. Project 82.57% → **82.63%**.

Across #165 and this PR, **260 lines have moved out of the ungated app root into gated, tested code.**

## Scope check

The two remaining `sessionBlockedClients` references in `main.kt` are the *"block for this session"* mutation handlers, not the gate — correctly left alone.

## Verification

- `./gradlew :composeApp:check` — full suite plus the 75% gate, green.
- `--tests '*RemoteAccess*' --tests '*AddScheduleItem*' --tests '*ExecuteProjectItem*' --rerun-tasks` three consecutive times, green. 8 tests, 0.02s, no fakes at all — it is a pure function.
