### PR TITLE
Render a chorus-only song instead of nothing

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
@@ -491,6 +491,11 @@ class SongsViewModel(
         // Second pass: auto-repeat chorus after each verse
         val chorusSection = sections.firstOrNull { it.type == Constants.SECTION_TYPE_CHORUS }
         if (chorusSection == null) return sections
+        // With no verse there is nothing to repeat the chorus after, and the loop below — which
+        // drops every original chorus and re-adds it only behind a verse — would return an empty
+        // list. A chorus-only song (a short refrain, or a choruses-only songbook) would then put
+        // nothing on screen at all.
+        if (sections.none { it.type == Constants.SECTION_TYPE_VERSE }) return sections
 
         val result = mutableListOf<LyricSection>()
         for (section in sections) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/LyricSectionsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/LyricSectionsTest.kt
@@ -133,20 +133,33 @@ class LyricSectionsTest {
     }
 
     /**
-     * Documents a CURRENT BUG. The repeat pass drops every original chorus section and re-inserts
-     * it only after a verse — so a song written as nothing but a chorus (common for short worship
-     * refrains and choruses-only songbooks) yields ZERO sections and puts nothing on screen at all.
+     * A song that is nothing but a chorus still has to go on screen.
      *
-     * Not fixed here — this slate is tests only. A fix would keep the chorus when there is no
-     * verse to attach it to.
+     * The auto-repeat pass drops every original chorus and re-inserts it after each verse. With no
+     * verse to attach it to, that used to leave **zero sections** — the operator selected the song
+     * and the congregation saw nothing at all. Short worship refrains and choruses-only songbooks
+     * are exactly the case, so this was not an edge.
+     *
+     * The auto-repeat has nothing to do without a verse, so the sections are returned as written.
      */
     @Test
-    fun `a chorus-only song produces no sections at all -- known bug`() {
+    fun `a chorus-only song still renders its chorus`() {
         val sections = vm.getLyricSections(song(listOf("{Chorus}", "Only a refrain")))
-        assertTrue(
-            sections.isEmpty(),
-            "current behaviour: a chorus-only song renders nothing (got $sections)",
+
+        assertEquals(1, sections.size, "got $sections")
+        assertEquals(listOf("Only a refrain"), sections.single().lines)
+        assertEquals(Constants.SECTION_TYPE_CHORUS, sections.single().type)
+        assertTrue(sections.single().isLastSection, "the only section is also the last")
+    }
+
+    @Test
+    fun `several choruses and no verse keep their written order`() {
+        val sections = vm.getLyricSections(
+            song(listOf("{Chorus 1}", "first refrain", "{Chorus 2}", "second refrain")),
         )
+
+        // Nothing to interleave them with, so neither is dropped nor repeated.
+        assertEquals(listOf(listOf("first refrain"), listOf("second refrain")), sections.map { it.lines })
     }
 
     // ── End-of-song marker ──────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes a live bug: a song written as nothing but a chorus put **nothing on screen at all**.

## The bug

`splitLyricsIntoSections`' second pass auto-repeats the chorus after each verse. It does that by dropping every original chorus section and re-inserting it behind each verse:

```kotlin
for (section in sections) {
    if (section.type == SECTION_TYPE_CHORUS) continue   // skip original
    result.add(section)
    if (section.type == SECTION_TYPE_VERSE) result.add(chorusSection)
}
```

With no verse in the song, every section is skipped and nothing is ever re-added, so the function returns an empty list. The operator selects the song, goes live, and the congregation sees a blank screen — no error, nothing in the log.

**This is not an edge case.** Short worship refrains and choruses-only songbooks are exactly this shape, which is what the test documenting it said too.

## The fix

The auto-repeat has nothing to do when there is no verse, so return the sections as written:

```kotlin
if (sections.none { it.type == SECTION_TYPE_VERSE }) return sections
```

One line, next to the existing "no chorus at all" early return it mirrors. A second test covers several choruses with no verse, so the guard is pinned as "return them in written order", not just "return something".

## This was already known

`LyricSectionsTest` carried `a chorus-only song produces no sections at all -- known bug`, whose comment described the cause, named the fix ("keep the chorus when there is no verse to attach it to"), and said it was "not fixed here — this slate is tests only". Reasonable for that PR; this is the follow-up.

The test is rewritten to assert correct behaviour rather than deleted, so the history stays visible.

## Evidence

**A genuine red-green** — the real prior code fails the new assertions:

- Fix stashed: both new tests fail, `expected:<1> but was:<0>` and `expected:<[[first refrain], [second refrain]]> but was:<[]>`.
- Fix applied: green.

**Three consecutive green `--rerun-tasks` runs of the full suite** (8,183 tests each) — full suite because this changes live production code. The 748 tests across the lyric/song suites specifically all pass, including the existing chorus auto-repeat coverage, so the ordinary verse+chorus behaviour is unchanged.

## There are more of these

This came out of grepping test comments for defect language rather than coverage gaps. The same sweep turned up several other documented-but-unfiled bugs — verses 11/21/31 being mistaken for verse 1 in the song title rule, `setNote` not marking the schedule changed, the QR-code toggle silently retiring the live question. Each is worth its own PR; noting it here so the pattern is visible rather than rediscovered.
