### PR TITLE
Fix the Studio theme not surviving a restart

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -135,6 +135,7 @@ import org.churchpresenter.app.churchpresenter.models.QuestionStatus
 import org.churchpresenter.app.churchpresenter.data.StrongsEntry
 import org.churchpresenter.app.churchpresenter.ui.theme.LanguageProvider
 import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
+import org.churchpresenter.app.churchpresenter.ui.theme.themeFromSettings
 import org.churchpresenter.app.churchpresenter.viewmodel.LocalMediaViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.InstanceLinkCommandFailure
 import org.churchpresenter.app.churchpresenter.viewmodel.MediaViewModel
@@ -378,20 +379,7 @@ fun main() {
         var identifyingScreen by remember { mutableStateOf(false) }
         val coroutineScope = rememberCoroutineScope { coroutineExceptionHandler }
 
-        var theme by remember {
-            val savedTheme = when (appSettings.theme.uppercase()) {
-                "LIGHT" -> ThemeMode.LIGHT
-                "DARK" -> ThemeMode.DARK
-                "WARM" -> ThemeMode.WARM
-                "OCEAN" -> ThemeMode.OCEAN
-                "ROSE" -> ThemeMode.ROSE
-                "MIDNIGHT" -> ThemeMode.MIDNIGHT
-                "FOREST" -> ThemeMode.FOREST
-                "MOCHA" -> ThemeMode.MOCHA
-                else -> ThemeMode.SYSTEM
-            }
-            mutableStateOf(savedTheme)
-        }
+        var theme by remember { mutableStateOf(themeFromSettings(appSettings.theme)) }
         val companionServer = remember { CompanionServer() }
         val qaManager = remember { QAManager() }
         val sttManager = remember { STTManager() }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/ThemeManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/ThemeManager.kt
@@ -46,3 +46,18 @@ fun ProvideThemeManager(
 fun rememberThemeManager(): ThemeManager {
     return LocalThemeManager.current
 }
+
+/**
+ * The [ThemeMode] a saved settings string means, falling back to [ThemeMode.SYSTEM] when it names
+ * nothing recognisable — a settings file from a newer version, or hand-edited.
+ *
+ * Matched against [ThemeMode.entries] rather than a hand-written `when`, so it cannot fall behind the
+ * enum. It already had: the `when` this replaces listed nine of the ten modes and omitted
+ * [ThemeMode.STUDIO], which is offered in the top bar, the theme switcher and the setup wizard — so
+ * choosing Studio and restarting silently landed the user back on System, with no error anywhere.
+ *
+ * The stored form is [ThemeMode.toString], i.e. the enum name; [saved] is upper-cased first because
+ * older settings files hold lower-case values.
+ */
+fun themeFromSettings(saved: String): ThemeMode =
+    ThemeMode.entries.find { it.name == saved.uppercase() } ?: ThemeMode.SYSTEM

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/ThemeFromSettingsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/ui/theme/ThemeFromSettingsTest.kt
@@ -1,0 +1,65 @@
+package org.churchpresenter.app.churchpresenter.ui.theme
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Turning the saved theme string back into a [ThemeMode] at startup.
+ *
+ * This replaced a hand-written `when` in `main.kt` that listed **nine of the ten** modes. The one it
+ * omitted was [ThemeMode.STUDIO] — which is offered in the top bar, the theme switcher *and* the
+ * setup wizard, and has its own colour scheme — so picking Studio and restarting silently dropped the
+ * user back on System. Nothing threw and nothing was logged; the theme just quietly reverted.
+ *
+ * `every mode survives a save and reload` is the test that would have caught it, and is the one to
+ * keep: it fails automatically the next time a mode is added to the enum and not to the parser.
+ * Matching on [ThemeMode.entries] means that can no longer happen, but the test outlives the
+ * implementation.
+ */
+class ThemeFromSettingsTest {
+
+    /** How the app stores it — see the `appSettings.copy(theme = it.toString())` call sites. */
+    private fun saved(mode: ThemeMode) = mode.toString()
+
+    @Test
+    fun `every mode survives a save and reload`() {
+        ThemeMode.entries.forEach { mode ->
+            assertEquals(mode, themeFromSettings(saved(mode)), "$mode did not survive a restart")
+        }
+    }
+
+    @Test
+    fun `the studio theme is restored rather than falling back to system`() {
+        // The regression this fixes: STUDIO was missing from the parser and fell through to SYSTEM.
+        assertEquals(ThemeMode.STUDIO, themeFromSettings("STUDIO"))
+    }
+
+    @Test
+    fun `an unrecognised theme falls back to system`() {
+        assertEquals(ThemeMode.SYSTEM, themeFromSettings("NEON"))
+        assertEquals(ThemeMode.SYSTEM, themeFromSettings(""))
+        assertEquals(ThemeMode.SYSTEM, themeFromSettings("   "))
+    }
+
+    @Test
+    fun `an older lower-case settings value is still understood`() {
+        assertEquals(ThemeMode.DARK, themeFromSettings("dark"))
+        assertEquals(ThemeMode.MIDNIGHT, themeFromSettings("Midnight"))
+        assertEquals(ThemeMode.STUDIO, themeFromSettings("studio"))
+    }
+
+    @Test
+    fun `system itself round-trips rather than only being the fallback`() {
+        assertEquals(
+            ThemeMode.SYSTEM, themeFromSettings("SYSTEM"),
+            "SYSTEM must be reachable by name, not only by failing to match",
+        )
+    }
+
+    @Test
+    fun `no two saved values map to the same mode`() {
+        val parsed = ThemeMode.entries.map { themeFromSettings(saved(it)) }
+
+        assertEquals(parsed.size, parsed.toSet().size, "two modes collapsed onto one: $parsed")
+    }
+}


### PR DESCRIPTION
**Fixes a live bug: choosing the Studio theme and restarting silently reverts to System.**

Found while extracting the last pure decisions out of `main.kt`'s startup block, the same way #165
turned up the batch-add gap.

## The bug

`ThemeMode` has **ten** entries. The startup parser in `main.kt` was a hand-written `when` listing
**nine** — `STUDIO` was missing, so it fell through to `else -> ThemeMode.SYSTEM`.

Studio is not a dead enum entry. It is offered in `NavigationTopBar`, in `ThemeSwitcher` and in
`SetupWizardDialog`, and it has its own colour scheme, string resource and icon. So anyone who picked
it lost it on every launch — and nothing threw, nothing logged, and the theme menu simply showed
System next time. There is exactly one theme parser in the codebase (swept for `"LIGHT" ->`,
`theme.uppercase()` and `ThemeMode.valueOf`), so this is the whole fix.

## The fix

`themeFromSettings` matches against `ThemeMode.entries` instead of a hand-written list, so the parser
**cannot** fall behind the enum again. It lives next to the enum in `ThemeManager.kt`; `main.kt`'s
fourteen-line `when` becomes one call.

Behaviour is otherwise identical: the stored form is the enum name, `uppercase()` is kept so older
lower-case settings files still load, and anything unrecognised still falls back to `SYSTEM`.

## This one is a real red-green pin

Unlike the recent extraction PRs, the old code exists to test against. I put the **verbatim original
`when` block** behind the new function and ran the suite: **4 of 6 tests fail**, including
`the studio theme is restored rather than falling back to system`. Restoring the fix turns them green.

The test to keep is `every mode survives a save and reload` — it iterates `ThemeMode.entries`, so it
fails automatically the next time a mode is added and the parser is not updated. It outlives this
implementation, which is the point: the current fix makes the failure impossible, but the test still
catches whoever replaces it with a `when` again.

Also covered: unrecognised and blank values, older lower-case files, `SYSTEM` being reachable by name
rather than only as the fallback, and no two modes collapsing onto one.

## Verification

`./gradlew :composeApp:jvmTest --rerun-tasks` three consecutive times: **7,884 tests, zero failures**
each run. `compileKotlinJvm` clean.
