### PR TITLE
Extract emitRemoteTabSelection out of main.kt and test it

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -183,6 +183,7 @@ import org.churchpresenter.app.churchpresenter.server.RemoteAccess
 import org.churchpresenter.app.churchpresenter.server.remoteAccessDecision
 import org.churchpresenter.app.churchpresenter.server.addScheduleItem
 import org.churchpresenter.app.churchpresenter.server.batchEventSummary
+import org.churchpresenter.app.churchpresenter.server.emitRemoteTabSelection
 import org.churchpresenter.app.churchpresenter.server.executeProjectItem
 import org.churchpresenter.app.churchpresenter.server.instanceLinkBackgroundCacheDir
 import org.churchpresenter.app.churchpresenter.server.instanceLinkPictureCacheDir
@@ -1197,14 +1198,11 @@ fun main() {
                                                 presenterManager,
                                                 statisticsManager
                                             )
-                                            if (item is ScheduleItem.SongItem) {
-                                                coroutineScope.launch { remoteSelectSongFlow.emit(item) }
-                                            }
-                                            if (item is ScheduleItem.PictureItem) {
-                                                coroutineScope.launch { remoteSelectPictureFlow.emit(item) }
-                                            }
-                                            if (item is ScheduleItem.PresentationItem) {
-                                                coroutineScope.launch { remoteSelectPresentationFlow.emit(item) }
+                                            coroutineScope.launch {
+                                                emitRemoteTabSelection(
+                                                    item, remoteSelectSongFlow,
+                                                    remoteSelectPictureFlow, remoteSelectPresentationFlow,
+                                                )
                                             }
                                             pending.decision.complete(true)
                                             // Show activity toast so operator is aware
@@ -1237,15 +1235,12 @@ fun main() {
                                                 presenterManager,
                                                 statisticsManager
                                             )
-                                            // Also drive Songs tab selection for song items
-                                            if (item is ScheduleItem.SongItem) {
-                                                coroutineScope.launch { remoteSelectSongFlow.emit(item) }
-                                            }
-                                            if (item is ScheduleItem.PictureItem) {
-                                                coroutineScope.launch { remoteSelectPictureFlow.emit(item) }
-                                            }
-                                            if (item is ScheduleItem.PresentationItem) {
-                                                coroutineScope.launch { remoteSelectPresentationFlow.emit(item) }
+                                            // Also drive the owning tab so it loads the real content
+                                            coroutineScope.launch {
+                                                emitRemoteTabSelection(
+                                                    item, remoteSelectSongFlow,
+                                                    remoteSelectPictureFlow, remoteSelectPresentationFlow,
+                                                )
                                             }
                                             pending.decision.complete(true)
                                         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.input.key.type
 import java.io.File
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.collectLatest
 import org.churchpresenter.app.churchpresenter.data.Bible
 import org.churchpresenter.app.churchpresenter.data.StatisticsManager
@@ -569,6 +570,35 @@ internal fun AppSettings.withAnnouncement(item: ScheduleItem.AnnouncementItem): 
             liveClockFormat     = item.liveClockFormat
         )
     )
+
+/**
+ * Hands a remotely-projected item to whichever tab has to load its real content, and reports whether
+ * any tab was asked.
+ *
+ * [executeProjectItem] adds the item to the schedule and flips `presentingMode`, but deliberately
+ * does **not** push picture or slide content itself — the tab that owns that content does, driven by
+ * these flows. So a type missing from this `when` goes live as an empty screen: the mode changes and
+ * nothing loads.
+ *
+ * **Only the project path drives all three.** The add-to-schedule path
+ * ([addScheduleItem]) navigates the Songs tab and nothing else, on purpose — adding a picture to the
+ * schedule must not hijack the Pictures tab away from what the operator is showing. Merging the two
+ * would do exactly that, which is why this is a separate function rather than a flag on that one.
+ *
+ * Returns false for every other type, so a test can pin "this drives no tab" as a positive result
+ * rather than as the absence of an emission.
+ */
+internal suspend fun emitRemoteTabSelection(
+    item: ScheduleItem,
+    songFlow: MutableSharedFlow<ScheduleItem.SongItem>,
+    pictureFlow: MutableSharedFlow<ScheduleItem.PictureItem>,
+    presentationFlow: MutableSharedFlow<ScheduleItem.PresentationItem>,
+): Boolean = when (item) {
+    is ScheduleItem.SongItem -> { songFlow.emit(item); true }
+    is ScheduleItem.PictureItem -> { pictureFlow.emit(item); true }
+    is ScheduleItem.PresentationItem -> { presentationFlow.emit(item); true }
+    else -> false
+}
 
 internal fun executeProjectItem(
     item: ScheduleItem,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/EmitRemoteTabSelectionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/EmitRemoteTabSelectionTest.kt
@@ -1,0 +1,132 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Which tab a remotely-projected item asks to load its content.
+ *
+ * `executeProjectItem` adds the item to the schedule and flips `presentingMode`, but deliberately
+ * does not push picture or slide content itself — the owning tab does, driven by these flows. A type
+ * missing from the dispatch therefore goes live as an **empty screen**: the mode changes and nothing
+ * loads. That is the failure these tests exist to catch, and it is silent.
+ *
+ * The dispatch was written twice in `main.kt` — once in the auto-approved branch and once in the
+ * approval dialog's allow lambda — so the two could drift and a request would behave differently
+ * depending on whether the operator had already trusted the device.
+ *
+ * Real [MutableSharedFlow]s with `replay = 1`, so an emission is observable straight after the call
+ * with no collector, no dispatcher and no waiting.
+ */
+class EmitRemoteTabSelectionTest {
+
+    private val songs = MutableSharedFlow<ScheduleItem.SongItem>(replay = 1)
+    private val pictures = MutableSharedFlow<ScheduleItem.PictureItem>(replay = 1)
+    private val presentations = MutableSharedFlow<ScheduleItem.PresentationItem>(replay = 1)
+
+    private fun emit(item: ScheduleItem): Boolean =
+        runBlocking { emitRemoteTabSelection(item, songs, pictures, presentations) }
+
+    private fun song() = ScheduleItem.SongItem(
+        id = "s", songNumber = 42, title = "Amazing Grace", songbook = "Hymnal", songId = "sid",
+    )
+
+    private fun picture() =
+        ScheduleItem.PictureItem(id = "pic", folderPath = "/photos/advent", folderName = "advent", imageCount = 12)
+
+    private fun presentation() = ScheduleItem.PresentationItem(
+        id = "p", filePath = "/decks/sunday.pdf", fileName = "sunday", slideCount = 4, fileType = "pdf",
+    )
+
+    /** Every emission that landed, as (flow name -> item), so a test can assert nothing else fired. */
+    private fun emitted(): Map<String, Any> = buildMap {
+        songs.replayCache.firstOrNull()?.let { put("songs", it) }
+        pictures.replayCache.firstOrNull()?.let { put("pictures", it) }
+        presentations.replayCache.firstOrNull()?.let { put("presentations", it) }
+    }
+
+    // ── Each type reaches its own tab ───────────────────────────────────────────
+
+    @Test
+    fun `a song is handed to the songs tab`() {
+        val item = song()
+        assertTrue(emit(item))
+
+        assertSame(item, songs.replayCache.single())
+        assertEquals(setOf("songs"), emitted().keys, "a song must not wake another tab")
+    }
+
+    @Test
+    fun `a picture is handed to the pictures tab`() {
+        val item = picture()
+        assertTrue(emit(item))
+
+        assertSame(item, pictures.replayCache.single())
+        assertEquals(setOf("pictures"), emitted().keys)
+    }
+
+    @Test
+    fun `a presentation is handed to the presentation tab`() {
+        val item = presentation()
+        assertTrue(emit(item))
+
+        assertSame(item, presentations.replayCache.single())
+        assertEquals(setOf("presentations"), emitted().keys)
+    }
+
+    // ── The types that own no tab ───────────────────────────────────────────────
+
+    @Test
+    fun `a bible verse drives no tab load`() {
+        val verse = ScheduleItem.BibleVerseItem(
+            id = "b", bookName = "John", chapter = 3, verseNumber = 16,
+            verseText = "For God so loved", verseRange = "16", bookId = 43,
+        )
+
+        assertFalse(emit(verse), "the presenter renders a verse itself; no tab has to load anything")
+        assertTrue(emitted().isEmpty())
+    }
+
+    @Test
+    fun `the remaining projectable types drive no tab load`() {
+        val others = listOf(
+            ScheduleItem.AnnouncementItem(id = "a", text = "Service starts at 10"),
+            ScheduleItem.WebsiteItem(id = "w", url = "https://example.org", title = "Notices"),
+            ScheduleItem.DictionaryItem(
+                id = "d", number = "G5485", word = "charis", transliteration = "charis", definition = "grace",
+            ),
+            ScheduleItem.LabelItem(id = "l", text = "Welcome", textColor = "#FFFFFF", backgroundColor = "#000000"),
+            ScheduleItem.MediaItem(id = "m", mediaUrl = "/clips/w.mp4", mediaTitle = "Welcome", mediaType = "local"),
+        )
+
+        others.forEach { assertFalse(emit(it), "$it should not drive a tab load") }
+        assertTrue(emitted().isEmpty(), "nothing should have been emitted, got ${emitted()}")
+    }
+
+    // ── The property that makes a drift visible ─────────────────────────────────
+
+    @Test
+    fun `exactly the three content-owning types report a tab load`() {
+        val reporting = listOf<ScheduleItem>(
+            song(), picture(), presentation(),
+            ScheduleItem.AnnouncementItem(id = "a", text = "x"),
+            ScheduleItem.WebsiteItem(id = "w", url = "https://example.org"),
+            ScheduleItem.LabelItem(id = "l", text = "x", textColor = "#FFFFFF", backgroundColor = "#000000"),
+        ).filter { emit(it) }
+
+        assertEquals(
+            listOf<Class<*>>(
+                ScheduleItem.SongItem::class.java,
+                ScheduleItem.PictureItem::class.java,
+                ScheduleItem.PresentationItem::class.java,
+            ),
+            reporting.map { it.javaClass },
+        )
+    }
+}


### PR DESCRIPTION
Extracts `emitRemoteTabSelection` — the dispatch that hands a remotely-projected item to whichever
tab has to load its content — out of `main.kt` into `server/RemoteApply.kt`, and tests it.

Continues the method of #165, #167 and #172: find logic written more than once inside the ungated app
root, move it where the coverage gate counts it, and pin the property that would otherwise break
silently.

## Why this one matters

`executeProjectItem` adds the item to the schedule and flips `presentingMode`, but deliberately does
**not** push picture or slide content itself — the tab that owns that content does, driven by these
flows. So a type missing from the dispatch does not throw and does not log: it goes live as an
**empty screen**, mode changed and nothing loaded.

The dispatch was written twice in the same handler — once in the auto-approved branch, once in the
approval dialog's `allow` lambda. Drift between them means a request behaves differently depending on
whether the operator had already trusted the device, which is the worst kind of bug to reproduce.

## The asymmetry this deliberately preserves

A sweep of all ten `remoteSelect*Flow.emit` sites found the three-flow dispatch exactly twice. The
other four are `addScheduleItem`'s callback and are **song-only on purpose**: adding a picture to the
schedule must not yank the Pictures tab away from what the operator currently has on screen. That is
now stated in the doc comment, so the two are not later "tidied" together — doing so would hijack the
tab on every remote add.

## Tests

Six tests in `server/EmitRemoteTabSelectionTest.kt`, 16ms total. Real `MutableSharedFlow(replay = 1)`,
so an emission is observable straight after the call with no collector, no dispatcher and no waiting —
no mocks anywhere.

- each of the three content-owning types reaches its own tab, and **wakes no other tab**;
- a bible verse and the five remaining projectable types drive no tab load — asserted as a `false`
  return rather than as the absence of an emission;
- the completeness property: exactly the three content-owning types report a tab load.

The function returns `Boolean` specifically so "this drives no tab" is a positive assertion instead of
proving a negative.

## Evidence

Not a red-green pin — the function did not exist before, so there is nothing to run it against red.
What was checked: deleting the `PictureItem` branch fails 2 of the 6 tests, so the assertions bite;
both call sites were diffed against the extracted body before the originals were removed; and the
`server` package is green three consecutive times with `--rerun-tasks`.

Behaviour is unchanged. The only structural difference is one `launch` per request instead of three
`if (item is …)` blocks each with its own `launch` — the types are mutually exclusive, so exactly one
ever fired before and exactly one fires now.
