### PR TITLE
chore: guard against direct commits on main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Refuse commits made directly on a protected branch.
+# Bypass deliberately with: git commit --no-verify
+
+protected="main master"
+branch=$(git symbolic-ref --short -q HEAD) || exit 0   # detached HEAD (rebase, bisect) — allow
+
+for p in $protected; do
+    if [ "$branch" = "$p" ]; then
+        echo "pre-commit: refusing to commit directly on '$branch'." >&2
+        echo "  Create a branch first:  git switch -c my-change" >&2
+        echo "  To move work you already staged, that branch keeps it." >&2
+        echo "  Override (rarely correct):  git commit --no-verify" >&2
+        exit 1
+    fi
+done
+
+exit 0

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -377,6 +377,24 @@ Submit crash logs by opening a GitHub Issue and attaching the file.
 3. Run `./gradlew :composeApp:run` to verify the build works
 4. Read this entire guide before making changes
 
+### Never commit directly to `main`
+
+`main` is protected on GitHub for everyone, admins included — it takes a pull request with the
+`test` check passing. To catch it earlier, the repo also ships a `pre-commit` hook in `.githooks/`
+that refuses a commit made while `main` (or `master`) is checked out.
+
+Git never clones `core.hooksPath` — a checkout is not allowed to activate hooks on your machine by
+itself — so it is set per working copy. **Any `./gradlew` invocation sets it for you**; the root
+build script does it on configuration when it isn't already pointing at `.githooks`. To set it by
+hand instead:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Work on a branch and open a PR. `git commit --no-verify` skips the hook, but the server-side
+protection still stands, so that only buys you a commit you will have to move onto a branch anyway.
+
 ### Running the tests, per platform
 
 The app's own suite is `./gradlew :composeApp:check`. It needs **JDK 21** and the submodules

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,3 +6,23 @@ plugins {
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
 }
+
+// Point Git at the repo's own hooks directory so every checkout gets the pre-commit branch
+// guard in .githooks/. `core.hooksPath` lives in .git/config, which is never cloned or pushed
+// — Git deliberately refuses to let a clone activate hooks by itself — so it has to be set
+// once per working copy. Doing it here means the first `./gradlew` run wires it up.
+val gitHooksPath = ".githooks"
+if (layout.projectDirectory.file(".git").asFile.exists()) {
+    val current = providers.exec {
+        commandLine("git", "config", "--get", "core.hooksPath")
+        isIgnoreExitValue = true          // exits 1 when the key is simply unset
+    }.standardOutput.asText.map { it.trim() }.getOrElse("")
+
+    if (current != gitHooksPath) {
+        providers.exec {
+            commandLine("git", "config", "core.hooksPath", gitHooksPath)
+            isIgnoreExitValue = true      // a missing/!working git must never fail the build
+        }.result.get()
+        logger.lifecycle("Configured git core.hooksPath = $gitHooksPath")
+    }
+}


### PR DESCRIPTION
Stops accidental commits landing on `main`, for every dev rather than just whoever remembers.

### `.githooks/pre-commit`
Refuses a commit made while `main` or `master` is checked out, and points at `git switch -c`.
Exits 0 on a detached HEAD so rebases and bisects are unaffected. `--no-verify` still overrides it.

### Auto-install in the root build script
`core.hooksPath` lives in `.git/config`, which is never cloned or pushed — Git deliberately won't
let a checkout activate hooks on your machine by itself, so it has to be set once per working copy.
The root `build.gradle.kts` now sets it during configuration whenever it isn't already `.githooks`,
so the first `./gradlew` run wires it up and nobody has to be told. Both `git` calls are
`isIgnoreExitValue = true` so a missing or unhappy git can never fail the build, and the whole block
is skipped when there is no `.git`.

Uses `providers.exec`, which is configuration-cache compatible — it adds no new CC problem. (The
build already reports one, from `git rev-list --count HEAD` in `composeApp/build.gradle.kts`;
untouched here.)

### Alongside this
Branch protection on `main` had `enforce_admins` off, so admins could push straight past the
required PR and `test` check. That is now on — the server-side rule is what actually guarantees it,
and the hook is the ergonomic half that catches it before the commit exists.

### Verified
- Hook blocks a commit on `main`, allows one on a branch.
- `git config --unset core.hooksPath` then `./gradlew help` restores it; a second run is a no-op.
- `--configuration-cache` reports only the pre-existing `composeApp` problem.

One wrinkle worth knowing: the hook can't guard `main` until this is merged, since `.githooks/`
doesn't exist on `main` until then.
