### PR TITLE
Recompute a website's row label when its title arrives

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/models/ScheduleItem.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/models/ScheduleItem.kt
@@ -143,7 +143,7 @@ sealed class ScheduleItem {
         override val id: String,
         val url: String,
         val title: String = url,
-        override val displayText: String = "${title.take(60)}${if (title.length > 60) "…" else ""}"
+        override val displayText: String = websiteDisplayText(title)
     ) : ScheduleItem()
 
     @Serializable
@@ -164,4 +164,16 @@ sealed class ScheduleItem {
         override val displayText: String = "$word ($number)"
     ) : ScheduleItem()
 }
+
+/**
+ * The schedule row's label for a website, truncated so a long page title cannot push the row out of
+ * shape.
+ *
+ * Named rather than inlined into [ScheduleItem.WebsiteItem]'s default because `copy()` does **not**
+ * re-apply constructor defaults — it carries the current instance's value for every parameter it is
+ * not given. Anything that changes the title therefore has to pass the new label explicitly, and
+ * both sides have to derive it the same way or the row and the title drift apart.
+ */
+internal fun websiteDisplayText(title: String): String =
+    "${title.take(60)}${if (title.length > 60) "…" else ""}"
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import org.churchpresenter.app.churchpresenter.models.websiteDisplayText
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.server.ScheduleItemDto
 import org.churchpresenter.app.churchpresenter.utils.CrashReporter
@@ -524,7 +525,9 @@ class ScheduleViewModel(
             // Only update if the current title is still the URL (i.e. no real title was set yet)
             if (existing.title == existing.url || existing.title.isBlank()) {
                 pushUndoSnapshot()
-                _scheduleItems[index] = existing.copy(title = title)
+                // displayText must be passed explicitly: copy() does not re-apply constructor
+                // defaults, so without this the row keeps showing the URL the item was added with.
+                _scheduleItems[index] = existing.copy(title = title, displayText = websiteDisplayText(title))
                 notifyChanged()
             }
         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModelEditingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModelEditingTest.kt
@@ -112,19 +112,34 @@ class ScheduleViewModelEditingTest {
     }
 
     /**
-     * Documents CURRENT behaviour, not desired behaviour: `updateWebsiteTitle` uses `copy(title = …)`,
-     * and `displayText` is a stored constructor property whose default was computed when the item was
-     * created — so the schedule row keeps showing the raw URL even after the real title arrives.
-     * Left unfixed here deliberately; this slate is tests only. If the copy is changed to recompute
-     * `displayText`, this assertion should flip.
+     * The schedule row shows the page's real title once it arrives, not the URL it was added with.
+     *
+     * `displayText` is a constructor parameter with a default, and **`copy()` never re-applies
+     * defaults** — it passes the current instance's value for every parameter not named. So
+     * `copy(title = …)` used to carry the old label forward, and the row went on showing the raw URL
+     * for the rest of the service while `title` said otherwise.
      */
     @Test
-    fun `the schedule row keeps showing the url after a title update -- known bug`() {
+    fun `the schedule row shows the real title once it arrives`() {
         val vm = newViewModel()
         vm.addWebsite("https://example.org", "")
+
         vm.updateWebsiteTitle("https://example.org", "Example Domain")
+
         assertEquals("Example Domain", vm.website.title)
-        assertEquals("https://example.org", vm.website.displayText, "current behaviour: the row label is stale")
+        assertEquals("Example Domain", vm.website.displayText, "the row label follows the title")
+    }
+
+    @Test
+    fun `a very long title is still truncated in the row after an update`() {
+        val vm = newViewModel()
+        vm.addWebsite("https://example.org", "")
+
+        vm.updateWebsiteTitle("https://example.org", "x".repeat(80))
+
+        // Pins that the label is re-derived through the same formatting, not just assigned the
+        // title — otherwise an 80-character page title would push the whole row out of shape.
+        assertEquals("x".repeat(60) + "…", vm.website.displayText)
     }
 
     // ── Labels ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes a live bug: a website added to the schedule kept showing its raw URL as the row label even after the page's real title arrived.

## The bug

`WebsiteItem.displayText` is a **constructor parameter with a default**:

```kotlin
data class WebsiteItem(
    override val id: String,
    val url: String,
    val title: String = url,
    override val displayText: String = "${title.take(60)}…"
)
```

**`copy()` does not re-apply constructor defaults.** It passes the current instance's value for every parameter it is not given, so `existing.copy(title = title)` carried the *old* label — computed from the URL the item was added with — forward unchanged.

The operator adds a website (label: `https://example.org`), the page loads and reports `Example Domain`, `title` updates, and the schedule row goes on saying `https://example.org` for the rest of the service.

## The fix

Name the formatting so the default and the update cannot drift, and pass it explicitly at the one site that copies:

```kotlin
internal fun websiteDisplayText(title: String): String =
    "${title.take(60)}${if (title.length > 60) "…" else ""}"
```

```kotlin
_scheduleItems[index] = existing.copy(title = title, displayText = websiteDisplayText(title))
```

The helper's doc comment states the `copy()` rule, since that is the part that is easy to get wrong again.

## Scope: this is one site, and that was checked

`LabelItem` has the identical shape (`displayText = text`), so it looked like a second instance. It is not — `updateLabel` **constructs a fresh `LabelItem`** rather than copying, so its default re-runs correctly. Sweeping every `.copy(` on a `ScheduleItem` subtype and every constructor site:

- `updateWebsiteTitle` — the only `copy()` mutating a field that feeds `displayText`. Fixed here.
- `updateLabel`, `addWebsite`, `addLabel`, the remote-item parsers, `CompanionServer`'s website builder — all fresh constructor calls, defaults apply, unaffected.
- `SongsTab`'s `copy(bpm =, capo =)` is on `data.SongItem`, a different class, and neither field feeds a label.

## Evidence

**A genuine red-green** — the real prior code fails both:

```
the row label follows the title  expected:<[Example Domain]> but was:<[https://example.org]>
```

The second test drives an 80-character title and asserts the truncated form, so the label is pinned as *re-derived through the same formatting* rather than merely assigned the title — otherwise a long page title would push the row out of shape.

**Three consecutive green `--rerun-tasks` runs of the full suite** (8,190 tests each) — full suite because this changes live production code — plus 338 tests across the schedule suites.

## Where this came from

`ScheduleViewModelEditingTest` carried `the schedule row keeps showing the url after a title update -- known bug`, describing the cause and naming the fix, left unmade because that PR was tests-only. Sixth item off the backlog of documented-but-unfiled bugs that a grep of test comments surfaces, after #191–#195. The test is rewritten to assert correct behaviour rather than deleted.
