### PR TITLE
Wait on a bindable port in PlanningCenterAuthServerTest

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/PlanningCenterAuthServerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/PlanningCenterAuthServerTest.kt
@@ -10,9 +10,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import org.churchpresenter.app.churchpresenter.utils.Constants
+import java.io.IOException
 import java.net.InetSocketAddress
+import java.net.ServerSocket
 import java.net.Socket
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -24,20 +27,49 @@ class PlanningCenterAuthServerTest {
 
     private fun url(query: String) = "http://127.0.0.1:${Constants.PLANNING_CENTER_OAUTH_PORT}/callback$query"
 
-    /** True once something is actually accepting connections on 127.0.0.1:port — a bind-based
-     *  check is wrong here since a wildcard probe bind can coexist with a loopback-specific one. */
+    /** True once something is actually accepting connections on 127.0.0.1:port. Used only to wait
+     *  for a server to come *up*, where "a connection is accepted" is the signal we want. */
     private fun isListening(): Boolean =
         runCatching { Socket().apply { connect(InetSocketAddress("127.0.0.1", Constants.PLANNING_CENTER_OAUTH_PORT), 200) }.close() }.isSuccess
 
-    // The fixed port isn't released by the OS the instant the previous test's server.stop()
-    // returns; without this, the next test's bind can race a still-closing socket.
+    /**
+     * Waits until the fixed port can actually be **bound**, and fails the test if it never can.
+     *
+     * Every test in this class binds the same port — [Constants.PLANNING_CENTER_OAUTH_PORT] — because
+     * PCO OAuth apps require an exact pre-registered redirect URI, so an ephemeral port is not an
+     * option and consecutive tests genuinely reuse one port.
+     *
+     * The signal has to be a bind, not a connect. `server.stop()` returning means the engine has
+     * stopped accepting, so a connect probe reports "free" while the listening socket is still
+     * closing — and the next test's bind then loses the race with `Address already in use`, which is
+     * how this surfaced on CI. Binding proves the exact thing the next test is about to do.
+     *
+     * The probe mirrors production's bind: the same loopback address Netty is given (a wildcard
+     * probe would answer a different question and could coexist with a loopback-specific bind), and
+     * `reuseAddress = true`, which is what a server socket uses — a stricter probe would sit out the
+     * TIME_WAIT of the previous test's *accepted* connections, which production never waits for.
+     */
+    @BeforeTest
     @AfterTest
-    fun awaitPortFree() {
-        val deadline = System.currentTimeMillis() + 5_000
+    fun awaitPortBindable() {
+        val deadline = System.currentTimeMillis() + 10_000
+        var lastFailure: Exception? = null
         while (System.currentTimeMillis() < deadline) {
-            if (!isListening()) return
-            Thread.sleep(20)
+            try {
+                ServerSocket().use { probe ->
+                    probe.reuseAddress = true
+                    probe.bind(InetSocketAddress("127.0.0.1", Constants.PLANNING_CENTER_OAUTH_PORT))
+                }
+                return
+            } catch (e: IOException) {
+                lastFailure = e
+                Thread.sleep(20)
+            }
         }
+        throw AssertionError(
+            "port ${Constants.PLANNING_CENTER_OAUTH_PORT} never became bindable within 10s; " +
+                "last bind failure: ${lastFailure?.message}"
+        )
     }
 
     private suspend fun awaitServerReady(resultDeferred: kotlinx.coroutines.Deferred<PlanningCenterAuthServer.CallbackResult>? = null) {


### PR DESCRIPTION
Fixes the `PlanningCenterAuthServerTest` port collision that failed on CI during #167 with
`server never bound: awaitAuthorizationCode already resolved to Error(message=Address already in
use)` — a flake unrelated to the PR it appeared on.

## Why it collides at all

`PlanningCenterAuthServer` binds a **fixed** loopback port. It has to: PCO OAuth apps require an
exact pre-registered redirect URI, so an ephemeral port is not an option the way it is for
`CompanionServer`. Every test in the class therefore reuses one port, and each has to wait for the
previous one to let go of it.

## What was wrong with the existing wait

There was already an `@AfterTest` guard, and it had two defects.

**It probed with `connect`, not `bind`.** `server.stop()` returning means the engine has stopped
accepting connections, so a connect probe reports the port free while the listening socket is still
closing. The next test then binds into that window and gets `Address already in use`. A connect probe
cannot distinguish "closed" from "closing" — only a bind answers the question the next test is
actually about to ask.

**On expiry it silently returned**, so once the wait failed to do its job the suite proceeded anyway
and the failure surfaced as a confusing message from the *next* test. `AGENT.md` rules out a wait
that ends by its timeout; this one ended by timeout and then said nothing.

## The fix

`awaitPortBindable()` retries a real `ServerSocket` bind until it succeeds, and throws with the last
bind failure if it never does. It mirrors production's bind so the probe answers the same question
Netty will:

- the same loopback address Netty is given — a wildcard probe would answer a different question and
  can coexist with a loopback-specific bind (this was the reason the original author gave for
  avoiding a bind probe; binding the same address is what resolves it);
- `reuseAddress = true`, as a server socket uses. A stricter probe would sit out the TIME_WAIT of the
  previous test's *accepted* connections, which production never waits for.

It now runs as both `@BeforeTest` and `@AfterTest`, so the first test is also protected against a
port left busy by something outside this class.

## Evidence, stated honestly

This is a CI-only flake that has never reproduced locally, so I cannot show it failing before and
passing after — and I am not claiming a red-green pin. What is verifiable:

- the mechanism is specific and checkable by reading: connect-free does not imply bindable;
- the suite is green three consecutive times across the whole `server` package with `--rerun-tasks`;
- it costs nothing in the normal case — all four tests are ≤0.24s and the suite is 0.855s, i.e. the
  bind probe succeeds on its first attempt when there is no contention.

The remaining risk is that the CI failure had some other cause. If it recurs, the new message names
the actual bind failure instead of surfacing as a mystery in the following test.
