### PR TITLE
Extract window placement and geometry persistence out of main.kt

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/WindowGeometry.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/settings/WindowGeometry.kt
@@ -1,0 +1,32 @@
+package org.churchpresenter.app.churchpresenter.data.settings
+
+/**
+ * The window size and position to persist when the app closes.
+ *
+ * Only a **floating** window has geometry worth remembering. A maximized or fullscreen window's
+ * measured bounds are the screen's, not the user's choice, so storing them would overwrite the size
+ * the window should return to when it is un-maximized — the user would maximize once and lose their
+ * layout permanently. Instead the previous floating size is kept and the coordinates are cleared to
+ * [NO_SAVED_POSITION].
+ *
+ * That sentinel is what the launch path checks (`windowX >= 0`) before restoring a position, so
+ * clearing it means "open where the OS puts you" rather than "open at 0,0" — a real difference on a
+ * multi-monitor setup, where 0,0 may be a screen that is no longer attached.
+ */
+fun AppSettings.withWindowGeometry(
+    placement: String,
+    isFloating: Boolean,
+    width: Int,
+    height: Int,
+    x: Int,
+    y: Int,
+): AppSettings = copy(
+    windowPlacement = placement,
+    windowWidth = if (isFloating) width else windowWidth,
+    windowHeight = if (isFloating) height else windowHeight,
+    windowX = if (isFloating) x else NO_SAVED_POSITION,
+    windowY = if (isFloating) y else NO_SAVED_POSITION,
+)
+
+/** `windowX`/`windowY` value meaning "no remembered position; let the OS place the window". */
+const val NO_SAVED_POSITION = -1

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -87,6 +87,9 @@ import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkRole
 import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
 import org.churchpresenter.app.churchpresenter.data.settings.ResolvedDisplay
 import org.churchpresenter.app.churchpresenter.data.settings.obsSceneFor
+import org.churchpresenter.app.churchpresenter.data.settings.withWindowGeometry
+import org.churchpresenter.app.churchpresenter.utils.windowPlacementFromSettings
+import org.churchpresenter.app.churchpresenter.utils.windowPlacementToSettings
 import org.churchpresenter.app.churchpresenter.data.settings.reconcileScreenAssignments
 import org.churchpresenter.app.churchpresenter.data.settings.withBundledBible
 import org.churchpresenter.app.churchpresenter.data.Language
@@ -906,11 +909,7 @@ fun main() {
 
 
         val screens = rememberScreenDevices()
-        val savedPlacement = when (appSettings.windowPlacement) {
-            "floating" -> WindowPlacement.Floating
-            "fullscreen" -> WindowPlacement.Fullscreen
-            else -> WindowPlacement.Maximized
-        }
+        val savedPlacement = windowPlacementFromSettings(appSettings.windowPlacement)
         // Use OS primary monitor bounds so maximized/fullscreen stays on one screen
         val primaryBounds = GraphicsEnvironment.getLocalGraphicsEnvironment()
             .defaultScreenDevice.defaultConfiguration.bounds
@@ -932,18 +931,13 @@ fun main() {
         if (appReady && eulaAccepted) {
             Window(
                 onCloseRequest = {
-                    val placementStr = when (state.placement) {
-                        WindowPlacement.Floating -> "floating"
-                        WindowPlacement.Fullscreen -> "fullscreen"
-                        WindowPlacement.Maximized -> "maximized"
-                    }
-                    val isFloating = state.placement == WindowPlacement.Floating
-                    appSettings = appSettings.copy(
-                        windowPlacement = placementStr,
-                        windowWidth = if (isFloating) state.size.width.value.toInt() else appSettings.windowWidth,
-                        windowHeight = if (isFloating) state.size.height.value.toInt() else appSettings.windowHeight,
-                        windowX = if (isFloating) state.position.x.value.toInt() else -1,
-                        windowY = if (isFloating) state.position.y.value.toInt() else -1
+                    appSettings = appSettings.withWindowGeometry(
+                        placement = windowPlacementToSettings(state.placement),
+                        isFloating = state.placement == WindowPlacement.Floating,
+                        width = state.size.width.value.toInt(),
+                        height = state.size.height.value.toInt(),
+                        x = state.position.x.value.toInt(),
+                        y = state.position.y.value.toInt(),
                     )
                     settingsManager.saveSettings(appSettings)
                     if (qaManager.sessionActive) qaManager.toggleSession()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/WindowPlacementSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/WindowPlacementSettings.kt
@@ -1,0 +1,35 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import androidx.compose.ui.window.WindowPlacement
+
+/**
+ * How the main window's placement is stored in settings and read back at launch.
+ *
+ * Lives in `utils/` rather than beside [org.churchpresenter.app.churchpresenter.data.settings.AppSettings]
+ * because [WindowPlacement] is a Compose type and `data/settings` is deliberately Compose-free.
+ */
+
+/** The persisted form of [placement]. Exhaustive on purpose: adding a placement fails to compile
+ *  here rather than silently writing a string the reader below does not understand. */
+fun windowPlacementToSettings(placement: WindowPlacement): String = when (placement) {
+    WindowPlacement.Floating -> FLOATING
+    WindowPlacement.Fullscreen -> FULLSCREEN
+    WindowPlacement.Maximized -> MAXIMIZED
+}
+
+/**
+ * The placement a saved string means, defaulting to [WindowPlacement.Maximized].
+ *
+ * Maximized is the right fallback for anything unrecognised: it is the shipped default, and it is the
+ * only one guaranteed to put the window somewhere visible. Restoring an unknown value as Floating
+ * would pair with saved coordinates that may no longer be on any attached display.
+ */
+fun windowPlacementFromSettings(saved: String): WindowPlacement = when (saved) {
+    FLOATING -> WindowPlacement.Floating
+    FULLSCREEN -> WindowPlacement.Fullscreen
+    else -> WindowPlacement.Maximized
+}
+
+private const val FLOATING = "floating"
+private const val FULLSCREEN = "fullscreen"
+private const val MAXIMIZED = "maximized"

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/WindowPlacementSettingsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/WindowPlacementSettingsTest.kt
@@ -1,0 +1,130 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import androidx.compose.ui.window.WindowPlacement
+import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.data.settings.NO_SAVED_POSITION
+import org.churchpresenter.app.churchpresenter.data.settings.withWindowGeometry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * How the main window's placement and geometry survive a restart.
+ *
+ * These were two hand-written `when` blocks in `main.kt` pointing in opposite directions — enum to
+ * string on close, string to enum on launch — with nothing tying them together. That is the shape
+ * that produced the Studio theme bug: a pair where one side is compiler-checked and the other is not.
+ * `every placement survives a save and reload` is the test that ties them, and it fails the moment
+ * someone adds a case to one side only.
+ *
+ * The geometry half matters for a different reason, spelled out in
+ * `a maximized window keeps the floating size it should return to`.
+ */
+class WindowPlacementSettingsTest {
+
+    // ── The round trip ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `every placement survives a save and reload`() {
+        listOf(WindowPlacement.Floating, WindowPlacement.Fullscreen, WindowPlacement.Maximized)
+            .forEach { placement ->
+                assertEquals(
+                    placement,
+                    windowPlacementFromSettings(windowPlacementToSettings(placement)),
+                    "$placement did not survive a restart",
+                )
+            }
+    }
+
+    @Test
+    fun `no two placements share a stored value`() {
+        val stored = listOf(WindowPlacement.Floating, WindowPlacement.Fullscreen, WindowPlacement.Maximized)
+            .map { windowPlacementToSettings(it) }
+
+        assertEquals(stored.size, stored.toSet().size, "two placements collapsed onto one: $stored")
+    }
+
+    @Test
+    fun `an unrecognised value opens maximized rather than floating`() {
+        // Floating would pair with saved coordinates that may be on a display no longer attached.
+        assertEquals(WindowPlacement.Maximized, windowPlacementFromSettings("tiled"))
+        assertEquals(WindowPlacement.Maximized, windowPlacementFromSettings(""))
+    }
+
+    @Test
+    fun `the shipped default is understood`() {
+        assertEquals(WindowPlacement.Maximized, windowPlacementFromSettings(AppSettings().windowPlacement))
+    }
+
+    // ── What gets persisted on close ────────────────────────────────────────────
+
+    @Test
+    fun `a floating window remembers where and how big it was`() {
+        val saved = AppSettings().withWindowGeometry(
+            placement = "floating", isFloating = true, width = 1280, height = 800, x = 120, y = 64,
+        )
+
+        assertEquals("floating", saved.windowPlacement)
+        assertEquals(1280, saved.windowWidth)
+        assertEquals(800, saved.windowHeight)
+        assertEquals(120, saved.windowX)
+        assertEquals(64, saved.windowY)
+    }
+
+    @Test
+    fun `a maximized window keeps the floating size it should return to`() {
+        val previous = AppSettings().copy(windowWidth = 1280, windowHeight = 800)
+
+        val saved = previous.withWindowGeometry(
+            placement = "maximized", isFloating = false, width = 3840, height = 2160, x = 0, y = 0,
+        )
+
+        assertEquals(1280, saved.windowWidth, "storing the screen size loses the user's layout for good")
+        assertEquals(800, saved.windowHeight)
+        assertEquals("maximized", saved.windowPlacement)
+    }
+
+    @Test
+    fun `a non-floating window clears its position rather than storing the screen origin`() {
+        val saved = AppSettings().copy(windowX = 120, windowY = 64).withWindowGeometry(
+            placement = "fullscreen", isFloating = false, width = 3840, height = 2160, x = 0, y = 0,
+        )
+
+        assertEquals(NO_SAVED_POSITION, saved.windowX, "0,0 may be a screen that is no longer attached")
+        assertEquals(NO_SAVED_POSITION, saved.windowY)
+    }
+
+    @Test
+    fun `the cleared position is what the launch path treats as absent`() {
+        val saved = AppSettings().withWindowGeometry(
+            placement = "maximized", isFloating = false, width = 100, height = 100, x = 5, y = 5,
+        )
+
+        // main.kt restores a saved position only when windowX >= 0.
+        assertEquals(true, saved.windowX < 0, "the sentinel must fail the launch path's own check")
+    }
+
+    @Test
+    fun `nothing outside the window fields is disturbed`() {
+        val before = AppSettings().copy(language = "de", theme = "STUDIO", setupWizardShown = true)
+
+        val after = before.withWindowGeometry(
+            placement = "floating", isFloating = true, width = 800, height = 600, x = 10, y = 10,
+        )
+
+        assertEquals("de", after.language)
+        assertEquals("STUDIO", after.theme)
+        assertEquals(true, after.setupWizardShown)
+    }
+
+    @Test
+    fun `a floating window round-trips its geometry through settings`() {
+        val saved = AppSettings().withWindowGeometry(
+            placement = windowPlacementToSettings(WindowPlacement.Floating),
+            isFloating = true, width = 1024, height = 768, x = 33, y = 44,
+        )
+
+        assertEquals(WindowPlacement.Floating, windowPlacementFromSettings(saved.windowPlacement))
+        assertEquals(1024, saved.windowWidth)
+        assertEquals(33, saved.windowX)
+    }
+}


### PR DESCRIPTION
Extracts the main window's placement round-trip and geometry persistence out of `main.kt`, and tests
them. Both were at **0% coverage**.

## Why this pair

It is the **same shape that produced the Studio theme bug in #178**: two hand-written `when` blocks
pointing in opposite directions — enum to string on close, string to enum on launch — with nothing
tying them together. The write side is exhaustive and compiler-checked; the read side has an `else`
and is not.

Unlike `ThemeMode`, this pair currently round-trips correctly — **there is no bug here**. What was
missing is the test that keeps it that way: `every placement survives a save and reload` now ties the
two directions, so adding a case to one side only fails immediately.

## The geometry half is the more interesting one

Only a **floating** window has geometry worth remembering. A maximized or fullscreen window's measured
bounds are the screen's, not the user's choice, so persisting them would overwrite the size the window
should return to when un-maximized — **maximize once and the layout is gone permanently**. The
previous floating size is kept instead.

The position is cleared to `-1` rather than stored as `0,0`, and that sentinel is exactly what the
launch path checks (`windowX >= 0`) before restoring a position. On a multi-monitor setup `0,0` may
belong to a display that is no longer attached, so "no remembered position" and "position 0,0" are
genuinely different answers. Removing those guards fails **3 of the 10** tests.

## Where the code lives

`WindowPlacement` is a Compose type and `data/settings` has **no** Compose imports anywhere, so the
placement helpers went to `utils/` (which already carries Compose types) rather than introducing the
first one there. The geometry helper is Compose-free and did go in `data/settings`.

## Tests

Ten tests, ~2ms, no fakes: the round trip across all three placements, no two placements sharing a
stored value, an unrecognised value opening maximized rather than floating (floating would pair with
coordinates that may be off-screen), the shipped default, and the geometry cases above — including
that nothing outside the window fields is disturbed.

## Verification

Behaviour is unchanged; the extracted bodies are the original logic. Mutation-checked: dropping the
`isFloating` guards fails 3 of 10.

`./gradlew :composeApp:jvmTest --rerun-tasks` — **four consecutive green runs, 7,905 tests, zero
failures** each. `compileKotlinJvm` clean with no new warnings.
