### PR TITLE
Stop excluding MainDesktop from the coverage gate

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -763,20 +763,17 @@ tasks.register<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
             // Kept in sync with jacocoTestReport above -- a hidden easter egg, out of scope for the
             // coverage floor regardless of how well tested it happens to be.
             exclude("**/CrosswordTabKt*")
-            // App entry / window wiring: `main` itself and the root composable tree.
-            // MainKt's ~200 synthetic lambda classes come along via the `$` globs.
+            // The app entry point: `main` itself, which opens real windows and binds real ports and
+            // so only runs under a display. MainKt's ~200 synthetic lambda classes come along via
+            // the `$` globs.
             //
-            // NavigationTopBar.kt used to be listed here too. It is now covered in full by
-            // NavigationTopBarTest, so excluding it would claim it cannot be tested when it
-            // demonstrably can — and would keep 212 covered lines out of the enforced number for
-            // no reason. This list is only worth reading if every entry on it is still true.
+            // Two files have left this list rather than sitting on it out of habit.
+            // NavigationTopBar.kt is covered in full by NavigationTopBarTest. MainDesktop.kt is at
+            // ~70% via MainDesktopComposeTest and the extracted MainDesktopLogic — excluding it
+            // claimed a demonstrably testable file could not be tested, and kept ~960 covered lines
+            // out of the enforced number. Counting it costs the gate about half a point against a
+            // ~14 point margin. This list is only worth reading if every entry on it is still true.
             exclude("org/churchpresenter/app/churchpresenter/MainKt*")
-            exclude("org/churchpresenter/app/churchpresenter/MainDesktopKt*")
-            // Declared in MainDesktop.kt but not named after it, so the glob above misses it: a
-            // holder for the schedule callbacks the root composable wires up. Named explicitly
-            // because leaving it in keeps every one of MainDesktop.kt's 1,521 lines in the
-            // denominator — JaCoCo drops a source file only once every class in it is excluded.
-            exclude("org/churchpresenter/app/churchpresenter/ScheduleActions*")
         }
     )
     sourceDirectories.setFrom(files("src/jvmMain/kotlin", "src/commonMain/kotlin"))


### PR DESCRIPTION
Removes `MainDesktop.kt` (and the `ScheduleActions` entry that existed only to force it out) from `jacocoTestCoverageVerification`'s exclusion list. Build-config only — no test or production change.

## Why

The exclusion list names what **cannot** be covered: window construction that only runs under a real display. `MainDesktop.kt` is no longer that. After #182's extraction and `MainDesktopComposeTest`, it stands at:

```
MainDesktop.kt   missed=401   covered=961   70.6%
```

Excluding it made two claims that are now false: that the file cannot be tested, and that its ~960 covered lines should not count toward the enforced number.

`ScheduleActions` goes with it. That entry existed solely because JaCoCo drops a source file only once *every* class in it is excluded — its own comment says so. With `MainDesktop.kt` deliberately counted, the reason for it is gone.

`main.kt` stays excluded and is untouched: it is at **0.4%**, and what remains there really is window and port setup.

## Cost, measured rather than asserted

| Gate scope | Ratio | Margin over the 75% floor |
|---|---|---|
| before | 48,175 / 53,936 = **89.32%** | 14.3pp |
| after | 49,136 / 55,298 = **88.86%** | 13.9pp |

**About half a point, against a ~14 point margin.** `./gradlew :composeApp:jacocoTestCoverageVerification` → `BUILD SUCCESSFUL`.

## The trade-off, stated plainly

This is not free, which is why it was raised as a decision rather than done quietly. The 401 lines still missed in `MainDesktop.kt` are genuinely display-bound, and they now sit permanently in the enforced denominator — so a future batch of window wiring will push the gate down with no practical way to test it back up. The margin absorbs a lot, but it is finite.

The alternative was leaving an entry on the list that says a 70%-covered file is untestable, which makes the whole list unreadable as a statement of what cannot be covered. That is the same argument #188 made for `NavigationTopBar.kt`, and the same reasoning recorded when `CrosswordTabKt*` was last debated.
