### PR TITLE
Extract obsSceneFor out of main.kt and test it

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ObsSceneSelection.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ObsSceneSelection.kt
@@ -1,0 +1,24 @@
+package org.churchpresenter.app.churchpresenter.data.settings
+
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+
+/**
+ * The OBS scene to switch to when the live content type becomes [mode], or **null** to leave OBS
+ * alone.
+ *
+ * Order: the scene mapped to this content type, else [OBSSettings.defaultScene], else no switch.
+ *
+ * **Blank is treated as unset at every step, and that is not a nicety.** `OBSSettingsTab` writes each
+ * mapping straight from a text field, so a user who types a scene name and then clears it leaves
+ * `""` in [OBSSettings.sceneMappings] rather than removing the key. Taking that literally would ask
+ * OBS to switch to a scene called "" the moment that content goes live — mid-service, on the stream.
+ * The same applies to a blank default, which means "no default", not "a scene with no name".
+ *
+ * Returns null when integration is disabled, so the caller has one condition to check rather than
+ * two.
+ */
+fun obsSceneFor(mode: Presenting, settings: OBSSettings): String? {
+    if (!settings.enabled) return null
+    return settings.sceneMappings[mode.name]?.takeIf { it.isNotBlank() }
+        ?: settings.defaultScene.takeIf { it.isNotBlank() }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -86,6 +86,7 @@ import org.churchpresenter.app.churchpresenter.data.settings.CompanionSatelliteS
 import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkRole
 import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
 import org.churchpresenter.app.churchpresenter.data.settings.ResolvedDisplay
+import org.churchpresenter.app.churchpresenter.data.settings.obsSceneFor
 import org.churchpresenter.app.churchpresenter.data.settings.reconcileScreenAssignments
 import org.churchpresenter.app.churchpresenter.data.settings.withBundledBible
 import org.churchpresenter.app.churchpresenter.data.Language
@@ -668,11 +669,7 @@ fun main() {
         LaunchedEffect(Unit) {
             snapshotFlow { presenterManager.presentingMode.value }
                 .collect { mode ->
-                    val obs = appSettings.obsSettings
-                    if (!obs.enabled) return@collect
-                    val sceneName = obs.sceneMappings[mode.name]?.takeIf { it.isNotBlank() }
-                        ?: obs.defaultScene.takeIf { it.isNotBlank() }
-                        ?: return@collect
+                    val sceneName = obsSceneFor(mode, appSettings.obsSettings) ?: return@collect
                     obsManager.setScene(sceneName)
                 }
         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ObsSceneSelectionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/settings/ObsSceneSelectionTest.kt
@@ -1,0 +1,126 @@
+package org.churchpresenter.app.churchpresenter.data.settings
+
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Which OBS scene the stream cuts to when the live content type changes.
+ *
+ * This runs on every content change during a service and drives a real scene switch on the broadcast.
+ * A wrong answer is visible to everyone watching, so the cases below are about *not* switching as
+ * much as about switching.
+ *
+ * The blank handling is the load-bearing part. `OBSSettingsTab` writes each mapping straight from a
+ * text field, so someone who types a scene name and then clears it leaves `""` in the map rather than
+ * removing the key. Taking that at face value would ask OBS to switch to a scene named `""` the next
+ * time that content goes live.
+ */
+class ObsSceneSelectionTest {
+
+    private fun settings(
+        enabled: Boolean = true,
+        default: String = "",
+        mappings: Map<String, String> = emptyMap(),
+    ) = OBSSettings(enabled = enabled, defaultScene = default, sceneMappings = mappings)
+
+    // ── Switching ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a mapped content type switches to its own scene`() {
+        val obs = settings(mappings = mapOf(Presenting.LYRICS.name to "Worship"))
+
+        assertEquals("Worship", obsSceneFor(Presenting.LYRICS, obs))
+    }
+
+    @Test
+    fun `a mapping wins over the default`() {
+        val obs = settings(default = "Wide", mappings = mapOf(Presenting.BIBLE.name to "Scripture"))
+
+        assertEquals("Scripture", obsSceneFor(Presenting.BIBLE, obs))
+    }
+
+    @Test
+    fun `an unmapped content type falls back to the default`() {
+        val obs = settings(default = "Wide", mappings = mapOf(Presenting.LYRICS.name to "Worship"))
+
+        assertEquals("Wide", obsSceneFor(Presenting.BIBLE, obs))
+    }
+
+    @Test
+    fun `each content type gets its own scene`() {
+        val obs = settings(
+            mappings = mapOf(
+                Presenting.LYRICS.name to "Worship",
+                Presenting.BIBLE.name to "Scripture",
+                Presenting.NONE.name to "Holding",
+            ),
+        )
+
+        assertEquals("Worship", obsSceneFor(Presenting.LYRICS, obs))
+        assertEquals("Scripture", obsSceneFor(Presenting.BIBLE, obs))
+        assertEquals("Holding", obsSceneFor(Presenting.NONE, obs))
+    }
+
+    // ── Not switching ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `integration disabled never switches, even with everything configured`() {
+        val obs = settings(enabled = false, default = "Wide", mappings = mapOf(Presenting.LYRICS.name to "Worship"))
+
+        assertNull(obsSceneFor(Presenting.LYRICS, obs))
+        assertNull(obsSceneFor(Presenting.BIBLE, obs))
+    }
+
+    @Test
+    fun `nothing configured means no switch rather than an empty scene name`() {
+        assertNull(obsSceneFor(Presenting.LYRICS, settings()))
+    }
+
+    // ── Blank is unset, not a scene name ────────────────────────────────────────
+
+    @Test
+    fun `a cleared mapping falls back to the default instead of switching to nothing`() {
+        val obs = settings(default = "Wide", mappings = mapOf(Presenting.LYRICS.name to ""))
+
+        assertEquals(
+            "Wide", obsSceneFor(Presenting.LYRICS, obs),
+            "clearing the text field leaves \"\" in the map; it must not reach OBS as a scene name",
+        )
+    }
+
+    @Test
+    fun `a whitespace-only mapping is also treated as unset`() {
+        val obs = settings(default = "Wide", mappings = mapOf(Presenting.LYRICS.name to "   "))
+
+        assertEquals("Wide", obsSceneFor(Presenting.LYRICS, obs))
+    }
+
+    @Test
+    fun `a blank default means no default, not a scene with no name`() {
+        val obs = settings(default = "  ", mappings = mapOf(Presenting.LYRICS.name to "Worship"))
+
+        assertNull(obsSceneFor(Presenting.BIBLE, obs))
+        assertEquals("Worship", obsSceneFor(Presenting.LYRICS, obs))
+    }
+
+    @Test
+    fun `a cleared mapping with no default switches nothing at all`() {
+        val obs = settings(mappings = mapOf(Presenting.LYRICS.name to ""))
+
+        assertNull(obsSceneFor(Presenting.LYRICS, obs))
+    }
+
+    // ── Keys are enum names, which is what the settings tab writes ──────────────
+
+    @Test
+    fun `a mapping keyed by something that is not a content type is ignored`() {
+        val obs = settings(default = "Wide", mappings = mapOf("Lyrics" to "Worship"))
+
+        assertEquals(
+            "Wide", obsSceneFor(Presenting.LYRICS, obs),
+            "keys are enum names — a stale or hand-edited key must not half-match",
+        )
+    }
+}


### PR DESCRIPTION
Extracts `obsSceneFor` — which OBS scene the stream cuts to when the live content type changes — out
of `main.kt` into `data/settings/ObsSceneSelection.kt`, and tests it.

It ran on every content change during a service, drove a real scene switch on the broadcast, and was
at **0% coverage**.

## The blank handling is the load-bearing part

`OBSSettingsTab` writes each mapping straight from a text field, so someone who types a scene name and
then clears it leaves `""` in `sceneMappings` rather than removing the key. Taking that at face value
asks OBS to cut to a scene named `""` the next time that content goes live — mid-service, on the
stream. The same reasoning applies to a blank `defaultScene`, which means "no default", not "a scene
with no name".

That is why the `isNotBlank()` guards exist, and it is what the tests are mostly about. Removing the
mapping guard fails **3 of the 11** tests.

## What it returns

The scene mapped to this content type, else `defaultScene`, else **null** meaning *leave OBS alone*.
Disabled integration also returns null, so the caller has one condition to check instead of two — the
`main.kt` collector goes from six lines to two.

Behaviour is unchanged.

## Tests

Eleven tests, ~1ms, no fakes. Deliberately balanced between switching and **not** switching, because
the failure that matters is an unwanted cut on a live broadcast:

- a mapping wins over the default; an unmapped type falls back to it; each type gets its own scene;
- integration disabled never switches even with everything configured;
- nothing configured yields no switch rather than an empty scene name;
- a cleared mapping falls back to the default, and with no default switches nothing at all;
- a whitespace-only mapping and a whitespace-only default are both treated as unset;
- a mapping keyed by something that is not a content type (`"Lyrics"` rather than `Presenting.LYRICS.name`)
  is ignored rather than half-matching — the keys are enum names, and a stale or hand-edited settings
  file should not steer the stream.

## Evidence

Not a red-green pin — the extracted body is the original logic, so it passes against both. What was
checked: dropping the blank guard fails 3 of 11; the extracted body was diffed against the original
before it was removed; `compileKotlinJvm` clean with no new warnings.

Validated with the **full** suite, since this edits live code rather than only adding a test file:
`./gradlew :composeApp:jvmTest --rerun-tasks` three consecutive times, **7,895 tests, zero failures**
each run.
