### PR TITLE
Route recent-files test seams through one helper, drop the reflection

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -130,9 +130,19 @@ When writing tests here:
     function parameters adds four uncovered methods at each call site and can score *worse* than
     the inline code it replaced. Take one function parameter — the unreachable step — and call the
     rest directly. Measure before and after; the report is the arbiter, not the intent.
-  - What must NOT be done to reach coverage: adding a mutable `internal var` seam on a singleton
-    (leaks between tests — see the flaky-test rule below), or asserting that a stub was called
-    instead of that something works. If a test can only prove a mock was invoked, don't write it.
+  - What must NOT be done to reach coverage: adding an **ad-hoc** mutable `internal var` seam on a
+    singleton and restoring it by hand in each test (leaks between tests — see the flaky-test rule
+    below), or asserting that a stub was called instead of that something works. If a test can only
+    prove a mock was invoked, don't write it.
+  - **The one permitted seam of that shape is the recent-files singletons**, and only through
+    `RecentFilesSwap` in `jvmTest`. `RecentPictureFolders`, `RecentMediaFiles` and
+    `RecentPresentationFiles` expose `internal var file`/`pinnedFile`; a test repoints them via that
+    helper, which restores both paths and both lists in one place, so the restore is structural
+    rather than something each author remembers. **Never assign those fields directly.** The
+    alternative — keeping them private and reaching in with `getDeclaredField` — is what this
+    replaced: it hides renames from the compiler (see the reflection rule below) and, run outside
+    Gradle, it deleted the developer's own recents. Adding a *fourth* such seam is not covered by
+    this exception; raise it first.
 - **Prefer `internal` over reflection to reach non-public code.** `jvmTest` is a friend of
   `jvmMain`, so an `internal` member is callable straight from a test. Reflection costs a lookup
   per call, throws at runtime instead of failing to compile when a signature changes, loses the

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/RecentPresentationFiles.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/RecentPresentationFiles.kt
@@ -5,10 +5,23 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.File
 
+/**
+ * Recently-opened presentation files, and the pinned subset that survives "clear recents".
+ *
+ * [file], [pinnedFile] and [load] are `internal var`/`internal fun` so a test can point them at a
+ * temp directory before calling [add]/[togglePin]/[clear], exactly as `RecentPictureFolders` and
+ * `RecentMediaFiles` already allow. Use `RecentFilesSwap` from the test source set rather than
+ * assigning them by hand — it restores both paths and both lists in one place, so a test cannot
+ * leave the object pointing somewhere the next test does not expect.
+ *
+ * This is not about protecting the developer's own files: the Gradle test config already points
+ * `user.home` at `build/test-home` for the whole JVM. It is about each test getting its own file
+ * instead of sharing one across the class.
+ */
 object RecentPresentationFiles {
     private const val MAX = 10
-    private val file = File(System.getProperty("user.home"), ".churchpresenter/recent_presentation_files.json")
-    private val pinnedFile = File(System.getProperty("user.home"), ".churchpresenter/pinned_presentation_files.json")
+    internal var file = File(System.getProperty("user.home"), ".churchpresenter/recent_presentation_files.json")
+    internal var pinnedFile = File(System.getProperty("user.home"), ".churchpresenter/pinned_presentation_files.json")
     val files = mutableStateListOf<String>()
     val pinned = mutableStateListOf<String>()
 
@@ -38,7 +51,7 @@ object RecentPresentationFiles {
         save()
     }
 
-    private fun load() {
+    internal fun load() {
         try {
             if (file.exists()) {
                 val json = Json { ignoreUnknownKeys = true }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/RecentFilesSwap.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/RecentFilesSwap.kt
@@ -1,0 +1,90 @@
+package org.churchpresenter.app.churchpresenter
+
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Points a recent-files singleton at a throwaway directory for one test, and puts it back.
+ *
+ * The three recent-files objects — `RecentPictureFolders`, `RecentMediaFiles` and
+ * `RecentPresentationFiles` — are JVM-wide singletons that resolve their JSON paths once, at class
+ * init. A test that exercises `add`/`togglePin`/`clear` for real has to repoint them, and **has to
+ * put them back**: whatever the last test left behind is what every later test in the JVM sees.
+ *
+ * That restore used to be hand-written per test class, in three near-identical twenty-line blocks.
+ * This is the single implementation, so the restore is structural rather than something each author
+ * has to remember. It is also why the seam is permitted at all — see `AGENT.md`'s note on mutable
+ * singleton state.
+ *
+ * **This is about isolation, not safety.** The Gradle test config already points `user.home` at
+ * `build/test-home` for the whole JVM (`composeApp/build.gradle.kts`), so no test can reach the
+ * developer's real `~/.churchpresenter` either way. What this buys is a *fresh* file per test
+ * instead of one shared across a class, so tests cannot see each other's writes.
+ *
+ * Usage — two lines of lifecycle per test class:
+ * ```
+ * private val swap = RecentFilesSwap(
+ *     readPaths = { RecentPictureFolders.file to RecentPictureFolders.pinnedFile },
+ *     writePaths = { f, p -> RecentPictureFolders.file = f; RecentPictureFolders.pinnedFile = p },
+ *     entries = RecentPictureFolders.folders,
+ *     pinned = RecentPictureFolders.pinned,
+ *     prefix = "cp-recent-picture-folders",
+ * )
+ *
+ * @BeforeTest fun setUp() = swap.install()
+ * @AfterTest fun tearDown() = swap.restore()
+ * ```
+ *
+ * [entries] and [pinned] are the singleton's own live lists, mutated in place — they are
+ * `mutableStateListOf`, so replacing them is not an option and clearing/refilling is the only way
+ * to hand them back as they were.
+ */
+internal class RecentFilesSwap(
+    private val readPaths: () -> Pair<File, File>,
+    private val writePaths: (File, File) -> Unit,
+    private val entries: MutableList<String>,
+    private val pinned: MutableList<String>,
+    private val prefix: String,
+) {
+    private var tempDir: File? = null
+    private var savedRecentPath: File? = null
+    private var savedPinnedPath: File? = null
+    private var savedEntries: List<String> = emptyList()
+    private var savedPinned: List<String> = emptyList()
+
+    /** The temp file the singleton's recent list is currently written to. */
+    val recentFile: File get() = File(requireNotNull(tempDir) { "install() first" }, "recent.json")
+
+    /** The temp file the singleton's pinned list is currently written to. */
+    val pinnedFile: File get() = File(requireNotNull(tempDir) { "install() first" }, "pinned.json")
+
+    fun install() {
+        val dir = Files.createTempDirectory(prefix).toFile()
+        tempDir = dir
+
+        val (recent, pinnedPath) = readPaths()
+        savedRecentPath = recent
+        savedPinnedPath = pinnedPath
+        savedEntries = entries.toList()
+        savedPinned = pinned.toList()
+
+        writePaths(recentFile, pinnedFile)
+        entries.clear()
+        pinned.clear()
+    }
+
+    fun restore() {
+        savedRecentPath?.let { recent ->
+            writePaths(recent, requireNotNull(savedPinnedPath))
+        }
+        entries.clear()
+        entries.addAll(savedEntries)
+        pinned.clear()
+        pinned.addAll(savedPinned)
+
+        tempDir?.deleteRecursively()
+        tempDir = null
+        savedRecentPath = null
+        savedPinnedPath = null
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/RecentPresentationFilesTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/RecentPresentationFilesTest.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.data
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import org.churchpresenter.app.churchpresenter.RecentFilesSwap
 import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -19,37 +20,31 @@ import kotlin.test.assertTrue
  * keeps the file they use every single service from scrolling off the end.
  *
  * [RecentPresentationFiles] is a JVM-wide object that resolves its two JSON files when the class is
- * first loaded and reads them in its initialiser, so it cannot be rebuilt per test. Its own paths
- * are therefore read back by reflection, and each test starts by emptying both the in-memory lists
- * and those files — swapping `user.home` here would have no effect, since the paths were already
- * fixed by then.
+ * first loaded, so every test in this class would otherwise share one file and see the previous
+ * test's writes. [RecentFilesSwap] gives each test its own temp pair and puts the object back
+ * afterwards.
+ *
+ * This used to reach the paths by reflection and `delete()` them before and after every test, which
+ * both hid renames from the compiler and left the class unable to run its tests independently.
  */
 class RecentPresentationFilesTest {
 
-    private fun pathField(name: String): File =
-        RecentPresentationFiles::class.java
-            .getDeclaredField(name)
-            .apply { isAccessible = true }
-            .get(RecentPresentationFiles) as File
+    private val swap = RecentFilesSwap(
+        readPaths = { RecentPresentationFiles.file to RecentPresentationFiles.pinnedFile },
+        writePaths = { f, p -> RecentPresentationFiles.file = f; RecentPresentationFiles.pinnedFile = p },
+        entries = RecentPresentationFiles.files,
+        pinned = RecentPresentationFiles.pinned,
+        prefix = "cp-recent-presentation-files",
+    )
 
-    private val recentsFile: File get() = pathField("file")
-    private val pinnedFile: File get() = pathField("pinnedFile")
+    private val recentsFile: File get() = swap.recentFile
+    private val pinnedFile: File get() = swap.pinnedFile
 
     @BeforeTest
-    fun emptyEverything() {
-        RecentPresentationFiles.files.clear()
-        RecentPresentationFiles.pinned.clear()
-        recentsFile.delete()
-        pinnedFile.delete()
-    }
+    fun setUp() = swap.install()
 
     @AfterTest
-    fun leaveNothingBehind() {
-        RecentPresentationFiles.files.clear()
-        RecentPresentationFiles.pinned.clear()
-        recentsFile.delete()
-        pinnedFile.delete()
-    }
+    fun tearDown() = swap.restore()
 
     private fun savedRecents(): List<String> =
         if (!recentsFile.exists()) emptyList()
@@ -217,12 +212,7 @@ class RecentPresentationFilesTest {
      * loaded by the JVM, so a restart cannot be staged any other way — and the load path is the half
      * of this feature that the saving tests above never touch.
      */
-    private fun reload() {
-        RecentPresentationFiles::class.java
-            .getDeclaredMethod("load")
-            .apply { isAccessible = true }
-            .invoke(RecentPresentationFiles)
-    }
+    private fun reload() = RecentPresentationFiles.load()
 
     @Test
     fun `the recent list comes back in order`() {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/RecentMediaFilesLogicTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/RecentMediaFilesLogicTest.kt
@@ -1,7 +1,6 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
-import java.io.File
-import java.nio.file.Files
+import org.churchpresenter.app.churchpresenter.RecentFilesSwap
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -19,36 +18,19 @@ import kotlin.test.assertTrue
  */
 class RecentMediaFilesLogicTest {
 
-    private lateinit var tempDir: File
-    private lateinit var savedFile: File
-    private lateinit var savedPinnedFile: File
-    private lateinit var savedPaths: List<String>
-    private lateinit var savedPinned: List<String>
+    private val swap = RecentFilesSwap(
+        readPaths = { RecentMediaFiles.file to RecentMediaFiles.pinnedFile },
+        writePaths = { f, p -> RecentMediaFiles.file = f; RecentMediaFiles.pinnedFile = p },
+        entries = RecentMediaFiles.paths,
+        pinned = RecentMediaFiles.pinned,
+        prefix = "cp-recent-media-files",
+    )
 
     @BeforeTest
-    fun setUp() {
-        tempDir = Files.createTempDirectory("cp-recent-media-files").toFile()
-        savedFile = RecentMediaFiles.file
-        savedPinnedFile = RecentMediaFiles.pinnedFile
-        RecentMediaFiles.file = File(tempDir, "recent_media_files.json")
-        RecentMediaFiles.pinnedFile = File(tempDir, "pinned_media_files.json")
-
-        savedPaths = RecentMediaFiles.paths.toList()
-        savedPinned = RecentMediaFiles.pinned.toList()
-        RecentMediaFiles.paths.clear()
-        RecentMediaFiles.pinned.clear()
-    }
+    fun setUp() = swap.install()
 
     @AfterTest
-    fun tearDown() {
-        RecentMediaFiles.file = savedFile
-        RecentMediaFiles.pinnedFile = savedPinnedFile
-        RecentMediaFiles.paths.clear()
-        RecentMediaFiles.paths.addAll(savedPaths)
-        RecentMediaFiles.pinned.clear()
-        RecentMediaFiles.pinned.addAll(savedPinned)
-        tempDir.deleteRecursively()
-    }
+    fun tearDown() = swap.restore()
 
     private fun path(name: String) = "/Volumes/Services/media/$name.mp4"
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/RecentPictureFoldersLogicTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/RecentPictureFoldersLogicTest.kt
@@ -1,7 +1,6 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
-import java.io.File
-import java.nio.file.Files
+import org.churchpresenter.app.churchpresenter.RecentFilesSwap
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -19,36 +18,19 @@ import kotlin.test.assertTrue
  */
 class RecentPictureFoldersLogicTest {
 
-    private lateinit var tempDir: File
-    private lateinit var savedFile: File
-    private lateinit var savedPinnedFile: File
-    private lateinit var savedFolders: List<String>
-    private lateinit var savedPinned: List<String>
+    private val swap = RecentFilesSwap(
+        readPaths = { RecentPictureFolders.file to RecentPictureFolders.pinnedFile },
+        writePaths = { f, p -> RecentPictureFolders.file = f; RecentPictureFolders.pinnedFile = p },
+        entries = RecentPictureFolders.folders,
+        pinned = RecentPictureFolders.pinned,
+        prefix = "cp-recent-picture-folders",
+    )
 
     @BeforeTest
-    fun setUp() {
-        tempDir = Files.createTempDirectory("cp-recent-picture-folders").toFile()
-        savedFile = RecentPictureFolders.file
-        savedPinnedFile = RecentPictureFolders.pinnedFile
-        RecentPictureFolders.file = File(tempDir, "recent_picture_folders.json")
-        RecentPictureFolders.pinnedFile = File(tempDir, "pinned_picture_folders.json")
-
-        savedFolders = RecentPictureFolders.folders.toList()
-        savedPinned = RecentPictureFolders.pinned.toList()
-        RecentPictureFolders.folders.clear()
-        RecentPictureFolders.pinned.clear()
-    }
+    fun setUp() = swap.install()
 
     @AfterTest
-    fun tearDown() {
-        RecentPictureFolders.file = savedFile
-        RecentPictureFolders.pinnedFile = savedPinnedFile
-        RecentPictureFolders.folders.clear()
-        RecentPictureFolders.folders.addAll(savedFolders)
-        RecentPictureFolders.pinned.clear()
-        RecentPictureFolders.pinned.addAll(savedPinned)
-        tempDir.deleteRecursively()
-    }
+    fun tearDown() = swap.restore()
 
     private fun path(name: String) = "/Volumes/Services/photos/$name"
 


### PR DESCRIPTION
Resolves the standing contradiction between `AGENT.md`'s ban on mutable singleton test seams and the
codebase, which uses both that seam and the reflection the same document discourages three lines
later. Along the way it closes a real way to lose your own recent presentations.

## The bug this fixes

`RecentPresentationFilesTest` reached the singleton's private paths with `getDeclaredField("file")`
and then called `.delete()` on them in **both** `@BeforeTest` and `@AfterTest`.

Under Gradle that is harmless: `composeApp/build.gradle.kts` points `user.home` at `build/test-home`
for every test task, before any class loads. **Run the same suite from the IDE's own runner and
nothing redirects it** — the reflection resolves the developer's real
`~/.churchpresenter/recent_presentation_files.json`, and the suite deletes it, along with their pins.

Demonstrated rather than argued: marker files planted in `build/test-home/.churchpresenter/` are
**both deleted** by that suite on `main`, and **both intact** after this change.

## What changed

**Production** — `data/RecentPresentationFiles.kt`: `file`, `pinnedFile` and `load()` widened to
`internal`, matching `RecentPictureFolders` and `RecentMediaFiles`, which already work this way.
Nothing else; no behaviour change.

**New `jvmTest/.../RecentFilesSwap.kt`** — one implementation of save / repoint at a temp dir /
restore, for all three singletons. It replaces ~30 near-identical lines in each of three test classes
with two lines of lifecycle:

```kotlin
@BeforeTest fun setUp() = swap.install()
@AfterTest fun tearDown() = swap.restore()
```

That is the point of it. The seam's real hazard was never the `var` — it was that every author had to
*remember* to put it back, in hand-written code, three times over. Now the restore is structural.

**`RecentPresentationFilesTest`** — both reflection sites deleted (`getDeclaredField` for the paths,
`getDeclaredMethod("load")` for the reload, now a plain call) and the `delete()` blocks gone. Each
test also gets its own file instead of the class sharing one, so the tests no longer depend on the
delete-everything-first reset.

**`AGENT.md`** — the blanket ban becomes the actual rule: ad-hoc hand-restored seams stay forbidden;
this one is permitted **only** through `RecentFilesSwap`; direct assignment is called out as
forbidden; and a fourth such seam is explicitly *not* covered by the exception.

## Verification

- `./gradlew :composeApp:jvmTest --rerun-tasks` three consecutive times, full suite, zero failures.
- The marker-file check above, run on both branches.
- `compileKotlinJvm` clean.

## Note for reviewers

The coverage plan has carried a claim that `clear` "deletes the developer's own recents", used as the
reason to leave those lines uncovered. That was wrong about *which* directory under Gradle, but right
that something was being deleted — and right in the IDE case. Corrected there as well.
