### PR TITLE
Stop excluding NavigationTopBar from the coverage gate

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -763,11 +763,15 @@ tasks.register<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
             // Kept in sync with jacocoTestReport above -- a hidden easter egg, out of scope for the
             // coverage floor regardless of how well tested it happens to be.
             exclude("**/CrosswordTabKt*")
-            // App entry / window wiring: `main` itself, the root composable tree and the top bar.
+            // App entry / window wiring: `main` itself and the root composable tree.
             // MainKt's ~200 synthetic lambda classes come along via the `$` globs.
+            //
+            // NavigationTopBar.kt used to be listed here too. It is now covered in full by
+            // NavigationTopBarTest, so excluding it would claim it cannot be tested when it
+            // demonstrably can — and would keep 212 covered lines out of the enforced number for
+            // no reason. This list is only worth reading if every entry on it is still true.
             exclude("org/churchpresenter/app/churchpresenter/MainKt*")
             exclude("org/churchpresenter/app/churchpresenter/MainDesktopKt*")
-            exclude("org/churchpresenter/app/churchpresenter/NavigationTopBarKt*")
             // Declared in MainDesktop.kt but not named after it, so the glob above misses it: a
             // holder for the schedule callbacks the root composable wires up. Named explicitly
             // because leaving it in keeps every one of MainDesktop.kt's 1,521 lines in the


### PR DESCRIPTION
Removes `NavigationTopBarKt*` from `jacocoTestCoverageVerification`'s exclusion list. No test or production change — one line of `build.gradle.kts` plus a comment.

## Why

The exclusion list exists to name what *cannot* be covered — window construction and the composable tree that only run under a real display. `NavigationTopBar.kt` is no longer one of those. `NavigationTopBarTest` (16 tests, added in `8792b155`) covers it **in full**:

```
NavigationTopBar.kt   missed=0   covered=212   100.0%
```

So the entry was making two claims that are both now false: that the file cannot be tested, and — because the gate skips it — that those 212 covered lines should not count toward the enforced number.

The comment in this very block already argues the principle ("JaCoCo drops a source file only once every class in it is excluded"), and the repo has been here before: a same-day revert over `CrosswordTabKt*` turned on exactly this question, and the reasoning recorded then was that **once one exclusion means "we didn't get to it", the list stops being readable as a list of what cannot be covered.** This is that case, resolved in the direction that keeps the list honest.

## Safety

- **The gate passes:** `./gradlew :composeApp:jacocoTestCoverageVerification` → `BUILD SUCCESSFUL`.
- The 212 lines entering the denominator are **all covered**, so the enforced ratio can only move up.
- Margin is not a concern either way: the floor is 75% and the gated figure is high-80s, so even a hypothetical 0% for this file on CI would move it a fraction of a point.
- `NavigationTopBar.kt` declares no classes of its own — only `@Composable` functions — so the `NavigationTopBarKt*` glob was covering the whole file and nothing is left half-excluded.

`main.kt` and `MainDesktop.kt` stay excluded; nothing about them has changed.

## Not included

`jacocoTestReport` never excluded this file — the headline figure has always counted it, which is how the discrepancy was visible at all. Only the verification task needed the edit.
