### PR TITLE
Move the Web tab's snapshot-wait messages into strings.xml

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -1045,6 +1045,8 @@
     <string name="web_refresh">Refresh</string>
     <string name="web_zoom_in">Zoom In</string>
     <string name="web_zoom_out">Zoom Out</string>
+    <string name="web_snapshot_waiting">Waiting for snapshot...</string>
+    <string name="web_snapshot_screen_recording_hint">If this persists, grant Screen Recording permission\nin System Settings > Privacy &amp; Security > Screen Recording</string>
     <string name="tooltip_add_website">Add Website</string>
     <string name="website_dialog_title">Add Website</string>
     <string name="website_url_label">URL</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTab.kt
@@ -90,6 +90,8 @@ import churchpresenter.composeapp.generated.resources.web_refresh
 import churchpresenter.composeapp.generated.resources.web_url_hint
 import churchpresenter.composeapp.generated.resources.web_zoom_in
 import churchpresenter.composeapp.generated.resources.web_zoom_out
+import churchpresenter.composeapp.generated.resources.web_snapshot_screen_recording_hint
+import churchpresenter.composeapp.generated.resources.web_snapshot_waiting
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.WebBookmark
 import org.churchpresenter.app.churchpresenter.presenter.CefManager
@@ -805,14 +807,14 @@ fun WebTab(
                                 Spacer(Modifier.height(12.dp))
                                 if (System.getProperty("os.name", "").lowercase().contains("mac")) {
                                     Text(
-                                        "If this persists, grant Screen Recording permission\nin System Settings > Privacy & Security > Screen Recording",
+                                        stringResource(Res.string.web_snapshot_screen_recording_hint),
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
                                         textAlign = TextAlign.Center
                                     )
                                 } else {
                                     Text(
-                                        "Waiting for snapshot...",
+                                        stringResource(Res.string.web_snapshot_waiting),
                                         style = MaterialTheme.typography.labelSmall,
                                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                                     )

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabMirrorPreviewTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabMirrorPreviewTest.kt
@@ -49,10 +49,9 @@ class WebTabMirrorPreviewTest {
     /** The wait hint the running platform shows — the other platform's is unreachable from here. */
     private val expectedHint: String =
         if (System.getProperty("os.name", "").lowercase().contains("mac")) {
-            "If this persists, grant Screen Recording permission\n" +
-                "in System Settings > Privacy & Security > Screen Recording"
+            WebLabel.SNAPSHOT_SCREEN_RECORDING_HINT
         } else {
-            "Waiting for snapshot..."
+            WebLabel.SNAPSHOT_WAITING
         }
 
     private fun ComposeUiTest.goLive(presenterMode: () -> Unit) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTabTestSupport.kt
@@ -97,6 +97,10 @@ internal object WebLabel {
     const val ENGINE_UNAVAILABLE_MACOS_TITLE = "Web browser requires a newer macOS"
     const val ENGINE_UNAVAILABLE_MACOS_BODY =
         "ChurchPresenter's browser engine no longer supports this version of macOS. Update to macOS 12 (Monterey) or later to use the Web tab and browser sources."
+    const val SNAPSHOT_WAITING = "Waiting for snapshot..."
+    const val SNAPSHOT_SCREEN_RECORDING_HINT =
+        "If this persists, grant Screen Recording permission\n" +
+            "in System Settings > Privacy & Security > Screen Recording"
 }
 
 internal fun zoomPercentText(level: Double): String = "${(Math.pow(1.2, level) * 100).toInt()}%"


### PR DESCRIPTION
Moves the Web tab's two snapshot-wait messages out of `Text("…")` literals and into `values/strings.xml`. Found while writing #184's tests.

## Why this is worth a PR rather than a lint note

Both strings are shown to the operator, and both were untranslatable in all 14 supported languages:

- **"Waiting for snapshot..."** — what the Web tab shows while the mirrored preview has not arrived.
- **"If this persists, grant Screen Recording permission…"** — the macOS branch of the same hint.

The second one is the case that matters. It appears precisely when the mirror never shows up, and it is the only thing telling the operator *why* and what to do about it. An operator running the app in Ukrainian or Polish hits a blank preview and an English-only instruction naming macOS System Settings panes. That is the wrong moment to fall back to English.

New strings are added to the default English `values/strings.xml` only — no other locale touched.

## Two notes for the record

**The DEVELOPMENT_GUIDE decision-log entry warning that new string resources do not compile in this environment is stale.** It records a 2026-07-13 investigation where a throwaway resource reproducibly failed with `Unresolved reference` — every caching layer ruled out, cause never found — and the `"%"` extraction was reverted because of it. 37 commits have touched `strings.xml` since, and this change compiled and ran green first try. Worth un-blocking that entry rather than leaving it to deter the next person.

**The escaping risk was covered for free by #184's tests.** The macOS hint carries a `\n` and an `&amp;`; if the resource compiler passed either through literally, the rendered text would silently differ from the old literal. `WebTabMirrorPreviewTest` asserts the exact multi-line string, so the extraction is verified rather than eyeballed. The test written one PR ago paid for itself here.

## Validation

Live production code, so the full suite rather than the package: **three consecutive green `--rerun-tasks` runs, 8,021 tests each.**

The test-side literals move into `WebLabel` in `WebTabTestSupport.kt`, matching how `PREVIEW_HINT`, `ENGINE_UNAVAILABLE_BODY` and the rest of that object already mirror `strings.xml`.
