### PR TITLE
Cover every Add-source menu entry

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabAddSourceTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabAddSourceTest.kt
@@ -1,0 +1,110 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import org.churchpresenter.app.churchpresenter.models.SceneSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Every type the Add-source menu offers, and what each one actually adds.
+ *
+ * [CanvasTabTest] covers three of the ten (text, image, clock) and the fact that a source lands in
+ * the current scene at all. The rest were never driven — and they are exactly where a wiring mistake
+ * hides, because every entry looks alike at the call site: one menu item, one `addSource` with a
+ * different `SceneSource` subclass and a different default rectangle.
+ *
+ * A menu entry bound to the wrong subclass gives the operator a text box when they asked for a QR
+ * code, and nothing about the menu would look wrong. So each test asserts the **type**, not just
+ * that something appeared.
+ *
+ * One source per test, deliberately: the add button cannot be driven twice in a single test (see
+ * `addSourceOfType`).
+ */
+class CanvasTabAddSourceTest {
+
+    /** The single source in the current scene, or null if the scene is empty. */
+    private fun soleSource(vm: org.churchpresenter.app.churchpresenter.viewmodel.SceneViewModel) =
+        vm.scenes.single().sources.singleOrNull()
+
+    @Test
+    fun `a colour source is added as a colour`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.COLOR)
+
+            assertEquals(listOf("Color"), vm.sourceNames())
+            assertTrue(soleSource(vm) is SceneSource.ColorSource, "got ${soleSource(vm)}")
+        }
+
+    @Test
+    fun `a video source is added as a video`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.VIDEO)
+
+            assertEquals(listOf("Video"), vm.sourceNames())
+            assertTrue(soleSource(vm) is SceneSource.VideoSource, "got ${soleSource(vm)}")
+        }
+
+    @Test
+    fun `a browser source is added as a browser, ready for a url`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.BROWSER)
+
+            val source = soleSource(vm)
+            assertTrue(source is SceneSource.BrowserSource, "got $source")
+            // Seeded rather than blank so the properties panel shows the operator what shape of
+            // value it wants.
+            assertEquals("http://www.", source.url)
+        }
+
+    @Test
+    fun `a QR code source is added as a QR code`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.QR_CODE)
+
+            assertEquals(listOf("QR Code"), vm.sourceNames())
+            assertTrue(soleSource(vm) is SceneSource.QRCodeSource, "got ${soleSource(vm)}")
+        }
+
+    @Test
+    fun `a camera source is added as a camera`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            // No camera is opened by adding one — the source is a description until it is rendered,
+            // which is why this is reachable on a machine with no device.
+            addSourceOfType(CanvasLabel.CAMERA)
+
+            assertTrue(soleSource(vm) is SceneSource.CameraSource, "got ${soleSource(vm)}")
+        }
+
+    @Test
+    fun `a screen capture source is added as a screen capture`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.SCREEN_CAPTURE)
+
+            assertTrue(soleSource(vm) is SceneSource.ScreenCaptureSource, "got ${soleSource(vm)}")
+        }
+
+    @Test
+    fun `a bible source is added as a bible`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.BIBLE)
+
+            assertEquals(listOf("Bible"), vm.sourceNames())
+            assertTrue(soleSource(vm) is SceneSource.BibleSource, "got ${soleSource(vm)}")
+        }
+
+    @Test
+    fun `a new source is placed inside the canvas rather than at its corner`() =
+        canvasTab(seed = { addScene("Scene") }) { vm, _ ->
+            addSourceOfType(CanvasLabel.BIBLE)
+
+            // Every entry sets its own default rectangle in fractions of the canvas. What they share
+            // is that a new source must be visible and grabbable — one pinned at 0,0 with zero size
+            // could not be selected or dragged.
+            val t = soleSource(vm)!!.transform
+            assertTrue(t.x > 0f && t.y > 0f, "inset from the corner, got ${t.x},${t.y}")
+            assertTrue(t.width > 0f && t.height > 0f, "and has size, got ${t.width}x${t.height}")
+            assertTrue(t.x + t.width <= 1f && t.y + t.height <= 1f, "and fits the canvas")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabTestSupport.kt
@@ -95,9 +95,18 @@ internal object CanvasLabel {
     const val TOGGLE_LOCK = "Toggle lock"
     const val MOVE_FORWARD = "Move forward"
     const val MOVE_BACKWARD = "Move backward"
+    // The Add-source menu offers ten types; each is also the name the new source is given, which is
+    // what makes `sourceNames()` enough to tell them apart.
     const val IMAGE = "Image"
     const val TEXT = "Text"
     const val CLOCK = "Clock"
+    const val COLOR = "Color"
+    const val VIDEO = "Video"
+    const val BROWSER = "Browser"
+    const val QR_CODE = "QR Code"
+    const val CAMERA = "Camera"
+    const val SCREEN_CAPTURE = "Screen Capture"
+    const val BIBLE = "Bible"
     const val GO_LIVE = "Go Live"
     const val ADD_TO_SCHEDULE = "Add to Schedule"
 }


### PR DESCRIPTION
Covers the seven Add-source menu entries that were never driven. Test-only.

## Why these

The Canvas tab's Add-source menu offers **ten** types. `CanvasTabTest` covered three — text, image, clock — plus the fact that a source lands in the current scene at all. The other seven were never exercised.

That is exactly where a wiring mistake hides. Every entry looks identical at the call site: one menu item, one `addSource`, a different `SceneSource` subclass, a different default rectangle. An entry bound to the wrong subclass hands the operator a text box when they asked for a QR code — the menu still looks right, the source still appears, and only the canvas shows the mistake.

So each test asserts the **type**, not just that something was added. Asserting the name alone would pass with every entry bound to the same subclass, since the name is a separate argument.

## The shared invariant

The eighth test pins what all ten entries have in common rather than restating any one of them: a new source must be **inset from the corner and have size**. One placed at `0,0` with zero extent could not be selected or dragged — it would be added and effectively lost.

That is asserted as a property (`x > 0`, `width > 0`, `x + width <= 1`) rather than by copying each entry's literals, so retuning a default rectangle does not break it while a genuinely broken placement still does.

## Evidence

**Mutation-checked**, each hitting exactly one test:

| Mutation | Fails |
|---|---|
| bind the Bible entry to `QRCodeSource` | `a bible source is added as a bible` |
| blank the browser's seeded `http://www.` | `a browser source is added as a browser, ready for a url` |
| pin a new bible source to `0,0` | `a new source is placed inside the canvas rather than at its corner` |

**Three consecutive green `--rerun-tasks` runs of the whole `tabs` package** (1,863 tests each) — the package rather than the class, since `CanvasLabel` is shared test support every Canvas suite uses.

## Notes

- **One source per test**, deliberately: the add button cannot be driven twice in a single test, which the existing `addSourceOfType` helper already documents.
- **Adding a camera or screen-capture source opens no device.** The source is a description until something renders it, which is why both are reachable on a machine with neither.
