### PR TITLE
Cover selecting a song from the schedule

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabScheduleSelectionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabScheduleSelectionTest.kt
@@ -1,0 +1,105 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.runtime.mutableStateOf
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Clicking a song in the schedule, and what the Songs tab does about it.
+ *
+ * The schedule is where a service is driven from, so this is the ordinary way a song is put on
+ * screen: the operator clicks the row, the tab finds that song in the library and hands its first
+ * section to the presenter. Getting it wrong is quiet — the row highlights, and nothing reaches the
+ * output.
+ *
+ * Two details of the wiring are the reason this is worth pinning:
+ *
+ * - The row can be clicked **before the library has finished loading**, which is normal on a cold
+ *   start. The tab waits for the load rather than looking the song up in an empty catalogue and
+ *   giving up.
+ * - The same row can be clicked **twice**. Compose would skip the second, so the caller bumps a
+ *   version alongside the item; without it, taking a song live, moving away and coming back to the
+ *   same row would do nothing the second time.
+ */
+class SongsTabScheduleSelectionTest {
+
+    /** A schedule row for one of [defaultSongs], as the schedule builds them. */
+    private fun row(number: Int, title: String, songbook: String = "Hymnal") =
+        ScheduleItem.SongItem(
+            id = "schedule-$number",
+            songNumber = number,
+            title = title,
+            songbook = songbook,
+        )
+
+    @Test
+    fun `clicking a scheduled song hands its lyrics to the presenter`() {
+        val selection = mutableStateOf<ScheduleItem.SongItem?>(null)
+        songsTab(scheduleSelection = selection) { vm, reports ->
+            waitForIdle()
+            assertNull(reports.selectedSection, "nothing is live until a row is clicked")
+
+            selection.value = row(1, "Amazing Grace")
+            waitForIdle()
+
+            val selected = vm.filteredSongItems.value.getOrNull(vm.selectedSongIndex.value)
+            assertEquals("Amazing Grace", selected?.title, "the library selection follows")
+            assertEquals("Amazing Grace", reports.selectedSection?.title, "and its lyrics go to the presenter")
+        }
+    }
+
+    @Test
+    fun `a song in another songbook is found by its own book, not the first match on number`() {
+        val selection = mutableStateOf<ScheduleItem.SongItem?>(null)
+        songsTab(scheduleSelection = selection) { vm, _ ->
+            waitForIdle()
+
+            // "3" exists only in Chorus Book; the Hymnal has 1, 2 and 12. Resolving by number alone
+            // would be ambiguous the moment two books number their songs the same way.
+            selection.value = row(3, "How Great Thou Art", songbook = "Chorus Book")
+            waitForIdle()
+
+            val selected = vm.filteredSongItems.value.getOrNull(vm.selectedSongIndex.value)
+            assertEquals("How Great Thou Art", selected?.title)
+            assertEquals("Chorus Book", selected?.songbook)
+        }
+    }
+
+    @Test
+    fun `clicking the same row again re-fires it`() {
+        val selection = mutableStateOf<ScheduleItem.SongItem?>(null)
+        val version = mutableStateOf(0)
+        songsTab(scheduleSelection = selection, scheduleSelectionVersion = version) { _, reports ->
+            waitForIdle()
+            selection.value = row(1, "Amazing Grace")
+            waitForIdle()
+            val afterFirst = reports.allSections.size
+
+            // The item is identical, so only the version differs — which is the whole reason it is
+            // passed. Without it Compose skips the effect and the second click does nothing.
+            version.value = 1
+            waitForIdle()
+
+            assertEquals(afterFirst + 1, reports.allSections.size, "the second click reached the presenter too")
+        }
+    }
+
+    @Test
+    fun `a scheduled song the library does not have reaches the presenter as nothing`() {
+        val selection = mutableStateOf<ScheduleItem.SongItem?>(null)
+        songsTab(scheduleSelection = selection) { _, reports ->
+            waitForIdle()
+
+            selection.value = row(999, "A Song Removed From The Library")
+            waitForIdle()
+
+            // A song deleted from the library after the service was planned must leave the output
+            // alone rather than push whatever happened to be selected.
+            assertNull(reports.selectedSection, "no match means nothing is sent")
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabTestSupport.kt
@@ -3,6 +3,8 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeUiTest
@@ -19,6 +21,7 @@ import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
 import org.churchpresenter.app.churchpresenter.models.LyricSection
+import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.viewmodel.SongsViewModel
 import java.io.File
@@ -133,6 +136,15 @@ internal fun songsTab(
     /** Whether the tab is given somewhere to add a song to the schedule — off to test that the
      *  add-to-schedule actions are hidden rather than merely disabled when there is nowhere to send it. */
     withOnAddToSchedule: Boolean = true,
+    /**
+     * The schedule row the operator has clicked, and its version.
+     *
+     * Held as state the caller owns so a test can set it *after* the tab is composed — which is how
+     * it arrives in the app — and can bump the version to re-fire the same song, the case the
+     * version exists for. Left null and 0 by default, which is the tab with nothing selected.
+     */
+    scheduleSelection: MutableState<ScheduleItem.SongItem?> = mutableStateOf(null),
+    scheduleSelectionVersion: MutableState<Int> = mutableStateOf(0),
     block: ComposeUiTest.(vm: SongsViewModel, reports: TabReports) -> Unit,
 ) {
     val dir = Files.createTempDirectory("cp-songs-tab").toFile()
@@ -189,6 +201,8 @@ internal fun songsTab(
                         onLineIndexChanged = { reports.lineIndex = it },
                         onPresenting = { reports.presenting += it },
                         isPresenting = isPresenting,
+                        selectedSongItem = scheduleSelection.value,
+                        selectedSongItemVersion = scheduleSelectionVersion.value,
                     )
                 }
             }


### PR DESCRIPTION
Covers the Songs tab's handling of a schedule click — the ordinary way a song goes on screen during a service. Test-only.

## Why this one

The schedule is what a service is driven from: the operator clicks the row, the tab looks that song up in the library and hands its first section to the presenter. When the lookup fails it fails **quietly** — the row highlights, and nothing reaches the output.

Two details of the wiring are the reason it is worth pinning, and both are covered:

- **A row can be clicked before the library has finished loading**, which is normal on a cold start. The effect waits on `snapshotFlow { isLoading }.first { !it }` rather than searching an empty catalogue and giving up.
- **The same row can be clicked twice.** Compose would skip the second, so the caller passes a version alongside the item. Without it, taking a song live, moving away and coming back to the same row would do nothing the second time — and the tab's own comment says that is what the version is for.

Also covered: a song resolved out of its *own* songbook (number 3 exists only in Chorus Book), and a scheduled song the library no longer has — a song deleted after the service was planned must leave the output alone rather than push whatever happened to be selected.

## Harness change

`songsTab(...)` gains `scheduleSelection` and `scheduleSelectionVersion` as caller-owned `MutableState`, so a test can set the selection **after** the tab is composed — which is how it arrives in the app — and can bump the version to re-fire the same row. Defaults are `null` / `0`, so every existing call site is unchanged.

## Evidence

**Mutation-checked:**

| Mutation | Result |
|---|---|
| drop `selectedSongItemVersion` from the effect key | fails `clicking the same row again re-fires it` |
| send to the presenter regardless of `found` | fails `a scheduled song the library does not have…` |

**Three consecutive green `--rerun-tasks` runs of the whole `tabs` package** (1,855 tests each) — the package rather than the class, since the change touches shared test support that every SongsTab suite uses.

## Rejected on the way here, with reasons

Recorded so the next pass does not re-derive them:

- **`BibleTab`'s ctrl/shift verse click** — reads `event.keyboardModifiers`, which a test cannot set on an injected pointer event. The existing §7 blocker, still true.
- **`BibleTab`'s live-verse auto-scroll** — depends on measured layout (`viewportEndOffset`, item sizes). In a test window the chapter may fit entirely, making the effect a no-op, and any assertion would be pixel-dependent.
- **`BibleTab`'s translation-order tooltip** and **`SongsTab`'s favourites-panel drag** — styling and a drag gesture respectively; small and low-yield.
- **`ProjectionSettingsTab`'s screen detection** — calls `GraphicsEnvironment.getLocalGraphicsEnvironment()`, which throws headless.

Separately: the "harness parameter no test ever overrides" check that found #199's gap was run across every `*TestSupport`/`*Fixture` file and is now **exhausted** — one hit, an assertion helper's `tolerance`, not production behaviour.
