### PR TITLE
Make a schedule note edit dirty the schedule and be undoable

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
@@ -248,7 +248,17 @@ class ScheduleViewModel(
     fun getNote(itemId: String): String = _notes[itemId] ?: ""
 
     fun setNote(itemId: String, note: String) {
-        if (note.isBlank()) _notes.remove(itemId) else _notes[itemId] = note
+        // A note is an edit like any other: it has to be snapshotted so it can be undone on its own,
+        // and notified so autosave knows the schedule changed. Without the notify a note-only change
+        // was never written; without the snapshot, undoing an unrelated edit restored a notes map
+        // that predated the note and silently discarded it.
+        val next = if (note.isBlank()) "" else note
+        // The ✓ that commits a note is also how its editor is closed, so pressing it unchanged must
+        // not push an undo step that appears to do nothing.
+        if ((_notes[itemId] ?: "") == next) return
+        pushUndoSnapshot()
+        if (next.isEmpty()) _notes.remove(itemId) else _notes[itemId] = next
+        notifyChanged()
     }
 
     // ── Encryption ────────────────────────────────────────────────────────────

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModelTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModelTest.kt
@@ -262,28 +262,73 @@ class ScheduleViewModelTest {
     }
 
     /**
-     * Documents a CURRENT BUG rather than desired behaviour: `setNote` calls neither
-     * `notifyChanged()` nor `pushUndoSnapshot()`. Two consequences:
-     *  - the schedule is never marked dirty, so the 60-second autosave loop skips a note-only
-     *    change entirely -- type a note, crash before touching anything else, the note is gone;
-     *  - the note change is not undoable, and an undo of an *unrelated* earlier edit will silently
-     *    revert it, because undo restores the notes map wholesale from its snapshot.
+     * A note is an edit like any other: it has to mark the schedule dirty and be undoable.
      *
-     * Left unfixed here deliberately -- this slate is tests only. If `setNote` is corrected to
-     * notify (and optionally snapshot), this test should flip to asserting the notification.
+     * `setNote` used to do neither, with two consequences. The autosave loop skips a schedule it is
+     * never told changed, so typing a note and then crashing lost it. And because undo restores the
+     * notes map wholesale from its snapshot, undoing an *unrelated* earlier edit silently reverted
+     * the note too — the operator pressed undo once and lost two things.
+     *
+     * A note is committed by the ✓ button, not on every keystroke, so one edit is one undo step.
      */
     @Test
-    fun `setNote does not mark the schedule changed -- known bug`() {
+    fun `a note edit marks the schedule changed`() {
         val vm = newViewModel()
         vm.addSongs("A")
         val id = vm.scheduleItems[0].id
         val before = notifications.size
 
         vm.setNote(id, "Key of G")
-        assertEquals(before, notifications.size, "current behaviour: note edits notify nobody")
 
-        vm.undo() // undoes the add; the note goes with it, having never been snapshotted
+        assertTrue(notifications.size > before, "autosave only runs for a schedule it knows changed")
+    }
+
+    @Test
+    fun `a note edit is undone on its own, leaving the item it belongs to`() {
+        val vm = newViewModel()
+        vm.addSongs("A")
+        val id = vm.scheduleItems[0].id
+        vm.setNote(id, "Key of G")
+
+        vm.undo()
+
+        // The most recent edit was the note, so that is what comes back off the stack — the song
+        // it was attached to must survive.
         assertEquals("", vm.getNote(id))
+        assertEquals(1, vm.scheduleItems.size, "undoing the note must not take the song with it")
+    }
+
+    @Test
+    fun `undoing an edit made before the note leaves the note alone`() {
+        val vm = newViewModel()
+        vm.addSongs("A")
+        val id = vm.scheduleItems[0].id
+        vm.setNote(id, "Key of G")
+        vm.addSongs("B")
+
+        vm.undo() // undoes adding B
+
+        // This is the case that used to lose work silently: the note was never snapshotted, so any
+        // undo restored a notes map that predated it.
+        assertEquals("Key of G", vm.getNote(id), "an unrelated undo must not discard the note")
+        assertEquals(1, vm.scheduleItems.size)
+    }
+
+    @Test
+    fun `committing the same note again is not a second undo step`() {
+        val vm = newViewModel()
+        vm.addSongs("A")
+        val id = vm.scheduleItems[0].id
+        vm.setNote(id, "Key of G")
+        val before = notifications.size
+
+        vm.setNote(id, "Key of G")
+
+        // The ✓ button is also how the editor is closed, so pressing it without having changed
+        // anything must not push an undo step that appears to do nothing.
+        assertEquals(before, notifications.size)
+        vm.undo()
+        assertEquals("", vm.getNote(id), "one edit, one undo")
     }
 
     // ── Selection ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes a live bug: a note typed against a schedule item could be lost twice over — silently.

## The bug

`setNote` mutated the notes map and called neither `notifyChanged()` nor `pushUndoSnapshot()`:

```kotlin
fun setNote(itemId: String, note: String) {
    if (note.isBlank()) _notes.remove(itemId) else _notes[itemId] = note
}
```

Two separate losses follow:

1. **Autosave never learned the schedule had changed.** Type a note, touch nothing else, crash — the note is gone. The 60-second autosave loop only writes a schedule it has been told is dirty.
2. **Undo silently reverted it.** `undo()` restores the notes map wholesale from its snapshot, and the note was never in one. So undoing an *unrelated* earlier edit discarded the note as well — one press of undo, two things lost, with nothing to indicate the second.

## The fix

Follow the convention every sibling mutator already uses — snapshot, mutate, notify:

```kotlin
val next = if (note.isBlank()) "" else note
if ((_notes[itemId] ?: "") == next) return
pushUndoSnapshot()
if (next.isEmpty()) _notes.remove(itemId) else _notes[itemId] = next
notifyChanged()
```

**The no-op guard is load-bearing, not tidiness.** The ✓ button that commits a note is also how its editor is closed, so pressing it without having changed anything would otherwise push an undo step that appears to do nothing.

## Why snapshotting is safe here

Adding an undo snapshot to something called per keystroke would flood the stack and make undo useless. That was checked rather than assumed: `onNoteChanged` fires only from the ✓ (done) and ✗ (clear) buttons in `ScheduleTab`, never on text change. One note edit is one undo step.

## Evidence

**Red-green, and stated precisely: 2 of the 4 new tests were red.**

- `a note edit marks the schedule changed` — failed: nothing notified.
- `a note edit is undone on its own, leaving the item it belongs to` — failed `expected:<1> but was:<0>`; undo took the song too.
- The other two (`undoing an edit made before the note leaves the note alone`, `committing the same note again is not a second undo step`) **pass against the old code by coincidence** — the pre-existing `addSongs` snapshot happens to carry the note along. They constrain the new behaviour and are worth keeping, but they are not evidence of the bug and are not claimed as such.

**Three consecutive green `--rerun-tasks` runs of the full suite** (8,187 tests each), plus 337 tests across the schedule suites.

## Where this came from

`ScheduleViewModelTest` carried `setNote does not mark the schedule changed -- known bug`, describing both consequences and saying it was "left unfixed here deliberately -- this slate is tests only". Third item off the backlog of documented-but-unfiled bugs that a grep of test comments surfaces, after #191 and #192. The test is rewritten to assert correct behaviour rather than deleted.
