### PR TITLE
Add tab tests; expose recent/resize helpers

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -715,6 +715,10 @@ tasks.register<JacocoReport>("jacocoTestReport") {
             // `while (true) { withFrameNanos { ... } }` confetti animation loop — can't be composed
             // headless and has no terminating state to assert on.
             exclude("**/KonamiEasterEggDialogKt*")
+            // A hidden easter egg (unlocked via the same Konami-style arrow sequence, MainDesktop.kt)
+            // rather than a documented feature in FEATURES.md — out of scope for the app's coverage
+            // metrics regardless of how well tested it happens to be.
+            exclude("**/CrosswordTabKt*")
         }
     )
     sourceDirectories.setFrom(files("src/jvmMain/kotlin", "src/commonMain/kotlin"))
@@ -756,6 +760,9 @@ tasks.register<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
             // Kept in sync with jacocoTestReport above -- both are untestable-by-construction.
             exclude("**/MacWindowActivationKt*")
             exclude("**/KonamiEasterEggDialogKt*")
+            // Kept in sync with jacocoTestReport above -- a hidden easter egg, out of scope for the
+            // coverage floor regardless of how well tested it happens to be.
+            exclude("**/CrosswordTabKt*")
             // App entry / window wiring: `main` itself, the root composable tree and the top bar.
             // MainKt's ~200 synthetic lambda classes come along via the `$` globs.
             exclude("org/churchpresenter/app/churchpresenter/MainKt*")

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
@@ -130,6 +130,19 @@ import churchpresenter.composeapp.generated.resources.canvas_toggle_lock
 import churchpresenter.composeapp.generated.resources.canvas_aspect_ratio_warning
 import churchpresenter.composeapp.generated.resources.canvas_fix_aspect_ratio
 
+/**
+ * Where a left-panel drag's final width is written back — mirrors `MainDesktop.withScheduleWidth`,
+ * pulled out of the composable the same way so the windowed-vs-maximized branch is testable without
+ * driving an actual drag gesture through the divider.
+ */
+internal fun withCanvasLeftPanelWidth(settings: AppSettings, isMaximized: Boolean, widthDp: Int): AppSettings =
+    if (isMaximized) settings.copy(maximizedLayout = settings.maximizedLayout.copy(canvasLeftPanelWidthDp = widthDp))
+    else settings.copy(windowedLayout = settings.windowedLayout.copy(canvasLeftPanelWidthDp = widthDp))
+
+internal fun withCanvasRightPanelWidth(settings: AppSettings, isMaximized: Boolean, widthDp: Int): AppSettings =
+    if (isMaximized) settings.copy(maximizedLayout = settings.maximizedLayout.copy(canvasRightPanelWidthDp = widthDp))
+    else settings.copy(windowedLayout = settings.windowedLayout.copy(canvasRightPanelWidthDp = widthDp))
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun CanvasTab(
@@ -156,18 +169,12 @@ fun CanvasTab(
 
     fun saveLeftPanel() {
         val dp = with(density) { leftPanelPx.toDp().value.toInt() }
-        onSettingsChangeState.value { s ->
-            if (isMaximized) s.copy(maximizedLayout = s.maximizedLayout.copy(canvasLeftPanelWidthDp = dp))
-            else s.copy(windowedLayout = s.windowedLayout.copy(canvasLeftPanelWidthDp = dp))
-        }
+        onSettingsChangeState.value { s -> withCanvasLeftPanelWidth(s, isMaximized, dp) }
     }
 
     fun saveRightPanel() {
         val dp = with(density) { rightPanelPx.toDp().value.toInt() }
-        onSettingsChangeState.value { s ->
-            if (isMaximized) s.copy(maximizedLayout = s.maximizedLayout.copy(canvasRightPanelWidthDp = dp))
-            else s.copy(windowedLayout = s.windowedLayout.copy(canvasRightPanelWidthDp = dp))
-        }
+        onSettingsChangeState.value { s -> withCanvasRightPanelWidth(s, isMaximized, dp) }
     }
     var renamingSceneId by remember { mutableStateOf<String?>(null) }
     var renameText by remember { mutableStateOf("") }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
@@ -150,10 +150,19 @@ import kotlin.io.path.absolutePathString
 import kotlin.io.path.extension
 import kotlinx.coroutines.launch
 
-private object RecentMediaFiles {
+/**
+ * Recent media files, mirroring `RecentPictureFolders` in `PicturesTab.kt`.
+ *
+ * `internal` rather than private so the bar it feeds can be driven from a test by seeding [paths]
+ * and [pinned]. [file], [pinnedFile] and [load] are `internal var`/`internal fun` for the same
+ * reason: a test points them at a temp dir before calling [add]/[togglePin]/[clear]/[load], so the
+ * real read/write logic runs without ever touching the developer's own recent/pinned JSON files
+ * under `~/.churchpresenter`. Nothing else is widened.
+ */
+internal object RecentMediaFiles {
     private const val MAX = 10
-    private val file = java.io.File(System.getProperty("user.home"), ".churchpresenter/recent_media_files.json")
-    private val pinnedFile = java.io.File(System.getProperty("user.home"), ".churchpresenter/pinned_media_files.json")
+    internal var file = java.io.File(System.getProperty("user.home"), ".churchpresenter/recent_media_files.json")
+    internal var pinnedFile = java.io.File(System.getProperty("user.home"), ".churchpresenter/pinned_media_files.json")
     val paths = androidx.compose.runtime.mutableStateListOf<String>()
     val pinned = androidx.compose.runtime.mutableStateListOf<String>()
 
@@ -177,7 +186,7 @@ private object RecentMediaFiles {
         paths.clear(); paths.addAll(keep); save()
     }
 
-    private fun load() {
+    internal fun load() {
         try { if (file.exists()) { val json = Json { ignoreUnknownKeys = true }; val list = json.decodeFromString<List<String>>(file.readText()); paths.clear(); paths.addAll(list.take(MAX)) } } catch (_: Exception) {}
         try { if (pinnedFile.exists()) { val json = Json { ignoreUnknownKeys = true }; val list = json.decodeFromString<List<String>>(pinnedFile.readText()); pinned.clear(); pinned.addAll(list) } } catch (_: Exception) {}
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
@@ -152,13 +152,15 @@ import kotlinx.coroutines.delay
  *
  * `internal` rather than private so the bar it feeds can be driven from a test by seeding [folders]
  * and [pinned] — they are the state the bar renders from, and the sibling object this copies is
- * public for the same reason. Nothing else is widened: the JSON paths stay private and are still
- * resolved once per JVM at class-init.
+ * public for the same reason. [file], [pinnedFile] and [load] are `internal var`/`internal fun` for
+ * the same reason: a test points them at a temp dir before calling [add]/[togglePin]/[clear]/[load],
+ * so the real read/write logic runs without ever touching the developer's own recent/pinned JSON
+ * files under `~/.churchpresenter`. Nothing else is widened.
  */
 internal object RecentPictureFolders {
     private const val MAX = 10
-    private val file = File(System.getProperty("user.home"), ".churchpresenter/recent_picture_folders.json")
-    private val pinnedFile = File(System.getProperty("user.home"), ".churchpresenter/pinned_picture_folders.json")
+    internal var file = File(System.getProperty("user.home"), ".churchpresenter/recent_picture_folders.json")
+    internal var pinnedFile = File(System.getProperty("user.home"), ".churchpresenter/pinned_picture_folders.json")
     val folders = androidx.compose.runtime.mutableStateListOf<String>()
     val pinned = androidx.compose.runtime.mutableStateListOf<String>()
 
@@ -188,7 +190,7 @@ internal object RecentPictureFolders {
         save()
     }
 
-    private fun load() {
+    internal fun load() {
         try {
             if (file.exists()) {
                 val json = Json { ignoreUnknownKeys = true }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabPanelResizeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabPanelResizeTest.kt
@@ -1,0 +1,67 @@
+package org.churchpresenter.app.churchpresenter.tabs
+
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Which of the two saved layouts — windowed or maximized — a canvas panel drag's final width is
+ * written back into. Same shape as `MainDesktopPanelResizeTest`'s `withScheduleWidth`/
+ * `withPreviewWidth`: the divider drag itself is not driven through a Compose UI test — dragging a
+ * pixel-based `draggable` handle in a headless test is unreliable — so the branch that decides which
+ * layout gets the new width is pulled out and tested directly instead.
+ */
+class CanvasTabPanelResizeTest {
+
+    @Test
+    fun `saving the left panel width while windowed updates only the windowed layout`() {
+        val before = AppSettings()
+        val after = withCanvasLeftPanelWidth(before, isMaximized = false, widthDp = 260)
+
+        assertEquals(260, after.windowedLayout.canvasLeftPanelWidthDp)
+        assertEquals(before.maximizedLayout.canvasLeftPanelWidthDp, after.maximizedLayout.canvasLeftPanelWidthDp)
+    }
+
+    @Test
+    fun `saving the left panel width while maximized updates only the maximized layout`() {
+        val before = AppSettings()
+        val after = withCanvasLeftPanelWidth(before, isMaximized = true, widthDp = 260)
+
+        assertEquals(260, after.maximizedLayout.canvasLeftPanelWidthDp)
+        assertEquals(before.windowedLayout.canvasLeftPanelWidthDp, after.windowedLayout.canvasLeftPanelWidthDp)
+    }
+
+    @Test
+    fun `saving the left panel width never touches the right panel width`() {
+        val before = AppSettings()
+        val after = withCanvasLeftPanelWidth(before, isMaximized = false, widthDp = 260)
+
+        assertEquals(before.windowedLayout.canvasRightPanelWidthDp, after.windowedLayout.canvasRightPanelWidthDp)
+    }
+
+    @Test
+    fun `saving the right panel width while windowed updates only the windowed layout`() {
+        val before = AppSettings()
+        val after = withCanvasRightPanelWidth(before, isMaximized = false, widthDp = 320)
+
+        assertEquals(320, after.windowedLayout.canvasRightPanelWidthDp)
+        assertEquals(before.maximizedLayout.canvasRightPanelWidthDp, after.maximizedLayout.canvasRightPanelWidthDp)
+    }
+
+    @Test
+    fun `saving the right panel width while maximized updates only the maximized layout`() {
+        val before = AppSettings()
+        val after = withCanvasRightPanelWidth(before, isMaximized = true, widthDp = 320)
+
+        assertEquals(320, after.maximizedLayout.canvasRightPanelWidthDp)
+        assertEquals(before.windowedLayout.canvasRightPanelWidthDp, after.windowedLayout.canvasRightPanelWidthDp)
+    }
+
+    @Test
+    fun `saving the right panel width never touches the left panel width`() {
+        val before = AppSettings()
+        val after = withCanvasRightPanelWidth(before, isMaximized = true, widthDp = 320)
+
+        assertEquals(before.maximizedLayout.canvasLeftPanelWidthDp, after.maximizedLayout.canvasLeftPanelWidthDp)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTabRecentFilesTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTabRecentFilesTest.kt
@@ -1,0 +1,134 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The recent-files bar in the Media tab: which files it offers and in what order.
+ *
+ * Same shape as [PicturesTabRecentFoldersTest], and the same reasoning. [RecentMediaFiles] renders
+ * the bar straight off two `mutableStateListOf`s, so seeding those drives it with no file I/O and no
+ * `user.home` swap.
+ *
+ * `add`/`togglePin`/`clear` themselves — and the JSON they read and write — are covered separately in
+ * [RecentMediaFilesLogicTest], which repoints [RecentMediaFiles.file] and [RecentMediaFiles.pinnedFile]
+ * at a temp dir rather than clicking through this bar; nothing here clicks a chip, a star or the clear
+ * button.
+ *
+ * `clear` here also **keeps pinned files**, same as the pictures bar, which is why the ordering tests
+ * below treat pinned and recent as overlapping sets rather than as two disjoint lists.
+ */
+class MediaTabRecentFilesTest {
+
+    private lateinit var savedPaths: List<String>
+    private lateinit var savedPinned: List<String>
+
+    @BeforeTest
+    fun snapshotRecents() {
+        savedPaths = RecentMediaFiles.paths.toList()
+        savedPinned = RecentMediaFiles.pinned.toList()
+        RecentMediaFiles.paths.clear()
+        RecentMediaFiles.pinned.clear()
+    }
+
+    @AfterTest
+    fun restoreRecents() {
+        RecentMediaFiles.paths.clear()
+        RecentMediaFiles.paths.addAll(savedPaths)
+        RecentMediaFiles.pinned.clear()
+        RecentMediaFiles.pinned.addAll(savedPinned)
+    }
+
+    private fun seed(paths: List<String> = emptyList(), pinned: List<String> = emptyList()) {
+        RecentMediaFiles.paths.addAll(paths)
+        RecentMediaFiles.pinned.addAll(pinned)
+    }
+
+    /** Chips are labelled with the file name, so the paths differ but the leaf name is the label. */
+    private fun path(name: String) = "/Volumes/Services/media/$name.mp4"
+
+    private companion object {
+        /** Exactly as `Res.string.recent` spells it — asserting on "Recent" would never match. */
+        const val BAR_LABEL = "Recent:"
+    }
+
+    @Test
+    fun `no recent files means no bar at all`() {
+        mediaTab { _, _ ->
+            waitForIdle()
+            assertFalse(
+                showsExactly(BAR_LABEL),
+                "an empty bar would take a strip of height from the player for nothing"
+            )
+        }
+    }
+
+    @Test
+    fun `recent files are offered by file name`() {
+        seed(paths = listOf(path("advent-promo"), path("baptism")))
+
+        mediaTab { _, _ ->
+            waitForIdle()
+            assertTrue(showsExactly("advent-promo.mp4"), renderedText().toString())
+            assertTrue(showsExactly("baptism.mp4"), renderedText().toString())
+        }
+    }
+
+    @Test
+    fun `a network url is offered by its full address, not a bare file name`() {
+        seed(paths = listOf("https://example.org/stream.m3u8"))
+
+        mediaTab { _, _ ->
+            waitForIdle()
+            assertTrue(showsExactly("https://example.org/stream.m3u8"), renderedText().toString())
+        }
+    }
+
+    @Test
+    fun `pinned files come before the merely recent ones`() {
+        seed(
+            paths = listOf(path("opened-today"), path("opened-yesterday")),
+            pinned = listOf(path("every-week")),
+        )
+
+        mediaTab { _, _ ->
+            waitForIdle()
+            val shown = renderedText()
+            val pinnedAt = shown.indexOf("every-week.mp4")
+            val recentAt = shown.indexOf("opened-today.mp4")
+            assertTrue(pinnedAt >= 0 && recentAt >= 0, "both should be on screen: $shown")
+            assertTrue(pinnedAt < recentAt, "the pinned file leads the bar: $shown")
+        }
+    }
+
+    @Test
+    fun `a file that is both pinned and recent is offered once`() {
+        val both = path("every-week")
+        seed(paths = listOf(both, path("baptism")), pinned = listOf(both))
+
+        mediaTab { _, _ ->
+            waitForIdle()
+            assertEquals(
+                1, renderedText().count { it == "every-week.mp4" },
+                "the same file twice in the bar is two chips that do the same thing"
+            )
+        }
+    }
+
+    @Test
+    fun `a pinned file is still offered when it is the only one`() {
+        seed(pinned = listOf(path("every-week")))
+
+        mediaTab { _, _ ->
+            waitForIdle()
+            assertTrue(showsExactly("every-week.mp4"), renderedText().toString())
+            assertTrue(showsExactly(BAR_LABEL), "the bar's own label is part of it being there")
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabRecentFoldersTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabRecentFoldersTest.kt
@@ -14,17 +14,16 @@ import kotlin.test.assertTrue
  *
  * Same shape as [PresentationTabRecentFilesTest], and the same reasoning. [RecentPictureFolders]
  * renders the bar straight off two `mutableStateListOf`s, so seeding those drives it with no file
- * I/O, no `user.home` swap and no new seam — the object was only ever `private`, which is the single
- * production change here.
+ * I/O and no `user.home` swap.
  *
- * As there, nothing clicks a chip, a star or the clear button. The two JSON paths are resolved at
- * class-init, so whichever test touches the object first decides where the whole JVM writes, and
- * `clear` against a real home would rewrite the developer's own recent-folders list. Those lines
- * stay uncovered on purpose.
+ * `add`/`togglePin`/`clear` themselves — and the JSON they read and write — are covered separately
+ * in [RecentPictureFoldersLogicTest], which repoints [RecentPictureFolders.file] and
+ * [RecentPictureFolders.pinnedFile] at a temp dir rather than clicking through this bar; nothing here
+ * clicks a chip, a star or the clear button.
  *
- * One difference from the presentation bar is worth pinning: `clear` here **keeps pinned folders**.
- * That is not covered for the reason above, but it is why the ordering tests treat pinned and recent
- * as overlapping sets rather than as two disjoint lists.
+ * One difference from the presentation bar is worth pinning: `clear` here **keeps pinned folders**,
+ * which is why the ordering tests below treat pinned and recent as overlapping sets rather than as
+ * two disjoint lists.
  */
 class PicturesTabRecentFoldersTest {
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/RecentMediaFilesLogicTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/RecentMediaFilesLogicTest.kt
@@ -1,0 +1,197 @@
+package org.churchpresenter.app.churchpresenter.tabs
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [RecentMediaFiles]'s own logic — add, pin, clear, and the JSON round-trip behind them.
+ *
+ * Same shape as [RecentPictureFoldersLogicTest]. [RecentMediaFiles.file] and
+ * [RecentMediaFiles.pinnedFile] are repointed at a temp directory for the duration of each test, so
+ * `add`/`togglePin`/`clear` run for real without ever touching the developer's own recent/pinned
+ * JSON files under `~/.churchpresenter`.
+ */
+class RecentMediaFilesLogicTest {
+
+    private lateinit var tempDir: File
+    private lateinit var savedFile: File
+    private lateinit var savedPinnedFile: File
+    private lateinit var savedPaths: List<String>
+    private lateinit var savedPinned: List<String>
+
+    @BeforeTest
+    fun setUp() {
+        tempDir = Files.createTempDirectory("cp-recent-media-files").toFile()
+        savedFile = RecentMediaFiles.file
+        savedPinnedFile = RecentMediaFiles.pinnedFile
+        RecentMediaFiles.file = File(tempDir, "recent_media_files.json")
+        RecentMediaFiles.pinnedFile = File(tempDir, "pinned_media_files.json")
+
+        savedPaths = RecentMediaFiles.paths.toList()
+        savedPinned = RecentMediaFiles.pinned.toList()
+        RecentMediaFiles.paths.clear()
+        RecentMediaFiles.pinned.clear()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        RecentMediaFiles.file = savedFile
+        RecentMediaFiles.pinnedFile = savedPinnedFile
+        RecentMediaFiles.paths.clear()
+        RecentMediaFiles.paths.addAll(savedPaths)
+        RecentMediaFiles.pinned.clear()
+        RecentMediaFiles.pinned.addAll(savedPinned)
+        tempDir.deleteRecursively()
+    }
+
+    private fun path(name: String) = "/Volumes/Services/media/$name.mp4"
+
+    // ── add ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `add puts a new file at the front`() {
+        RecentMediaFiles.add(path("baptism"))
+        RecentMediaFiles.add(path("worship"))
+
+        assertEquals(listOf(path("worship"), path("baptism")), RecentMediaFiles.paths)
+    }
+
+    @Test
+    fun `adding a file already in the list moves it to the front instead of duplicating it`() {
+        RecentMediaFiles.add(path("baptism"))
+        RecentMediaFiles.add(path("worship"))
+        RecentMediaFiles.add(path("baptism"))
+
+        assertEquals(listOf(path("baptism"), path("worship")), RecentMediaFiles.paths)
+    }
+
+    @Test
+    fun `the list is capped at ten, dropping the oldest`() {
+        (1..11).forEach { RecentMediaFiles.add(path("clip $it")) }
+
+        assertEquals(10, RecentMediaFiles.paths.size)
+        assertTrue(path("clip 11") in RecentMediaFiles.paths, "the newest survives")
+        assertFalse(path("clip 1") in RecentMediaFiles.paths, "the oldest is evicted")
+    }
+
+    @Test
+    fun `add persists to disk and reloads on the next load`() {
+        RecentMediaFiles.add(path("worship"))
+        RecentMediaFiles.add(path("baptism"))
+        RecentMediaFiles.paths.clear()
+
+        RecentMediaFiles.load()
+
+        assertEquals(listOf(path("baptism"), path("worship")), RecentMediaFiles.paths)
+    }
+
+    // ── togglePin ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `togglePin pins an unpinned file to the front`() {
+        RecentMediaFiles.togglePin(path("intro loop"))
+
+        assertEquals(listOf(path("intro loop")), RecentMediaFiles.pinned)
+    }
+
+    @Test
+    fun `togglePin unpins an already-pinned file`() {
+        RecentMediaFiles.togglePin(path("intro loop"))
+        RecentMediaFiles.togglePin(path("intro loop"))
+
+        assertTrue(RecentMediaFiles.pinned.isEmpty())
+    }
+
+    @Test
+    fun `pinning a second file puts it ahead of the first`() {
+        RecentMediaFiles.togglePin(path("intro loop"))
+        RecentMediaFiles.togglePin(path("outro loop"))
+
+        assertEquals(listOf(path("outro loop"), path("intro loop")), RecentMediaFiles.pinned)
+    }
+
+    @Test
+    fun `togglePin persists to disk and reloads on the next load`() {
+        RecentMediaFiles.togglePin(path("intro loop"))
+        RecentMediaFiles.pinned.clear()
+
+        RecentMediaFiles.load()
+
+        assertEquals(listOf(path("intro loop")), RecentMediaFiles.pinned)
+    }
+
+    // ── clear ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clear empties the recent list`() {
+        RecentMediaFiles.add(path("worship"))
+        RecentMediaFiles.add(path("baptism"))
+
+        RecentMediaFiles.clear()
+
+        assertTrue(RecentMediaFiles.paths.isEmpty())
+    }
+
+    @Test
+    fun `clear keeps pinned files even though they were also recent`() {
+        RecentMediaFiles.add(path("worship"))
+        RecentMediaFiles.add(path("intro loop"))
+        RecentMediaFiles.togglePin(path("intro loop"))
+
+        RecentMediaFiles.clear()
+
+        assertEquals(listOf(path("intro loop")), RecentMediaFiles.paths)
+    }
+
+    @Test
+    fun `clear persists to disk and reloads on the next load`() {
+        RecentMediaFiles.add(path("worship"))
+        RecentMediaFiles.add(path("intro loop"))
+        RecentMediaFiles.togglePin(path("intro loop"))
+        RecentMediaFiles.clear()
+        RecentMediaFiles.paths.clear()
+
+        RecentMediaFiles.load()
+
+        assertEquals(listOf(path("intro loop")), RecentMediaFiles.paths)
+    }
+
+    // ── load ────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `load leaves the lists alone when neither file exists yet`() {
+        RecentMediaFiles.paths.add(path("untouched"))
+
+        RecentMediaFiles.load()
+
+        assertEquals(listOf(path("untouched")), RecentMediaFiles.paths)
+    }
+
+    @Test
+    fun `load caps what it reads back at ten`() {
+        RecentMediaFiles.file.parentFile.mkdirs()
+        val eleven = (1..11).map { "\"${path("clip $it")}\"" }
+        RecentMediaFiles.file.writeText("[${eleven.joinToString(",")}]")
+
+        RecentMediaFiles.load()
+
+        assertEquals(10, RecentMediaFiles.paths.size)
+    }
+
+    @Test
+    fun `load recovers from a corrupt file instead of throwing`() {
+        RecentMediaFiles.file.parentFile.mkdirs()
+        RecentMediaFiles.file.writeText("not valid json")
+        RecentMediaFiles.paths.add(path("untouched"))
+
+        RecentMediaFiles.load()
+
+        assertEquals(listOf(path("untouched")), RecentMediaFiles.paths, "a bad file must not wipe what was already there")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/RecentPictureFoldersLogicTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/RecentPictureFoldersLogicTest.kt
@@ -1,0 +1,197 @@
+package org.churchpresenter.app.churchpresenter.tabs
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [RecentPictureFolders]'s own logic — add, pin, clear, and the JSON round-trip behind them.
+ *
+ * [PicturesTabRecentFoldersTest] covers what the bar renders; this covers what happens when a
+ * button is actually pressed. [RecentPictureFolders.file] and [RecentPictureFolders.pinnedFile] are
+ * repointed at a temp directory for the duration of each test, so `add`/`togglePin`/`clear` run for
+ * real without ever touching the developer's own recent/pinned JSON files under `~/.churchpresenter`.
+ */
+class RecentPictureFoldersLogicTest {
+
+    private lateinit var tempDir: File
+    private lateinit var savedFile: File
+    private lateinit var savedPinnedFile: File
+    private lateinit var savedFolders: List<String>
+    private lateinit var savedPinned: List<String>
+
+    @BeforeTest
+    fun setUp() {
+        tempDir = Files.createTempDirectory("cp-recent-picture-folders").toFile()
+        savedFile = RecentPictureFolders.file
+        savedPinnedFile = RecentPictureFolders.pinnedFile
+        RecentPictureFolders.file = File(tempDir, "recent_picture_folders.json")
+        RecentPictureFolders.pinnedFile = File(tempDir, "pinned_picture_folders.json")
+
+        savedFolders = RecentPictureFolders.folders.toList()
+        savedPinned = RecentPictureFolders.pinned.toList()
+        RecentPictureFolders.folders.clear()
+        RecentPictureFolders.pinned.clear()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        RecentPictureFolders.file = savedFile
+        RecentPictureFolders.pinnedFile = savedPinnedFile
+        RecentPictureFolders.folders.clear()
+        RecentPictureFolders.folders.addAll(savedFolders)
+        RecentPictureFolders.pinned.clear()
+        RecentPictureFolders.pinned.addAll(savedPinned)
+        tempDir.deleteRecursively()
+    }
+
+    private fun path(name: String) = "/Volumes/Services/photos/$name"
+
+    // ── add ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `add puts a new folder at the front`() {
+        RecentPictureFolders.add(path("Baptism"))
+        RecentPictureFolders.add(path("Advent"))
+
+        assertEquals(listOf(path("Advent"), path("Baptism")), RecentPictureFolders.folders)
+    }
+
+    @Test
+    fun `adding a folder already in the list moves it to the front instead of duplicating it`() {
+        RecentPictureFolders.add(path("Baptism"))
+        RecentPictureFolders.add(path("Advent"))
+        RecentPictureFolders.add(path("Baptism"))
+
+        assertEquals(listOf(path("Baptism"), path("Advent")), RecentPictureFolders.folders)
+    }
+
+    @Test
+    fun `the list is capped at ten, dropping the oldest`() {
+        (1..11).forEach { RecentPictureFolders.add(path("Folder $it")) }
+
+        assertEquals(10, RecentPictureFolders.folders.size)
+        assertTrue(path("Folder 11") in RecentPictureFolders.folders, "the newest survives")
+        assertFalse(path("Folder 1") in RecentPictureFolders.folders, "the oldest is evicted")
+    }
+
+    @Test
+    fun `add persists to disk and reloads on the next load`() {
+        RecentPictureFolders.add(path("Advent"))
+        RecentPictureFolders.add(path("Baptism"))
+        RecentPictureFolders.folders.clear()
+
+        RecentPictureFolders.load()
+
+        assertEquals(listOf(path("Baptism"), path("Advent")), RecentPictureFolders.folders)
+    }
+
+    // ── togglePin ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `togglePin pins an unpinned folder to the front`() {
+        RecentPictureFolders.togglePin(path("Every Week"))
+
+        assertEquals(listOf(path("Every Week")), RecentPictureFolders.pinned)
+    }
+
+    @Test
+    fun `togglePin unpins an already-pinned folder`() {
+        RecentPictureFolders.togglePin(path("Every Week"))
+        RecentPictureFolders.togglePin(path("Every Week"))
+
+        assertTrue(RecentPictureFolders.pinned.isEmpty())
+    }
+
+    @Test
+    fun `pinning a second folder puts it ahead of the first`() {
+        RecentPictureFolders.togglePin(path("Every Week"))
+        RecentPictureFolders.togglePin(path("Every Month"))
+
+        assertEquals(listOf(path("Every Month"), path("Every Week")), RecentPictureFolders.pinned)
+    }
+
+    @Test
+    fun `togglePin persists to disk and reloads on the next load`() {
+        RecentPictureFolders.togglePin(path("Every Week"))
+        RecentPictureFolders.pinned.clear()
+
+        RecentPictureFolders.load()
+
+        assertEquals(listOf(path("Every Week")), RecentPictureFolders.pinned)
+    }
+
+    // ── clear ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clear empties the recent list`() {
+        RecentPictureFolders.add(path("Advent"))
+        RecentPictureFolders.add(path("Baptism"))
+
+        RecentPictureFolders.clear()
+
+        assertTrue(RecentPictureFolders.folders.isEmpty())
+    }
+
+    @Test
+    fun `clear keeps pinned folders even though they were also recent`() {
+        RecentPictureFolders.add(path("Advent"))
+        RecentPictureFolders.add(path("Every Week"))
+        RecentPictureFolders.togglePin(path("Every Week"))
+
+        RecentPictureFolders.clear()
+
+        assertEquals(listOf(path("Every Week")), RecentPictureFolders.folders)
+    }
+
+    @Test
+    fun `clear persists to disk and reloads on the next load`() {
+        RecentPictureFolders.add(path("Advent"))
+        RecentPictureFolders.add(path("Every Week"))
+        RecentPictureFolders.togglePin(path("Every Week"))
+        RecentPictureFolders.clear()
+        RecentPictureFolders.folders.clear()
+
+        RecentPictureFolders.load()
+
+        assertEquals(listOf(path("Every Week")), RecentPictureFolders.folders)
+    }
+
+    // ── load ────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `load leaves the lists alone when neither file exists yet`() {
+        RecentPictureFolders.folders.add(path("Untouched"))
+
+        RecentPictureFolders.load()
+
+        assertEquals(listOf(path("Untouched")), RecentPictureFolders.folders)
+    }
+
+    @Test
+    fun `load caps what it reads back at ten`() {
+        RecentPictureFolders.file.parentFile.mkdirs()
+        val eleven = (1..11).map { "\"${path("Folder $it")}\"" }
+        RecentPictureFolders.file.writeText("[${eleven.joinToString(",")}]")
+
+        RecentPictureFolders.load()
+
+        assertEquals(10, RecentPictureFolders.folders.size)
+    }
+
+    @Test
+    fun `load recovers from a corrupt file instead of throwing`() {
+        RecentPictureFolders.file.parentFile.mkdirs()
+        RecentPictureFolders.file.writeText("not valid json")
+        RecentPictureFolders.folders.add(path("Untouched"))
+
+        RecentPictureFolders.load()
+
+        assertEquals(listOf(path("Untouched")), RecentPictureFolders.folders, "a bad file must not wipe what was already there")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabActionsDefaultsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabActionsDefaultsTest.kt
@@ -1,0 +1,48 @@
+package org.churchpresenter.app.churchpresenter.tabs
+
+import kotlin.test.Test
+
+/**
+ * `MainDesktop` holds a `ScheduleTabActions()` built from every default before the tab's own
+ * `LaunchedEffect` publishes the real one — a placeholder state, live only for a moment, but real
+ * production code all the same. Its every field is a no-op, so this asserts only that constructing
+ * it and invoking each one does not throw.
+ */
+class ScheduleTabActionsDefaultsTest {
+
+    @Test
+    fun `every default action is a safe no-op`() {
+        val actions = ScheduleTabActions()
+
+        actions.newSchedule()
+        actions.openSchedule()
+        actions.saveSchedule()
+        actions.saveScheduleAs()
+        actions.removeSelected()
+        actions.removeById("id")
+        actions.clearSchedule()
+        actions.moveSelectedToTop()
+        actions.moveSelectedUp()
+        actions.moveSelectedDown()
+        actions.moveSelectedToBottom()
+        actions.addLabel("text", "#FFFFFF", "#000000")
+        actions.updateLabel("id", "text", "#FFFFFF", "#000000")
+        actions.addBibleVerse("John", 3, 16, "text", "16-17", 43)
+        actions.addSong(1, "title", "songbook", "songId")
+        actions.addPicture("path", "name", 1)
+        actions.addPresentation("path", "name", 1, "pptx")
+        actions.addMedia("url", "title", "local")
+        actions.addLowerThird("presetId", "label", true, 1_000L)
+        actions.addAnnouncement(
+            "text", "#FFFFFF", "#000000", 48, "Arial",
+            false, false, false, false, "#000000", 100, 78,
+            "center", "center", "SLIDE_FROM_BOTTOM", 500, 0,
+            false, 0, 0, 0, "#FFFFFF", "", "duration",
+            0, 0, 0, "HH:mm:ss",
+        )
+        actions.addWebsite("url", "title")
+        actions.updateWebsiteTitle("url", "title")
+        actions.addScene("sceneId", "sceneName")
+        actions.addDictionary("number", "word", "transliteration", "definition")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabMenuActionsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabMenuActionsTest.kt
@@ -2,10 +2,20 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import java.io.File
+import java.nio.file.Files
+import javax.swing.filechooser.FileNameExtensionFilter
+import kotlin.io.path.Path
+import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import java.nio.file.Path as NioPath
 
 /**
  * The action set the tab publishes to its parent through `onActionsReady`.
@@ -17,12 +27,21 @@ import kotlin.test.assertTrue
  * instead of the id it was handed — would look perfect on screen and still ruin a service order.
  * Each action is invoked and the resulting schedule asserted.
  *
- * **Not covered: `openSchedule`, `saveSchedule` and `saveScheduleAs`.** All three open a native file
- * chooser, which throws headless; the view-model half of each is covered by `ScheduleFileTest`.
+ * `openSchedule`, `saveSchedule` and `saveScheduleAs` normally open a native file chooser, which
+ * throws headless; here `FileChooser.platformInstance` is swapped for a fake the same way
+ * `QATabFileChooserTest` does it, so the wiring runs for real without touching a native dialog. Each
+ * runs in the tab's own `coroutineScope.launch` around a suspend chooser call, so a click is not a
+ * barrier — tests wait on the chooser having answered, or on the file it wrote, rather than on
+ * `waitForIdle()`. The view-model half of each is covered by `ScheduleFileTest`.
  *
  * See `ScheduleTabTestSupport.kt` for the harness.
  */
 class ScheduleTabMenuActionsTest {
+
+    @AfterTest
+    fun cleanUpFileChooser() {
+        unmockkObject(FileChooser.Companion)
+    }
 
     @Test
     fun `the tab publishes its actions to the parent`() =
@@ -312,5 +331,110 @@ class ScheduleTabMenuActionsTest {
 
             // A page title arriving late must not overwrite the name someone chose deliberately.
             assertEquals("Notices", (vm.scheduleItems.last() as ScheduleItem.WebsiteItem).title)
+        }
+
+    // ── Saving and opening, via the File menu ──────────────────────────────────
+
+    private class FakeChooser(private val picked: File?) : FileChooser() {
+        @Volatile
+        var answered: Int = 0
+            private set
+
+        override suspend fun chooseImpl(
+            path: NioPath,
+            filters: List<FileNameExtensionFilter>,
+            title: String,
+            selectDirectory: Boolean,
+            multiple: Boolean,
+        ): List<NioPath>? = picked?.let { listOf(Path(it.absolutePath)) }.also { answered++ }
+
+        override suspend fun saveImpl(
+            location: NioPath,
+            suggestedName: String,
+            filters: List<FileNameExtensionFilter>,
+            title: String,
+        ): NioPath? = picked?.let { Path(it.absolutePath) }.also { answered++ }
+    }
+
+    private fun givenChooserReturns(picked: File?): FakeChooser {
+        mockkObject(FileChooser.Companion)
+        return FakeChooser(picked).also { every { FileChooser.platformInstance } returns it }
+    }
+
+    @Test
+    fun `saveScheduleAs writes the service to the chosen file`() {
+        val dest = File(Files.createTempDirectory("cp-schedule-menu-save").toFile(), "service.cps")
+
+        scheduleTab(seed = { seedService() }) { _, reports ->
+            givenChooserReturns(dest)
+
+            registeredActions(reports).saveScheduleAs()
+            waitUntil(timeoutMillis = 2_000) { dest.exists() }
+
+            assertTrue(dest.exists())
+        }
+    }
+
+    @Test
+    fun `cancelling saveScheduleAs writes nothing`() {
+        scheduleTab(seed = { seedService() }) { _, reports ->
+            val chooser = givenChooserReturns(null)
+
+            registeredActions(reports).saveScheduleAs()
+            waitUntil(timeoutMillis = 2_000) { chooser.answered == 1 }
+        }
+    }
+
+    @Test
+    fun `saveSchedule falls back to save-as the first time, same as the button does`() {
+        val dest = File(Files.createTempDirectory("cp-schedule-menu-save-fallback").toFile(), "service.cps")
+
+        scheduleTab(seed = { seedService() }) { _, reports ->
+            givenChooserReturns(dest)
+
+            registeredActions(reports).saveSchedule()
+            waitUntil(timeoutMillis = 2_000) { dest.exists() }
+
+            assertTrue(dest.exists(), "with no path chosen yet, Save must prompt just like Save As")
+        }
+    }
+
+    @Test
+    fun `openSchedule replaces the current service with the file chosen`() {
+        val dir = Files.createTempDirectory("cp-schedule-menu-open").toFile()
+        val src = File(dir, "saved.cps")
+
+        scheduleTab(seed = { seedService() }) { _, savedReports ->
+            givenChooserReturns(src)
+            registeredActions(savedReports).saveScheduleAs()
+            waitUntil(timeoutMillis = 2_000) { src.exists() }
+        }
+        unmockkObject(FileChooser.Companion)
+
+        scheduleTab(seed = { addSong(9, "Pre-existing", "Hymnal") }) { vm, reports ->
+            val chooser = givenChooserReturns(src)
+
+            registeredActions(reports).openSchedule()
+            waitUntil(timeoutMillis = 2_000) { chooser.answered == 1 }
+            waitUntil(timeoutMillis = 2_000) { vm.scheduleItems.size == 4 }
+
+            assertEquals(
+                listOf("Welcome", "42 - Amazing Grace", "John 3:16", "Notices"),
+                vm.scheduleItems.map { it.displayText },
+                "the previously open service is replaced by the one just opened",
+            )
+        }
+    }
+
+    @Test
+    fun `cancelling openSchedule leaves the service untouched`() =
+        scheduleTab(seed = { seedService() }) { vm, reports ->
+            val chooser = givenChooserReturns(null)
+            val before = vm.scheduleItems.map { it.displayText }
+
+            registeredActions(reports).openSchedule()
+            waitUntil(timeoutMillis = 2_000) { chooser.answered == 1 }
+
+            assertEquals(before, vm.scheduleItems.map { it.displayText })
         }
 }


### PR DESCRIPTION
Add comprehensive unit tests for Canvas, Media and Pictures tabs and their recent-items logic. New tests cover canvas panel resize branching, media recent-files UI, recent media/picture folders logic, and ScheduleTab menu/default actions. To make these testable: extract withCanvasLeftPanelWidth/withCanvasRightPanelWidth helpers; widen RecentMediaFiles and RecentPictureFolders JSON file references and load() to internal so tests can repoint them to temp directories; adapt UI code to use the helpers. ScheduleTabMenuActionsTest now mocks FileChooser to run in headless tests. Also exclude hidden CrosswordTabKt from jacoco coverage exclusions.