### PR TITLE
Announce that the QR code took the displayed question down

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/QAManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/QAManager.kt
@@ -175,7 +175,15 @@ class QAManager {
 
     fun toggleQRCodeDisplay(): Unit = synchronized(this) {
         _showQRCodeOnDisplay.value = !_showQRCodeOnDisplay.value
-        if (_showQRCodeOnDisplay.value) _displayedQuestion.value = null
+        // Taking the question down has to be announced, or a connected phone and any follower go on
+        // showing a question the operator has already retired.
+        //
+        // Emitted inline rather than by calling clearDisplay(): that also sets showQRCodeOnDisplay
+        // back to false, which would undo the toggle being performed here.
+        if (_showQRCodeOnDisplay.value && _displayedQuestion.value != null) {
+            _displayedQuestion.value = null
+            emitEvent(QAEvent.DisplayChanged(null))
+        }
     }
 
     fun toggleSession(): Unit = synchronized(this) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/QAManagerStateTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/QAManagerStateTest.kt
@@ -396,17 +396,17 @@ class QAManagerStateTest {
     }
 
     /**
-     * Documents a KNOWN GAP rather than desired behaviour: [QAManager.toggleQRCodeDisplay] clears
-     * the displayed question locally but emits no [QAEvent.DisplayChanged], so anything driven by
-     * the event stream — a connected phone, a follower instance — is never told the question came
-     * down and keeps showing it alongside the operator's QR code.
+     * Switching to the QR code takes the question down everywhere, not just on the operator's screen.
      *
-     * Every other path that clears the display does emit. The fix is one `emitEvent` call; left
-     * unmade here because this slate is tests only. When it is made, this flips to asserting the
-     * event arrives.
+     * [QAManager.toggleQRCodeDisplay] used to clear the displayed question locally and emit nothing,
+     * so every consumer of the event stream — a connected phone, a follower instance — went on
+     * showing a question the operator had already retired.
+     *
+     * The event is emitted **inline** rather than by calling [QAManager.clearDisplay], which also
+     * sets `showQRCodeOnDisplay` back to false and would undo the toggle that is being performed.
      */
     @Test
-    fun `switching to the QR code retires the question without telling anyone -- known gap`() {
+    fun `switching to the QR code broadcasts that the question came down`() {
         val qa = openSession()
         val id = qa.submitApproved("Still on the phones")
         assertTrue(qa.displayQuestion(id))
@@ -414,10 +414,33 @@ class QAManagerStateTest {
         val events = qa.eventsDuring { qa.toggleQRCodeDisplay() }
 
         assertNull(qa.displayedQuestion, "locally the question is down")
-        assertTrue(qa.showQRCodeOnDisplay)
-        assertTrue(
-            events.filterIsInstance<QAEvent.DisplayChanged>().isEmpty(),
-            "current behaviour: nothing is broadcast, so a phone still shows the retired question",
+        assertTrue(qa.showQRCodeOnDisplay, "and the QR code stays up — the toggle is not undone")
+        assertNull(
+            events.filterIsInstance<QAEvent.DisplayChanged>().single().question,
+            "a phone must be told the question is gone, not left showing it",
         )
+    }
+
+    @Test
+    fun `toggling the QR code back off leaves the display alone`() {
+        val qa = openSession()
+        qa.toggleQRCodeDisplay()
+
+        val events = qa.eventsDuring { qa.toggleQRCodeDisplay() }
+
+        // Turning the QR code off retires nothing, so there is nothing to announce. Emitting here
+        // would tell followers a question came down that was never up.
+        assertFalse(qa.showQRCodeOnDisplay)
+        assertTrue(events.filterIsInstance<QAEvent.DisplayChanged>().isEmpty())
+    }
+
+    @Test
+    fun `switching to the QR code with nothing displayed announces nothing`() {
+        val qa = openSession()
+
+        val events = qa.eventsDuring { qa.toggleQRCodeDisplay() }
+
+        assertTrue(qa.showQRCodeOnDisplay)
+        assertTrue(events.filterIsInstance<QAEvent.DisplayChanged>().isEmpty())
     }
 }


### PR DESCRIPTION
Fixes a live bug: switching the Q&A display to the QR code took the question down on the operator's screen only. Every connected phone and any follower instance kept showing it.

## The bug

```kotlin
fun toggleQRCodeDisplay(): Unit = synchronized(this) {
    _showQRCodeOnDisplay.value = !_showQRCodeOnDisplay.value
    if (_showQRCodeOnDisplay.value) _displayedQuestion.value = null
}
```

The displayed question is cleared locally and **no `DisplayChanged` event is emitted**. Everything downstream is driven by that event stream, so a question the operator has retired stays on the phones — beside a QR code inviting new ones.

Every other path that clears the display emits. This was the one that didn't.

## The fix, and the trap in the obvious version

Emit inline, guarded on a question actually being displayed:

```kotlin
if (_showQRCodeOnDisplay.value && _displayedQuestion.value != null) {
    _displayedQuestion.value = null
    emitEvent(QAEvent.DisplayChanged(null))
}
```

**Routing this through `clearDisplay()` — which is what every other clearing path does, and the obvious tidy-up — would break the feature.** `clearDisplay()` also sets `_showQRCodeOnDisplay.value = false`, so calling it here would immediately undo the toggle being performed and the QR code would never appear. There is a test asserting the QR code stays up, so that mistake fails rather than ships.

The `!= null` guard keeps the toggle quiet when it has nothing to announce: turning the QR code on with no question displayed, or turning it off at all, emits nothing. Otherwise followers would be told a question came down that was never up.

## Evidence

**Red-green, stated precisely: 1 of the 3 new tests was red.**

- `switching to the QR code broadcasts that the question came down` — failed, `NoSuchElementException: List is empty` (no event at all).
- The two guard tests (`toggling the QR code back off leaves the display alone`, `switching to the QR code with nothing displayed announces nothing`) **pass against the old code trivially**, since it emits nothing in any case. They constrain the new behaviour and are worth keeping, but they are not evidence of the bug and are not claimed as such.

**Three consecutive green `--rerun-tasks` runs of the full suite** (8,189 tests each) — the full suite because this changes live production code — plus 199 tests across the QA suites.

## Where this came from

`QAManagerStateTest` carried `switching to the QR code retires the question without telling anyone -- known gap`, describing the cause and naming the fix, left unmade because that PR was tests-only. Fourth item off the backlog of documented-but-unfiled bugs that a grep of test comments surfaces, after #191, #192 and #193. The test is rewritten to assert the correct behaviour rather than deleted, so the history stays visible.
