### PR TITLE
Cover the browser source's DevTools target discovery

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
@@ -495,7 +495,7 @@ object SharedBrowserFrameCache {
         return false
     }
 
-    private fun getPageWebSocketUrl(port: Int): String? {
+    internal fun getPageWebSocketUrl(port: Int): String? {
         return try {
             val request = HttpRequest.newBuilder()
                 .uri(URI.create("http://localhost:$port/json"))

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCachePageDiscoveryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCachePageDiscoveryTest.kt
@@ -1,0 +1,143 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import io.ktor.server.application.call
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.runBlocking
+import java.net.ServerSocket
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * How a browser source finds the tab it is going to render.
+ *
+ * Before any CDP traffic happens, [SharedBrowserFrameCache.getPageWebSocketUrl] asks the freshly
+ * launched browser's `/json` endpoint what targets it has and picks one to attach to. Everything
+ * downstream — the whole WebSocket protocol client [SharedBrowserFrameCacheTest] covers — is aimed
+ * at whatever this returns, so choosing the wrong target means the output renders the wrong thing
+ * (or nothing) with no error anywhere.
+ *
+ * **The rule worth pinning is which target it picks.** A browser lists more than its page: extension
+ * background pages, service workers and the like are all in `/json`, and several of them can sort
+ * ahead of the page. Attaching to a background page yields a connection that works, accepts screen
+ * capture commands and produces no frames — an output that is black for the congregation and healthy
+ * from the app's point of view. So the `type == "page"` filter is the whole point of this function,
+ * and the tests below are weighted toward it rather than toward the happy path.
+ *
+ * Driven against a real Ktor server on an ephemeral port — the endpoint is plain HTTP and a JSON
+ * body, so there is no reason to fake the client's own parser. Same approach as
+ * [SharedBrowserFrameCacheTest]'s WebSocket fake, one layer earlier.
+ */
+class SharedBrowserFrameCachePageDiscoveryTest {
+
+    private val servers = mutableListOf<FakeDevToolsEndpoint>()
+
+    @AfterTest
+    fun cleanUp() {
+        servers.forEach { runCatching { it.stop() } }
+        servers.clear()
+    }
+
+    /** Stands in for the `/json` target list a headless Chrome or Edge serves on its debug port. */
+    private class FakeDevToolsEndpoint(private val body: String) {
+        var port: Int = 0
+            private set
+
+        private val server = embeddedServer(Netty, port = 0) {
+            routing {
+                get("/json") { call.respondText(body, io.ktor.http.ContentType.Application.Json) }
+            }
+        }
+
+        fun start() {
+            server.start(wait = false)
+            port = runBlocking { server.engine.resolvedConnectors().first().port }
+        }
+
+        fun stop() = server.stop(0, 0)
+    }
+
+    private fun serving(body: String): Int {
+        val endpoint = FakeDevToolsEndpoint(body)
+        servers.add(endpoint)
+        endpoint.start()
+        return endpoint.port
+    }
+
+    @Test
+    fun `the page tab is chosen over a background page listed ahead of it`() {
+        val port = serving(
+            """
+            [
+              {"type":"background_page","webSocketDebuggerUrl":"ws://localhost/devtools/page/EXT"},
+              {"type":"page","webSocketDebuggerUrl":"ws://localhost/devtools/page/REAL"}
+            ]
+            """.trimIndent()
+        )
+
+        assertEquals(
+            "ws://localhost/devtools/page/REAL",
+            SharedBrowserFrameCache.getPageWebSocketUrl(port),
+            "ordering must not decide this — the type does",
+        )
+    }
+
+    @Test
+    fun `a service worker ahead of the page does not win either`() {
+        val port = serving(
+            """
+            [
+              {"type":"service_worker","webSocketDebuggerUrl":"ws://localhost/devtools/page/SW"},
+              {"type":"page","webSocketDebuggerUrl":"ws://localhost/devtools/page/REAL"}
+            ]
+            """.trimIndent()
+        )
+
+        assertEquals("ws://localhost/devtools/page/REAL", SharedBrowserFrameCache.getPageWebSocketUrl(port))
+    }
+
+    @Test
+    fun `with no page-typed target at all it falls back to the first one`() {
+        val port = serving(
+            """[{"type":"other","webSocketDebuggerUrl":"ws://localhost/devtools/page/ONLY"}]"""
+        )
+
+        // Deliberate: a browser build that labels its tab something unexpected should still render
+        // rather than refuse outright. The fallback is only reached once the filter finds nothing.
+        assertEquals("ws://localhost/devtools/page/ONLY", SharedBrowserFrameCache.getPageWebSocketUrl(port))
+    }
+
+    @Test
+    fun `an empty target list yields no url`() {
+        assertNull(SharedBrowserFrameCache.getPageWebSocketUrl(serving("[]")))
+    }
+
+    @Test
+    fun `a target with no debugger url yields no url`() {
+        val port = serving("""[{"type":"page","title":"no socket here"}]""")
+
+        assertNull(SharedBrowserFrameCache.getPageWebSocketUrl(port))
+    }
+
+    @Test
+    fun `a body that is not the expected json yields no url rather than throwing`() {
+        // The browser is a separate process on a port anything could be listening on; a parse failure
+        // has to come back as "no target" so the caller retries, not as an exception through it.
+        assertNull(SharedBrowserFrameCache.getPageWebSocketUrl(serving("""{"not":"an array"}""")))
+    }
+
+    @Test
+    fun `nothing listening on the port yields no url`() {
+        // A port taken and released, so it is genuinely closed and the connection is refused at once.
+        // A server that was constructed but never started would still hold its listening socket, and
+        // the request would hang instead of failing — this call sets no read timeout.
+        val deadPort = ServerSocket(0).use { it.localPort }
+
+        assertNull(SharedBrowserFrameCache.getPageWebSocketUrl(deadPort))
+    }
+}


### PR DESCRIPTION
Covers `SharedBrowserFrameCache.getPageWebSocketUrl` — the step that decides which browser target a Browser Source output attaches to. One-word production change (`private` → `internal`, matching the five siblings already widened for this suite).

## The file was filed under the wrong blocker

It sits on the "JCEF/VLC render surfaces" list, which is why nobody had looked. **It does not use JCEF.** It launches an external headless Chrome/Edge *process* and drives it over the DevTools protocol — `findBrowserExecutable`, `buildBrowserLaunchCommand`, `killZombieBrowsers`, `getPageWebSocketUrl`. `SharedBrowserFrameCacheTest` already fakes the CDP WebSocket end of that with a Ktor server and says so in its class doc; the doc also enumerates what it covers, and this function is not in the list. So the gap was one HTTP call sitting in front of a protocol client that was already tested for real.

## Why this function is worth pinning

Everything downstream is aimed at whatever it returns. A browser's `/json` lists more than its page — extension background pages, service workers — and any of them can sort ahead of the real tab.

**Attaching to a background page fails silently in the worst way.** The connection succeeds, the screen-capture commands are accepted, and no frames ever arrive: black for the congregation, healthy from the app's point of view, nothing in any log. The `type == "page"` filter is the entire point of the function, so the tests are weighted toward it rather than toward the happy path.

The fallback to the first entry is deliberate too, and now stated: a browser build that labels its tab something unexpected should still render rather than refuse outright.

## Evidence

**Mutation-checked:**

| Mutation | Result |
|---|---|
| invert the `type == "page"` filter | fails 2 of 7 |
| drop the `?: pages.firstOrNull()` fallback | fails 1 of 7 |

**Three consecutive green `--rerun-tasks` runs of the full suite, 8,028 tests each** — the full suite rather than the package because production code changed, even by one word.

7 tests, **0.743s**, driven against a real Ktor server on an ephemeral port. The endpoint is plain HTTP with a JSON body, so there is no reason to fake the client's own parser — same approach as the existing WebSocket fake, one layer earlier.

## One trap avoided, noted at the site

The dead-port test takes a port from a `ServerSocket` it actually closes. A server constructed but never started still holds its listening socket, so the kernel would complete the handshake into a backlog nobody serves and this call — which sets no read timeout — would hang rather than fail. That is the same trap `STTManagerTest` hit for ten minutes.
