### PR TITLE
Cover WebTab's mirror-mode preview: placeholder, snapshot and inert input

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabMirrorPreviewTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabMirrorPreviewTest.kt
@@ -1,0 +1,151 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.input.key.Key
+import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What the operator sees in the Web tab between going live and the first frame arriving.
+ *
+ * Mirror mode is the default once a page is live: the tab stops rendering its own browser and shows
+ * the presenter's screenshot instead, so that what is checked here is the picture the operator uses
+ * to see what the congregation is looking at. Until the first snapshot lands there is a spinner, and
+ * after a long enough wait a hint saying why one might never arrive.
+ *
+ * [WebTabLiveTest] drives live mode, the mirror/interactive toggle and the type-to-page field, but
+ * never sets a snapshot — so the whole `webSnapshot != null` branch, and the placeholder that stands
+ * in for it, went unexercised. Nothing proved the mirrored image ever appears at all.
+ *
+ * **What this cannot reach, and why.** The mirrored image forwards mouse, scroll and keyboard input
+ * to the presenter's live `CefBrowser` by reflection. Those bodies need a real browser — a JCEF
+ * render surface, which is not available headless — and every one of them begins with a
+ * `liveBrowser == null` early return. So the tests below drive the input paths with no browser
+ * attached, which covers the guard and pins that the mirror is inert rather than crashing; the
+ * forwarding itself stays uncovered and is listed in the coverage plan under JCEF.
+ *
+ * The hint text is chosen from `os.name` — macOS gets a Screen Recording permission hint, everything
+ * else a plain wait message. Only the host's own branch is asserted here. Faking `os.name` to reach
+ * the other one would resolve skiko's host OS against the fake and break every later Compose test in
+ * the JVM, which is the trap `TestSingletons.latchSkikoHostOs` exists for.
+ */
+class WebTabMirrorPreviewTest {
+
+    private val spinner = SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo)
+
+    /** The wait hint the running platform shows — the other platform's is unreachable from here. */
+    private val expectedHint: String =
+        if (System.getProperty("os.name", "").lowercase().contains("mac")) {
+            "If this persists, grant Screen Recording permission\n" +
+                "in System Settings > Privacy & Security > Screen Recording"
+        } else {
+            "Waiting for snapshot..."
+        }
+
+    private fun ComposeUiTest.goLive(presenterMode: () -> Unit) {
+        presenterMode()
+        waitForIdle()
+    }
+
+    @Test
+    fun `going live with no snapshot yet shows the waiting spinner`() = webTab { presenter, _ ->
+        goLive { presenter.setPresentingMode(Presenting.WEBSITE) }
+
+        onNode(spinner).assertExists()
+        // The hint is deliberately not up yet — it only earns the operator's attention once the wait
+        // has become abnormal, and showing it immediately would read as an error on every go-live.
+        onNodeWithText(expectedHint).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the hint appears only once the wait has gone on long enough`() = webTab { presenter, _ ->
+        goLive { presenter.setPresentingMode(Presenting.WEBSITE) }
+
+        // Virtual time: the production delay is 7s, which the test clock advances instantly. Nothing
+        // here waits on a real clock.
+        mainClock.advanceTimeBy(7_001)
+        waitForIdle()
+
+        onNodeWithText(expectedHint).assertExists()
+        onNode(spinner).assertExists()
+    }
+
+    @Test
+    fun `a snapshot replaces the placeholder with the mirrored image`() = webTab { presenter, _ ->
+        goLive { presenter.setPresentingMode(Presenting.WEBSITE) }
+        onNode(spinner).assertExists()
+
+        presenter.setWebSnapshot(ImageBitmap(8, 8))
+        waitForIdle()
+
+        // The image itself carries no contentDescription, so it contributes no semantics node to
+        // assert on. The placeholder disappearing is the positive signal that the snapshot branch —
+        // and only it — is what composed.
+        onNode(spinner).assertDoesNotExist()
+        onNodeWithText(expectedHint).assertDoesNotExist()
+    }
+
+    @Test
+    fun `clearing the snapshot puts the operator back on the placeholder`() = webTab { presenter, _ ->
+        goLive { presenter.setPresentingMode(Presenting.WEBSITE) }
+        presenter.setWebSnapshot(ImageBitmap(8, 8))
+        waitForIdle()
+        onNode(spinner).assertDoesNotExist()
+
+        presenter.setWebSnapshot(null)
+        waitForIdle()
+
+        // A snapshot stream that dies mid-service has to show the wait state again rather than leave
+        // a frozen frame the operator would read as still live.
+        onNode(spinner).assertExists()
+    }
+
+    @Test
+    fun `input over the mirrored image is inert with no browser attached`() = webTab { presenter, _ ->
+        goLive { presenter.setPresentingMode(Presenting.WEBSITE) }
+        presenter.setWebSnapshot(ImageBitmap(8, 8))
+        waitForIdle()
+
+        // Each forwarding path guards on liveBrowser being null before it reflects anything. Driving
+        // all three proves the guards hold rather than that the events are unreachable.
+        onRoot().performMouseInput {
+            moveTo(center)
+            press()
+            release()
+            scroll(1f)
+        }
+        onRoot().performKeyInput { pressKey(Key.A) }
+        waitForIdle()
+
+        assertEquals(null, presenter.liveBrowser.value, "no browser was ever attached")
+        assertEquals(Presenting.WEBSITE, presenter.presentingMode.value, "and nothing was torn down")
+        onNode(spinner).assertDoesNotExist()
+    }
+
+    @Test
+    fun `switching to interactive mode drops the mirror entirely`() = webTab { presenter, _ ->
+        goLive { presenter.setPresentingMode(Presenting.WEBSITE) }
+        onNode(spinner).assertExists()
+
+        onNodeWithText(WebLabel.MIRROR).performClick()
+        waitForIdle()
+
+        // Interactive mode renders the tab's own browser, so neither the snapshot nor its placeholder
+        // belongs on screen — a leftover spinner there would sit on top of a live page.
+        onNode(spinner).assertDoesNotExist()
+        assertTrue(hasWebButton(WebLabel.FOCUS_FIRST_INPUT).not(), "mirror-only controls go with it")
+    }
+}


### PR DESCRIPTION
Covers what the operator sees in the Web tab between going live and the first frame arriving. Test-only — no production change.

## Why this was uncovered, and why the reason was wrong

`WebTab`'s mirror mode replaces the tab's own browser with the presenter's screenshot once a page is live. It had been written off wholesale as JCEF-bound: the mirrored image forwards mouse, scroll and keyboard input to a real `CefBrowser` by reflection, which needs a render surface no headless run has.

That is true of the forwarding, and false of everything around it. The gate is `webSnapshot != null` — a plain `PresenterManager` state value set through `setWebSnapshot`, not a JCEF object — and every forwarding body begins with a `liveBrowser == null` early return. So the branch, the image, the waiting placeholder and the guards were all reachable the whole time.

`WebTabLiveTest` already drives live mode, the mirror/interactive toggle and the type-to-page field, but never sets a snapshot. So **nothing proved the mirrored image ever appears at all** — if that block broke, every existing test still passed.

## What is pinned

- The spinner is up on go-live, and the wait hint is **not** — showing it immediately would read as an error on every go-live.
- The hint appears once the wait becomes abnormal. Production's 7s `delay` is advanced on the Compose test clock (`mainClock.advanceTimeBy`), so this is virtual time and costs nothing; no test waits on a real clock.
- A snapshot replaces the placeholder, and clearing it puts the operator back on the wait state — a snapshot stream that dies mid-service must not leave a frozen frame that reads as still live.
- Mouse, scroll and key input over the mirror are inert with no browser attached, which drives the three `liveBrowser == null` guards.
- Switching to interactive mode drops the mirror entirely; a leftover spinner there would sit on top of a live page.

## Evidence

**Mutation-checked**, not claimed — the production code exists here, but these tests do not run red against it because nothing was changed, so mutation is the honest evidence:

| Mutation | Result |
|---|---|
| `delay(7000)` → `delay(1)` in the hint effect | fails 1 of 6 |
| snapshot forced permanently absent | fails 3 of 6 |

A third mutation — inverting `if (webSnapshot != null)` — was discarded rather than reported: it does not compile, because the `Image(bitmap = webSnapshot)` smart cast goes with it. A mutation that fails to build is not a passing mutation test.

**Three consecutive green `--rerun-tasks` runs of the whole `tabs` package** (1,844 tests each), not just this suite — the #130 and #144 flakes only ever appeared when neighbouring suites ran together.

6 tests, **1.226s** total, slowest 0.866s (a one-time skia cost on the first `ImageBitmap`).

## Limits, stated rather than papered over

- The input **forwarding** stays uncovered and is still correctly listed under JCEF. What is covered is the guard in front of it.
- The image carries `contentDescription = null`, so it contributes no semantics node. The placeholder disappearing is the positive signal that the snapshot branch composed — there is nothing to assert on directly.
- The hint text is chosen from `os.name`, so only the host's branch is asserted. Faking `os.name` to reach the other would resolve skiko's host OS against the fake and break every later Compose test in the JVM.

## Separate finding, deliberately not fixed here

`WebTab.kt:807` and `:814` are hardcoded `Text("…")` literals ("Waiting for snapshot...", and the macOS Screen Recording hint) rather than `stringResource` — a `DEVELOPMENT_GUIDE.md` zero-tolerance violation. Fixing it is a production change touching `strings.xml`, an append-only shared file, so it belongs in its own PR rather than riding along in a test-only one.
