### PR TITLE
Read a section's number as a number, so verse 11 is not verse 1

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/SongPresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/SongPresenter.kt
@@ -1028,7 +1028,11 @@ private fun shouldShowText(display: String, lyricSection: LyricSection): Boolean
             // Chorus/bridge sections are not "first page"
             if (lyricSection.type == Constants.SECTION_TYPE_CHORUS) return false
             val inner = header.trim().removePrefix("[").removePrefix("{").removeSuffix("]").removeSuffix("}").trim()
-            inner.endsWith("1") || !inner.any { it.isDigit() }
+            // The trailing number is compared as a number, not as a string ending in "1" — that read
+            // verses 11, 21 and 31 as the opening slide, so the title came back over them part-way
+            // through any hymn long enough to have eleven sections.
+            val sectionNumber = inner.takeLastWhile { it.isDigit() }.toIntOrNull()
+            sectionNumber == 1 || !inner.any { it.isDigit() }
         }
 
         else -> false

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/SongPresenterTitleRuleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/SongPresenterTitleRuleTest.kt
@@ -124,20 +124,26 @@ class SongPresenterTitleRuleTest {
     }
 
     /**
-     * Documents a KNOWN GAP: the rule is "ends with 1", so verse 11, 21 and 31 all read as the
-     * first page and the title reappears over them.
+     * Only verse *one* is the first page — not every verse whose number happens to end in a 1.
      *
-     * Reachable in any song with eleven or more numbered sections — long hymns and psalm settings
-     * do reach that. The fix is to match the trailing number as a whole (`\b1$`); this expectation
-     * then becomes false.
+     * The rule used to be `endsWith("1")`, so verses 11, 21 and 31 all read as the opening slide and
+     * the title reappeared over them part-way through the song. Any hymn or psalm setting with
+     * eleven or more numbered sections reaches it, and the failure is quiet: the title simply covers
+     * the lyric again with nothing to say why.
      */
     @Test
-    fun `verse eleven is mistaken for verse one -- known gap`() {
-        assertTrue(
-            shouldShowText(Constants.FIRST_PAGE, section("[Verse 11]")),
-            "current behaviour: the title comes back over verse 11",
-        )
-        assertTrue(shouldShowText(Constants.FIRST_PAGE, section("[Verse 21]")))
+    fun `a verse whose number merely ends in one is not the first page`() {
+        assertFalse(shouldShowText(Constants.FIRST_PAGE, section("[Verse 11]")))
+        assertFalse(shouldShowText(Constants.FIRST_PAGE, section("[Verse 21]")))
+        assertFalse(shouldShowText(Constants.FIRST_PAGE, section("[Verse 31]")))
+        assertFalse(shouldShowText(Constants.FIRST_PAGE, section("[Куплет 11]")), "and in any language")
+    }
+
+    @Test
+    fun `a zero-padded first verse is still the first page`() {
+        // Numbering typed as 01/02 is read as a number, not as a string ending in "1".
+        assertTrue(shouldShowText(Constants.FIRST_PAGE, section("[Verse 01]")))
+        assertFalse(shouldShowText(Constants.FIRST_PAGE, section("[Verse 011]")))
     }
 
     // ── Turning it off ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes a live bug: with the "First Page" title setting, the song title reappeared over verses 11, 21 and 31.

## The bug

`shouldShowText` decided "is this the opening slide?" with a string test:

```kotlin
inner.endsWith("1") || !inner.any { it.isDigit() }
```

So `[Verse 11]`, `[Verse 21]` and `[Verse 31]` all read as verse one. Part-way through the song the title and number came back and sat over the lyric, with nothing to indicate why.

**"First Page" is the setting most churches run**, and any hymn or psalm setting with eleven or more numbered sections reaches this. It fails quietly in the way that matters — the congregation just sees the title covering the words again.

## The fix

Compare the trailing number **as a number** rather than as a string suffix:

```kotlin
val sectionNumber = inner.takeLastWhile { it.isDigit() }.toIntOrNull()
sectionNumber == 1 || !inner.any { it.isDigit() }
```

## A case the original note got wrong

The comment documenting this proposed matching `\b1$`. That regex fixes verse 11 — and **breaks zero-padded numbering**: `[Verse 01]` is a legitimate first verse, and `\b1$` would not match it (the `1` is preceded by `0`, so there is no word boundary). The old `endsWith("1")` happened to get `[Verse 01]` right by accident.

Parsing the digits and comparing to `1` gets both: `[Verse 01]` is the first page, `[Verse 011]` is not. Each has its own test, so a later "simplification" back to a regex fails.

## Evidence

**A genuine red-green** — the real prior code fails the new assertions:

- Fix stashed: both new tests fail, `Expected value to be false`.
- Fix applied: green.

**Three consecutive green `--rerun-tasks` runs of the full suite** (8,184 tests each), plus 1,043 tests across the song and presenter suites specifically — including the existing rule coverage for null headers, chorus sections, unnumbered headings and non-English headings (`[Куплет 1]`), none of which changes.

## Where this came from

`SongPresenterTitleRuleTest` carried `verse eleven is mistaken for verse one -- known gap`, describing the defect and naming a fix, left unfixed because that PR was tests-only. It is the second item off the backlog of documented-but-unfiled bugs that a grep of test comments for defect language turns up (after #191's chorus-only song). The test is rewritten to assert the correct behaviour rather than deleted, so the history stays visible.
