### PR TITLE
Remove the unused FileManager.deleteFile and its tests

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/FileManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/FileManager.kt
@@ -169,28 +169,6 @@ class FileManager {
     }
 
     /**
-     * Delete a file from directory
-     * Returns error message if failed, null if successful
-     */
-    fun deleteFile(directory: String, fileName: String): String? {
-        val fileToDelete = File(directory, fileName)
-        val dirCanonical = File(directory).canonicalPath
-        if (!fileToDelete.canonicalPath.startsWith(dirCanonical + File.separator) &&
-            fileToDelete.canonicalPath != dirCanonical) {
-            return "Invalid file path"
-        }
-        return try {
-            if (fileToDelete.delete()) {
-                null // Success
-            } else {
-                "Failed to delete file"
-            }
-        } catch (e: Exception) {
-            "Error deleting file: ${e.message}"
-        }
-    }
-
-    /**
      * Show confirmation dialog
      * Returns true if user confirmed
      */

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/FileManagerFileOpsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/FileManagerFileOpsTest.kt
@@ -21,16 +21,17 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Copying songs and Bibles into the library, and deleting them out of it.
+ * Copying songs and Bibles into the library, and choosing the files to copy.
  *
  * [FileManagerTest] covers the directory scans; this covers the operations that actually write to
- * the user's disk, where a mistake costs them a file rather than a listing.
+ * the user's disk, where a mistake costs the operator a file rather than a listing.
  *
- * The sharpest of these is `deleteFile`'s path check: it takes a directory and a *file name* from
- * the UI, and refuses anything whose canonical path escapes that directory — so a crafted name like
- * `../../something.sps` deletes nothing. That guard is the reason a name coming from a list row can
- * be trusted, and it is asserted here from both sides: the escape is refused, and the file it
- * pointed at is still there afterwards.
+ * There used to be a `deleteFile` section here, covering a canonical-path guard that refused a name
+ * escaping the library (`../../something.sps`). Both it and the function were removed once a search
+ * for its callers found none: it had never been wired to anything, so the untrusted name its guard
+ * was written for could not arrive. **If a delete-file feature is ever built, that guard was
+ * deliberately deleted rather than never written** — recover it from this file's history rather than
+ * shipping the feature without one.
  */
 class FileManagerFileOpsTest {
 
@@ -136,105 +137,6 @@ class FileManagerFileOpsTest {
             library.list()?.sorted(),
             "a half-failed import must still deliver what it could",
         )
-    }
-
-    // ── Deleting ────────────────────────────────────────────────────────────────
-
-    @Test
-    fun `deleting removes the file and reports success`() {
-        val file = libraryFile("song.sps")
-
-        val error = fileManager.deleteFile(library.path, "song.sps")
-
-        assertNull(error, "null means it worked")
-        assertFalse(file.exists())
-    }
-
-    @Test
-    fun `deleting something that is not there is reported`() {
-        val error = fileManager.deleteFile(library.path, "never-existed.sps")
-
-        assertEquals("Failed to delete file", error)
-    }
-
-    @Test
-    fun `deleting one file leaves the others alone`() {
-        libraryFile("keep.sps")
-        libraryFile("remove.sps")
-
-        fileManager.deleteFile(library.path, "remove.sps")
-
-        assertEquals(listOf("keep.sps"), library.list()?.sorted())
-    }
-
-    @Test
-    fun `a name that climbs out of the library is refused`() {
-        val outside = File(root, "important.sps").also { it.writeText("not yours to delete") }
-
-        val error = fileManager.deleteFile(library.path, "../important.sps")
-
-        assertEquals("Invalid file path", error)
-        assertTrue(outside.exists(), "a crafted name must not reach a file outside the chosen folder")
-    }
-
-    @Test
-    fun `a deeper climb out is refused too`() {
-        val outside = File(root, "important.sps").also { it.writeText("not yours to delete") }
-
-        val error = fileManager.deleteFile(library.path, "../../${root.name}/important.sps")
-
-        assertEquals("Invalid file path", error)
-        assertTrue(outside.exists())
-    }
-
-    @Test
-    fun `an absolute name pointing elsewhere deletes nothing`() {
-        // Java resolves an absolute child against the parent rather than replacing it, so this
-        // lands on a nonexistent path *inside* the library instead of escaping — a different route
-        // to the same outcome. Either way the file outside must survive, which is what matters.
-        val outside = File(root, "important.sps").also { it.writeText("not yours to delete") }
-
-        val error = fileManager.deleteFile(library.path, outside.absolutePath)
-
-        assertNotNull(error, "an operation that deleted nothing must not report success")
-        assertTrue(outside.exists(), "a crafted name must not reach a file outside the chosen folder")
-    }
-
-    @Test
-    fun `a name inside a subfolder of the library is allowed`() {
-        val nested = File(library, "Hymnal").also { it.mkdirs() }
-        val song = File(nested, "song.sps").also { it.writeText("x") }
-
-        val error = fileManager.deleteFile(library.path, "Hymnal/song.sps")
-
-        assertNull(error, "songbooks are real subfolders of the library — deleting inside one is legitimate")
-        assertFalse(song.exists())
-    }
-
-    /**
-     * Documents CURRENT behaviour rather than desired: a blank name resolves to the library folder
-     * itself, which passes the "does not escape the directory" check, so an empty folder would be
-     * deleted. Not reachable from the UI — the name always comes from a listed file — but the guard
-     * is about untrusted names, so it is worth knowing it stops at the folder rather than inside it.
-     */
-    @Test
-    fun `a blank name targets the folder itself -- known gap`() {
-        val empty = File(root, "empty-library").also { it.mkdirs() }
-
-        val error = fileManager.deleteFile(empty.path, "")
-
-        assertNull(error)
-        assertFalse(empty.exists(), "current behaviour: the folder itself was removed")
-    }
-
-    @Test
-    fun `a non-empty folder cannot be deleted by that route`() {
-        libraryFile("song.sps")
-
-        val error = fileManager.deleteFile(library.path, "")
-
-        assertEquals("Failed to delete file", error, "the filesystem refuses to remove a folder with contents")
-        assertTrue(library.exists())
     }
 
     // ── Choosing files ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Removes `FileManager.deleteFile` and its nine tests. It has no callers.

## Why

`deleteFile` was never wired to anything. Every reference in the tree is its own test file:

```
$ grep -rn "deleteFile" composeApp/src/
jvmMain/…/viewmodel/FileManager.kt:175          ← the declaration
jvmTest/…/viewmodel/FileManagerFileOpsTest.kt   ← nine call sites, all tests
```

(The `deleteFilesTitle` hits in the Converter sub-build are an unrelated string resource.)

`DEVELOPMENT_GUIDE.md` puts unused functions on the zero-tolerance list — removed, or documented as deliberately kept. There is nothing to document here: no feature references it, and the schedule/library UI does its own file handling.

## This started as a bug report and turned out not to be one

`FileManagerFileOpsTest` carried `a blank name targets the folder itself -- known gap`: `deleteFile(dir, "")` resolves to the directory and deletes it when empty, filed as a weakness in the path guard.

The guard is not the problem. **The check that settled it was one search for callers** — with none, the untrusted name the guard was written for cannot arrive, and tightening it would have been work on unreachable code. Sixth and last item off the backlog of documented-but-unfiled bugs, and the only one that turned out to need no fix.

## What is deliberately recorded rather than silently dropped

The removed tests covered a real canonical-path guard: a crafted name like `../../something.sps` was refused, asserted from both sides (the escape rejected, and the file it pointed at still present afterwards).

That is worth knowing about later. `FileManagerFileOpsTest`'s class doc — which previously opened by calling this guard "the sharpest of these", and would otherwise now describe code that does not exist — says explicitly that **the guard was deliberately deleted rather than never written**, and points at the file history. If a delete-file feature is ever built, recover the guard from here instead of shipping without one.

## Validation

**Three consecutive green `--rerun-tasks` runs of the full suite**, 8,181 tests each — down exactly nine from 8,190, which is the removed tests and nothing else. `FileManagerFileOpsTest` goes 23 → 14; `FileManagerTest`'s 17 are untouched. All four `kotlin.test` imports in the file are still used.
