### PR TITLE
Extract reconcileScreenAssignments out of main.kt and test it

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ScreenAssignmentReconcile.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ScreenAssignmentReconcile.kt
@@ -1,0 +1,86 @@
+package org.churchpresenter.app.churchpresenter.data.settings
+
+import org.churchpresenter.app.churchpresenter.utils.Constants
+
+/**
+ * A physical display an output slot can be sent to, already resolved from `GraphicsEnvironment`.
+ *
+ * [deviceIndex] is the position in the full `screenDevices` array — *not* in the non-primary list —
+ * because that is what [ScreenAssignment.targetDisplay] stores and what the presenter windows look
+ * up later. Passing the non-primary index here would send every output to the wrong screen on any
+ * machine whose primary is not device 0.
+ */
+data class ResolvedDisplay(
+    val deviceIndex: Int,
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+)
+
+/**
+ * Brings saved screen assignments into line with the displays and DeckLink devices actually present,
+ * at startup and before the UI renders.
+ *
+ * Two things are fixed here:
+ * - **Missing slots are added.** There is one slot per non-primary display plus one per DeckLink
+ *   device. A slot with no display behind it (a DeckLink-only slot) is created as
+ *   [Constants.KEY_TARGET_NONE] rather than left at auto, which is the whole reason this runs before
+ *   the UI: an unresolved slot would otherwise render as if it were pointed at a screen.
+ * - **`-1` (auto) is resolved.** An assignment saved as auto takes the display in its own position,
+ *   or becomes `KEY_TARGET_NONE` when that position has no display — the case where someone unplugs
+ *   the second monitor between services.
+ *
+ * Saved assignments that already name a display are left completely alone, including when that
+ * display is currently absent: the operator chose it, and a monitor that is unplugged today is
+ * usually plugged back in tomorrow. Silently repointing it would move the output somewhere the
+ * operator never asked for.
+ *
+ * Returns **null when nothing needed changing**, so a normal launch does not rewrite the settings
+ * file. Callers persist only a non-null result.
+ */
+fun reconcileScreenAssignments(
+    saved: List<ScreenAssignment>,
+    nonPrimaryDisplays: List<ResolvedDisplay>,
+    deckLinkCount: Int,
+): List<ScreenAssignment>? {
+    val slotCount = (nonPrimaryDisplays.size + deckLinkCount).coerceAtLeast(0)
+    var changed = false
+    val assignments = saved.toMutableList()
+
+    while (assignments.size < slotCount) {
+        val display = nonPrimaryDisplays.getOrNull(assignments.size)
+        assignments.add(
+            ScreenAssignment(
+                targetDisplay = display?.deviceIndex ?: Constants.KEY_TARGET_NONE,
+                targetBoundsX = display?.x ?: Int.MIN_VALUE,
+                targetBoundsY = display?.y ?: Int.MIN_VALUE,
+                targetBoundsW = display?.width ?: 0,
+                targetBoundsH = display?.height ?: 0,
+            )
+        )
+        changed = true
+    }
+
+    for (idx in assignments.indices) {
+        if (assignments[idx].targetDisplay != AUTO_TARGET_DISPLAY) continue
+        val display = nonPrimaryDisplays.getOrNull(idx)
+        assignments[idx] = if (display != null) {
+            assignments[idx].copy(
+                targetDisplay = display.deviceIndex,
+                targetBoundsX = display.x,
+                targetBoundsY = display.y,
+                targetBoundsW = display.width,
+                targetBoundsH = display.height,
+            )
+        } else {
+            assignments[idx].copy(targetDisplay = Constants.KEY_TARGET_NONE)
+        }
+        changed = true
+    }
+
+    return if (changed) assignments else null
+}
+
+/** `targetDisplay` value meaning "decide at startup" — see [ScreenAssignment.targetDisplay]. */
+internal const val AUTO_TARGET_DISPLAY = -1

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -85,6 +85,8 @@ import org.churchpresenter.app.churchpresenter.data.settings.BibleSyncMode
 import org.churchpresenter.app.churchpresenter.data.settings.CompanionSatelliteSettings
 import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkRole
 import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
+import org.churchpresenter.app.churchpresenter.data.settings.ResolvedDisplay
+import org.churchpresenter.app.churchpresenter.data.settings.reconcileScreenAssignments
 import org.churchpresenter.app.churchpresenter.data.settings.withBundledBible
 import org.churchpresenter.app.churchpresenter.data.Language
 import org.churchpresenter.app.churchpresenter.data.RemoteClientManager
@@ -328,49 +330,18 @@ fun main() {
         remember {
             val screenDevicesAll = GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices
             val primaryDevice = GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice
-            val nonPrimaryDevices = screenDevicesAll.filter { it != primaryDevice }
+            val nonPrimaryDisplays = screenDevicesAll.filter { it != primaryDevice }.map { device ->
+                val bounds = device.defaultConfiguration.bounds
+                ResolvedDisplay(
+                    deviceIndex = screenDevicesAll.indexOf(device),
+                    x = bounds.x, y = bounds.y, width = bounds.width, height = bounds.height,
+                )
+            }
             val deckLinkCount = if (DeckLinkManager.isAvailable()) DeckLinkManager.listDevices().size else 0
-            val slotCount = (nonPrimaryDevices.size + deckLinkCount).coerceAtLeast(0)
 
             val proj = appSettings.projectionSettings
-            var changed = false
-            val assignments = proj.screenAssignments.toMutableList()
-            while (assignments.size < slotCount) {
-                val npIdx = assignments.size
-                val device = nonPrimaryDevices.getOrNull(npIdx)
-                val deviceIdx = if (device != null) screenDevicesAll.indexOf(device) else Constants.KEY_TARGET_NONE
-                val bounds = device?.defaultConfiguration?.bounds
-                assignments.add(
-                    ScreenAssignment(
-                        targetDisplay = deviceIdx,
-                        targetBoundsX = bounds?.x ?: Int.MIN_VALUE,
-                        targetBoundsY = bounds?.y ?: Int.MIN_VALUE,
-                        targetBoundsW = bounds?.width ?: 0,
-                        targetBoundsH = bounds?.height ?: 0
-                    )
-                )
-                changed = true
-            }
-            for (idx in assignments.indices) {
-                if (assignments[idx].targetDisplay == -1) {
-                    val device = nonPrimaryDevices.getOrNull(idx)
-                    if (device != null) {
-                        val deviceIdx = screenDevicesAll.indexOf(device)
-                        val bounds = device.defaultConfiguration.bounds
-                        assignments[idx] = assignments[idx].copy(
-                            targetDisplay = deviceIdx,
-                            targetBoundsX = bounds.x,
-                            targetBoundsY = bounds.y,
-                            targetBoundsW = bounds.width,
-                            targetBoundsH = bounds.height
-                        )
-                    } else {
-                        assignments[idx] = assignments[idx].copy(targetDisplay = Constants.KEY_TARGET_NONE)
-                    }
-                    changed = true
-                }
-            }
-            if (changed) {
+            val assignments = reconcileScreenAssignments(proj.screenAssignments, nonPrimaryDisplays, deckLinkCount)
+            if (assignments != null) {
                 appSettings = appSettings.copy(
                     projectionSettings = proj.copy(screenAssignments = assignments)
                 )

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ScreenAssignmentReconcileTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ScreenAssignmentReconcileTest.kt
@@ -1,0 +1,156 @@
+package org.churchpresenter.app.churchpresenter.data.settings
+
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Bringing saved screen assignments into line with the displays actually plugged in.
+ *
+ * This runs once at startup, before the UI renders, and decides **which physical screen each output
+ * goes to**. Getting it wrong is not a cosmetic bug: the congregation sees the wrong thing, or an
+ * output lands on the operator's own laptop screen mid-service. It lived in `main.kt` inside a
+ * `remember { }` at 0% coverage, mixed in with the `GraphicsEnvironment` calls that made it look
+ * untestable — those stay at the call site; everything below is the decision.
+ *
+ * The case that matters most is the one it deliberately does *not* touch: an assignment naming a
+ * display that is currently absent is left alone. See the test at the bottom.
+ */
+class ScreenAssignmentReconcileTest {
+
+    private fun display(deviceIndex: Int, x: Int = 0, w: Int = 1920, h: Int = 1080) =
+        ResolvedDisplay(deviceIndex = deviceIndex, x = x, y = 0, width = w, height = h)
+
+    private fun auto() = ScreenAssignment(targetDisplay = -1)
+
+    // ── Nothing to do ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `an already-resolved set is left alone and reports no change`() {
+        val saved = listOf(ScreenAssignment(targetDisplay = 1), ScreenAssignment(targetDisplay = 2))
+
+        assertNull(
+            reconcileScreenAssignments(saved, listOf(display(1), display(2)), deckLinkCount = 0),
+            "a normal launch must not rewrite the settings file",
+        )
+    }
+
+    @Test
+    fun `no displays and no devices needs no slots`() {
+        assertNull(reconcileScreenAssignments(emptyList(), emptyList(), deckLinkCount = 0))
+    }
+
+    // ── Adding missing slots ────────────────────────────────────────────────────
+
+    @Test
+    fun `a slot is created for each non-primary display, carrying its bounds`() {
+        val result = assertNotNull(
+            reconcileScreenAssignments(emptyList(), listOf(display(1, x = 1920), display(2, x = 3840)), 0)
+        )
+
+        assertEquals(2, result.size)
+        assertEquals(listOf(1, 2), result.map { it.targetDisplay })
+        assertEquals(listOf(1920, 3840), result.map { it.targetBoundsX })
+        assertEquals(listOf(1920, 1920), result.map { it.targetBoundsW })
+    }
+
+    @Test
+    fun `a DeckLink-only slot is created as none rather than left on auto`() {
+        val result = assertNotNull(reconcileScreenAssignments(emptyList(), emptyList(), deckLinkCount = 2))
+
+        assertEquals(2, result.size)
+        assertEquals(
+            listOf(Constants.KEY_TARGET_NONE, Constants.KEY_TARGET_NONE), result.map { it.targetDisplay },
+            "an unresolved slot renders as if pointed at a screen — this is why it runs before the UI",
+        )
+    }
+
+    @Test
+    fun `displays fill the first slots and DeckLinks take the rest`() {
+        val result = assertNotNull(
+            reconcileScreenAssignments(emptyList(), listOf(display(1)), deckLinkCount = 1)
+        )
+
+        assertEquals(listOf(1, Constants.KEY_TARGET_NONE), result.map { it.targetDisplay })
+    }
+
+    // ── Resolving auto ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `auto takes the display in its own position`() {
+        val result = assertNotNull(
+            reconcileScreenAssignments(listOf(auto(), auto()), listOf(display(1, x = 100), display(3, x = 200)), 0)
+        )
+
+        assertEquals(listOf(1, 3), result.map { it.targetDisplay })
+        assertEquals(listOf(100, 200), result.map { it.targetBoundsX })
+    }
+
+    @Test
+    fun `auto with no display behind it becomes none`() {
+        val result = assertNotNull(reconcileScreenAssignments(listOf(auto()), emptyList(), deckLinkCount = 0))
+
+        assertEquals(Constants.KEY_TARGET_NONE, result.single().targetDisplay)
+    }
+
+    @Test
+    fun `the device index is the one in the full device list, not the non-primary list`() {
+        // Primary is device 0, so the two extra screens are devices 1 and 2 — never 0 and 1.
+        val result = assertNotNull(reconcileScreenAssignments(listOf(auto(), auto()), listOf(display(1), display(2)), 0))
+
+        assertEquals(
+            listOf(1, 2), result.map { it.targetDisplay },
+            "using the non-primary position here sends every output to the wrong screen",
+        )
+    }
+
+    // ── The case it must NOT touch ──────────────────────────────────────────────
+
+    @Test
+    fun `an assignment naming an absent display is left where the operator put it`() {
+        val saved = listOf(ScreenAssignment(targetDisplay = 5, targetBoundsX = 999))
+
+        assertNull(
+            reconcileScreenAssignments(saved, emptyList(), deckLinkCount = 1),
+            "a monitor unplugged today is usually plugged back in tomorrow; repointing it silently " +
+                "moves the output somewhere nobody asked for",
+        )
+    }
+
+    @Test
+    fun `resolving auto does not disturb a neighbouring explicit assignment`() {
+        val saved = listOf(ScreenAssignment(targetDisplay = 4, targetBoundsX = 777), auto())
+
+        val result = assertNotNull(reconcileScreenAssignments(saved, listOf(display(1), display(2, x = 55)), 0))
+
+        assertEquals(4, result[0].targetDisplay)
+        assertEquals(777, result[0].targetBoundsX)
+        assertEquals(2, result[1].targetDisplay)
+        assertEquals(55, result[1].targetBoundsX)
+    }
+
+    @Test
+    fun `other fields of an assignment survive the resolve`() {
+        val saved = listOf(auto().copy(targetType = "decklink", keyTargetDisplay = 3, bibleTranslations = listOf(0, 2)))
+
+        val result = assertNotNull(reconcileScreenAssignments(saved, listOf(display(1)), 0)).single()
+
+        assertEquals("decklink", result.targetType)
+        assertEquals(3, result.keyTargetDisplay)
+        assertEquals(listOf(0, 2), result.bibleTranslations)
+    }
+
+    // ── Slots already sufficient ────────────────────────────────────────────────
+
+    @Test
+    fun `more saved slots than devices are not truncated`() {
+        val saved = listOf(ScreenAssignment(targetDisplay = 1), ScreenAssignment(targetDisplay = 2))
+
+        assertNull(
+            reconcileScreenAssignments(saved, listOf(display(1)), deckLinkCount = 0),
+            "unplugging a screen must not delete its saved output configuration",
+        )
+    }
+}


### PR DESCRIPTION
Extracts `reconcileScreenAssignments` — the startup logic deciding **which physical screen each
output goes to** — out of `main.kt` into `data/settings/ScreenAssignmentReconcile.kt`, and tests it.

The remote-handler region is now exhausted (#165, #167, #172, #174, #175, #176), so this moves to the
other untested block in the app root.

## Why it matters

This runs once at startup, before the UI renders. Getting it wrong is not cosmetic: an output lands
on the wrong screen, or on the operator's own laptop, and the congregation sees it.

It was 0% covered and looked untestable because it sits among `GraphicsEnvironment` and
`DeckLinkManager` calls. Those are **three lines**; the decision around them is **thirty**. The call
site keeps the environment lookup and maps it to a list of `ResolvedDisplay`; the extracted function
takes that list plus a DeckLink count, and takes **zero function parameters** — so it adds no
uncovered lambda methods at the call site.

## The trap, which has its own test

`ResolvedDisplay.deviceIndex` is the index in the **full** `screenDevices` array, not in the
non-primary list. That is what `ScreenAssignment.targetDisplay` stores and what the presenter windows
look up later, so using the non-primary position sends every output to the wrong screen on any
machine whose primary display is not device 0. `the device index is the one in the full device list,
not the non-primary list` exists for exactly this.

## What it deliberately does NOT do

An assignment that already names a display is left completely alone, **including when that display is
currently absent**, and saved slots are never truncated. A monitor unplugged today is usually plugged
back in tomorrow; silently repointing it moves the output somewhere the operator never asked for. Two
tests cover this, and they are the ones most worth keeping.

It also returns **null when nothing changed**, so a normal launch does not rewrite the settings file.

## Tests

Twelve tests, sub-millisecond, no fakes and no mocks: no-op cases, slot creation for displays and for
DeckLink-only slots (created as `KEY_TARGET_NONE` rather than left on auto — the stated reason the
whole block runs before the UI), auto resolution, field preservation, and the two leave-it-alone
cases above.

## Evidence

Not a red-green pin — the function is new. What was checked: a mutation using the non-primary index
and repointing absent displays fails **4 of the 12** tests, including the one named for the index
trap; and the extracted body was diffed against the original before the original was removed.

Validated with the **full** suite rather than a package, since this edits live startup code:
`./gradlew :composeApp:jvmTest --rerun-tasks` three consecutive times, **7,878 tests, zero failures**
each run.
