### PR TITLE
Apply remoteApproval to the four remaining remote handlers

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -1042,44 +1042,31 @@ fun main() {
                                             remoteClientManager.allowedClients, remoteClientManager.blockedClients,
                                             sessionAllowedClients, sessionBlockedClients,
                                         )
-                                        if (access == RemoteAccess.AUTO_REJECT) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        if (access == RemoteAccess.AUTO_APPROVE) {
-                                            val item = pending.item
-                                            addScheduleItem(item, currentScheduleActions) { song ->
-                                                coroutineScope.launch { remoteSelectSongFlow.emit(song) }
-                                            }
-                                            pending.decision.complete(true)
-                                            // Show activity toast so operator is aware
-                                            val (eTitle, eDetail) = remoteEventLabel(item)
-                                            remoteActivityNotifications.add(RemoteActivityNotification(
-                                                type = RemoteEventType.ADD_TO_SCHEDULE,
-                                                title = eTitle,
-                                                detail = eDetail,
-                                                clientId = clientId,
-                                                clientLabel = remoteClientManager.getLabel(clientId)
-                                            ))
-                                            return@collect
-                                        }
                                         val item = pending.item
-                                        val (eventTitle, eventDetail) = remoteEventLabel(item)
-                                        val event = RemoteEvent(
-                                            type = RemoteEventType.ADD_TO_SCHEDULE,
-                                            title = eventTitle,
-                                            detail = eventDetail,
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId)
-                                        )
-                                        val allow: () -> Unit = {
+                                        val add: () -> Unit = {
                                             addScheduleItem(item, currentScheduleActions) { song ->
                                                 coroutineScope.launch { remoteSelectSongFlow.emit(song) }
                                             }
                                             pending.decision.complete(true)
                                         }
-                                        val deny: () -> Unit = { pending.decision.complete(false) }
-                                        remoteEventQueue.add(Triple(event, allow, deny))
+                                        val (eTitle, eDetail) = remoteEventLabel(item)
+                                        when (val outcome = remoteApproval(
+                                            access,
+                                            type = RemoteEventType.ADD_TO_SCHEDULE,
+                                            title = eTitle,
+                                            detail = eDetail,
+                                            clientId = clientId,
+                                            clientLabel = remoteClientManager.getLabel(clientId),
+                                        )) {
+                                            RemoteApproval.Reject -> pending.decision.complete(false)
+                                            is RemoteApproval.Approve -> {
+                                                add()
+                                                remoteActivityNotifications.add(outcome.notification)
+                                            }
+                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                                outcome.event, add, { pending.decision.complete(false) },
+                                            ))
+                                        }
                                     }
                                 }
 
@@ -1092,34 +1079,26 @@ fun main() {
                                             remoteClientManager.allowedClients, remoteClientManager.blockedClients,
                                             sessionAllowedClients, sessionBlockedClients,
                                         )
-                                        if (access == RemoteAccess.AUTO_REJECT) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        if (access == RemoteAccess.AUTO_APPROVE) {
+                                        val remove: () -> Unit = {
                                             currentScheduleActions.removeById(pending.id)
                                             pending.decision.complete(true)
-                                            // Show activity toast so operator is aware
-                                            remoteActivityNotifications.add(RemoteActivityNotification(
-                                                type = RemoteEventType.REMOVE_FROM_SCHEDULE,
-                                                title = pending.label,
-                                                clientId = clientId,
-                                                clientLabel = remoteClientManager.getLabel(clientId)
-                                            ))
-                                            return@collect
                                         }
-                                        val event = RemoteEvent(
+                                        when (val outcome = remoteApproval(
+                                            access,
                                             type = RemoteEventType.REMOVE_FROM_SCHEDULE,
                                             title = pending.label,
                                             clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId)
-                                        )
-                                        val allow: () -> Unit = {
-                                            currentScheduleActions.removeById(pending.id)
-                                            pending.decision.complete(true)
+                                            clientLabel = remoteClientManager.getLabel(clientId),
+                                        )) {
+                                            RemoteApproval.Reject -> pending.decision.complete(false)
+                                            is RemoteApproval.Approve -> {
+                                                remove()
+                                                remoteActivityNotifications.add(outcome.notification)
+                                            }
+                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                                outcome.event, remove, { pending.decision.complete(false) },
+                                            ))
                                         }
-                                        val deny: () -> Unit = { pending.decision.complete(false) }
-                                        remoteEventQueue.add(Triple(event, allow, deny))
                                     }
                                 }
 
@@ -1132,47 +1111,33 @@ fun main() {
                                             remoteClientManager.allowedClients, remoteClientManager.blockedClients,
                                             sessionAllowedClients, sessionBlockedClients,
                                         )
-                                        if (access == RemoteAccess.AUTO_REJECT) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        if (access == RemoteAccess.AUTO_APPROVE) {
+                                        val addAll: () -> Unit = {
                                             for (item in pending.items) {
                                                 addScheduleItem(item, currentScheduleActions) { song ->
                                                     coroutineScope.launch { remoteSelectSongFlow.emit(song) }
                                                 }
                                             }
                                             pending.decision.complete(true)
-                                            // Show activity toast so operator is aware
-                                            val (batchTitle, batchDetail) = batchEventSummary(pending.items)
-                                            remoteActivityNotifications.add(RemoteActivityNotification(
-                                                type = RemoteEventType.ADD_TO_SCHEDULE,
-                                                title = batchTitle,
-                                                detail = batchDetail,
-                                                clientId = clientId,
-                                                clientLabel = remoteClientManager.getLabel(clientId)
-                                            ))
-                                            return@collect
                                         }
-                                        // Build a human-readable summary: first 3 items joined, then "…" if more
-                                        val (summaryTitle, summaryDetail) = batchEventSummary(pending.items)
-                                        val event = RemoteEvent(
+                                        // First 3 items joined, then "…" if more
+                                        val (batchTitle, batchDetail) = batchEventSummary(pending.items)
+                                        when (val outcome = remoteApproval(
+                                            access,
                                             type = RemoteEventType.ADD_TO_SCHEDULE,
-                                            title = summaryTitle,
-                                            detail = summaryDetail,
+                                            title = batchTitle,
+                                            detail = batchDetail,
                                             clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId)
-                                        )
-                                        val allow: () -> Unit = {
-                                            for (item in pending.items) {
-                                                addScheduleItem(item, currentScheduleActions) { song ->
-                                                    coroutineScope.launch { remoteSelectSongFlow.emit(song) }
-                                                }
+                                            clientLabel = remoteClientManager.getLabel(clientId),
+                                        )) {
+                                            RemoteApproval.Reject -> pending.decision.complete(false)
+                                            is RemoteApproval.Approve -> {
+                                                addAll()
+                                                remoteActivityNotifications.add(outcome.notification)
                                             }
-                                            pending.decision.complete(true)
+                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                                outcome.event, addAll, { pending.decision.complete(false) },
+                                            ))
                                         }
-                                        val deny: () -> Unit = { pending.decision.complete(false) }
-                                        remoteEventQueue.add(Triple(event, allow, deny))
                                     }
                                 }
 
@@ -1185,49 +1150,8 @@ fun main() {
                                             remoteClientManager.allowedClients, remoteClientManager.blockedClients,
                                             sessionAllowedClients, sessionBlockedClients,
                                         )
-                                        if (access == RemoteAccess.AUTO_REJECT) {
-                                            pending.decision.complete(false)
-                                            return@collect
-                                        }
-                                        if (access == RemoteAccess.AUTO_APPROVE) {
-                                            val item = pending.item
-                                            if (item is ScheduleItem.AnnouncementItem) {
-                                                appSettings = appSettings.withAnnouncement(item)
-                                            }
-                                            executeProjectItem(
-                                                item,
-                                                currentScheduleActions,
-                                                presenterManager,
-                                                statisticsManager
-                                            )
-                                            coroutineScope.launch {
-                                                emitRemoteTabSelection(
-                                                    item, remoteSelectSongFlow,
-                                                    remoteSelectPictureFlow, remoteSelectPresentationFlow,
-                                                )
-                                            }
-                                            pending.decision.complete(true)
-                                            // Show activity toast so operator is aware
-                                            val (pTitle, pDetail) = remoteEventLabel(item)
-                                            remoteActivityNotifications.add(RemoteActivityNotification(
-                                                type = RemoteEventType.PROJECT,
-                                                title = pTitle,
-                                                detail = pDetail,
-                                                clientId = clientId,
-                                                clientLabel = remoteClientManager.getLabel(clientId)
-                                            ))
-                                            return@collect
-                                        }
                                         val item = pending.item
-                                        val (eventTitle, eventDetail) = remoteEventLabel(item)
-                                        val event = RemoteEvent(
-                                            type = RemoteEventType.PROJECT,
-                                            title = eventTitle,
-                                            detail = eventDetail,
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId)
-                                        )
-                                        val allow: () -> Unit = {
+                                        val project: () -> Unit = {
                                             if (item is ScheduleItem.AnnouncementItem) {
                                                 appSettings = appSettings.withAnnouncement(item)
                                             }
@@ -1246,8 +1170,24 @@ fun main() {
                                             }
                                             pending.decision.complete(true)
                                         }
-                                        val deny: () -> Unit = { pending.decision.complete(false) }
-                                        remoteEventQueue.add(Triple(event, allow, deny))
+                                        val (pTitle, pDetail) = remoteEventLabel(item)
+                                        when (val outcome = remoteApproval(
+                                            access,
+                                            type = RemoteEventType.PROJECT,
+                                            title = pTitle,
+                                            detail = pDetail,
+                                            clientId = clientId,
+                                            clientLabel = remoteClientManager.getLabel(clientId),
+                                        )) {
+                                            RemoteApproval.Reject -> pending.decision.complete(false)
+                                            is RemoteApproval.Approve -> {
+                                                project()
+                                                remoteActivityNotifications.add(outcome.notification)
+                                            }
+                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                                outcome.event, project, { pending.decision.complete(false) },
+                                            ))
+                                        }
                                     }
                                 }
 


### PR DESCRIPTION
Applies `remoteApproval` (added and tested in #175) to the four remaining remote handlers, so all
**seven** now share one tested gate and none writes it by hand.

## Why finish it rather than leave it

#175 converted the three approval-only handlers. That left three of seven on the safe path and four
off it — which is a worse state than either extreme, because nothing at a call site tells a reader
which handlers can still drift. This removes the ambiguity: `grep "access == RemoteAccess"` in
`main.kt` now returns nothing.

Converted: `onAddToSchedule`, `onRemoveFromSchedule`, `onAddBatchToSchedule`, `onProject`.

## A second duplication this collapses

Each of these handlers wrote its **action** twice — once in the auto-approve branch and once in the
`allow` lambda. Binding it to a single local (`add`, `remove`, `addAll`, `project`) used by both
branches means the approved path and the prompted path are now literally the same code, rather than
two copies that happen to agree today. That is the same class of defect #165 found for real, where
the batch copy of a dispatch had drifted to five branches while the single-add copy had eight.

## Behaviour is unchanged — the two things worth checking

No new tests here; this applies a helper #175 already covers. So the review question is whether it is
faithful, and two details are worth stating rather than leaving to inspection:

- **`remoteEventLabel(item)` and `remoteClientManager.getLabel(clientId)` now run once, before the
  branch, instead of inside each branch.** Safe: both are pure reads, and neither depends on
  `appSettings`, which the project action mutates via `withAnnouncement`.
- **Ordering within each branch is preserved** — action first, then the notification. In the project
  handler the notification is now *constructed* before the action runs, but its fields come only from
  the item and the client label, neither of which the action changes.

`main.kt` is 60 lines shorter (62 insertions, 122 deletions).

## Verification

Because this edits live code broadly rather than adding a test file, a package-scoped run would not
have exercised what it can break: `./gradlew :composeApp:jvmTest --rerun-tasks` **three consecutive
times over the full suite**, all green, zero failures. `compileKotlinJvm` clean with no new warnings.
