### PR TITLE
Wrap the hour when the countdown minute spinner crosses midnight

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/AnnouncementsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/AnnouncementsViewModel.kt
@@ -349,11 +349,14 @@ class AnnouncementsViewModel {
 
     fun stepTargetMinute(delta: Int) {
         val cur = _targetMinute.value
+        // The carry goes through stepTargetHour, not setTargetHour: the latter coerces into 0..23,
+        // which left the minute wrapping while the hour stuck (23:59 stepped up to 23:00, 00:00
+        // stepped down to 00:59). A countdown aimed at midnight was 23 hours out.
         if (delta > 0) {
-            if (cur >= 59) { _targetMinute.value = 0; setTargetHour(_targetHour.value + 1) }
+            if (cur >= 59) { _targetMinute.value = 0; stepTargetHour(1) }
             else setTargetMinute(cur + 1)
         } else {
-            if (cur <= 0) { _targetMinute.value = 59; setTargetHour(_targetHour.value - 1) }
+            if (cur <= 0) { _targetMinute.value = 59; stepTargetHour(-1) }
             else setTargetMinute(cur - 1)
         }
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/AnnouncementsViewModelTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/AnnouncementsViewModelTest.kt
@@ -204,31 +204,50 @@ class AnnouncementsViewModelTest {
     }
 
     /**
-     * Documents a CURRENT INCONSISTENCY rather than desired behaviour. [stepTargetHour] wraps
-     * around midnight on purpose (its own comment says so), but the hour *carry* performed by
-     * [stepTargetMinute] goes through `setTargetHour`, which coerces into 0..23 instead of
-     * wrapping. So the minute wraps while the hour sticks:
-     *   23:59 --step minute up--> 23:00   (rather than 00:00)
-     *   00:00 --step minute down--> 00:59  (rather than 23:59)
+     * The minute spinner's hour carry has to wrap across midnight, like [stepTargetHour] does.
      *
-     * Only reachable by stepping the minute spinner across the hour boundary at the very top or
-     * bottom of the clock. Fix would be to route the carry through `stepTargetHour`, which already
-     * wraps correctly -- deliberately not changed here, since this slate is tests only.
+     * This used to document the opposite as a known inconsistency: the carry went through
+     * `setTargetHour`, which coerces into 0..23, so the minute wrapped while the hour stuck —
+     * 23:59 stepped up to **23:00** instead of 00:00, and 00:00 stepped down to **00:59** instead of
+     * 23:59. A countdown aimed at midnight is exactly the one a church sets, and it was 23 hours out.
+     *
+     * Both directions are asserted because they fail through different halves of the carry.
      */
     @Test
-    fun `minute carry clamps the hour at midnight instead of wrapping -- known inconsistency`() {
+    fun `stepping the minute across midnight wraps the hour rather than clamping it`() {
         val vm = vm()
         vm.setTargetHour(23)
         vm.setTargetMinute(59)
         vm.stepTargetMinute(1)
         assertEquals(0, vm.targetMinute)
-        assertEquals(23, vm.targetHour, "current behaviour: hour clamps rather than wrapping to 0")
+        assertEquals(0, vm.targetHour, "23:59 + 1min is 00:00, not 23:00")
 
         vm.setTargetHour(0)
         vm.setTargetMinute(0)
         vm.stepTargetMinute(-1)
         assertEquals(59, vm.targetMinute)
-        assertEquals(0, vm.targetHour, "current behaviour: hour clamps rather than wrapping to 23")
+        assertEquals(23, vm.targetHour, "00:00 - 1min is 23:59, not 00:59")
+    }
+
+    /**
+     * The seconds spinner reached the same defect one level deeper, and is a separate user action.
+     *
+     * `stepTargetSecond` already carried through `stepTargetMinute` — the correct pattern, and the
+     * reason the fix was to make the minute carry match it rather than to invent a new convention.
+     * But the hour it eventually reached was still clamped, so stepping seconds down from midnight
+     * landed on hour 0 instead of 23.
+     */
+    @Test
+    fun `stepping the second down from midnight carries all the way through the hour`() {
+        val vm = vm()
+        vm.setTargetHour(0)
+        vm.setTargetMinute(0)
+        vm.setTargetSecond(0)
+
+        vm.stepTargetSecond(-1)
+
+        assertEquals(23, vm.targetHour, "00:00:00 stepped down is 23:59:55")
+        assertEquals(59, vm.targetMinute)
     }
 
     @Test


### PR DESCRIPTION
Fixes a live bug in the countdown timer's "count down to a clock time" mode: the minute spinner's hour carry clamped instead of wrapping across midnight.

## The bug

`stepTargetMinute` carried into the hour through `setTargetHour`, which coerces into `0..23`, rather than through `stepTargetHour`, which wraps. So the minute wrapped while the hour stuck:

```
23:59  --step minute up-->    23:00   (should be 00:00)
00:00  --step minute down-->  00:59   (should be 23:59)
```

An operator setting a countdown to midnight by stepping the spinner up past 23:59 got a target 23 hours away, with nothing to indicate it. Midnight is not an obscure target — a New Year's service or a late-night meeting is exactly when you would set one.

**It reached one level further than that.** `stepTargetSecond` already carried correctly via `stepTargetMinute`, so the seconds spinner hit the same defect through it: `00:00:00` stepped down landed on hour 0 rather than 23. That is a separate user action and has its own test.

## The fix

Route the carry through `stepTargetHour`, which already wraps and whose own comment says that is deliberate. This is one line each way, and it makes the minute carry match what `stepTargetSecond` was already doing — restoring the file's existing convention rather than introducing a new one.

## This was already known

`AnnouncementsViewModelTest` carried a test named `minute carry clamps the hour at midnight instead of wrapping -- known inconsistency`, whose doc comment described the behaviour, named the correct fix, and said it was "deliberately not changed here, since this slate is tests only". That was a reasonable call for a tests-only PR; this is the follow-up it implied.

That test is rewritten to assert the correct behaviour rather than deleted, so the history of the mistake stays visible.

## Evidence

**A genuine red-green, not a mutation check.** The prior production code exists and fails the new assertions:

- With the fix stashed: **2 of 20 fail** — `expected:<0> but was:<23>` for the minute path, and the seconds path alongside it.
- With the fix applied: 20 of 20 pass.

**Three consecutive green `--rerun-tasks` runs of the full suite** (8,182 tests each) — the full suite rather than the package, since this changes live production code.

Swept for other tests pinning the old clamping behaviour: none. `AnnouncementsViewModelSteppingTest` covers `stepTargetHour` directly and is unaffected.
