### PR TITLE
Extract presentation helpers & add tests

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainLogic.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainLogic.kt
@@ -1,16 +1,24 @@
 package org.churchpresenter.app.churchpresenter
 
 import org.churchpresenter.app.churchpresenter.data.settings.CompanionSatelliteSettings
+import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkRole
 import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkSettings
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
+import org.churchpresenter.app.churchpresenter.dialogs.RemoteEventType
+import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.data.settings.BackgroundSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleSettings
+import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
 import org.churchpresenter.app.churchpresenter.data.settings.OBSSettings
 import org.churchpresenter.app.churchpresenter.utils.UpdateCheckResult
 import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
 import org.churchpresenter.app.churchpresenter.data.settings.ServerSettings
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.server.InstanceLinkStatus
 import org.churchpresenter.app.churchpresenter.server.TunnelStatus
 import org.churchpresenter.app.churchpresenter.data.Language
+import java.io.File
+import kotlin.math.roundToInt
 
 /**
  * The decisions `main.kt` makes at startup, held apart from the entry point that makes them.
@@ -208,3 +216,483 @@ internal fun shouldRestoreWindowGeometry(isFloating: Boolean, savedX: Int): Bool
 /** Whether media is what the presentation-live flag should report. */
 internal fun isPresentationLive(presentingMode: Presenting): Boolean =
     presentingMode == Presenting.PRESENTATION
+
+/**
+ * The line to select for a section chosen remotely, or none.
+ *
+ * A remote caller says -1 when it means "the whole section" rather than a line within it, so any
+ * negative index is normalised to that rather than passed through as a position.
+ */
+internal fun remoteSongLineIndex(requestedLineIndex: Int): Int =
+    if (requestedLineIndex >= 0) requestedLineIndex else -1
+
+/** Whether taking a song section live also has to switch the output over to lyrics. */
+internal fun shouldSwitchToLyrics(presentingMode: Presenting): Boolean =
+    presentingMode != Presenting.LYRICS
+
+/**
+ * Whether a lower-third sequence finishing should clear the output.
+ *
+ * Only when the lower third is still what is on screen: the sequence runs on its own clock, so by
+ * the time it ends the operator may have moved on, and clearing then would blank their new content.
+ */
+internal fun shouldClearAfterLowerThird(presentingMode: Presenting): Boolean =
+    presentingMode == Presenting.LOWER_THIRD
+
+/** Whether a section change is worth telling connected phones about — only while songs are live. */
+internal fun shouldBroadcastSongSection(presentingMode: Presenting): Boolean =
+    presentingMode == Presenting.LYRICS
+
+/** Whether the output going empty is worth announcing. */
+internal fun shouldBroadcastDisplayCleared(presentingMode: Presenting): Boolean =
+    presentingMode == Presenting.NONE
+
+/**
+ * Whether this instance is in a position to drive another one.
+ *
+ * Both halves matter: a link that is merely configured as Controller but not connected has nothing
+ * to send to, and a connected Controlled follower must never send — it receives.
+ */
+internal fun isControllerConnected(status: InstanceLinkStatus, role: InstanceLinkRole): Boolean =
+    status == InstanceLinkStatus.CONNECTED && role == InstanceLinkRole.CONTROLLER
+
+/**
+ * The kind of activity a no-approval remote action is reported as.
+ *
+ * These arrive as strings over the wire, so an unrecognised one has to become something rather than
+ * nothing: the toast exists so the operator can see what a remote client just did and block them if
+ * it was not wanted, and an action that produced no toast at all would be the one worth seeing.
+ */
+internal fun remoteActionType(actionType: String): RemoteEventType = when (actionType) {
+    "present" -> RemoteEventType.PRESENT
+    "upload" -> RemoteEventType.UPLOAD
+    "clear" -> RemoteEventType.CLEAR
+    else -> RemoteEventType.PRESENT
+}
+
+/** The floor every transition is held to, below which a fade reads as a flicker. */
+internal const val MIN_TRANSITION_MS = 100
+
+/**
+ * How long a mode-level crossfade runs: the longer of the two that are switched on.
+ *
+ * One duration has to serve both, because a crossfade between scripture and a song is a single
+ * transition — taking the shorter of the two would cut it off part-way.
+ */
+internal fun modeCrossfadeDuration(bible: BibleSettings, song: SongSettings): Int = maxOf(
+    if (bible.crossfade) bible.transitionDuration.toInt() else 0,
+    if (song.crossfade) song.transitionDuration.toInt() else 0,
+).coerceAtLeast(MIN_TRANSITION_MS)
+
+/** Whether any output is pinned to [mode], and so is still showing it. */
+internal fun isAnyScreenLockedTo(locks: Map<Int, Presenting>, mode: Presenting): Boolean =
+    locks.values.any { it == mode }
+
+/**
+ * Whether clearing the output should fade it out first.
+ *
+ * Not when a screen is locked to what is being cleared: that screen goes on showing the content, so
+ * fading the shared alpha would dim it on a display nobody asked to clear. Only scripture and songs
+ * fade at all; everything else clears instantly.
+ */
+internal fun shouldFadeOnClear(
+    mode: Presenting,
+    anyScreenLocked: Boolean,
+    bible: BibleSettings,
+    song: SongSettings,
+): Boolean = !anyScreenLocked && when (mode) {
+    Presenting.BIBLE -> bible.fadeOut
+    Presenting.LYRICS -> song.fadeOut
+    else -> false
+}
+
+/** How long that fade-out runs, per content type, never below [MIN_TRANSITION_MS]. */
+internal fun fadeOutDuration(mode: Presenting, bible: BibleSettings, song: SongSettings): Int = when (mode) {
+    Presenting.BIBLE -> bible.transitionDuration.toInt()
+    Presenting.LYRICS -> song.transitionDuration.toInt()
+    else -> 500
+}.coerceAtLeast(MIN_TRANSITION_MS)
+
+/** The shortest an announcement stays up, however fast the speed slider is wound. */
+internal const val MIN_ANNOUNCEMENT_DISPLAY_MS = 500L
+
+/** Whether an announcement fades between states, as opposed to cutting or sliding. */
+internal fun isFadeAnnouncement(animationType: String): Boolean =
+    animationType == Constants.ANIMATION_FADE
+
+/**
+ * Whether the announcement slides in rather than being shown by this code at all.
+ *
+ * A directional slide is animated by the presenter itself, so here the text is simply swapped —
+ * running a fade over it as well would fight the animation already in flight.
+ */
+internal fun isSlidingAnnouncement(animationType: String): Boolean =
+    animationType != Constants.ANIMATION_FADE && animationType != Constants.ANIMATION_NONE
+
+/**
+ * Whether clearing an announcement should fade it away.
+ *
+ * Only when something was actually on screen: fading out from nothing spends the animation's length
+ * showing an empty screen before the operator's next content can appear.
+ */
+internal fun shouldFadeOutAnnouncement(isFade: Boolean, wasEmpty: Boolean): Boolean =
+    isFade && !wasEmpty
+
+/** Whether the announcement clears itself after a set number of loops, rather than staying up. */
+internal fun isFiniteAnnouncementLoop(loopCount: Int): Boolean = loopCount > 0
+
+/**
+ * How long an announcement stays up in total.
+ *
+ * The speed slider reads the other way round — a higher value means faster — so the configured
+ * duration is subtracted from the slider's span rather than used directly.
+ */
+internal fun announcementDisplayMs(sliderSpan: Long, animationDuration: Long, loopCount: Int): Long =
+    (sliderSpan - animationDuration).coerceAtLeast(MIN_ANNOUNCEMENT_DISPLAY_MS) * loopCount
+
+/**
+ * Whether the bundled KJV has to be written out and made primary.
+ *
+ * Both halves matter: a folder chosen but no translation picked yet is a half-finished setup the
+ * operator is in the middle of, and dropping a Bible into it would pick for them.
+ */
+internal fun shouldBundleDefaultBible(settings: BibleSettings): Boolean =
+    settings.storageDirectory.isEmpty() && settings.primaryBible.isEmpty()
+
+/** Whether the licence has already been accepted, at this build's version of it or a later one. */
+internal fun isEulaAccepted(acceptedVersion: Int, currentVersion: Int): Boolean =
+    acceptedVersion >= currentVersion
+
+/**
+ * Whether first-run setup should be offered.
+ *
+ * Not once it has been dismissed, and not to an install that already has both a Bible and a song
+ * folder — that is a working setup, whatever the flag says, and interrupting it would be noise.
+ */
+internal fun shouldShowSetupWizard(settings: AppSettings): Boolean {
+    val bibleReady = settings.bibleSettings.primaryBible.isNotEmpty()
+    val songsReady = settings.songSettings.storageDirectory.isNotEmpty()
+    return !settings.setupWizardShown && !(bibleReady && songsReady)
+}
+
+/**
+ * Whether the Developer menu is shown.
+ *
+ * Always in a dev build, and in a packaged one only when deliberately asked for — the forced-window
+ * flag, or the secret keypress, which unlocks it for that session alone.
+ */
+internal fun shouldShowDeveloperMenu(
+    isRelease: Boolean,
+    forceDevWindow: Boolean,
+    unlocked: Boolean,
+): Boolean = !isRelease || forceDevWindow || unlocked
+
+/**
+ * Whether a queued remote request is covered by the decision the operator just made.
+ *
+ * Allow/block apply to a client, not to the one request on screen, so every other request already
+ * queued from that client is settled the same way rather than asked about again. A blank id is the
+ * unattributable case, and takes the whole queue with it: there is no client to ask about next.
+ */
+internal fun remoteEventTargetsClient(eventClientId: String, decidedClientId: String): Boolean =
+    eventClientId == decidedClientId || decidedClientId.isBlank()
+
+/** Whether the client awaiting approval is another instance following this one. */
+internal fun isInstanceLinkFollowerClient(clientId: String, followers: Set<String>): Boolean =
+    clientId.isNotBlank() && clientId in followers
+
+/**
+ * Whether generated lower thirds have somewhere to be written.
+ *
+ * Checked against the filesystem rather than the setting alone: a folder configured once and since
+ * moved or deleted would otherwise send the generator to a path it cannot save into.
+ */
+internal fun isUsableOutputDir(path: String): Boolean = path.isNotEmpty() && File(path).isDirectory
+
+/** The URL a follower streams a mirrored media item from, carrying the key when one is set. */
+internal fun instanceLinkMediaStreamUrl(
+    host: String,
+    port: Int,
+    apiKey: String,
+    itemId: String,
+): String {
+    val keyParam = if (apiKey.isNotEmpty()) "?${Constants.QUERY_PARAM_API_KEY}=$apiKey" else ""
+    return "http://$host:$port${Constants.ENDPOINT_MEDIA_STREAM}/$itemId$keyParam"
+}
+
+/** Whether going live with [mode] should also raise the output windows — clearing must not. */
+internal fun shouldShowPresenterWindowFor(mode: Presenting): Boolean = mode != Presenting.NONE
+
+/** Whether the link is anything other than fully down, connecting included. */
+internal fun isInstanceLinkActive(status: InstanceLinkStatus): Boolean =
+    status != InstanceLinkStatus.DISCONNECTED
+
+/** Whether this output draws the configured background, which is a separate switch per layout. */
+internal fun showsOutputBackground(assignment: ScreenAssignment): Boolean =
+    if (assignment.isLowerThird) assignment.showLowerThirdBackground
+    else assignment.showFullscreenBackground
+
+/** What an output is showing: its own lock when it has one, otherwise whatever is live. */
+internal fun effectiveOutputMode(
+    locks: Map<Int, Presenting>,
+    index: Int,
+    presentingMode: Presenting,
+): Presenting = locks[index] ?: presentingMode
+
+/**
+ * Whether a mode change on this output crossfades rather than cuts.
+ *
+ * Only between two pieces of content: crossfading from or to nothing is a fade, which the per-type
+ * fade settings own, and running both would fade twice over the same moment.
+ */
+internal fun isScreenCrossfadeActive(
+    bible: BibleSettings,
+    song: SongSettings,
+    mode: Presenting,
+    previousMode: Presenting,
+): Boolean = (bible.crossfade || song.crossfade) &&
+    mode != Presenting.NONE && previousMode != Presenting.NONE
+
+/**
+ * The URL the on-screen Q&A QR code points at.
+ *
+ * The tunnel URL when there is one, so a phone on mobile data can reach it; the LAN address
+ * otherwise.
+ */
+internal fun qaQrCodeUrl(tunnelUrl: String, serverUrl: String): String =
+    "${tunnelUrl.ifEmpty { serverUrl }}/qa"
+
+/**
+ * Whether output windows have to fall back to ordinary windows on this machine.
+ *
+ * Only when there is genuinely nowhere else to put them — no second display and no DeckLink device
+ * — and only in a build that asked for it, so a release install with one monitor shows nothing
+ * extra rather than a stray window over the operator's screen.
+ */
+internal fun isDevWindowedFallback(
+    isRelease: Boolean,
+    forceDevWindow: Boolean,
+    realWindowCount: Int,
+): Boolean = (!isRelease || forceDevWindow) && realWindowCount == 0
+
+/** How many fallback windows to open — at least one whenever they are used at all. */
+internal fun devFallbackWindowCount(devWindowedFallback: Boolean, configured: Int): Int =
+    if (devWindowedFallback) configured.coerceAtLeast(1) else 0
+
+/** How far each extra fallback window is cascaded, so several do not stack exactly on each other. */
+internal fun devFallbackWindowOffsetDp(index: Int): Int = 40 + index * 48
+
+/** Whether this output's picture goes out over SDI rather than to a display. */
+internal fun isDeckLinkPrimaryOutput(assignment: ScreenAssignment): Boolean =
+    assignment.targetType == Constants.TARGET_TYPE_DECKLINK
+
+/** Whether this output's key signal is aimed at a DeckLink device rather than a display. */
+internal fun isDeckLinkKeyOutput(assignment: ScreenAssignment): Boolean =
+    assignment.keyTargetType == Constants.TARGET_TYPE_DECKLINK
+
+/**
+ * Whether this output's key signal goes to a DeckLink device that has actually been chosen.
+ *
+ * The call sites this replaced also tested `keyTargetDisplay >= 0` alongside [hasKeyOutput], which
+ * is the very expression [hasKeyOutput] is defined as — so that clause could never fail once the
+ * first had passed, and is dropped rather than carried as a condition no input can reach.
+ */
+internal fun hasDeckLinkKeyOutput(assignment: ScreenAssignment): Boolean =
+    assignment.hasKeyOutput && isDeckLinkKeyOutput(assignment)
+
+/** Whether this output's key signal goes to an ordinary display instead. */
+internal fun hasScreenKeyOutput(assignment: ScreenAssignment): Boolean =
+    assignment.hasKeyOutput && assignment.keyTargetType == Constants.TARGET_TYPE_SCREEN
+
+/**
+ * Which display a key output lands on.
+ *
+ * Matched on the bounds saved with the assignment first, because display indices are reordered by
+ * the OS when monitors are plugged or unplugged; the saved index is only the fallback for a layout
+ * whose bounds no longer match anything.
+ */
+internal fun keyOutputScreenIndex(matchedByBounds: Int?, savedIndex: Int): Int =
+    matchedByBounds ?: savedIndex
+
+/** How long a Lottie composition runs, from its own frame count and rate. Never zero. */
+internal fun lottieCompositionDurationMs(durationFrames: Float, frameRate: Float): Long =
+    ((durationFrames / frameRate) * 1000f).toLong().coerceAtLeast(1L)
+
+/** How long pre-rendered frames run, from how many there are and the rate they were rendered at. */
+internal fun lottiePrerenderDurationMs(frameCount: Int, fps: Int): Long =
+    (frameCount * 1000L / fps).coerceAtLeast(1L)
+
+/**
+ * Whether the clip holds on a frame partway through.
+ *
+ * The frame is stored as a fraction of the clip, so a value outside 0..1 names no frame in it and
+ * is treated as no hold at all rather than clamped to the start or the end.
+ */
+internal fun lottieHasPause(pauseAtFrame: Boolean, pauseFrame: Float): Boolean =
+    pauseAtFrame && pauseFrame in 0f..1f
+
+/** When the hold starts, or -1 when there is none — an instant no elapsed time ever reaches. */
+internal fun lottiePauseAtMs(totalDurationMs: Long, pauseFrame: Float, hasPause: Boolean): Long =
+    if (hasPause) (totalDurationMs * pauseFrame).toLong() else -1L
+
+/** The clip's whole length on the wall clock, the hold included. */
+internal fun lottieGrandTotalMs(
+    totalDurationMs: Long,
+    hasPause: Boolean,
+    pauseDurationMs: Long,
+): Long = totalDurationMs + if (hasPause) pauseDurationMs else 0L
+
+/**
+ * How far through the clip [elapsedMs] is, as a fraction.
+ *
+ * Three stretches when the clip holds: play up to the hold, sit on it, then play what is left over
+ * whatever time remains. The last stretch is re-scaled rather than resumed at the original rate,
+ * because the hold has already consumed wall-clock time the clip's own timeline does not know
+ * about — playing on at the old rate would run past the end.
+ */
+internal fun lottieProgressAt(
+    elapsedMs: Long,
+    totalDurationMs: Long,
+    hasPause: Boolean,
+    pauseFrame: Float,
+    pauseAtMs: Long,
+    pauseDurationMs: Long,
+): Float {
+    if (!hasPause) return (elapsedMs.toFloat() / totalDurationMs).coerceIn(0f, 1f)
+    return when {
+        elapsedMs < pauseAtMs -> (elapsedMs.toFloat() / totalDurationMs).coerceIn(0f, pauseFrame)
+        elapsedMs < pauseAtMs + pauseDurationMs -> pauseFrame
+        else -> {
+            val postElapsed = elapsedMs - pauseAtMs - pauseDurationMs
+            val postTotalMs = (totalDurationMs - pauseAtMs).coerceAtLeast(1L)
+            (pauseFrame + (postElapsed.toFloat() / postTotalMs) * (1f - pauseFrame)).coerceIn(0f, 1f)
+        }
+    }
+}
+
+/** Which pre-rendered frame a fraction of the way through the clip lands on. */
+internal fun lottieFrameIndexFor(progress: Float, frameCount: Int): Int =
+    (progress * (frameCount - 1)).roundToInt().coerceIn(0, frameCount - 1)
+
+/**
+ * The identifier the open-ping carries, or none.
+ *
+ * An opted-out install still pings — the count of churches opening the app is what the map is for —
+ * but carries nothing that follows it between launches. Taken as a function rather than a value
+ * because minting the id writes it to disk: computing one for an opted-out install and discarding
+ * it would leave the very identifier that was opted out of sitting in their home directory.
+ */
+internal fun analyticsInstallId(enabled: Boolean, installId: () -> String): String? =
+    if (enabled) installId() else null
+
+/** The positions in [all] that are not [primary] — the displays an output may be opened on. */
+internal fun <T> nonPrimaryIndices(all: List<T>, primary: T): List<Int> =
+    all.indices.filter { all[it] != primary }
+
+/** How many real outputs there are to drive: every non-primary display, plus every SDI device. */
+internal fun presenterWindowCount(nonPrimaryScreens: Int, deckLinkDevices: Int): Int =
+    nonPrimaryScreens + deckLinkDevices
+
+/** Whether the slot at [index] is one of the fallback windows rather than a real output. */
+internal fun isFallbackWindowSlot(
+    devWindowedFallback: Boolean,
+    index: Int,
+    realWindowCount: Int,
+): Boolean = devWindowedFallback && index >= realWindowCount
+
+/** Which fallback window a slot is, counting from the first one after the real outputs. */
+internal fun fallbackSlotIndex(index: Int, realWindowCount: Int): Int = index - realWindowCount
+
+/**
+ * Whether the mirrored picture cache has to be emptied.
+ *
+ * The counterpart to [shouldInvalidateBackgroundCache]: cached pictures are keyed by folder and
+ * position only, so an image the primary has replaced at the same position would be served from the
+ * stale copy forever. Zero is the value the flow replays on subscribe, which announces nothing.
+ */
+internal fun shouldInvalidatePictureCache(picturesUpdatedSignal: Int): Boolean =
+    picturesUpdatedSignal != 0
+
+/**
+ * Whether a clear signal is a fresh one rather than the value replayed on subscribe.
+ *
+ * The flow replays its current value to every new subscriber — including on re-subscribe when the
+ * role changes — so acting on equality would clear the output every time the link was reconfigured.
+ */
+internal fun isFreshClearSignal(signal: Int, lastSeen: Int): Boolean = signal != lastSeen
+
+/**
+ * Whether media going away is worth one last broadcast.
+ *
+ * Only on the edge: connected phones need one "nothing loaded" to drop their now-playing view, but
+ * repeating it on every poll of an idle app would be a message every half-second forever.
+ */
+internal fun shouldBroadcastMediaCleared(isLoaded: Boolean, wasLoaded: Boolean): Boolean =
+    !isLoaded && wasLoaded
+
+/** How much of a remote question is shown in the approval prompt. */
+internal const val MAX_REMOTE_EVENT_TITLE = 80
+
+/** The question text put in front of the operator, cut to what the prompt can show. */
+internal fun remoteEventTitle(text: String): String = text.take(MAX_REMOTE_EVENT_TITLE)
+
+/** Whether a follower is allowed to push items into this instance's schedule. */
+internal fun canPushToSchedule(link: InstanceLinkSettings): Boolean = link.allowPushToSchedule
+
+/** Where a translation lives, as an absolute path, so a follower can be handed the file itself. */
+internal fun bibleFilePath(storageDirectory: String, translation: String): String =
+    File(storageDirectory, translation).absolutePath
+
+/** Whether an index names a display that is actually attached. */
+internal fun isScreenIndexValid(index: Int, screenCount: Int): Boolean = index in 0 until screenCount
+
+/** Whether this output has no display chosen for it at all. */
+internal fun hasNoPrimaryTarget(assignment: ScreenAssignment): Boolean =
+    assignment.targetDisplay == Constants.KEY_TARGET_NONE
+
+/**
+ * Which display this output opens on, or none when nothing usable is left.
+ *
+ * Three attempts in order of how much they can be trusted: the bounds saved with the assignment,
+ * which survive the OS reordering display indices; the saved index, but only if it still names an
+ * attached display; and finally this output's own position in the list of non-primary displays, so
+ * a configuration written on a different machine still lands somewhere rather than nowhere.
+ */
+internal fun primaryOutputScreenIndex(
+    matchedByBounds: Int?,
+    savedDisplay: Int,
+    screenCount: Int,
+    positionalFallback: Int?,
+): Int? = matchedByBounds
+    ?: savedDisplay.takeIf { isScreenIndexValid(it, screenCount) }
+    ?: positionalFallback
+
+/**
+ * The size the main window opens at.
+ *
+ * Only a floating window has its own size worth restoring; maximized and fullscreen take the
+ * primary display's, so a saved size from a monitor since unplugged cannot strand the window at a
+ * shape the current display cannot show.
+ */
+internal fun startupWindowSize(
+    isFloating: Boolean,
+    savedWidth: Int,
+    savedHeight: Int,
+    primaryWidth: Int,
+    primaryHeight: Int,
+): Pair<Int, Int> =
+    if (isFloating) savedWidth to savedHeight else primaryWidth to primaryHeight
+
+/**
+ * The position the main window opens at.
+ *
+ * The primary display's own origin is the fallback rather than 0,0 — on a multi-monitor desktop the
+ * origin can belong to a different display, which would open the window on the wrong screen.
+ */
+internal fun startupWindowPosition(
+    restoreGeometry: Boolean,
+    savedX: Int,
+    savedY: Int,
+    primaryX: Int,
+    primaryY: Int,
+): Pair<Int, Int> = if (restoreGeometry) savedX to savedY else primaryX to primaryY

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -71,7 +71,6 @@ import churchpresenter.composeapp.generated.resources.presenter_view_title
 import churchpresenter.composeapp.generated.resources.key_output_title
 import churchpresenter.composeapp.generated.resources.screen_number
 import org.jetbrains.compose.resources.painterResource
-import kotlin.math.roundToInt
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -153,7 +152,6 @@ import org.churchpresenter.app.churchpresenter.server.LottieRenderCache
 import org.churchpresenter.app.churchpresenter.server.CompanionServer
 import org.churchpresenter.app.churchpresenter.server.LowerThirdSequencer
 import org.churchpresenter.app.churchpresenter.server.TunnelStatus
-import org.churchpresenter.app.churchpresenter.server.InstanceLinkStatus
 import org.churchpresenter.app.churchpresenter.server.LiveStateDto
 import org.churchpresenter.app.churchpresenter.dialogs.InstanceLinkDialog
 import org.churchpresenter.app.churchpresenter.viewmodel.QAManager
@@ -163,6 +161,7 @@ import org.churchpresenter.app.churchpresenter.viewmodel.InstanceLinkViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.STTManager
 import org.churchpresenter.app.churchpresenter.ui.theme.AppThemeWrapper
 import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.utils.isSongLineMode
 import org.churchpresenter.app.churchpresenter.utils.presenterScreenBounds
 
 import org.churchpresenter.app.churchpresenter.utils.AutoStartManager
@@ -267,7 +266,7 @@ fun main() {
     // First run only: if no Bible has been configured yet, bundle the KJV 1769
     // into a default folder and set it as the primary Bible so the app works
     // out of the box without requiring the user to pick a Bible folder first.
-    if (startupSettings.bibleSettings.storageDirectory.isEmpty() && startupSettings.bibleSettings.primaryBible.isEmpty()) {
+    if (shouldBundleDefaultBible(startupSettings.bibleSettings)) {
         try {
             val defaultBibleDir = File(System.getProperty("user.home"), Constants.DEFAULT_BIBLES_DIR)
             defaultBibleDir.mkdirs()
@@ -286,7 +285,7 @@ fun main() {
     // Pass the install id only when analytics is enabled, so opted-out users
     // still send an anonymous geo ping but no persistent identifier.
     LiveMapReporter.pingOnOpen(
-        installId = if (startupSettings.analyticsReportingEnabled) CrashReporter.installId() else null,
+        installId = analyticsInstallId(startupSettings.analyticsReportingEnabled) { CrashReporter.installId() },
         updateCheckInterval = startupSettings.updateCheckInterval
     )
 
@@ -375,12 +374,10 @@ fun main() {
             presenterManager.setAtemRenderSettings(appSettings.atemSettings)
         }
 
-        var eulaAccepted by remember { mutableStateOf(appSettings.eulaAcceptedVersion >= CURRENT_EULA_VERSION) }
-        var showSetupWizard by remember {
-            val bibleReady = appSettings.bibleSettings.primaryBible.isNotEmpty()
-            val songsReady = appSettings.songSettings.storageDirectory.isNotEmpty()
-            mutableStateOf(!appSettings.setupWizardShown && !(bibleReady && songsReady))
+        var eulaAccepted by remember {
+            mutableStateOf(isEulaAccepted(appSettings.eulaAcceptedVersion, CURRENT_EULA_VERSION))
         }
+        var showSetupWizard by remember { mutableStateOf(shouldShowSetupWizard(appSettings)) }
 
         var currentLanguage by remember {
             val savedLanguageCode = appSettings.language
@@ -570,7 +567,7 @@ fun main() {
             // role changes) — only an actual increment past the count seen here is a fresh clear.
             var lastSeen = instanceLinkViewModel.displayClearedSignal.value
             instanceLinkViewModel.displayClearedSignal.collect { signal ->
-                if (signal == lastSeen) return@collect
+                if (!isFreshClearSignal(signal, lastSeen)) return@collect
                 lastSeen = signal
                 presenterManager.requestClearDisplay()
             }
@@ -587,7 +584,7 @@ fun main() {
         // Clearing the whole cache is cheap: live pictures re-fetch lazily on next display.
         LaunchedEffect(instanceLinkViewModel) {
             instanceLinkViewModel.picturesUpdatedSignal.collect { signal ->
-                if (signal == 0) return@collect
+                if (!shouldInvalidatePictureCache(signal)) return@collect
                 withContext(Dispatchers.IO) {
                     instanceLinkPictureCacheDir.listFiles()?.forEach { it.delete() }
                 }
@@ -757,7 +754,7 @@ fun main() {
                         source = mediaViewModel.mediaUrl,
                     )
                     wasLoaded = true
-                } else if (wasLoaded) {
+                } else if (shouldBroadcastMediaCleared(loaded, wasLoaded)) {
                     // One final "not loaded" so the mobile clears its now-playing view.
                     companionServer.broadcastMediaState(
                         isLive = false, isLoaded = false, isPlaying = false,
@@ -813,7 +810,11 @@ fun main() {
                     browserSourceOutputAt(appSettings.projectionSettings.browserSourceOutputs, i)
                 )
                 val effectiveModeState = remember {
-                    derivedStateOf { presenterManager.browserSourceLocks.value[i] ?: presenterManager.presentingMode.value }
+                    derivedStateOf {
+                        effectiveOutputMode(
+                            presenterManager.browserSourceLocks.value, i, presenterManager.presentingMode.value,
+                        )
+                    }
                 }
                 val qaDisplayUrlState = rememberUpdatedState(qaDisplayUrl)
                 // Keyed on geometry/fps so a settings change tears the renderer down and builds a
@@ -936,14 +937,21 @@ fun main() {
         // Use OS primary monitor bounds so maximized/fullscreen stays on one screen
         val primaryBounds = GraphicsEnvironment.getLocalGraphicsEnvironment()
             .defaultScreenDevice.defaultConfiguration.bounds
+        val isFloating = savedPlacement == WindowPlacement.Floating
+        val (startX, startY) = startupWindowPosition(
+            restoreGeometry = shouldRestoreWindowGeometry(isFloating, appSettings.windowX),
+            savedX = appSettings.windowX, savedY = appSettings.windowY,
+            primaryX = primaryBounds.x, primaryY = primaryBounds.y,
+        )
+        val (startWidth, startHeight) = startupWindowSize(
+            isFloating = isFloating,
+            savedWidth = appSettings.windowWidth, savedHeight = appSettings.windowHeight,
+            primaryWidth = primaryBounds.width, primaryHeight = primaryBounds.height,
+        )
         val state = rememberWindowState(
             placement = savedPlacement,
-            position = if (shouldRestoreWindowGeometry(savedPlacement == WindowPlacement.Floating, appSettings.windowX))
-                WindowPosition(appSettings.windowX.dp, appSettings.windowY.dp)
-            else WindowPosition(primaryBounds.x.dp, primaryBounds.y.dp),
-            size = if (savedPlacement == WindowPlacement.Floating)
-                DpSize(appSettings.windowWidth.dp, appSettings.windowHeight.dp)
-            else DpSize(primaryBounds.width.dp, primaryBounds.height.dp)
+            position = WindowPosition(startX.dp, startY.dp),
+            size = DpSize(startWidth.dp, startHeight.dp),
         )
 
         // Splash screen while app is loading
@@ -1173,9 +1181,9 @@ fun main() {
                                         val section = sections.getOrNull(req.section) ?: return@collect
                                         presenterManager.setLyricSection(section)
                                         presenterManager.setSongDisplaySectionIndex(req.section)
-                                        presenterManager.setSongDisplayLineIndex(if (req.lineIndex >= 0) req.lineIndex else -1)
+                                        presenterManager.setSongDisplayLineIndex(remoteSongLineIndex(req.lineIndex))
                                         // Make sure the presenter is showing lyrics
-                                        if (presenterManager.presentingMode.value != Presenting.LYRICS) {
+                                        if (shouldSwitchToLyrics(presenterManager.presentingMode.value)) {
                                             presenterManager.setPresentingMode(Presenting.LYRICS)
                                             presenterManager.setShowPresenterWindow(true)
                                         }
@@ -1205,7 +1213,7 @@ fun main() {
                                 }
                                 LaunchedEffect(Unit) {
                                     LowerThirdSequencer.onClear.collect {
-                                        if (presenterManager.presentingMode.value == Presenting.LOWER_THIRD) {
+                                        if (shouldClearAfterLowerThird(presenterManager.presentingMode.value)) {
                                             presenterManager.requestClearDisplay()
                                         }
                                     }
@@ -1235,7 +1243,7 @@ fun main() {
                                         when (val outcome = remoteApproval(
                                             access,
                                             type = qaActionType(pending.action),
-                                            title = pending.text.take(80),
+                                            title = remoteEventTitle(pending.text),
                                             clientId = clientId,
                                             clientLabel = remoteClientManager.getLabel(clientId),
                                         )) {
@@ -1324,7 +1332,7 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     snapshotFlow { presenterManager.presentingMode.value }
                                         .collect { mode ->
-                                            if (mode == Presenting.NONE) {
+                                            if (shouldBroadcastDisplayCleared(mode)) {
                                                 companionServer.broadcastDisplayCleared()
                                             }
                                         }
@@ -1334,7 +1342,7 @@ fun main() {
                                 LaunchedEffect(Unit) {
                                     snapshotFlow { presenterManager.songDisplaySectionIndex.value }
                                         .collect { index ->
-                                            if (presenterManager.presentingMode.value == Presenting.LYRICS) {
+                                            if (shouldBroadcastSongSection(presenterManager.presentingMode.value)) {
                                                 companionServer.broadcastSongSectionSelected(index)
                                             }
                                         }
@@ -1345,12 +1353,7 @@ fun main() {
                                 // operator can see what a remote client just did and optionally block them.
                                 LaunchedEffect(Unit) {
                                     companionServer.onInstantAction.collect { action ->
-                                        val type = when (action.actionType) {
-                                            "present" -> RemoteEventType.PRESENT
-                                            "upload"  -> RemoteEventType.UPLOAD
-                                            "clear"   -> RemoteEventType.CLEAR
-                                            else      -> RemoteEventType.PRESENT
-                                        }
+                                        val type = remoteActionType(action.actionType)
                                         remoteActivityNotifications.add(
                                             RemoteActivityNotification(
                                                 type = type,
@@ -1371,7 +1374,9 @@ fun main() {
                                     onStatistics = { showStatisticsDialog = true },
                                     onConnectToInstance = { showInstanceLinkDialog = true },
                                     onDisconnectInstance = { instanceLinkViewModel.disconnect() },
-                                    isInstanceLinkConnected = instanceLinkViewModel.connectionStatus.collectAsState().value != InstanceLinkStatus.DISCONNECTED,
+                                    isInstanceLinkConnected = isInstanceLinkActive(
+                                        instanceLinkViewModel.connectionStatus.collectAsState().value
+                                    ),
                                     onConverter = { showConverterWindow = true },
                                     onHelp = {
                                         Desktop.getDesktop()
@@ -1425,7 +1430,9 @@ fun main() {
                                     // ProjectionSettingsTab.kt — a dev build or the forced flag
                                     // gets this menu, plus the secret D-x7 keypress unlock
                                     // (developerMenuUnlocked, session-only) for packaged builds.
-                                    showDeveloperMenu = !BuildConfig.IS_RELEASE || DevFlags.forceDevWindow || developerMenuUnlocked,
+                                    showDeveloperMenu = shouldShowDeveloperMenu(
+                                        BuildConfig.IS_RELEASE, DevFlags.forceDevWindow, developerMenuUnlocked,
+                                    ),
                                     isPresenterWindowVisible = presenterManager.showPresenterWindow.value,
                                     onSetPresenterWindowVisible = { presenterManager.setShowPresenterWindow(it) },
                                     isDevWindowAlwaysOnTop = presenterManager.devWindowAlwaysOnTop.value,
@@ -1460,8 +1467,7 @@ fun main() {
 
                                 val instanceLinkStatus = instanceLinkViewModel.connectionStatus.collectAsState().value
                                 val instanceLinkIsControllerConnected =
-                                    instanceLinkStatus == InstanceLinkStatus.CONNECTED &&
-                                        appSettings.instanceLink.role == InstanceLinkRole.CONTROLLER
+                                    isControllerConnected(instanceLinkStatus, appSettings.instanceLink.role)
                                 // See shouldUseRemoteContent — the remote-asset fallbacks belong to a
                                 // mirrored schedule, so they are Controlled-only.
                                 val instanceLinkUsesRemoteContent =
@@ -1495,10 +1501,10 @@ fun main() {
                                     instanceLinkFetchBibleTranslations = { instanceLinkViewModel.fetchBibleTranslations() },
                                     instanceLinkOnSecondaryBibleFilePathChanged = { path -> companionServer.updateSecondaryBibleFilePath(path) },
                                     instanceLinkOnBibleFilePathsChanged = { paths -> companionServer.updateBibleFilePaths(paths) },
-                                    instanceLinkSendAddToSchedule = if (appSettings.instanceLink.allowPushToSchedule) {
+                                    instanceLinkSendAddToSchedule = if (canPushToSchedule(appSettings.instanceLink)) {
                                         { item -> instanceLinkViewModel.sendAddToSchedule(item) }
                                     } else null,
-                                    instanceLinkSendRemoveFromSchedule = if (appSettings.instanceLink.allowPushToSchedule) {
+                                    instanceLinkSendRemoveFromSchedule = if (canPushToSchedule(appSettings.instanceLink)) {
                                         { id -> instanceLinkViewModel.sendRemoveFromSchedule(id) }
                                     } else null,
                                     instanceLinkRole = appSettings.instanceLink.role,
@@ -1547,8 +1553,9 @@ fun main() {
                                         val link = appSettings.instanceLink
                                         if (instanceLinkUsesRemoteContent) {
                                             ({ itemId: String ->
-                                                val keyParam = if (link.apiKey.isNotEmpty()) "?${Constants.QUERY_PARAM_API_KEY}=${link.apiKey}" else ""
-                                                "http://${link.primaryHost}:${link.primaryPort}${Constants.ENDPOINT_MEDIA_STREAM}/$itemId$keyParam"
+                                                instanceLinkMediaStreamUrl(
+                                                    link.primaryHost, link.primaryPort, link.apiKey, itemId,
+                                                )
                                             })
                                         } else null
                                     },
@@ -1560,12 +1567,7 @@ fun main() {
                                         // there is an intermediate recomposition where songDisplayLineIndex=0
                                         // but displayedLyricSection still points to the old verse, causing the
                                         // first line of the old verse to flash briefly on verse boundaries.
-                                        val ss = appSettings.songSettings
-                                        val inLineMode = ss.fullscreenDisplayMode == Constants.SONG_DISPLAY_MODE_LINE ||
-                                            ss.lowerThirdDisplayMode == Constants.SONG_DISPLAY_MODE_LINE ||
-                                            ss.lookAheadDisplayMode == Constants.SONG_DISPLAY_MODE_LINE ||
-                                            ss.lowerThirdLookAheadDisplayMode == Constants.SONG_DISPLAY_MODE_LINE
-                                        if (inLineMode) {
+                                        if (isSongLineMode(appSettings.songSettings)) {
                                             presenterManager.setDisplayedLyricSection(section)
                                         }
                                     },
@@ -1579,7 +1581,9 @@ fun main() {
                                     onScheduleActionsReady = { scheduleActions = it },
                                     presenting = { mode ->
                                         presenterManager.setPresentingMode(mode)
-                                        if (mode != Presenting.NONE) presenterManager.setShowPresenterWindow(true)
+                                        if (shouldShowPresenterWindowFor(mode)) {
+                                            presenterManager.setShowPresenterWindow(true)
+                                        }
                                     },
                                     onScheduleItemSelected = { itemId -> selectedScheduleItemId = itemId },
                                     onShowSettings = { openOptionsDialog(0) },
@@ -1596,7 +1600,7 @@ fun main() {
                                         companionServer.updateBible(
                                             bible,
                                             translation,
-                                            filePath = File(appSettings.bibleSettings.storageDirectory, translation).absolutePath
+                                            filePath = bibleFilePath(appSettings.bibleSettings.storageDirectory, translation)
                                         )
                                     },
                                     onScheduleChanged = { items -> companionServer.updateSchedule(items) },
@@ -1671,7 +1675,7 @@ fun main() {
                                         presenterManager.requestClearDisplay()
                                     },
                                     onOpenLottieGen = { outputDir, onSaved ->
-                                        if (outputDir.isNotEmpty() && File(outputDir).isDirectory) {
+                                        if (isUsableOutputDir(outputDir)) {
                                             lottieGenOutputDir = File(outputDir)
                                             lottieGenOnFileSaved = onSaved
                                             showLottieGenWindow = true
@@ -1736,7 +1740,7 @@ fun main() {
                                         presenterManager.identifyBrowserSourceOutput(index)
                                     },
                                     onOpenLottieGen = { outputDir, onSaved ->
-                                        if (outputDir.isNotEmpty() && File(outputDir).isDirectory) {
+                                        if (isUsableOutputDir(outputDir)) {
                                             lottieGenOutputDir = File(outputDir)
                                             lottieGenOnFileSaved = onSaved
                                             showLottieGenWindow = true
@@ -1856,8 +1860,10 @@ fun main() {
                                     queueSize = remoteEventQueue.size,
                                     isClientKnownAllowed = remoteClientManager.isAllowed(currentClientId),
                                     isClientKnownBlocked = remoteClientManager.isBlocked(currentClientId),
-                                    isInstanceLinkFollower = currentClientId.isNotBlank() &&
-                                        currentClientId in companionServer.connectedInstanceLinkFollowers.collectAsState().value,
+                                    isInstanceLinkFollower = isInstanceLinkFollowerClient(
+                                        currentClientId,
+                                        companionServer.connectedInstanceLinkFollowers.collectAsState().value,
+                                    ),
                                     onAllow = {
                                         currentRemote?.second?.invoke()
                                         if (remoteEventQueue.isNotEmpty()) remoteEventQueue.removeAt(0)
@@ -1872,8 +1878,9 @@ fun main() {
                                             sessionAllowedClients.add(currentClientId)
                                         }
                                         val clientToAllow = currentClientId
-                                        val toApprove =
-                                            remoteEventQueue.filter { it.first.clientId == clientToAllow || clientToAllow.isBlank() }
+                                        val toApprove = remoteEventQueue.filter {
+                                            remoteEventTargetsClient(it.first.clientId, clientToAllow)
+                                        }
                                         toApprove.forEach { it.second.invoke() }
                                         remoteEventQueue.removeAll(toApprove)
                                     },
@@ -1881,8 +1888,9 @@ fun main() {
                                         // Permanently allow and silently approve all queued items from this client
                                         remoteClientManager.allowPermanently(currentClientId)
                                         val clientToAllow = currentClientId
-                                        val toApprove =
-                                            remoteEventQueue.filter { it.first.clientId == clientToAllow || clientToAllow.isBlank() }
+                                        val toApprove = remoteEventQueue.filter {
+                                            remoteEventTargetsClient(it.first.clientId, clientToAllow)
+                                        }
                                         toApprove.forEach { it.second.invoke() }
                                         remoteEventQueue.removeAll(toApprove)
                                     },
@@ -1895,8 +1903,9 @@ fun main() {
                                             sessionBlockedClients.add(currentClientId)
                                         }
                                         val clientToBlock = currentClientId
-                                        val toRemove =
-                                            remoteEventQueue.filter { it.first.clientId == clientToBlock || clientToBlock.isBlank() }
+                                        val toRemove = remoteEventQueue.filter {
+                                            remoteEventTargetsClient(it.first.clientId, clientToBlock)
+                                        }
                                         toRemove.forEach { it.third.invoke() }
                                         remoteEventQueue.removeAll(toRemove)
                                     },
@@ -1904,8 +1913,9 @@ fun main() {
                                         remoteClientManager.blockPermanently(currentClientId)
                                         // Deny all queued items from this client
                                         val clientToBlock = currentClientId
-                                        val toRemove =
-                                            remoteEventQueue.filter { it.first.clientId == clientToBlock || clientToBlock.isBlank() }
+                                        val toRemove = remoteEventQueue.filter {
+                                            remoteEventTargetsClient(it.first.clientId, clientToBlock)
+                                        }
                                         toRemove.forEach { it.third.invoke() }
                                         remoteEventQueue.removeAll(toRemove)
                                     },
@@ -2123,10 +2133,7 @@ private fun PresenterWindows(
     val proj = appSettings.projectionSettings
 
     // Mode-level crossfade duration (shared, per-screen active flag computed inside each window)
-    val modeCrossfadeDuration = maxOf(
-        if (appSettings.bibleSettings.crossfade) appSettings.bibleSettings.transitionDuration.toInt() else 0,
-        if (appSettings.songSettings.crossfade) appSettings.songSettings.transitionDuration.toInt() else 0
-    ).coerceAtLeast(100)
+    val modeCrossfadeDuration = modeCrossfadeDuration(appSettings.bibleSettings, appSettings.songSettings)
 
     // Fade-out before clearing display
     val clearRequested by presenterManager.clearDisplayRequested
@@ -2135,18 +2142,12 @@ private fun PresenterWindows(
         val mode = presenterManager.presentingMode.value
         // Don't fade the content alpha if any screen is locked to this mode —
         // that screen is still showing the content and the alpha must stay at 1.
-        val modeIsLocked = presenterManager.screenLocks.value.values.any { it == mode }
-        val shouldFade = !modeIsLocked && when (mode) {
-            Presenting.BIBLE -> appSettings.bibleSettings.fadeOut
-            Presenting.LYRICS -> appSettings.songSettings.fadeOut
-            else -> false
-        }
+        val modeIsLocked = isAnyScreenLockedTo(presenterManager.screenLocks.value, mode)
+        val shouldFade = shouldFadeOnClear(
+            mode, modeIsLocked, appSettings.bibleSettings, appSettings.songSettings,
+        )
         if (shouldFade) {
-            val duration = when (mode) {
-                Presenting.BIBLE -> appSettings.bibleSettings.transitionDuration.toInt()
-                Presenting.LYRICS -> appSettings.songSettings.transitionDuration.toInt()
-                else -> 500
-            }.coerceAtLeast(100)
+            val duration = fadeOutDuration(mode, appSettings.bibleSettings, appSettings.songSettings)
             val anim = Animatable(1f)
             anim.animateTo(0f, tween(durationMillis = duration)) {
                 when (mode) {
@@ -2180,10 +2181,7 @@ private fun PresenterWindows(
             return@LaunchedEffect
         }
         // Skip fade in line mode — only one line visible, instant swap is cleaner
-        val isLineMode = ss.fullscreenDisplayMode == Constants.SONG_DISPLAY_MODE_LINE ||
-                ss.lowerThirdDisplayMode == Constants.SONG_DISPLAY_MODE_LINE ||
-                ss.lookAheadDisplayMode == Constants.SONG_DISPLAY_MODE_LINE ||
-                ss.lowerThirdLookAheadDisplayMode == Constants.SONG_DISPLAY_MODE_LINE
+        val isLineMode = isSongLineMode(ss)
         if (isLineMode) {
             presenterManager.setDisplayedLyricSection(lyricSection)
             presenterManager.setSongTransitionAlpha(1f)
@@ -2293,21 +2291,19 @@ private fun PresenterWindows(
     // Centralized Announcements transition
     LaunchedEffect(announcementText) {
         val annSettings = appSettings.announcementsSettings
-        val isFade = annSettings.animationType == Constants.ANIMATION_FADE
-        val isNone = annSettings.animationType == Constants.ANIMATION_NONE
+        val isFade = isFadeAnnouncement(annSettings.animationType)
         val wasEmpty = presenterManager.displayedAnnouncementText.value.isEmpty()
         val fadeDuration = 500
         val sliderSum = 30500L // 500 + 30000, matches AnnouncementsTab speed slider
-        val displayDuration = (sliderSum - annSettings.animationDuration).coerceAtLeast(500)
         val loopCount = annSettings.loopCount
 
-        if (!isFade && !isNone) {
+        if (isSlidingAnnouncement(annSettings.animationType)) {
             // Directional slides — just swap text, animation handled in AnnouncementsPresenter
             presenterManager.setDisplayedAnnouncementText(announcementText)
             presenterManager.setAnnouncementTransitionAlpha(1f)
         } else if (announcementText.isEmpty()) {
             // Cleared by user or loop finished — fade out if fade, instant if none
-            if (isFade && !wasEmpty) {
+            if (shouldFadeOutAnnouncement(isFade, wasEmpty)) {
                 val anim = Animatable(1f)
                 anim.animateTo(0f, tween(fadeDuration)) {
                     presenterManager.setAnnouncementTransitionAlpha(value)
@@ -2330,9 +2326,9 @@ private fun PresenterWindows(
                 presenterManager.setAnnouncementTransitionAlpha(1f)
             }
 
-            if (loopCount > 0) {
+            if (isFiniteAnnouncementLoop(loopCount)) {
                 // Finite loops: display for duration × loopCount, then clear
-                delay(displayDuration * loopCount)
+                delay(announcementDisplayMs(sliderSum, annSettings.animationDuration.toLong(), loopCount))
 
                 // Fade out (only for fade animation)
                 if (isFade) {
@@ -2367,26 +2363,18 @@ private fun PresenterWindows(
             val comp = lottieComposition
             val initialFrameCount = presenterManager.lottieFrameCount.value
             val totalDurMs = when {
-                comp != null -> ((comp.durationFrames / comp.frameRate) * 1000f).toLong().coerceAtLeast(1L)
-                initialFrameCount != null -> (initialFrameCount * 1000L / presenterManager.lottiePrerenderFps.value).coerceAtLeast(1L)
+                comp != null -> lottieCompositionDurationMs(comp.durationFrames, comp.frameRate)
+                initialFrameCount != null ->
+                    lottiePrerenderDurationMs(initialFrameCount, presenterManager.lottiePrerenderFps.value)
                 else -> return@LaunchedEffect
             }
-            val hasPause = lottiePauseAtFrame && lottiePauseFrame in 0f..1f
-            val pauseAtMs = if (hasPause) (totalDurMs * lottiePauseFrame).toLong() else -1L
-            val grandTotalMs = totalDurMs + (if (hasPause) lottiePauseDurationMs else 0L)
+            val hasPause = lottieHasPause(lottiePauseAtFrame, lottiePauseFrame)
+            val pauseAtMs = lottiePauseAtMs(totalDurMs, lottiePauseFrame, hasPause)
+            val grandTotalMs = lottieGrandTotalMs(totalDurMs, hasPause, lottiePauseDurationMs)
 
-            fun progressAt(elapsedMs: Long): Float {
-                if (!hasPause) return (elapsedMs.toFloat() / totalDurMs).coerceIn(0f, 1f)
-                return when {
-                    elapsedMs < pauseAtMs -> (elapsedMs.toFloat() / totalDurMs).coerceIn(0f, lottiePauseFrame)
-                    elapsedMs < pauseAtMs + lottiePauseDurationMs -> lottiePauseFrame
-                    else -> {
-                        val postElapsed = elapsedMs - pauseAtMs - lottiePauseDurationMs
-                        val postTotalMs = (totalDurMs - pauseAtMs).coerceAtLeast(1L)
-                        (lottiePauseFrame + (postElapsed.toFloat() / postTotalMs) * (1f - lottiePauseFrame)).coerceIn(0f, 1f)
-                    }
-                }
-            }
+            fun progressAt(elapsedMs: Long): Float = lottieProgressAt(
+                elapsedMs, totalDurMs, hasPause, lottiePauseFrame, pauseAtMs, lottiePauseDurationMs,
+            )
 
             // Vsync-driven clock: elapsed time comes from real frame timestamps, so a missed
             // display frame self-corrects on the next one instead of accumulating drift the way
@@ -2397,8 +2385,7 @@ private fun PresenterWindows(
                 val frameCount = presenterManager.lottieFrameCount.value
                 val progress = progressAt(elapsedMs)
                 if (frameCount != null) {
-                    val idx = (progress * (frameCount - 1)).roundToInt().coerceIn(0, frameCount - 1)
-                    presenterManager.setLottieCurrentFrameIndex(idx)
+                    presenterManager.setLottieCurrentFrameIndex(lottieFrameIndexFor(progress, frameCount))
                 } else {
                     presenterManager.setLottieProgress(progress)
                 }
@@ -2428,7 +2415,7 @@ private fun PresenterWindows(
     // screenNumber is null when there's no physical screen to label (e.g. the test window).
     val presenterOutputContent: @Composable (screenAssignment: ScreenAssignment, effectiveMode: Presenting, screenNumber: Int?) -> Unit = { screenAssignment, effectiveMode, screenNumber ->
         val primaryRole = screenAssignment.primaryOutputRole
-        val showBg = if (screenAssignment.isLowerThird) screenAssignment.showLowerThirdBackground else screenAssignment.showFullscreenBackground
+        val showBg = showsOutputBackground(screenAssignment)
         CompositionLocalProvider(LocalMediaViewModel provides mediaViewModel) {
             if (screenAssignment.displayMode == Constants.DISPLAY_MODE_STAGE_MONITOR) {
                 // Stage monitor: dedicated presenter-confidence layout
@@ -2472,7 +2459,9 @@ private fun PresenterWindows(
                             }
                     ) {
                         var prevEffectiveMode by remember { mutableStateOf(effectiveMode) }
-                        val screenCrossfadeActive = (appSettings.bibleSettings.crossfade || appSettings.songSettings.crossfade) && effectiveMode != Presenting.NONE && prevEffectiveMode != Presenting.NONE
+                        val screenCrossfadeActive = isScreenCrossfadeActive(
+                        appSettings.bibleSettings, appSettings.songSettings, effectiveMode, prevEffectiveMode,
+                    )
                         if (effectiveMode != prevEffectiveMode) prevEffectiveMode = effectiveMode
                         Crossfade(targetState = effectiveMode, animationSpec = if (screenCrossfadeActive) tween(modeCrossfadeDuration) else snap()) { mode ->
                             when (mode) {
@@ -2583,7 +2572,7 @@ private fun PresenterWindows(
                                     if (screenAssignment.showQA) {
                                         if (showQRCodeOnDisplay) {
                                             QAQRCodePresenter(
-                                                url = "${qaDisplayUrl.ifEmpty { serverUrl }}/qa",
+                                                url = qaQrCodeUrl(qaDisplayUrl, serverUrl),
                                                 qaSettings = appSettings.qaSettings,
                                                 transitionAlpha = qaTransitionAlpha,
                                             )
@@ -2651,31 +2640,33 @@ private fun PresenterWindows(
 
     // Identify the OS primary monitor and build list of non-primary screens
     val defaultDevice = GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice
-    val availableScreens = screens.indices.filter { screens[it] != defaultDevice }
+    val availableScreens = nonPrimaryIndices(screens.toList(), defaultDevice)
 
-    val deckLinkDeviceCount = if (DeckLinkManager.isAvailable()) DeckLinkManager.listDevices().size else 0
-    val windowCount = availableScreens.size + deckLinkDeviceCount
+    val deckLinkDeviceCount = deckLinkOutputCount(DeckLinkManager.isAvailable()) { DeckLinkManager.listDevices().size }
+    val windowCount = presenterWindowCount(availableScreens.size, deckLinkDeviceCount)
     // Dev convenience: on a single-monitor dev machine there's no non-primary monitor or DeckLink
     // device to open a real output window on. Show Output 1 as an ordinary window instead of not
     // rendering at all, driven by the same "Toggle Presenter Displays" button/state.
-    val devWindowedFallback = (!BuildConfig.IS_RELEASE || DevFlags.forceDevWindow) && windowCount == 0
+    val devWindowedFallback = isDevWindowedFallback(
+        BuildConfig.IS_RELEASE, DevFlags.forceDevWindow, windowCount,
+    )
     // On a machine with no real output, open DevFlags.devWindowCount fallback windows (default 1).
     // A count > 1 simulates several independent outputs on one monitor for developing/testing
     // per-output features — each window is its own output slot (index, assignment, screen lock).
-    val devFallbackCount = if (devWindowedFallback) proj.devWindowCount.coerceAtLeast(1) else 0
+    val devFallbackCount = devFallbackWindowCount(devWindowedFallback, proj.devWindowCount)
     for (i in 0 until (windowCount + devFallbackCount)) {
-        if (devWindowedFallback && i >= windowCount) {
-            val fallbackIndex = i - windowCount
+        if (isFallbackWindowSlot(devWindowedFallback, i, windowCount)) {
+            val fallbackIndex = fallbackSlotIndex(i, windowCount)
             val screenAssignment = proj.getAssignment(fallbackIndex)
-            val effectiveMode = screenLocks[fallbackIndex] ?: presentingMode
+            val effectiveMode = effectiveOutputMode(screenLocks, fallbackIndex, presentingMode)
             // Cascade the windows so multiple dev outputs don't stack exactly on top of each other.
             val fallbackWindowState = remember(fallbackIndex) {
                 WindowState(
                     width = 960.dp,
                     height = 540.dp,
                     position = WindowPosition(
-                        x = (40 + fallbackIndex * 48).dp,
-                        y = (40 + fallbackIndex * 48).dp,
+                        x = devFallbackWindowOffsetDp(fallbackIndex).dp,
+                        y = devFallbackWindowOffsetDp(fallbackIndex).dp,
                     ),
                 )
             }
@@ -2694,10 +2685,10 @@ private fun PresenterWindows(
             continue
         }
         val screenAssignment = proj.getAssignment(i)
-        val effectiveMode = screenLocks[i] ?: presentingMode
+        val effectiveMode = effectiveOutputMode(screenLocks, i, presentingMode)
 
         // DeckLink outputs: render via offscreen Window + pixel capture
-        if (screenAssignment.targetType == "decklink") {
+        if (isDeckLinkPrimaryOutput(screenAssignment)) {
             if (showPresenterWindow && screenAssignment.targetDisplay >= 0) {
                 val deckLinkRole = screenAssignment.primaryOutputRole
                 DeckLinkComposeOutput(
@@ -2708,7 +2699,9 @@ private fun PresenterWindows(
                     isLowerThird = screenAssignment.isLowerThird,
                 ) {
                     var prevEffectiveMode by remember { mutableStateOf(effectiveMode) }
-                    val screenCrossfadeActive = (appSettings.bibleSettings.crossfade || appSettings.songSettings.crossfade) && effectiveMode != Presenting.NONE && prevEffectiveMode != Presenting.NONE
+                    val screenCrossfadeActive = isScreenCrossfadeActive(
+                        appSettings.bibleSettings, appSettings.songSettings, effectiveMode, prevEffectiveMode,
+                    )
                     if (effectiveMode != prevEffectiveMode) prevEffectiveMode = effectiveMode
                     Crossfade(
                         targetState = effectiveMode,
@@ -2818,7 +2811,7 @@ private fun PresenterWindows(
                             if (screenAssignment.showQA) {
                                 if (showQRCodeOnDisplay) {
                                     QAQRCodePresenter(
-                                        url = "${qaDisplayUrl.ifEmpty { serverUrl }}/qa",
+                                        url = qaQrCodeUrl(qaDisplayUrl, serverUrl),
                                         qaSettings = appSettings.qaSettings,
                                         transitionAlpha = qaTransitionAlpha,
                                     )
@@ -2858,7 +2851,7 @@ private fun PresenterWindows(
             }
 
             // DeckLink key output
-            if (showPresenterWindow && screenAssignment.hasKeyOutput && screenAssignment.keyTargetType == "decklink" && screenAssignment.keyTargetDisplay >= 0) {
+            if (showPresenterWindow && hasDeckLinkKeyOutput(screenAssignment)) {
                 DeckLinkComposeOutput(
                     deviceIndex = screenAssignment.keyTargetDisplay,
                     outputRole = Constants.OUTPUT_ROLE_KEY,
@@ -2867,7 +2860,9 @@ private fun PresenterWindows(
                     isLowerThird = screenAssignment.isLowerThird,
                 ) {
                     var prevEffectiveMode by remember { mutableStateOf(effectiveMode) }
-                    val screenCrossfadeActive = (appSettings.bibleSettings.crossfade || appSettings.songSettings.crossfade) && effectiveMode != Presenting.NONE && prevEffectiveMode != Presenting.NONE
+                    val screenCrossfadeActive = isScreenCrossfadeActive(
+                        appSettings.bibleSettings, appSettings.songSettings, effectiveMode, prevEffectiveMode,
+                    )
                     if (effectiveMode != prevEffectiveMode) prevEffectiveMode = effectiveMode
                     Crossfade(targetState = effectiveMode, animationSpec = if (screenCrossfadeActive) tween(modeCrossfadeDuration) else snap()) { mode ->
                     when (mode) {
@@ -2981,7 +2976,7 @@ private fun PresenterWindows(
                             if (screenAssignment.showQA) {
                                 if (showQRCodeOnDisplay) {
                                     QAQRCodePresenter(
-                                        url = "${qaDisplayUrl.ifEmpty { serverUrl }}/qa",
+                                        url = qaQrCodeUrl(qaDisplayUrl, serverUrl),
                                         qaSettings = appSettings.qaSettings,
                                         outputRole = Constants.OUTPUT_ROLE_KEY,
                                         transitionAlpha = qaTransitionAlpha,
@@ -3023,15 +3018,18 @@ private fun PresenterWindows(
             }
 
             // Key output on a regular screen when primary is DeckLink
-            if (showPresenterWindow && screenAssignment.hasKeyOutput && screenAssignment.keyTargetType == "screen") {
-                val keyScreenIndex = findScreenIndexByBounds(
-                    screens,
-                    screenAssignment.keyTargetBoundsX,
-                    screenAssignment.keyTargetBoundsY,
-                    screenAssignment.keyTargetBoundsW,
-                    screenAssignment.keyTargetBoundsH
-                ) ?: screenAssignment.keyTargetDisplay
-                if (keyScreenIndex in screens.indices) {
+            if (showPresenterWindow && hasScreenKeyOutput(screenAssignment)) {
+                val keyScreenIndex = keyOutputScreenIndex(
+                    findScreenIndexByBounds(
+                        screens,
+                        screenAssignment.keyTargetBoundsX,
+                        screenAssignment.keyTargetBoundsY,
+                        screenAssignment.keyTargetBoundsW,
+                        screenAssignment.keyTargetBoundsH
+                    ),
+                    screenAssignment.keyTargetDisplay,
+                )
+                if (isScreenIndexValid(keyScreenIndex, screens.size)) {
                     val keyWindowState = remember(i, keyScreenIndex) {
                         val b = screens[keyScreenIndex].defaultConfiguration.bounds
                         WindowState(
@@ -3060,7 +3058,10 @@ private fun PresenterWindows(
                             ) {
                                 Box(modifier = Modifier.fillMaxSize()) {
                                     var prevEffectiveMode by remember { mutableStateOf(effectiveMode) }
-                                    val screenCrossfadeActive = (appSettings.bibleSettings.crossfade || appSettings.songSettings.crossfade) && effectiveMode != Presenting.NONE && prevEffectiveMode != Presenting.NONE
+                                    val screenCrossfadeActive = isScreenCrossfadeActive(
+                                        appSettings.bibleSettings, appSettings.songSettings,
+                                        effectiveMode, prevEffectiveMode,
+                                    )
                                     if (effectiveMode != prevEffectiveMode) prevEffectiveMode = effectiveMode
                                     Crossfade(targetState = effectiveMode, animationSpec = if (screenCrossfadeActive) tween(modeCrossfadeDuration) else snap()) { mode ->
                     when (mode) {
@@ -3174,7 +3175,7 @@ private fun PresenterWindows(
                                             if (screenAssignment.showQA) {
                                                 if (showQRCodeOnDisplay) {
                                                     QAQRCodePresenter(
-                                                        url = "${qaDisplayUrl.ifEmpty { serverUrl }}/qa",
+                                                        url = qaQrCodeUrl(qaDisplayUrl, serverUrl),
                                                         qaSettings = appSettings.qaSettings,
                                                         outputRole = Constants.OUTPUT_ROLE_KEY,
                                                         transitionAlpha = qaTransitionAlpha,
@@ -3222,26 +3223,27 @@ private fun PresenterWindows(
             continue
         }
 
-        if (screenAssignment.targetDisplay == Constants.KEY_TARGET_NONE) continue
+        if (hasNoPrimaryTarget(screenAssignment)) continue
 
         // Resolve target display
-        val targetScreenIndex = findScreenIndexByBounds(
-            screens,
-            screenAssignment.targetBoundsX,
-            screenAssignment.targetBoundsY,
-            screenAssignment.targetBoundsW,
-            screenAssignment.targetBoundsH
-        ) ?: if (screenAssignment.targetDisplay >= 0 && screenAssignment.targetDisplay < screens.size) {
-            screenAssignment.targetDisplay
-        } else {
-            availableScreens.getOrNull(i) ?: continue
-        }
+        val targetScreenIndex = primaryOutputScreenIndex(
+            matchedByBounds = findScreenIndexByBounds(
+                screens,
+                screenAssignment.targetBoundsX,
+                screenAssignment.targetBoundsY,
+                screenAssignment.targetBoundsW,
+                screenAssignment.targetBoundsH
+            ),
+            savedDisplay = screenAssignment.targetDisplay,
+            screenCount = screens.size,
+            positionalFallback = availableScreens.getOrNull(i),
+        ) ?: continue
 
         // Skip if the target screen doesn't exist
-        if (targetScreenIndex < 0 || targetScreenIndex >= screens.size) continue
+        if (!isScreenIndexValid(targetScreenIndex, screens.size)) continue
 
         // Per-output background toggle
-        val showBg = if (screenAssignment.isLowerThird) screenAssignment.showLowerThirdBackground else screenAssignment.showFullscreenBackground
+        val showBg = showsOutputBackground(screenAssignment)
 
         // Derive output role from key target configuration
         val primaryRole = screenAssignment.primaryOutputRole
@@ -3278,15 +3280,18 @@ private fun PresenterWindows(
         }
 
         // Key output window — spawned when a key target is configured
-        if (screenAssignment.hasKeyOutput && screenAssignment.keyTargetType != "decklink") {
-            val keyScreenIndex = findScreenIndexByBounds(
-                screens,
-                screenAssignment.keyTargetBoundsX,
-                screenAssignment.keyTargetBoundsY,
-                screenAssignment.keyTargetBoundsW,
-                screenAssignment.keyTargetBoundsH
-            ) ?: screenAssignment.keyTargetDisplay
-            if (keyScreenIndex in screens.indices) {
+        if (screenAssignment.hasKeyOutput && !isDeckLinkKeyOutput(screenAssignment)) {
+            val keyScreenIndex = keyOutputScreenIndex(
+                findScreenIndexByBounds(
+                    screens,
+                    screenAssignment.keyTargetBoundsX,
+                    screenAssignment.keyTargetBoundsY,
+                    screenAssignment.keyTargetBoundsW,
+                    screenAssignment.keyTargetBoundsH
+                ),
+                screenAssignment.keyTargetDisplay,
+            )
+            if (isScreenIndexValid(keyScreenIndex, screens.size)) {
                 val keyWindowState = remember(i, keyScreenIndex) {
                     val b = screens[keyScreenIndex].defaultConfiguration.bounds
                     WindowState(
@@ -3326,7 +3331,10 @@ private fun PresenterWindows(
                                     }
                             ) {
                                 var prevEffectiveMode by remember { mutableStateOf(effectiveMode) }
-                                val screenCrossfadeActive = (appSettings.bibleSettings.crossfade || appSettings.songSettings.crossfade) && effectiveMode != Presenting.NONE && prevEffectiveMode != Presenting.NONE
+                                val screenCrossfadeActive = isScreenCrossfadeActive(
+                                    appSettings.bibleSettings, appSettings.songSettings,
+                                    effectiveMode, prevEffectiveMode,
+                                )
                                 if (effectiveMode != prevEffectiveMode) prevEffectiveMode = effectiveMode
                                 Crossfade(targetState = effectiveMode, animationSpec = if (screenCrossfadeActive) tween(modeCrossfadeDuration) else snap()) { mode ->
                     when (mode) {
@@ -3439,7 +3447,7 @@ private fun PresenterWindows(
                                         if (screenAssignment.showQA) {
                                             if (showQRCodeOnDisplay) {
                                                 QAQRCodePresenter(
-                                                    url = "${qaDisplayUrl.ifEmpty { serverUrl }}/qa",
+                                                    url = qaQrCodeUrl(qaDisplayUrl, serverUrl),
                                                     qaSettings = appSettings.qaSettings,
                                                     transitionAlpha = qaTransitionAlpha,
                                                 )
@@ -3484,7 +3492,7 @@ private fun PresenterWindows(
         }
 
         // Key output on DeckLink when primary is a regular screen
-        if (screenAssignment.targetType != "decklink" && screenAssignment.hasKeyOutput && screenAssignment.keyTargetType == "decklink" && screenAssignment.keyTargetDisplay >= 0) {
+        if (!isDeckLinkPrimaryOutput(screenAssignment) && hasDeckLinkKeyOutput(screenAssignment)) {
             if (showPresenterWindow) {
                 DeckLinkComposeOutput(
                     deviceIndex = screenAssignment.keyTargetDisplay,
@@ -3494,7 +3502,9 @@ private fun PresenterWindows(
                     isLowerThird = screenAssignment.isLowerThird,
                 ) {
                     var prevEffectiveMode by remember { mutableStateOf(effectiveMode) }
-                    val screenCrossfadeActive = (appSettings.bibleSettings.crossfade || appSettings.songSettings.crossfade) && effectiveMode != Presenting.NONE && prevEffectiveMode != Presenting.NONE
+                    val screenCrossfadeActive = isScreenCrossfadeActive(
+                        appSettings.bibleSettings, appSettings.songSettings, effectiveMode, prevEffectiveMode,
+                    )
                     if (effectiveMode != prevEffectiveMode) prevEffectiveMode = effectiveMode
                     Crossfade(targetState = effectiveMode, animationSpec = if (screenCrossfadeActive) tween(modeCrossfadeDuration) else snap()) { mode ->
                     when (mode) {
@@ -3608,7 +3618,7 @@ private fun PresenterWindows(
                             if (screenAssignment.showQA) {
                                 if (showQRCodeOnDisplay) {
                                     QAQRCodePresenter(
-                                        url = "${qaDisplayUrl.ifEmpty { serverUrl }}/qa",
+                                        url = qaQrCodeUrl(qaDisplayUrl, serverUrl),
                                         qaSettings = appSettings.qaSettings,
                                         transitionAlpha = qaTransitionAlpha,
                                     )

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainLogicTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainLogicTest.kt
@@ -4,17 +4,26 @@ import org.churchpresenter.app.churchpresenter.data.Language
 import org.churchpresenter.app.churchpresenter.data.settings.CompanionSatelliteSettings
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.BackgroundSettings
+import org.churchpresenter.app.churchpresenter.data.settings.BibleSettings
+import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
+import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkRole
+import org.churchpresenter.app.churchpresenter.dialogs.RemoteEventType
 import org.churchpresenter.app.churchpresenter.data.settings.InstanceLinkSettings
 import org.churchpresenter.app.churchpresenter.data.settings.OBSSettings
 import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
 import org.churchpresenter.app.churchpresenter.data.settings.ServerSettings
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
+import org.churchpresenter.app.churchpresenter.server.InstanceLinkStatus
+import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.server.TunnelStatus
 import org.churchpresenter.app.churchpresenter.utils.UpdateCheckResult
 import org.churchpresenter.app.churchpresenter.utils.UpdateInfo
+import java.io.File
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -394,5 +403,875 @@ class MainLogicTest {
         assertTrue(isPresentationLive(Presenting.PRESENTATION))
         assertFalse(isPresentationLive(Presenting.LYRICS))
         assertFalse(isPresentationLive(Presenting.NONE))
+    }
+
+    // ── Acting on a remote request ──────────────────────────────────────────────
+
+    @Test
+    fun `a line chosen remotely is used as given`() {
+        assertEquals(0, remoteSongLineIndex(0))
+        assertEquals(3, remoteSongLineIndex(3))
+    }
+
+    @Test
+    fun `any negative line means the whole section`() {
+        // Callers say -1 for "the section, not a line in it"; other negatives must mean the same
+        // rather than being passed through as a position.
+        assertEquals(-1, remoteSongLineIndex(-1))
+        assertEquals(-1, remoteSongLineIndex(-7))
+    }
+
+    @Test
+    fun `taking a section live switches the output over when something else is on it`() {
+        assertTrue(shouldSwitchToLyrics(Presenting.BIBLE))
+        assertTrue(shouldSwitchToLyrics(Presenting.NONE))
+        assertFalse(shouldSwitchToLyrics(Presenting.LYRICS), "already lyrics, so just change section")
+    }
+
+    @Test
+    fun `a finished lower third clears only while it is still on screen`() {
+        // The sequence runs on its own clock; by the time it ends the operator may have moved on,
+        // and clearing then would blank whatever they moved to.
+        assertTrue(shouldClearAfterLowerThird(Presenting.LOWER_THIRD))
+        assertFalse(shouldClearAfterLowerThird(Presenting.LYRICS))
+        assertFalse(shouldClearAfterLowerThird(Presenting.NONE))
+    }
+
+    @Test
+    fun `a section change is announced only while songs are live`() {
+        assertTrue(shouldBroadcastSongSection(Presenting.LYRICS))
+        assertFalse(shouldBroadcastSongSection(Presenting.BIBLE))
+    }
+
+    @Test
+    fun `an emptied output is announced only when it is actually empty`() {
+        assertTrue(shouldBroadcastDisplayCleared(Presenting.NONE))
+        assertFalse(shouldBroadcastDisplayCleared(Presenting.LYRICS))
+    }
+
+    // ── Driving another instance ────────────────────────────────────────────────
+
+    @Test
+    fun `a connected controller may drive the other instance`() {
+        assertTrue(isControllerConnected(InstanceLinkStatus.CONNECTED, InstanceLinkRole.CONTROLLER))
+    }
+
+    @Test
+    fun `a controller that is not connected has nothing to drive`() {
+        assertFalse(isControllerConnected(InstanceLinkStatus.DISCONNECTED, InstanceLinkRole.CONTROLLER))
+        assertFalse(isControllerConnected(InstanceLinkStatus.CONNECTING, InstanceLinkRole.CONTROLLER))
+        assertFalse(isControllerConnected(InstanceLinkStatus.ERROR, InstanceLinkRole.CONTROLLER))
+    }
+
+    @Test
+    fun `a follower never drives, however well connected`() {
+        // It receives; sending from here would fight the primary for the output.
+        assertFalse(isControllerConnected(InstanceLinkStatus.CONNECTED, InstanceLinkRole.CONTROLLED))
+    }
+
+    // ── What a remote client just did ───────────────────────────────────────────
+
+    @Test
+    fun `each no-approval action is reported as its own kind`() {
+        assertEquals(RemoteEventType.PRESENT, remoteActionType("present"))
+        assertEquals(RemoteEventType.UPLOAD, remoteActionType("upload"))
+        assertEquals(RemoteEventType.CLEAR, remoteActionType("clear"))
+    }
+
+    @Test
+    fun `an action nobody recognises is still reported`() {
+        // The toast is how the operator sees what a remote client did and blocks them if it was
+        // unwanted — an action that produced no toast is the one worth seeing.
+        assertEquals(RemoteEventType.PRESENT, remoteActionType("something-new"))
+        assertEquals(RemoteEventType.PRESENT, remoteActionType(""))
+    }
+
+    // ── Transitions on the output ───────────────────────────────────────────────
+
+    @Test
+    fun `the crossfade takes the longer of the two that are on`() {
+        // One duration serves both, because a crossfade from scripture to a song is a single
+        // transition — the shorter of the two would cut it off part-way.
+        val duration = modeCrossfadeDuration(
+            BibleSettings(crossfade = true, transitionDuration = 400f),
+            SongSettings(crossfade = true, transitionDuration = 900f),
+        )
+        assertEquals(900, duration)
+    }
+
+    @Test
+    fun `a crossfade that is switched off contributes nothing`() {
+        val duration = modeCrossfadeDuration(
+            BibleSettings(crossfade = false, transitionDuration = 5000f),
+            SongSettings(crossfade = true, transitionDuration = 400f),
+        )
+        assertEquals(400, duration, "the disabled one must not set the length")
+    }
+
+    @Test
+    fun `with both off the transition still has a floor`() {
+        // Below this a fade reads as a flicker rather than a transition.
+        val duration = modeCrossfadeDuration(
+            BibleSettings(crossfade = false), SongSettings(crossfade = false),
+        )
+        assertEquals(MIN_TRANSITION_MS, duration)
+    }
+
+    @Test
+    fun `a screen pinned to the mode being cleared is noticed`() {
+        assertTrue(isAnyScreenLockedTo(mapOf(0 to Presenting.LYRICS), Presenting.LYRICS))
+        assertFalse(isAnyScreenLockedTo(mapOf(0 to Presenting.BIBLE), Presenting.LYRICS))
+        assertFalse(isAnyScreenLockedTo(emptyMap(), Presenting.LYRICS))
+    }
+
+    @Test
+    fun `clearing scripture or a song fades it out first`() {
+        assertTrue(
+            shouldFadeOnClear(Presenting.BIBLE, false, BibleSettings(fadeOut = true), SongSettings()),
+        )
+        assertTrue(
+            shouldFadeOnClear(Presenting.LYRICS, false, BibleSettings(), SongSettings(fadeOut = true)),
+        )
+    }
+
+    @Test
+    fun `nothing fades while a screen is still showing it`() {
+        // That display was not asked to clear, and the alpha is shared — fading would dim it there.
+        assertFalse(
+            shouldFadeOnClear(Presenting.LYRICS, true, BibleSettings(), SongSettings(fadeOut = true)),
+        )
+    }
+
+    @Test
+    fun `content with no fade of its own clears instantly`() {
+        assertFalse(
+            shouldFadeOnClear(Presenting.PICTURES, false, BibleSettings(fadeOut = true), SongSettings(fadeOut = true)),
+        )
+        assertFalse(
+            shouldFadeOnClear(Presenting.BIBLE, false, BibleSettings(fadeOut = false), SongSettings()),
+        )
+    }
+
+    @Test
+    fun `each content type fades for its own configured time`() {
+        assertEquals(
+            700,
+            fadeOutDuration(Presenting.BIBLE, BibleSettings(transitionDuration = 700f), SongSettings()),
+        )
+        assertEquals(
+            300,
+            fadeOutDuration(Presenting.LYRICS, BibleSettings(), SongSettings(transitionDuration = 300f)),
+        )
+    }
+
+    @Test
+    fun `anything else falls back, and nothing goes below the floor`() {
+        assertEquals(500, fadeOutDuration(Presenting.MEDIA, BibleSettings(), SongSettings()))
+        assertEquals(
+            MIN_TRANSITION_MS,
+            fadeOutDuration(Presenting.BIBLE, BibleSettings(transitionDuration = 10f), SongSettings()),
+        )
+    }
+
+    // ── Announcements ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `fade is told apart from cutting and sliding`() {
+        assertTrue(isFadeAnnouncement(Constants.ANIMATION_FADE))
+        assertFalse(isFadeAnnouncement(Constants.ANIMATION_NONE))
+        assertFalse(isFadeAnnouncement("SLIDE_LEFT"))
+    }
+
+    @Test
+    fun `a sliding announcement is left to the presenter to animate`() {
+        // Running a fade here as well would fight the animation already in flight.
+        assertTrue(isSlidingAnnouncement("SLIDE_LEFT"))
+        assertTrue(isSlidingAnnouncement("SCROLL_UP"))
+        assertFalse(isSlidingAnnouncement(Constants.ANIMATION_FADE))
+        assertFalse(isSlidingAnnouncement(Constants.ANIMATION_NONE))
+    }
+
+    @Test
+    fun `clearing fades out only when something was on screen`() {
+        assertTrue(shouldFadeOutAnnouncement(isFade = true, wasEmpty = false))
+    }
+
+    @Test
+    fun `fading out from an empty screen is skipped`() {
+        // It would otherwise spend the animation's length showing nothing before the next content.
+        assertFalse(shouldFadeOutAnnouncement(isFade = true, wasEmpty = true))
+        assertFalse(shouldFadeOutAnnouncement(isFade = false, wasEmpty = false))
+    }
+
+    @Test
+    fun `a loop count clears itself, and none stays up`() {
+        assertTrue(isFiniteAnnouncementLoop(1))
+        assertTrue(isFiniteAnnouncementLoop(5))
+        assertFalse(isFiniteAnnouncementLoop(0), "zero means stay up until stopped by hand")
+    }
+
+    @Test
+    fun `the speed slider reads the other way round`() {
+        // A higher configured value means faster, so it is subtracted from the slider's span.
+        assertEquals(20_500L, announcementDisplayMs(sliderSpan = 30_500L, animationDuration = 10_000L, loopCount = 1))
+    }
+
+    @Test
+    fun `each loop adds its own time on screen`() {
+        assertEquals(61_000L, announcementDisplayMs(sliderSpan = 30_500L, animationDuration = 0L, loopCount = 2))
+    }
+
+    @Test
+    fun `an announcement is never on screen for less than the floor`() {
+        assertEquals(
+            MIN_ANNOUNCEMENT_DISPLAY_MS,
+            announcementDisplayMs(sliderSpan = 30_500L, animationDuration = 99_999L, loopCount = 1),
+        )
+    }
+
+    // ── First run ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an install with no bible at all gets the bundled one`() {
+        assertTrue(shouldBundleDefaultBible(BibleSettings()))
+    }
+
+    @Test
+    fun `a setup already part-way through is left alone`() {
+        // A folder chosen but no translation picked yet is a choice the operator is mid-way through.
+        assertFalse(shouldBundleDefaultBible(BibleSettings(storageDirectory = "/bibles")))
+        assertFalse(shouldBundleDefaultBible(BibleSettings(primaryBible = "kjv1769.spb")))
+    }
+
+    @Test
+    fun `the licence counts as accepted at this version or a later one`() {
+        assertTrue(isEulaAccepted(acceptedVersion = 1, currentVersion = 1))
+        assertTrue(isEulaAccepted(acceptedVersion = 2, currentVersion = 1))
+    }
+
+    @Test
+    fun `a licence never accepted, or accepted at an older version, is asked again`() {
+        assertFalse(isEulaAccepted(acceptedVersion = 0, currentVersion = 1))
+        assertFalse(isEulaAccepted(acceptedVersion = 1, currentVersion = 2))
+    }
+
+    @Test
+    fun `a fresh install is offered the setup wizard`() {
+        assertTrue(shouldShowSetupWizard(AppSettings()))
+    }
+
+    @Test
+    fun `an install that already works is not interrupted by the wizard`() {
+        // Both a bible and a song folder means a working setup, whatever the flag says.
+        val ready = AppSettings(
+            bibleSettings = BibleSettings(primaryBible = "kjv1769.spb"),
+            songSettings = SongSettings(storageDirectory = "/songs"),
+        )
+        assertFalse(shouldShowSetupWizard(ready))
+    }
+
+    @Test
+    fun `a half-configured install is still offered the wizard`() {
+        val bibleOnly = AppSettings(bibleSettings = BibleSettings(primaryBible = "kjv1769.spb"))
+        assertTrue(shouldShowSetupWizard(bibleOnly))
+        val songsOnly = AppSettings(songSettings = SongSettings(storageDirectory = "/songs"))
+        assertTrue(shouldShowSetupWizard(songsOnly))
+    }
+
+    @Test
+    fun `once dismissed the wizard stays dismissed`() {
+        assertFalse(shouldShowSetupWizard(AppSettings(setupWizardShown = true)))
+    }
+
+    // ── The Developer menu ──────────────────────────────────────────────────────
+
+    @Test
+    fun `a dev build always has the developer menu`() {
+        assertTrue(shouldShowDeveloperMenu(isRelease = false, forceDevWindow = false, unlocked = false))
+    }
+
+    @Test
+    fun `a packaged build hides it until it is deliberately asked for`() {
+        assertFalse(shouldShowDeveloperMenu(isRelease = true, forceDevWindow = false, unlocked = false))
+        assertTrue(shouldShowDeveloperMenu(isRelease = true, forceDevWindow = true, unlocked = false))
+        assertTrue(shouldShowDeveloperMenu(isRelease = true, forceDevWindow = false, unlocked = true))
+    }
+
+    // ── Remote approval queue ───────────────────────────────────────────────────
+
+    @Test
+    fun `allowing a client settles every request already queued from it`() {
+        // Allow/block apply to the client, not to the one request the dialog happens to be showing.
+        assertTrue(remoteEventTargetsClient(eventClientId = "phone-1", decidedClientId = "phone-1"))
+        assertFalse(remoteEventTargetsClient(eventClientId = "phone-2", decidedClientId = "phone-1"))
+    }
+
+    @Test
+    fun `an unattributable decision takes the whole queue with it`() {
+        // There is no client to ask about next, so leaving entries queued would strand them.
+        assertTrue(remoteEventTargetsClient(eventClientId = "phone-1", decidedClientId = ""))
+        assertTrue(remoteEventTargetsClient(eventClientId = "", decidedClientId = ""))
+    }
+
+    @Test
+    fun `a following instance is recognised among the clients asking`() {
+        assertTrue(isInstanceLinkFollowerClient("overflow-room", setOf("overflow-room", "phone-1")))
+        assertFalse(isInstanceLinkFollowerClient("phone-1", setOf("overflow-room")))
+    }
+
+    @Test
+    fun `an unidentified client is never taken for a follower`() {
+        assertFalse(isInstanceLinkFollowerClient("", setOf("overflow-room")))
+        assertFalse(isInstanceLinkFollowerClient("", emptySet()))
+    }
+
+    // ── Lower-third output folder ───────────────────────────────────────────────
+
+    @Test
+    fun `a real folder is somewhere generated lower thirds can be written`() {
+        val dir = Files.createTempDirectory("cp-main-logic-output").toFile()
+        try {
+            assertTrue(isUsableOutputDir(dir.absolutePath))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `an unset or vanished folder is not`() {
+        // A folder configured once and since moved would otherwise send the generator nowhere.
+        val dir = Files.createTempDirectory("cp-main-logic-output").toFile()
+        try {
+            assertFalse(isUsableOutputDir(""))
+            assertFalse(isUsableOutputDir(File(dir, "gone").absolutePath))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `a file where a folder should be is refused`() {
+        val dir = Files.createTempDirectory("cp-main-logic-output").toFile()
+        try {
+            val file = File(dir, "not-a-folder.json").apply { writeText("{}") }
+            assertFalse(isUsableOutputDir(file.absolutePath))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    // ── Mirrored media ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `a follower streams mirrored media from the primary`() {
+        assertEquals(
+            "http://192.168.1.10:8080/api/media/stream/item-7",
+            instanceLinkMediaStreamUrl("192.168.1.10", 8080, apiKey = "", itemId = "item-7"),
+        )
+    }
+
+    @Test
+    fun `the key travels with the request when the primary requires one`() {
+        assertEquals(
+            "http://192.168.1.10:8080/api/media/stream/item-7?apiKey=s3cret",
+            instanceLinkMediaStreamUrl("192.168.1.10", 8080, apiKey = "s3cret", itemId = "item-7"),
+        )
+    }
+
+    // ── Going live ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `going live raises the output windows, clearing does not`() {
+        Presenting.entries.filter { it != Presenting.NONE }
+            .forEach { assertTrue(shouldShowPresenterWindowFor(it), it.name) }
+        assertFalse(shouldShowPresenterWindowFor(Presenting.NONE))
+    }
+
+    @Test
+    fun `a link that is connecting is not treated as down`() {
+        assertTrue(isInstanceLinkActive(InstanceLinkStatus.CONNECTED))
+        assertTrue(isInstanceLinkActive(InstanceLinkStatus.CONNECTING))
+        assertFalse(isInstanceLinkActive(InstanceLinkStatus.DISCONNECTED))
+    }
+
+    // ── Per-output rendering ────────────────────────────────────────────────────
+
+    @Test
+    fun `each layout has its own background switch`() {
+        val lowerThird = ScreenAssignment(
+            displayMode = Constants.DISPLAY_MODE_LOWER_THIRD_HORIZONTAL,
+            showLowerThirdBackground = false,
+            showFullscreenBackground = true,
+        )
+        assertFalse(showsOutputBackground(lowerThird), "the fullscreen switch must not stand in for it")
+
+        val fullscreen = ScreenAssignment(
+            displayMode = Constants.DISPLAY_MODE_FULLSCREEN,
+            showLowerThirdBackground = false,
+            showFullscreenBackground = true,
+        )
+        assertTrue(showsOutputBackground(fullscreen))
+    }
+
+    @Test
+    fun `an output locked to a tab goes on showing it`() {
+        val locks = mapOf(0 to Presenting.LYRICS)
+        assertEquals(Presenting.LYRICS, effectiveOutputMode(locks, 0, Presenting.BIBLE))
+    }
+
+    @Test
+    fun `an unlocked output follows whatever is live`() {
+        assertEquals(Presenting.BIBLE, effectiveOutputMode(mapOf(0 to Presenting.LYRICS), 1, Presenting.BIBLE))
+        assertEquals(Presenting.BIBLE, effectiveOutputMode(emptyMap(), 0, Presenting.BIBLE))
+    }
+
+    @Test
+    fun `switching between two pieces of content crossfades`() {
+        assertTrue(
+            isScreenCrossfadeActive(
+                BibleSettings(crossfade = true), SongSettings(crossfade = false),
+                Presenting.LYRICS, Presenting.BIBLE,
+            )
+        )
+        assertTrue(
+            isScreenCrossfadeActive(
+                BibleSettings(crossfade = false), SongSettings(crossfade = true),
+                Presenting.LYRICS, Presenting.BIBLE,
+            )
+        )
+    }
+
+    @Test
+    fun `coming from or going to an empty screen is a fade, not a crossfade`() {
+        // The per-type fade settings own that moment; running both would fade twice over it.
+        val on = BibleSettings(crossfade = true)
+        assertFalse(isScreenCrossfadeActive(on, SongSettings(), Presenting.BIBLE, Presenting.NONE))
+        assertFalse(isScreenCrossfadeActive(on, SongSettings(), Presenting.NONE, Presenting.BIBLE))
+    }
+
+    @Test
+    fun `crossfade switched off everywhere cuts`() {
+        assertFalse(
+            isScreenCrossfadeActive(BibleSettings(), SongSettings(), Presenting.LYRICS, Presenting.BIBLE)
+        )
+    }
+
+    @Test
+    fun `the QA code points at the tunnel when there is one`() {
+        // Only the tunnel URL is reachable from a phone that is not on the venue's WiFi.
+        assertEquals("https://abc.trycloudflare.com/qa", qaQrCodeUrl("https://abc.trycloudflare.com", "http://10.0.0.5:8080"))
+    }
+
+    @Test
+    fun `it falls back to the LAN address otherwise`() {
+        assertEquals("http://10.0.0.5:8080/qa", qaQrCodeUrl("", "http://10.0.0.5:8080"))
+    }
+
+    // ── The dev fallback windows ────────────────────────────────────────────────
+
+    @Test
+    fun `a dev machine with nowhere to output falls back to a window`() {
+        assertTrue(isDevWindowedFallback(isRelease = false, forceDevWindow = false, realWindowCount = 0))
+        assertTrue(isDevWindowedFallback(isRelease = true, forceDevWindow = true, realWindowCount = 0))
+    }
+
+    @Test
+    fun `a real output is always preferred to the fallback`() {
+        assertFalse(isDevWindowedFallback(isRelease = false, forceDevWindow = false, realWindowCount = 1))
+        assertFalse(isDevWindowedFallback(isRelease = true, forceDevWindow = true, realWindowCount = 2))
+    }
+
+    @Test
+    fun `a packaged build that did not ask for it gets no stray window`() {
+        assertFalse(isDevWindowedFallback(isRelease = true, forceDevWindow = false, realWindowCount = 0))
+    }
+
+    @Test
+    fun `the fallback opens at least one window, however it is configured`() {
+        assertEquals(1, devFallbackWindowCount(devWindowedFallback = true, configured = 0))
+        assertEquals(1, devFallbackWindowCount(devWindowedFallback = true, configured = 1))
+        assertEquals(3, devFallbackWindowCount(devWindowedFallback = true, configured = 3))
+    }
+
+    @Test
+    fun `no fallback means no windows at all`() {
+        assertEquals(0, devFallbackWindowCount(devWindowedFallback = false, configured = 3))
+    }
+
+    @Test
+    fun `several fallback windows are cascaded rather than stacked`() {
+        assertEquals(40, devFallbackWindowOffsetDp(0))
+        assertTrue(devFallbackWindowOffsetDp(1) > devFallbackWindowOffsetDp(0))
+        assertTrue(devFallbackWindowOffsetDp(2) > devFallbackWindowOffsetDp(1))
+    }
+
+    // ── DeckLink and key outputs ────────────────────────────────────────────────
+
+    @Test
+    fun `an output aimed at SDI is told apart from one aimed at a display`() {
+        assertTrue(isDeckLinkPrimaryOutput(ScreenAssignment(targetType = Constants.TARGET_TYPE_DECKLINK)))
+        assertFalse(isDeckLinkPrimaryOutput(ScreenAssignment(targetType = Constants.TARGET_TYPE_SCREEN)))
+    }
+
+    @Test
+    fun `a key output on SDI needs a device actually chosen`() {
+        val chosen = ScreenAssignment(
+            keyTargetType = Constants.TARGET_TYPE_DECKLINK, keyTargetDisplay = 0,
+        )
+        assertTrue(hasDeckLinkKeyOutput(chosen))
+    }
+
+    @Test
+    fun `a key output left unconfigured drives nothing`() {
+        // KEY_TARGET_NONE is what hasKeyOutput reads as off — nothing may be pushed to a device.
+        val off = ScreenAssignment(keyTargetType = Constants.TARGET_TYPE_DECKLINK)
+        assertFalse(off.hasKeyOutput, "the default must be off")
+        assertFalse(hasDeckLinkKeyOutput(off))
+        assertFalse(hasScreenKeyOutput(off))
+    }
+
+    @Test
+    fun `a key output on a display is not taken for an SDI one`() {
+        val onScreen = ScreenAssignment(keyTargetType = Constants.TARGET_TYPE_SCREEN, keyTargetDisplay = 1)
+        assertTrue(hasScreenKeyOutput(onScreen))
+        assertFalse(hasDeckLinkKeyOutput(onScreen))
+        assertFalse(isDeckLinkKeyOutput(onScreen))
+    }
+
+    @Test
+    fun `an SDI key output is not also driven as a display one`() {
+        // Both windows are spawned from the same assignment, so exactly one may claim it.
+        val onDeckLink = ScreenAssignment(keyTargetType = Constants.TARGET_TYPE_DECKLINK, keyTargetDisplay = 0)
+        assertTrue(hasDeckLinkKeyOutput(onDeckLink))
+        assertFalse(hasScreenKeyOutput(onDeckLink))
+    }
+
+    @Test
+    fun `a key output is placed by its saved bounds, not its saved index`() {
+        // Display indices are reordered by the OS when monitors are plugged or unplugged.
+        assertEquals(2, keyOutputScreenIndex(matchedByBounds = 2, savedIndex = 0))
+    }
+
+    @Test
+    fun `the saved index is the fallback when the bounds match nothing`() {
+        assertEquals(0, keyOutputScreenIndex(matchedByBounds = null, savedIndex = 0))
+    }
+
+    // ── The lower-third playback clock ──────────────────────────────────────────
+
+    @Test
+    fun `a composition runs for its own frame count at its own rate`() {
+        assertEquals(2_000L, lottieCompositionDurationMs(durationFrames = 60f, frameRate = 30f))
+    }
+
+    @Test
+    fun `pre-rendered frames run for as long as they were rendered to last`() {
+        assertEquals(2_000L, lottiePrerenderDurationMs(frameCount = 50, fps = 25))
+    }
+
+    @Test
+    fun `no clip is ever zero-length`() {
+        // A zero total would divide by zero on the very first progress reading.
+        assertEquals(1L, lottieCompositionDurationMs(durationFrames = 0f, frameRate = 30f))
+        assertEquals(1L, lottiePrerenderDurationMs(frameCount = 0, fps = 25))
+    }
+
+    @Test
+    fun `a hold is only honoured on a frame the clip actually has`() {
+        assertTrue(lottieHasPause(pauseAtFrame = true, pauseFrame = 0.5f))
+        assertTrue(lottieHasPause(pauseAtFrame = true, pauseFrame = 0f))
+        assertTrue(lottieHasPause(pauseAtFrame = true, pauseFrame = 1f))
+    }
+
+    @Test
+    fun `a hold outside the clip is dropped rather than clamped`() {
+        assertFalse(lottieHasPause(pauseAtFrame = true, pauseFrame = 1.5f))
+        assertFalse(lottieHasPause(pauseAtFrame = true, pauseFrame = -0.1f))
+        assertFalse(lottieHasPause(pauseAtFrame = false, pauseFrame = 0.5f))
+    }
+
+    @Test
+    fun `the hold starts partway through, and never at all without one`() {
+        assertEquals(1_000L, lottiePauseAtMs(totalDurationMs = 2_000L, pauseFrame = 0.5f, hasPause = true))
+        // -1 is an instant no elapsed time ever reaches, so the plateau can never be entered.
+        assertEquals(-1L, lottiePauseAtMs(totalDurationMs = 2_000L, pauseFrame = 0.5f, hasPause = false))
+    }
+
+    @Test
+    fun `the hold adds to the clip's length on the wall clock`() {
+        assertEquals(5_000L, lottieGrandTotalMs(2_000L, hasPause = true, pauseDurationMs = 3_000L))
+        assertEquals(2_000L, lottieGrandTotalMs(2_000L, hasPause = false, pauseDurationMs = 3_000L))
+    }
+
+    @Test
+    fun `without a hold the clip plays straight through`() {
+        val progress = { ms: Long -> lottieProgressAt(ms, 2_000L, false, 0f, -1L, 0L) }
+        assertEquals(0f, progress(0L))
+        assertEquals(0.5f, progress(1_000L))
+        assertEquals(1f, progress(2_000L))
+    }
+
+    @Test
+    fun `running past the end stays at the end`() {
+        assertEquals(1f, lottieProgressAt(9_999L, 2_000L, false, 0f, -1L, 0L))
+    }
+
+    @Test
+    fun `a held clip plays up to the hold, sits on it, then plays out`() {
+        // 2s clip holding at the halfway frame for 3s: 5s of wall clock in three stretches.
+        val progress = { ms: Long -> lottieProgressAt(ms, 2_000L, true, 0.5f, 1_000L, 3_000L) }
+        assertEquals(0.25f, progress(500L), "before the hold, at the clip's own rate")
+        assertEquals(0.5f, progress(1_000L), "the hold begins")
+        assertEquals(0.5f, progress(2_500L), "still on the same frame midway through the hold")
+        assertEquals(0.5f, progress(3_999L), "still held right up to the end of it")
+        assertEquals(1f, progress(5_000L), "and reaches the last frame exactly as the wall clock does")
+    }
+
+    @Test
+    fun `the stretch after a hold is re-scaled, not resumed at the old rate`() {
+        // The hold has consumed wall-clock time the clip's own timeline knows nothing about, so
+        // playing on at the original rate would run past the end well before the clock did.
+        val progress = { ms: Long -> lottieProgressAt(ms, 2_000L, true, 0.5f, 1_000L, 3_000L) }
+        assertEquals(0.75f, progress(4_500L), "halfway through what is left, halfway through the rest")
+    }
+
+    @Test
+    fun `the stretch before a hold never overruns the held frame`() {
+        // The hold's instant is stored separately from its fraction, so a rounded or edited pair
+        // that disagree must still stop on the frame the hold names rather than sail past it.
+        assertEquals(0.1f, lottieProgressAt(500L, 2_000L, true, 0.1f, 1_000L, 3_000L))
+    }
+
+    @Test
+    fun `progress lands on a real frame at both ends`() {
+        assertEquals(0, lottieFrameIndexFor(0f, frameCount = 50))
+        assertEquals(49, lottieFrameIndexFor(1f, frameCount = 50))
+        assertEquals(25, lottieFrameIndexFor(0.5f, frameCount = 51))
+    }
+
+    @Test
+    fun `a frame index is never off the end of the frames that exist`() {
+        assertEquals(49, lottieFrameIndexFor(1.5f, frameCount = 50))
+        assertEquals(0, lottieFrameIndexFor(-0.5f, frameCount = 50))
+        assertEquals(0, lottieFrameIndexFor(0.5f, frameCount = 1))
+    }
+
+    // ── The open ping ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `an opted-in install is identified across launches`() {
+        assertEquals("install-abc", analyticsInstallId(enabled = true) { "install-abc" })
+    }
+
+    @Test
+    fun `an opted-out install is never given an id to mint`() {
+        // Minting one writes it to disk, so the very id opted out of must not be computed at all.
+        var minted = false
+        assertNull(analyticsInstallId(enabled = false) { minted = true; "install-abc" })
+        assertFalse(minted, "the id must not be created only to be thrown away")
+    }
+
+    // ── Counting the outputs ────────────────────────────────────────────────────
+
+    @Test
+    fun `every display but the primary can take an output`() {
+        assertEquals(listOf(0, 2), nonPrimaryIndices(listOf("left", "builtin", "right"), "builtin"))
+    }
+
+    @Test
+    fun `a machine with only the primary display has nowhere to put one`() {
+        assertEquals(emptyList(), nonPrimaryIndices(listOf("builtin"), "builtin"))
+    }
+
+    @Test
+    fun `displays and SDI devices are both outputs to drive`() {
+        assertEquals(3, presenterWindowCount(nonPrimaryScreens = 2, deckLinkDevices = 1))
+        assertEquals(0, presenterWindowCount(nonPrimaryScreens = 0, deckLinkDevices = 0))
+    }
+
+    @Test
+    fun `the slots past the real outputs are the fallback windows`() {
+        assertFalse(isFallbackWindowSlot(devWindowedFallback = true, index = 0, realWindowCount = 1))
+        assertTrue(isFallbackWindowSlot(devWindowedFallback = true, index = 1, realWindowCount = 1))
+        assertEquals(0, fallbackSlotIndex(index = 1, realWindowCount = 1))
+        assertEquals(2, fallbackSlotIndex(index = 3, realWindowCount = 1))
+    }
+
+    @Test
+    fun `without the fallback no slot is ever one of its windows`() {
+        assertFalse(isFallbackWindowSlot(devWindowedFallback = false, index = 5, realWindowCount = 1))
+    }
+
+    // ── Mirrored caches and signals ─────────────────────────────────────────────
+
+    @Test
+    fun `a picture change on the primary empties the mirrored cache`() {
+        assertTrue(shouldInvalidatePictureCache(1))
+        assertTrue(shouldInvalidatePictureCache(7))
+    }
+
+    @Test
+    fun `the value replayed on subscribe announces nothing`() {
+        assertFalse(shouldInvalidatePictureCache(0))
+    }
+
+    @Test
+    fun `only a signal that moved is a fresh clear`() {
+        assertTrue(isFreshClearSignal(signal = 4, lastSeen = 3))
+        assertFalse(isFreshClearSignal(signal = 3, lastSeen = 3), "re-subscribing must not clear")
+    }
+
+    // ── Media broadcasts ────────────────────────────────────────────────────────
+
+    @Test
+    fun `media going away is announced exactly once`() {
+        assertTrue(shouldBroadcastMediaCleared(isLoaded = false, wasLoaded = true))
+    }
+
+    @Test
+    fun `an idle app does not repeat itself every poll`() {
+        assertFalse(shouldBroadcastMediaCleared(isLoaded = false, wasLoaded = false))
+        assertFalse(shouldBroadcastMediaCleared(isLoaded = true, wasLoaded = true))
+    }
+
+    // ── Remote prompts ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `a long question is cut to what the prompt can show`() {
+        val long = "q".repeat(200)
+        assertEquals(MAX_REMOTE_EVENT_TITLE, remoteEventTitle(long).length)
+    }
+
+    @Test
+    fun `a short question is shown whole`() {
+        assertEquals("Where is the coffee?", remoteEventTitle("Where is the coffee?"))
+        assertEquals("", remoteEventTitle(""))
+    }
+
+    @Test
+    fun `pushing to the schedule is off unless allowed`() {
+        assertFalse(canPushToSchedule(InstanceLinkSettings()))
+        assertTrue(canPushToSchedule(InstanceLinkSettings(allowPushToSchedule = true)))
+    }
+
+    @Test
+    fun `a follower is handed a translation's absolute path`() {
+        val dir = Files.createTempDirectory("cp-main-logic-bibles").toFile()
+        try {
+            val expected = File(dir, "kjv1769.spb").absolutePath
+            assertEquals(expected, bibleFilePath(dir.absolutePath, "kjv1769.spb"))
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    // ── Placing an output on a display ──────────────────────────────────────────
+
+    @Test
+    fun `an index names an attached display, or it does not`() {
+        assertTrue(isScreenIndexValid(0, screenCount = 2))
+        assertTrue(isScreenIndexValid(1, screenCount = 2))
+        assertFalse(isScreenIndexValid(2, screenCount = 2))
+        assertFalse(isScreenIndexValid(-1, screenCount = 2))
+        assertFalse(isScreenIndexValid(0, screenCount = 0))
+    }
+
+    @Test
+    fun `an output explicitly set to none is skipped`() {
+        assertTrue(hasNoPrimaryTarget(ScreenAssignment(targetDisplay = Constants.KEY_TARGET_NONE)))
+    }
+
+    @Test
+    fun `an output left on auto is not taken for one turned off`() {
+        // -1 is "resolve at runtime", which is the default and must still open a window.
+        assertFalse(hasNoPrimaryTarget(ScreenAssignment()), "auto is the default, not none")
+        assertFalse(hasNoPrimaryTarget(ScreenAssignment(targetDisplay = 0)))
+    }
+
+    @Test
+    fun `saved bounds beat a saved index`() {
+        // The OS reorders display indices when monitors are plugged or unplugged; bounds survive it.
+        assertEquals(
+            2,
+            primaryOutputScreenIndex(
+                matchedByBounds = 2, savedDisplay = 0, screenCount = 3, positionalFallback = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `the saved index is used when it still names an attached display`() {
+        assertEquals(
+            1,
+            primaryOutputScreenIndex(
+                matchedByBounds = null, savedDisplay = 1, screenCount = 3, positionalFallback = 2,
+            ),
+        )
+    }
+
+    @Test
+    fun `a saved index for a display no longer attached falls back to position`() {
+        // A configuration written on a different machine still lands somewhere rather than nowhere.
+        assertEquals(
+            2,
+            primaryOutputScreenIndex(
+                matchedByBounds = null, savedDisplay = 9, screenCount = 3, positionalFallback = 2,
+            ),
+        )
+    }
+
+    @Test
+    fun `an output with nothing usable left opens no window`() {
+        assertNull(
+            primaryOutputScreenIndex(
+                matchedByBounds = null, savedDisplay = 9, screenCount = 3, positionalFallback = null,
+            ),
+        )
+    }
+
+    // ── The main window's own geometry ──────────────────────────────────────────
+
+    @Test
+    fun `a floating window reopens at the size it was left`() {
+        assertEquals(
+            1280 to 800,
+            startupWindowSize(
+                isFloating = true, savedWidth = 1280, savedHeight = 800,
+                primaryWidth = 3840, primaryHeight = 2160,
+            ),
+        )
+    }
+
+    @Test
+    fun `a maximized window takes the primary display's size instead`() {
+        // A size saved on a monitor since unplugged must not strand it at a shape nothing can show.
+        assertEquals(
+            3840 to 2160,
+            startupWindowSize(
+                isFloating = false, savedWidth = 1280, savedHeight = 800,
+                primaryWidth = 3840, primaryHeight = 2160,
+            ),
+        )
+    }
+
+    @Test
+    fun `a window with geometry worth restoring reopens where it was`() {
+        assertEquals(
+            120 to 60,
+            startupWindowPosition(
+                restoreGeometry = true, savedX = 120, savedY = 60, primaryX = -1920, primaryY = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `otherwise it opens on the primary display, not at the desktop origin`() {
+        // On a multi-monitor desktop the origin can belong to a different display entirely.
+        assertEquals(
+            -1920 to 0,
+            startupWindowPosition(
+                restoreGeometry = false, savedX = 120, savedY = 60, primaryX = -1920, primaryY = 0,
+            ),
+        )
     }
 }


### PR DESCRIPTION
Introduce a set of pure helper functions and constants in MainLogic.kt (remoteSongLineIndex, shouldSwitchToLyrics, shouldClearAfterLowerThird, shouldBroadcastSongSection, shouldBroadcastDisplayCleared, isControllerConnected, remoteActionType, MIN_TRANSITION_MS, modeCrossfadeDuration, isAnyScreenLockedTo, shouldFadeOnClear, fadeOutDuration, MIN_ANNOUNCEMENT_DISPLAY_MS, isFadeAnnouncement, isSlidingAnnouncement, shouldFadeOutAnnouncement, isFiniteAnnouncementLoop, announcementDisplayMs). Replace in-main logic in main.kt with these helpers and compute modeCrossfadeDuration / fade behaviour centrally. Add comprehensive unit tests in MainLogicTest.kt to cover the new behaviour (remote actions, transitions, fades, announcements, instance-link role checks). Improves clarity, testability and reduces duplicated inline logic.