### PR TITLE
Resend the secondary-bible invalidation on connect

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
@@ -3496,6 +3496,12 @@ class CompanionServer {
                     // primary's background changed while it was disconnected.
                     send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
                         WebSocketMessage(Constants.WS_EVENT_BACKGROUNDS_UPDATED, payload = ""))))
+                    // The secondary bible needs exactly the same treatment, and for exactly the same
+                    // reason: it is an invalidation signal with an empty payload, so a follower that
+                    // reconnects without it keeps serving the .spb it cached last session even if the
+                    // primary changed translation while it was away.
+                    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+                        WebSocketMessage(Constants.WS_EVENT_SECONDARY_BIBLE_UPDATED, payload = ""))))
                     send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
                         WebSocketMessage(
                             type = Constants.WS_EVENT_PRESENTATION_SLIDE_CHANGED,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerTest.kt
@@ -171,6 +171,10 @@ class CompanionServerTest {
             Constants.WS_EVENT_SONGS_UPDATED,
             Constants.WS_EVENT_SCHEDULE_UPDATED,
             Constants.WS_EVENT_BACKGROUNDS_UPDATED,
+            // Both of the pure invalidation signals belong here. They carry no payload, so there is
+            // no "nothing is loaded" case to withhold them for — a follower needs them on every
+            // reconnect or it trusts a cache the primary may have changed while it was away.
+            Constants.WS_EVENT_SECONDARY_BIBLE_UPDATED,
         )) {
             assertTrue(expected in types, "connect snapshot is missing $expected; got $types")
         }
@@ -190,22 +194,25 @@ class CompanionServerTest {
     }
 
     /**
-     * Documents a KNOWN GAP, deliberately not fixed here.
+     * A follower must not be left trusting a secondary bible it cached in an earlier session.
      *
-     * `secondary_bible_updated` is broadcast live whenever the secondary bible changes, but it is
-     * absent from the connect snapshot — the exact bug already found and fixed for
-     * `backgrounds_updated`. A follower that reconnects (app restart, network blip, or the normal
-     * backoff reconnect) therefore keeps serving its previously cached secondary bible forever.
+     * `secondary_bible_updated` is broadcast live whenever the secondary bible changes, but it used
+     * to be absent from the connect snapshot — the exact bug already found and fixed for
+     * `backgrounds_updated`. A follower that reconnected (app restart, network blip, or the normal
+     * backoff reconnect) therefore kept serving its previously cached `.spb` **forever**, with no
+     * error and nothing in any log to notice by.
      *
-     * When the missing resend is added, this test will fail — flip it to the positive assertion
-     * and move the event up into the snapshot test above.
+     * The positive assertion now lives in the snapshot test above, alongside `backgrounds_updated`;
+     * what is checked here is the property that makes it unconditional — it is sent even though this
+     * server has no secondary bible configured, because the event is an invalidation signal with an
+     * empty payload rather than a catalogue.
      */
     @Test
-    fun `secondary bible is missing from the connect snapshot -- known gap`() {
+    fun `the secondary bible invalidation is resent even with none configured`() {
         val types = connectAndCollect().types()
-        assertFalse(
+        assertTrue(
             Constants.WS_EVENT_SECONDARY_BIBLE_UPDATED in types,
-            "secondary_bible_updated is now resent on connect — the gap is fixed, update this test",
+            "a reconnecting follower must be told to re-check; got $types",
         )
     }
 


### PR DESCRIPTION
Fixes a live bug: a follower that reconnects kept serving the secondary bible it cached in an earlier session, indefinitely.

## The bug

`secondary_bible_updated` is broadcast live whenever the secondary bible changes — it is an invalidation signal telling a follower to re-download the `.spb` instead of trusting its cache. It was **missing from the connect snapshot**.

So a follower that reconnects — app restart, network blip, or the routine backoff reconnect — was never told to re-check. If the primary changed translation while it was away, the follower went on serving the old one **forever**, with no error and nothing in any log to notice by.

## This is the same bug that was already fixed once

`backgrounds_updated` had exactly this defect, and the fix sits three lines above the new one, with a comment stating the reasoning verbatim:

> Resent on every (re)connect so a follower mirroring backgrounds always invalidates its local asset cache once per connection […] Without this, a follower that reconnects […] keeps serving whatever it cached last session even if the primary's background changed while it was disconnected.

The secondary bible needed the identical treatment. The fix is the same send, placed beside its twin.

## Why it is unconditional

Both are invalidation signals with an **empty payload**, not catalogues — so there is no "nothing is loaded" case to withhold them for, unlike `bible_updated` / `presentation_updated` / `pictures_updated`, which are deliberately conditional because sending them empty would have a follower cache an empty catalog.

That distinction is now pinned on both sides: the positive assertion moved up into the shared snapshot test alongside `backgrounds_updated`, and the remaining test asserts the property that makes it unconditional — it is sent even though this server has **no secondary bible configured**.

## Evidence

**A genuine red-green** — the real prior code fails both:

```
connect snapshot is missing secondary_bible_updated;
  got [songs_updated, schedule_updated, backgrounds_updated, …]
```

**Three consecutive green `--rerun-tasks` runs of the full suite** (8,189 tests each) — full suite because this changes live production code — plus 772 tests across the `server` package.

## Where this came from

`CompanionServerTest` carried `secondary bible is missing from the connect snapshot -- known gap`, describing the cause, naming the precedent, and instructing that when the resend is added the test should flip to the positive assertion **and move up into the snapshot test**. Both were done rather than the test simply deleted. Fifth item off the backlog of documented-but-unfiled bugs that a grep of test comments surfaces, after #191–#194.
