### PR TITLE
Extract batchEventSummary out of main.kt and test it

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -182,6 +182,7 @@ import org.churchpresenter.app.churchpresenter.server.downloadMirroredBackground
 import org.churchpresenter.app.churchpresenter.server.RemoteAccess
 import org.churchpresenter.app.churchpresenter.server.remoteAccessDecision
 import org.churchpresenter.app.churchpresenter.server.addScheduleItem
+import org.churchpresenter.app.churchpresenter.server.batchEventSummary
 import org.churchpresenter.app.churchpresenter.server.executeProjectItem
 import org.churchpresenter.app.churchpresenter.server.instanceLinkBackgroundCacheDir
 import org.churchpresenter.app.churchpresenter.server.instanceLinkPictureCacheDir
@@ -1140,17 +1141,7 @@ fun main() {
                                             }
                                             pending.decision.complete(true)
                                             // Show activity toast so operator is aware
-                                            val batchCount = pending.items.size
-                                            val batchTitle = if (batchCount == 1)
-                                                remoteEventLabel(pending.items.first()).first
-                                            else "$batchCount items"
-                                            val batchDetail = pending.items.take(3).joinToString(" · ") { item ->
-                                                when (item) {
-                                                    is ScheduleItem.BibleVerseItem -> "${item.bookName} ${item.chapter}:${item.verseNumber}"
-                                                    is ScheduleItem.SongItem -> "${item.songNumber} – ${item.title}"
-                                                    else -> item.displayText.take(30)
-                                                }
-                                            }.let { if (batchCount > 3) "$it …" else it }
+                                            val (batchTitle, batchDetail) = batchEventSummary(pending.items)
                                             remoteActivityNotifications.add(RemoteActivityNotification(
                                                 type = RemoteEventType.ADD_TO_SCHEDULE,
                                                 title = batchTitle,
@@ -1160,24 +1151,8 @@ fun main() {
                                             ))
                                             return@collect
                                         }
-                                        val count = pending.items.size
                                         // Build a human-readable summary: first 3 items joined, then "…" if more
-                                        val summaryTitle = if (count == 1) {
-                                            remoteEventLabel(pending.items.first()).first
-                                        } else {
-                                            "$count items"
-                                        }
-                                        val summaryDetail = pending.items.take(3).joinToString(" · ") { item ->
-                                            when (item) {
-                                                is ScheduleItem.BibleVerseItem ->
-                                                    "${item.bookName} ${item.chapter}:${item.verseNumber}"
-
-                                                is ScheduleItem.SongItem ->
-                                                    "${item.songNumber} – ${item.title}"
-
-                                                else -> item.displayText.take(30)
-                                            }
-                                        }.let { if (count > 3) "$it …" else it }
+                                        val (summaryTitle, summaryDetail) = batchEventSummary(pending.items)
                                         val event = RemoteEvent(
                                             type = RemoteEventType.ADD_TO_SCHEDULE,
                                             title = summaryTitle,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
@@ -501,6 +501,33 @@ internal fun remoteEventLabel(item: ScheduleItem): Pair<String, String> = when (
 }
 
 /**
+ * Returns a (title, detail) pair summarising a batch add-to-schedule request for the operator's
+ * approval prompt and activity toast.
+ *
+ * A single item is described by [remoteEventLabel] rather than as "1 items" — the operator is being
+ * asked to approve something specific and a count tells them nothing.
+ *
+ * The detail lists the first three items joined by " · ", with " …" appended only when a fourth
+ * exists; exactly three items get no ellipsis.
+ *
+ * Deliberately does **not** reuse [remoteEventLabel] for the per-item detail text: this renders a
+ * song with an en dash and a verse without its [ScheduleItem.BibleVerseItem.verseRange], because the
+ * detail is a compact one-line list rather than a banner heading.
+ */
+internal fun batchEventSummary(items: List<ScheduleItem>): Pair<String, String> {
+    val count = items.size
+    val title = if (count == 1) remoteEventLabel(items.first()).first else "$count items"
+    val detail = items.take(3).joinToString(" · ") { item ->
+        when (item) {
+            is ScheduleItem.BibleVerseItem -> "${item.bookName} ${item.chapter}:${item.verseNumber}"
+            is ScheduleItem.SongItem -> "${item.songNumber} – ${item.title}"
+            else -> item.displayText.take(30)
+        }
+    }.let { if (count > 3) "$it …" else it }
+    return title to detail
+}
+
+/**
  * Executes a project request — adds to schedule and sets presenter state.
  * Fixes the original bug where SongItem projection never selected the song in the Songs tab.
  */

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/BatchEventSummaryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/BatchEventSummaryTest.kt
@@ -1,0 +1,141 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * How a batch add-to-schedule request is described to the operator.
+ *
+ * This is what the approval prompt and the activity toast both show, and it was computed twice in
+ * `main.kt` — once for the auto-approved path and once for the prompt — in two spellings of the same
+ * logic. The two are now one function, which is what these tests drive.
+ *
+ * The two properties that fail quietly if the shared version drifts: a single item is described by
+ * [remoteEventLabel] rather than as "1 items", and the " …" suffix marks a *fourth* item, so exactly
+ * three carries no ellipsis.
+ */
+class BatchEventSummaryTest {
+
+    private fun song(number: Int = 42, title: String = "Amazing Grace") = ScheduleItem.SongItem(
+        id = "s$number", songNumber = number, title = title, songbook = "Hymnal", songId = "sid",
+    )
+
+    private fun bibleVerse(book: String = "John", chapter: Int = 3, verse: Int = 16) =
+        ScheduleItem.BibleVerseItem(
+            id = "b$verse", bookName = book, chapter = chapter, verseNumber = verse,
+            verseText = "For God so loved the world", verseRange = "16-18", bookId = 43,
+        )
+
+    private fun announcement(text: String = "Service starts at 10") =
+        ScheduleItem.AnnouncementItem(id = "a", text = text)
+
+    private fun website(title: String = "Notices") =
+        ScheduleItem.WebsiteItem(id = "w", url = "https://example.org", title = title)
+
+    private fun dictionary() = ScheduleItem.DictionaryItem(
+        id = "d", number = "G5485", word = "charis", transliteration = "charis", definition = "grace",
+    )
+
+    // ── The title ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a single item is named, not counted`() {
+        val (title, _) = batchEventSummary(listOf(song()))
+
+        assertEquals(remoteEventLabel(song()).first, title)
+        assertFalse(title.contains("items"), "the operator is approving something specific, not a count: $title")
+    }
+
+    @Test
+    fun `a single verse is named by its reference`() {
+        val (title, _) = batchEventSummary(listOf(bibleVerse()))
+
+        assertEquals(remoteEventLabel(bibleVerse()).first, title)
+    }
+
+    @Test
+    fun `more than one item is counted`() {
+        assertEquals("2 items", batchEventSummary(listOf(song(), bibleVerse())).first)
+        assertEquals("5 items", batchEventSummary(List(5) { song(it) }).first)
+    }
+
+    // ── The " …" suffix, and its off-by-one ─────────────────────────────────────
+
+    @Test
+    fun `exactly three items carry no ellipsis`() {
+        val (_, detail) = batchEventSummary(listOf(song(1), song(2), song(3)))
+
+        assertFalse(detail.endsWith("…"), "the ellipsis means a fourth item is hidden; there is none: $detail")
+        assertEquals(3, detail.split(" · ").size)
+    }
+
+    @Test
+    fun `a fourth item is what adds the ellipsis`() {
+        val (_, detail) = batchEventSummary(listOf(song(1), song(2), song(3), song(4)))
+
+        assertTrue(detail.endsWith(" …"), detail)
+        assertFalse(detail.contains("4 –"), "only the first three are listed: $detail")
+    }
+
+    @Test
+    fun `only the first three are listed however long the batch`() {
+        val (title, detail) = batchEventSummary(List(20) { song(it + 1) })
+
+        assertEquals("20 items", title)
+        assertEquals(3, detail.removeSuffix(" …").split(" · ").size)
+    }
+
+    // ── Per-item formatting ─────────────────────────────────────────────────────
+
+    @Test
+    fun `a verse is listed as book chapter and verse`() {
+        val (_, detail) = batchEventSummary(listOf(bibleVerse(book = "Psalms", chapter = 23, verse = 1), song()))
+
+        assertTrue(detail.startsWith("Psalms 23:1"), detail)
+    }
+
+    @Test
+    fun `a song is listed as number and title`() {
+        val (_, detail) = batchEventSummary(listOf(song(number = 7, title = "Be Thou My Vision"), song(8)))
+
+        assertTrue(detail.startsWith("7 – Be Thou My Vision"), detail)
+    }
+
+    @Test
+    fun `anything else is listed by its own display text`() {
+        val (_, detail) = batchEventSummary(listOf(dictionary(), website(), announcement()))
+
+        assertEquals(
+            listOf(dictionary().displayText, website().displayText, announcement().displayText),
+            detail.split(" · "),
+        )
+    }
+
+    @Test
+    fun `a long display text is truncated so one item cannot fill the line`() {
+        val long = "A very long website title that would otherwise run off the end of the toast"
+        val (_, detail) = batchEventSummary(listOf(website(title = long), song()))
+
+        assertEquals(long.take(30), detail.split(" · ").first())
+    }
+
+    // ── Order and edges ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `items are listed in the order they were sent`() {
+        val (_, detail) = batchEventSummary(listOf(song(1, "First"), bibleVerse(verse = 2), website("Third")))
+
+        assertEquals(listOf("1 – First", "John 3:2", "Third"), detail.split(" · "))
+    }
+
+    @Test
+    fun `an empty batch does not throw`() {
+        val (title, detail) = batchEventSummary(emptyList())
+
+        assertEquals("0 items", title)
+        assertEquals("", detail)
+    }
+}


### PR DESCRIPTION
Extracts `batchEventSummary` — the (title, detail) pair shown when a phone asks to add several
items to the schedule at once — out of `main.kt` into `server/RemoteApply.kt`, and tests it.

This is the last item of the extraction plan that #165 (`addScheduleItem`) and #167
(`remoteAccessDecision`) worked through. Same method: find logic written more than once inside the
ungated app root, move it to a file the coverage gate counts, and pin it.

## What was duplicated

The summary was computed twice in the same `LaunchedEffect` — once for the auto-approved path
(feeding the activity toast) and once for the path that prompts the operator (feeding the approval
dialog). Identical logic, two spellings: one commented, one not, and the second broken across lines
differently. Four independent greps (`" · "`, `displayText.take`, `take(3)`, `" items"`) all agree
the count is exactly two, so this is not the "found 4 of 7" case from #167.

Pure refactor — no behaviour change. The extracted function keeps both quirks that distinguish the
detail line from `remoteEventLabel`, and the doc comment says why rather than leaving them to look
like slips:

- a song renders with an **en dash** here and a hyphen in the banner heading;
- a verse omits its `verseRange`.

## What the tests pin

Twelve tests in `server/BatchEventSummaryTest.kt`, sub-millisecond, no fakes or coroutines. The two
that matter:

- **a single item is named, not counted** — the title uses `remoteEventLabel`, not "1 items". The
  operator is being asked to approve something specific and a count tells them nothing.
- **the `" …"` off-by-one** — the ellipsis marks a hidden *fourth* item, so exactly three items
  carry none. Both sides of the boundary are asserted.

Plus per-item formatting, list order, the 30-character truncation that stops one long title filling
the line, and an empty batch.

## Honest note on evidence

These are not red-green pins against the old code — the function did not exist there, so there is
nothing to run them against. What was checked instead is that the assertions bite: mutating
`count > 3` to `count >= 3` and dropping the single-item title branch fails 5 of the 12 tests.
Both call sites were also diffed against the extracted body before the originals were deleted.

## Verification

- `./gradlew compileKotlinJvm` clean.
- `./gradlew :composeApp:jvmTest --tests '*server*' --rerun-tasks` three consecutive times, green.
