### PR TITLE
Extract remoteApproval out of main.kt and test it

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -184,6 +184,8 @@ import org.churchpresenter.app.churchpresenter.server.remoteAccessDecision
 import org.churchpresenter.app.churchpresenter.server.addScheduleItem
 import org.churchpresenter.app.churchpresenter.server.batchEventSummary
 import org.churchpresenter.app.churchpresenter.server.emitRemoteTabSelection
+import org.churchpresenter.app.churchpresenter.server.RemoteApproval
+import org.churchpresenter.app.churchpresenter.server.remoteApproval
 import org.churchpresenter.app.churchpresenter.server.executeProjectItem
 import org.churchpresenter.app.churchpresenter.server.instanceLinkBackgroundCacheDir
 import org.churchpresenter.app.churchpresenter.server.instanceLinkPictureCacheDir
@@ -1317,30 +1319,24 @@ fun main() {
                                             remoteClientManager.allowedClients, remoteClientManager.blockedClients,
                                             sessionAllowedClients, sessionBlockedClients,
                                         )
-                                        if (access == RemoteAccess.AUTO_REJECT) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        if (access == RemoteAccess.AUTO_APPROVE) {
-                                            pending.decision.complete(true)
-                                            remoteActivityNotifications.add(RemoteActivityNotification(
-                                                type = qaActionType(pending.action),
-                                                title = pending.text.take(80),
-                                                clientId = clientId,
-                                                clientLabel = remoteClientManager.getLabel(clientId)
-                                            ))
-                                            return@collect
-                                        }
-                                        val eventType = qaActionType(pending.action)
-                                        val event = RemoteEvent(
-                                            type = eventType,
+                                        when (val outcome = remoteApproval(
+                                            access,
+                                            type = qaActionType(pending.action),
                                             title = pending.text.take(80),
                                             clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId)
-                                        )
-                                        val allow: () -> Unit = { pending.decision.complete(true) }
-                                        val deny: () -> Unit  = { pending.decision.complete(false) }
-                                        remoteEventQueue.add(Triple(event, allow, deny))
+                                            clientLabel = remoteClientManager.getLabel(clientId),
+                                        )) {
+                                            RemoteApproval.Reject -> pending.decision.complete(false)
+                                            is RemoteApproval.Approve -> {
+                                                pending.decision.complete(true)
+                                                remoteActivityNotifications.add(outcome.notification)
+                                            }
+                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                                outcome.event,
+                                                { pending.decision.complete(true) },
+                                                { pending.decision.complete(false) },
+                                            ))
+                                        }
                                     }
                                 }
 
@@ -1353,29 +1349,24 @@ fun main() {
                                             remoteClientManager.allowedClients, remoteClientManager.blockedClients,
                                             sessionAllowedClients, sessionBlockedClients,
                                         )
-                                        if (access == RemoteAccess.AUTO_REJECT) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        if (access == RemoteAccess.AUTO_APPROVE) {
-                                            pending.decision.complete(true)
-                                            remoteActivityNotifications.add(RemoteActivityNotification(
-                                                type = RemoteEventType.PRESENTATION_CONNECT,
-                                                title = "",
-                                                clientId = clientId,
-                                                clientLabel = remoteClientManager.getLabel(clientId)
-                                            ))
-                                            return@collect
-                                        }
-                                        val event = RemoteEvent(
+                                        when (val outcome = remoteApproval(
+                                            access,
                                             type = RemoteEventType.PRESENTATION_CONNECT,
                                             title = "",
                                             clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId)
-                                        )
-                                        val allow: () -> Unit = { pending.decision.complete(true) }
-                                        val deny: () -> Unit  = { pending.decision.complete(false) }
-                                        remoteEventQueue.add(Triple(event, allow, deny))
+                                            clientLabel = remoteClientManager.getLabel(clientId),
+                                        )) {
+                                            RemoteApproval.Reject -> pending.decision.complete(false)
+                                            is RemoteApproval.Approve -> {
+                                                pending.decision.complete(true)
+                                                remoteActivityNotifications.add(outcome.notification)
+                                            }
+                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                                outcome.event,
+                                                { pending.decision.complete(true) },
+                                                { pending.decision.complete(false) },
+                                            ))
+                                        }
                                     }
                                 }
 
@@ -1388,29 +1379,24 @@ fun main() {
                                             remoteClientManager.allowedClients, remoteClientManager.blockedClients,
                                             sessionAllowedClients, sessionBlockedClients,
                                         )
-                                        if (access == RemoteAccess.AUTO_REJECT) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        if (access == RemoteAccess.AUTO_APPROVE) {
-                                            pending.decision.complete(true)
-                                            remoteActivityNotifications.add(RemoteActivityNotification(
-                                                type = RemoteEventType.QA_ADMIN_CONNECT,
-                                                title = "",
-                                                clientId = clientId,
-                                                clientLabel = remoteClientManager.getLabel(clientId)
-                                            ))
-                                            return@collect
-                                        }
-                                        val event = RemoteEvent(
+                                        when (val outcome = remoteApproval(
+                                            access,
                                             type = RemoteEventType.QA_ADMIN_CONNECT,
                                             title = "",
                                             clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId)
-                                        )
-                                        val allow: () -> Unit = { pending.decision.complete(true) }
-                                        val deny: () -> Unit  = { pending.decision.complete(false) }
-                                        remoteEventQueue.add(Triple(event, allow, deny))
+                                            clientLabel = remoteClientManager.getLabel(clientId),
+                                        )) {
+                                            RemoteApproval.Reject -> pending.decision.complete(false)
+                                            is RemoteApproval.Approve -> {
+                                                pending.decision.complete(true)
+                                                remoteActivityNotifications.add(outcome.notification)
+                                            }
+                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                                outcome.event,
+                                                { pending.decision.complete(true) },
+                                                { pending.decision.complete(false) },
+                                            ))
+                                        }
                                     }
                                 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApproval.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApproval.kt
@@ -1,0 +1,53 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import org.churchpresenter.app.churchpresenter.dialogs.RemoteActivityNotification
+import org.churchpresenter.app.churchpresenter.dialogs.RemoteEvent
+import org.churchpresenter.app.churchpresenter.dialogs.RemoteEventType
+
+/**
+ * What the desktop does with an approval-only remote request: refuse it, carry it out and tell the
+ * operator afterwards, or put it in front of them first.
+ *
+ * Pairs with [remoteAccessDecision], which answers *whether* the device is trusted. This answers
+ * what that verdict means for the request, and it is deliberately a **value** rather than a callback:
+ * the caller applies it. That keeps the branch testable without a Compose state holder, an event
+ * queue or a `CompletableDeferred` anywhere near the test.
+ */
+internal sealed interface RemoteApproval {
+    /** The device is blocked. Refuse without telling the operator — a blocked phone must not be
+     *  able to raise a prompt, or blocking it would achieve nothing. */
+    data object Reject : RemoteApproval
+
+    /** Trusted device: carry the request out, then show [notification] so the operator can see what
+     *  happened and block the device if it was not them. */
+    data class Approve(val notification: RemoteActivityNotification) : RemoteApproval
+
+    /** Unknown device: ask, via [event], before anything happens. */
+    data class Ask(val event: RemoteEvent) : RemoteApproval
+}
+
+/**
+ * Decides the outcome above and builds the operator-facing description **once**.
+ *
+ * That single construction is the point. Each handler used to build a [RemoteActivityNotification]
+ * in its approve branch and a [RemoteEvent] in its prompt branch from the same values, by hand, in
+ * eight places — and the two classes carry identical fields, so nothing stopped the toast and the
+ * approval dialog describing the same request differently. Here they cannot: one set of arguments
+ * feeds whichever of the two the outcome calls for.
+ */
+internal fun remoteApproval(
+    access: RemoteAccess,
+    type: RemoteEventType,
+    title: String,
+    detail: String = "",
+    clientId: String,
+    clientLabel: String,
+): RemoteApproval = when (access) {
+    RemoteAccess.AUTO_REJECT -> RemoteApproval.Reject
+    RemoteAccess.AUTO_APPROVE -> RemoteApproval.Approve(
+        RemoteActivityNotification(type, title, detail, clientId, clientLabel)
+    )
+    RemoteAccess.PROMPT -> RemoteApproval.Ask(
+        RemoteEvent(type, title, detail, clientId, clientLabel)
+    )
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApprovalTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApprovalTest.kt
@@ -1,0 +1,116 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import org.churchpresenter.app.churchpresenter.dialogs.RemoteEventType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+
+/**
+ * What an approval-only remote request turns into: a refusal, a toast after the fact, or a prompt.
+ *
+ * Pairs with [RemoteAccessDecisionTest], which covers *whether* a device is trusted. This covers what
+ * that verdict means for the request. The two were written out by hand together in eight handlers in
+ * `main.kt`, all at 0% coverage.
+ *
+ * The property worth having a test for is the last one here: `RemoteActivityNotification` and
+ * `RemoteEvent` carry **identical fields**, and each handler used to build one in its approve branch
+ * and the other in its prompt branch, separately, from the same values. Nothing stopped the toast and
+ * the approval dialog describing the same request differently — a drift no compiler and no type
+ * checker would catch, and one an operator would only notice mid-service.
+ */
+class RemoteApprovalTest {
+
+    private fun approval(access: RemoteAccess) = remoteApproval(
+        access,
+        type = RemoteEventType.QA_APPROVE,
+        title = "Is the car park full?",
+        detail = "from row 3",
+        clientId = "phone-7",
+        clientLabel = "Sam's phone",
+    )
+
+    // ── One outcome per verdict ─────────────────────────────────────────────────
+
+    @Test
+    fun `a blocked device is refused without raising a prompt`() {
+        assertEquals(RemoteApproval.Reject, approval(RemoteAccess.AUTO_REJECT))
+    }
+
+    @Test
+    fun `a trusted device is carried out and reported afterwards`() {
+        val approve = assertIs<RemoteApproval.Approve>(approval(RemoteAccess.AUTO_APPROVE))
+
+        assertEquals(RemoteEventType.QA_APPROVE, approve.notification.type)
+        assertEquals("Is the car park full?", approve.notification.title)
+        assertEquals("from row 3", approve.notification.detail)
+        assertEquals("phone-7", approve.notification.clientId)
+        assertEquals("Sam's phone", approve.notification.clientLabel)
+    }
+
+    @Test
+    fun `an unknown device is asked about first`() {
+        val ask = assertIs<RemoteApproval.Ask>(approval(RemoteAccess.PROMPT))
+
+        assertEquals(RemoteEventType.QA_APPROVE, ask.event.type)
+        assertEquals("Is the car park full?", ask.event.title)
+        assertEquals("from row 3", ask.event.detail)
+        assertEquals("phone-7", ask.event.clientId)
+        assertEquals("Sam's phone", ask.event.clientLabel)
+    }
+
+    @Test
+    fun `every verdict produces an outcome`() {
+        val outcomes = RemoteAccess.entries.map { approval(it) }
+
+        assertEquals(RemoteAccess.entries.size, outcomes.size)
+        assertEquals(outcomes.size, outcomes.distinct().size, "two verdicts must not collapse: $outcomes")
+    }
+
+    // ── The drift this exists to prevent ────────────────────────────────────────
+
+    @Test
+    fun `the toast and the prompt describe the request identically`() {
+        val notification = assertIs<RemoteApproval.Approve>(approval(RemoteAccess.AUTO_APPROVE)).notification
+        val event = assertIs<RemoteApproval.Ask>(approval(RemoteAccess.PROMPT)).event
+
+        assertEquals(
+            listOf(notification.type, notification.title, notification.detail, notification.clientId, notification.clientLabel),
+            listOf(event.type, event.title, event.detail, event.clientId, event.clientLabel),
+            "the operator must see the same request whether it was auto-approved or asked about",
+        )
+    }
+
+    @Test
+    fun `a request with no detail leaves the detail empty rather than inventing one`() {
+        val bare = remoteApproval(
+            RemoteAccess.PROMPT,
+            type = RemoteEventType.PRESENTATION_CONNECT,
+            title = "",
+            clientId = "tablet-1",
+            clientLabel = "",
+        )
+
+        val ask = assertIs<RemoteApproval.Ask>(bare)
+        assertEquals("", ask.event.detail)
+        assertEquals("", ask.event.title)
+        assertEquals("tablet-1", ask.event.clientId)
+    }
+
+    @Test
+    fun `the description follows its arguments rather than being fixed`() {
+        val a = assertIs<RemoteApproval.Ask>(approval(RemoteAccess.PROMPT)).event
+        val b = assertIs<RemoteApproval.Ask>(
+            remoteApproval(
+                RemoteAccess.PROMPT,
+                type = RemoteEventType.QA_DENY,
+                title = "another question",
+                clientId = "phone-9",
+                clientLabel = "Alex's phone",
+            )
+        ).event
+
+        assertNotEquals(a, b)
+        assertEquals(RemoteEventType.QA_DENY, b.type)
+    }
+}


### PR DESCRIPTION
Extracts `remoteApproval` — what an approval-only remote request turns into — out of `main.kt` into
a new `server/RemoteApproval.kt`, and tests it.

Continues #165, #167, #172 and #174: logic written repeatedly inside the ungated app root, moved to
where the coverage gate counts it, with the silent-failure property pinned.

## What was duplicated

Three handlers — `onQAAdminRequest`, `onPresentationRemoteConnect` and `onQaAdminConnect` — are
**approval-only**: they carry out no action beyond completing the decision. All three were the same
30-line gate, differing only in the event type and title.

## The property this pins

`RemoteActivityNotification` and `RemoteEvent` carry **identical fields**
(`type, title, detail, clientId, clientLabel`). Every handler built one of them in its auto-approve
branch and the other in its prompt branch, by hand, from the same values.

Nothing stopped the toast and the approval dialog describing the same request **differently**. No
compiler or type checker catches that — the two are separate classes that happen to agree — and an
operator would only notice mid-service, when the dialog asks about one thing and the toast reports
another. One set of arguments now feeds whichever of the two the outcome calls for, so the drift is
impossible rather than merely absent.

## Why a value and not a callback

`remoteApproval` returns a sealed `RemoteApproval` — `Reject`, `Approve(notification)`,
`Ask(event)` — and the caller applies it. That keeps the branch testable with no Compose state
holder, no event queue and no `CompletableDeferred` anywhere near the test, and it takes **zero
function parameters**, so it does not add uncovered lambda methods at each call site the way a
`perform: () -> Unit` helper would.

`Reject` deliberately raises no prompt: a blocked device must not be able to put a dialog in front of
the operator, or blocking it would achieve nothing. That is stated at the declaration.

## Tests

Seven tests in `server/RemoteApprovalTest.kt`, 10ms, no fakes and no coroutines — one outcome per
verdict with every field asserted, a completeness check that no two verdicts collapse, the empty-detail
case, that the description follows its arguments, and the drift test above.

Pairs with the existing `RemoteAccessDecisionTest`, which covers *whether* a device is trusted; this
covers what that verdict then means.

## Evidence

Not a red-green pin — the function is new, so there is nothing to run it against red. What was
checked: blanking the notification's `detail` so the two descriptions diverge fails 2 of the 7 tests,
including the drift assertion specifically; all three call sites were diffed against the extracted
body before the originals were removed; and the `server` package is green three consecutive times
with `--rerun-tasks`.

Behaviour is unchanged, and `main.kt` is 14 lines shorter net.
