### PR TITLE
Support multi-language song section headers

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SongChordPreview.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SongChordPreview.kt
@@ -50,6 +50,8 @@ import churchpresenter.composeapp.generated.resources.song_transpose_up
 import org.churchpresenter.app.churchpresenter.models.LyricSection
 import org.churchpresenter.app.churchpresenter.utils.ChordSegment
 import org.churchpresenter.app.churchpresenter.utils.ChordTransposer
+import org.churchpresenter.app.churchpresenter.utils.SongSectionWordGroup
+import org.churchpresenter.app.churchpresenter.utils.SongSectionWords
 import org.jetbrains.compose.resources.stringResource
 
 /** How a section reads in the preview — the colour tells verses from choruses at a glance. */
@@ -66,31 +68,21 @@ data class PreviewSection(
 data class SongStats(val sections: Int, val lines: Int, val words: Int)
 
 /**
- * The words a header may open with, per kind, in the languages song files actually arrive in — the
- * same set `ChordSheetImporter` canonicalises by, so a song written with Russian markers colours
- * like the English one it would import to. Verse is the fallback and needs no list.
- *
- * Order is the match order: no word here is a prefix of one in a later kind, so it is only a
- * reading aid today, but a new word has to be checked against it.
- */
-private val SECTION_WORDS: List<Pair<SongSectionKind, List<String>>> = listOf(
-    SongSectionKind.CHORUS to listOf("chorus", "refrain", "припев", "приспів"),
-    SongSectionKind.BRIDGE to listOf("bridge", "бридж", "мост", "міст"),
-    SongSectionKind.TAG to listOf("tag", "outro", "ending", "кода", "концовка", "закінчення"),
-)
-
-/**
  * Which kind of section a header names.
  *
- * Matched on the section words the song format itself uses — these are file markers, not interface
- * text, so they are not translated, but the same file may write them in its own language. Anything
- * unrecognised reads as a verse, which is what an unlabelled block is anyway; that also covers
- * "Pre-Chorus", which is deliberately not a chorus here.
+ * Matched on the section words the song format itself uses, in every language at once — see
+ * [SongSectionWords], which the wrapping and importing sides read too, so a song written with
+ * Polish or Russian markers colours like the English one it would import to.
+ *
+ * Only the four kinds that have an ink of their own are distinguished. Everything else — an intro,
+ * an instrumental, a pre-chorus, an unrecognised name — reads as a verse, which is what an
+ * unlabelled block is anyway.
  */
-fun sectionKindOf(label: String): SongSectionKind {
-    val l = label.trim().lowercase()
-    return SECTION_WORDS.firstOrNull { (_, words) -> words.any { l.startsWith(it) } }?.first
-        ?: SongSectionKind.VERSE
+fun sectionKindOf(label: String): SongSectionKind = when (SongSectionWords.groupOf(label)) {
+    SongSectionWordGroup.CHORUS -> SongSectionKind.CHORUS
+    SongSectionWordGroup.BRIDGE -> SongSectionKind.BRIDGE
+    SongSectionWordGroup.TAG -> SongSectionKind.TAG
+    else -> SongSectionKind.VERSE
 }
 
 /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SongChordPreview.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SongChordPreview.kt
@@ -66,20 +66,31 @@ data class PreviewSection(
 data class SongStats(val sections: Int, val lines: Int, val words: Int)
 
 /**
+ * The words a header may open with, per kind, in the languages song files actually arrive in — the
+ * same set `ChordSheetImporter` canonicalises by, so a song written with Russian markers colours
+ * like the English one it would import to. Verse is the fallback and needs no list.
+ *
+ * Order is the match order: no word here is a prefix of one in a later kind, so it is only a
+ * reading aid today, but a new word has to be checked against it.
+ */
+private val SECTION_WORDS: List<Pair<SongSectionKind, List<String>>> = listOf(
+    SongSectionKind.CHORUS to listOf("chorus", "refrain", "припев", "приспів"),
+    SongSectionKind.BRIDGE to listOf("bridge", "бридж", "мост", "міст"),
+    SongSectionKind.TAG to listOf("tag", "outro", "ending", "кода", "концовка", "закінчення"),
+)
+
+/**
  * Which kind of section a header names.
  *
- * Matched on the English section words the song format itself uses — these are file markers, not
- * interface text, so they are not translated. Anything unrecognised reads as a verse, which is what
- * an unlabelled block is anyway.
+ * Matched on the section words the song format itself uses — these are file markers, not interface
+ * text, so they are not translated, but the same file may write them in its own language. Anything
+ * unrecognised reads as a verse, which is what an unlabelled block is anyway; that also covers
+ * "Pre-Chorus", which is deliberately not a chorus here.
  */
 fun sectionKindOf(label: String): SongSectionKind {
     val l = label.trim().lowercase()
-    return when {
-        l.startsWith("chorus") || l.startsWith("refrain") -> SongSectionKind.CHORUS
-        l.startsWith("bridge") -> SongSectionKind.BRIDGE
-        l.startsWith("tag") || l.startsWith("outro") || l.startsWith("ending") -> SongSectionKind.TAG
-        else -> SongSectionKind.VERSE
-    }
+    return SECTION_WORDS.firstOrNull { (_, words) -> words.any { l.startsWith(it) } }?.first
+        ?: SongSectionKind.VERSE
 }
 
 /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Songs.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Songs.kt
@@ -2,6 +2,8 @@ package org.churchpresenter.app.churchpresenter.data
 
 import androidx.compose.runtime.mutableStateListOf
 import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.utils.SongSectionWords
+import org.churchpresenter.app.churchpresenter.utils.isHeaderLine
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
@@ -231,11 +233,15 @@ class Songs {
         return lyrics
     }
 
+    /**
+     * Brackets a bare header line — SQLite and SPS write "Куплет 1" or "Zwrotka 1" plain, while the
+     * rest of the app reads `[]`/`{}`. Recognised in every language at once; see [SongSectionWords].
+     */
     private fun wrapSectionHeader(line: String): String {
         val t = line.trim()
         return when {
-            t.matches(Regex("^(Припев|Chorus|Refrain).*", RegexOption.IGNORE_CASE)) -> "{$t}"
-            t.matches(Regex("^(Куплет|Verse|Bridge).*", RegexOption.IGNORE_CASE)) -> "[$t]"
+            SongSectionWords.isChorus(t) -> "{$t}"
+            SongSectionWords.isKnownSection(t) -> "[$t]"
             else -> line
         }
     }
@@ -383,7 +389,7 @@ class Songs {
      * Format lyrics list back to SPS format
      * Converts List<String> back to the @$ and @% delimited format
      */
-    private fun formatLyricsForSps(lyrics: List<String>): String {
+    internal fun formatLyricsForSps(lyrics: List<String>): String {
         if (lyrics.isEmpty()) return ""
 
         val result = StringBuilder()
@@ -392,8 +398,10 @@ class Songs {
         for (line in lyrics) {
             val trimmedLine = line.trim()
 
-            // Check if this is a section marker ([Куплет], {Припев}, etc.)
-            if (trimmedLine.matches(Regex("^[\\[{](Куплет|Припев|Verse|Chorus|Refrain|Bridge).*[\\]}]$", RegexOption.IGNORE_CASE))) {
+            // A section marker is any bracketed line — [Куплет], {Припев}, [Zwrotka 1], and equally
+            // a name this app has no word for. Matching on a word list here instead would write
+            // every unrecognised header back out as a lyric line, brackets and all.
+            if (isHeaderLine(trimmedLine)) {
                 // If we have accumulated lines, save them as a section
                 if (currentSection.isNotEmpty()) {
                     if (result.isNotEmpty()) result.append("@\$")

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
@@ -1611,11 +1611,11 @@ fun SongsTab(
                                     )
                                     .padding(8.dp)
                             ) {
-                                Text(
-                                    text = stringResource(Res.string.song_title_slide),
-                                    style = MaterialTheme.typography.labelSmall,
-                                    color = MaterialTheme.colorScheme.secondary,
-                                    modifier = Modifier.padding(bottom = 2.dp)
+                                // Same chip the lyric sections use, so the title slide reads as
+                                // one more entry in the list rather than a differently-styled one.
+                                SectionLabelRow(
+                                    label = stringResource(Res.string.song_title_slide),
+                                    modifier = Modifier.padding(vertical = 4.dp),
                                 )
                                 Text(
                                     text = titleLine,
@@ -1632,7 +1632,6 @@ fun SongsTab(
                                     )
                                 }
                             }
-                            HorizontalDivider(thickness = 1.dp, color = MaterialTheme.colorScheme.outlineVariant)
                         }
                     }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ChordSheetImporter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ChordSheetImporter.kt
@@ -16,22 +16,6 @@ package org.churchpresenter.app.churchpresenter.utils
  */
 object ChordSheetImporter {
 
-    /**
-     * Section words, in the languages these sheets actually arrive in, mapped onto the markers the
-     * app parses. Canonicalised to English on purpose: [isChorusHeader] keys the chorus off braces,
-     * and the preview colours sections by the English words in `sectionKindOf`.
-     */
-    private val SECTION_WORDS: List<Pair<Regex, String>> = listOf(
-        // Pre-chorus has to be tested before chorus, or it matches as a plain chorus.
-        Regex("pre[- ]?chorus|предприпев|передприспів") to "Pre-Chorus",
-        Regex("chorus|refrain|припев|приспів") to "Chorus",
-        Regex("bridge|бридж|мост|міст") to "Bridge",
-        Regex("intro|интро|вступление|вступ") to "Intro",
-        Regex("instrumental|проигрыш|програш") to "Instrumental",
-        Regex("tag|outro|ending|кода|концовка|закінчення") to "Tag",
-        Regex("verse|куплет") to "Verse",
-    )
-
     private val URL = Regex("^\\s*https?://\\S+\\s*$")
 
     /** Splits a line into its whitespace-separated tokens with the column each one starts on. */
@@ -51,21 +35,24 @@ object ChordSheetImporter {
         return tokens.size >= 2 || tokens.first().length >= 2 || line.first().isWhitespace()
     }
 
-    /** The marker a section heading becomes, or null when the line is not a heading. */
+    /**
+     * The marker a section heading becomes, or null when the line is not a heading.
+     *
+     * Canonicalised to English on purpose — [isChorusHeader] keys the chorus off braces, and
+     * everything downstream reads the marker rather than the language it was written in. The words
+     * themselves come from [SongSectionWords], shared with the parser and the preview's colouring.
+     */
     fun sectionMarkerOf(line: String, verseCounter: () -> Int): String? {
         val t = line.trim()
         if (t.isEmpty()) return null
         // Already in the app's own form — take it as it stands.
         if (ChordTransposer.isSectionHeader(t)) return t
-        // A heading is short and names a section; a lyric line that merely contains the word is not.
-        if (t.length > 32) return null
-        val lower = t.lowercase()
-        val (_, name) = SECTION_WORDS.firstOrNull { (pattern, _) -> pattern.containsMatchIn(lower) }
-            ?: return null
-        if (name == "Chorus") return "{Chorus}"
-        if (name != "Verse") return "[$name]"
+        val group = SongSectionWords.looseGroupOf(t) ?: return null
+        val name = SongSectionWords.CANONICAL.getValue(group)
+        if (group == SongSectionWordGroup.CHORUS) return "{$name}"
+        if (group != SongSectionWordGroup.VERSE) return "[$name]"
         val number = Regex("\\d+").find(t)?.value?.toIntOrNull() ?: verseCounter()
-        return "[Verse $number]"
+        return "[$name $number]"
     }
 
     /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SongSectionWords.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SongSectionWords.kt
@@ -1,0 +1,109 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+/** The kind of section a header word names, before it is narrowed to a colour or a bracket. */
+enum class SongSectionWordGroup { PRE_CHORUS, CHORUS, BRIDGE, TAG, INTRO, INSTRUMENTAL, VERSE }
+
+/**
+ * The words a song file may name a section with, in the languages songbooks actually arrive in.
+ *
+ * These are **file markers, not interface text**, so they deliberately do not come from string
+ * resources: a Russian songbook has to parse for an operator running the app in English, and a
+ * Polish one for an operator running it in Russian. Every language is matched at once, always,
+ * independently of the chosen locale — keying them off the UI language would be exactly backwards.
+ *
+ * The single source of truth for the three places that read section words: [SongSectionWords.isChorus]
+ * decides `{}` vs `[]` when wrapping a bare header, `sectionKindOf` colours the chip from
+ * [SongSectionWords.groupOf], and `ChordSheetImporter` canonicalises to English from [CANONICAL].
+ */
+object SongSectionWords {
+
+    /**
+     * Ordered, because pre-chorus has to be tested before chorus or it matches as a plain one.
+     * Words are lowercase; matching lowercases the header first.
+     */
+    private val WORDS: List<Pair<SongSectionWordGroup, List<String>>> = listOf(
+        SongSectionWordGroup.PRE_CHORUS to listOf(
+            "pre-chorus", "prechorus", "pre chorus", "предприпев", "передприспів", "przedrefren",
+        ),
+        SongSectionWordGroup.CHORUS to listOf(
+            "chorus", "refrain", "припев", "припеў", "приспів", "refren", "refrén", "refrein",
+            "refrään", "kehrvers", "estribillo", "estribilho", "refrão", "coro", "қайырма",
+        ),
+        SongSectionWordGroup.BRIDGE to listOf(
+            "bridge", "бридж", "мост", "міст", "most", "brücke", "puente", "ponte", "brug",
+            "punte", "көпір", "sild",
+        ),
+        SongSectionWordGroup.TAG to listOf(
+            "tag", "outro", "ending", "coda", "кода", "концовка", "закінчення", "zakończenie",
+            "závěr", "záver", "schluss", "slot", "finale", "final",
+        ),
+        SongSectionWordGroup.INTRO to listOf(
+            "intro", "интро", "вступление", "вступ", "wstęp", "einleitung",
+        ),
+        SongSectionWordGroup.INSTRUMENTAL to listOf(
+            "instrumental", "проигрыш", "програш", "przegrywka",
+        ),
+        SongSectionWordGroup.VERSE to listOf(
+            "verse", "vers", "verso", "куплет", "куплэт", "zwrotka", "strophe", "strofa",
+            "estrofa", "estrofe", "couplet", "sloka", "salm", "шумақ",
+        ),
+    )
+
+    /**
+     * What a header may carry after its word: a number, punctuation, a repeat count, a
+     * parenthetical — "Verse 2", "Припев:", "Chorus 2x", "Припев (2 раза)".
+     *
+     * Anything that runs on into further words is a lyric that merely opens with the word, not a
+     * header: "Most of all I love you", "Refrain from evil", "Bridge over troubled water". That
+     * distinction is what lets the list above carry short, common words like `most` and `slot`
+     * without swallowing English lyrics.
+     */
+    private val HEADER_TAIL = Regex(
+        "^[^\\p{L}]*(?:[xх][^\\p{L}]*)?(?:\\(.*\\)|\\[.*\\])?[^\\p{L}]*$",
+        RegexOption.IGNORE_CASE,
+    )
+
+    /** The canonical English name each group is written as when a chord sheet is imported. */
+    val CANONICAL: Map<SongSectionWordGroup, String> = mapOf(
+        SongSectionWordGroup.PRE_CHORUS to "Pre-Chorus",
+        SongSectionWordGroup.CHORUS to "Chorus",
+        SongSectionWordGroup.BRIDGE to "Bridge",
+        SongSectionWordGroup.TAG to "Tag",
+        SongSectionWordGroup.INTRO to "Intro",
+        SongSectionWordGroup.INSTRUMENTAL to "Instrumental",
+        SongSectionWordGroup.VERSE to "Verse",
+    )
+
+    /**
+     * Which group [label] names, or null when no language's word opens it.
+     *
+     * [label] is the bare header — any `[]`/`{}` already off it.
+     */
+    fun groupOf(label: String): SongSectionWordGroup? {
+        val l = label.trim().lowercase()
+        if (l.isEmpty()) return null
+        return WORDS.firstOrNull { (_, words) ->
+            words.any { w -> l.startsWith(w) && HEADER_TAIL.matches(l.substring(w.length)) }
+        }?.first
+    }
+
+    /** True when [label] names a chorus — a pre-chorus deliberately does not count as one. */
+    fun isChorus(label: String): Boolean = groupOf(label) == SongSectionWordGroup.CHORUS
+
+    /** True when [label] names any section this app knows a word for. */
+    fun isKnownSection(label: String): Boolean = groupOf(label) != null
+
+    /**
+     * The group a free-text chord-sheet heading names, matched loosely — the word may sit anywhere
+     * in a short line ("2. Zwrotka", "CHORUS:"), which a sheet written by hand often does.
+     *
+     * Length-capped because a lyric line that merely contains the word is not a heading; the strict
+     * [groupOf] cannot be used here because such a sheet has no brackets to anchor on.
+     */
+    fun looseGroupOf(line: String, maxLength: Int = 32): SongSectionWordGroup? {
+        val t = line.trim()
+        if (t.isEmpty() || t.length > maxLength) return null
+        val l = t.lowercase()
+        return WORDS.firstOrNull { (_, words) -> words.any { l.contains(it) } }?.first
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SongChartTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SongChartTest.kt
@@ -48,6 +48,19 @@ class SongChartTest {
         assertEquals(SongSectionKind.VERSE, sectionKindOf("Something Else"))
     }
 
+    @Test
+    fun `a section written in its own language is coloured the same as the English one`() {
+        assertEquals(SongSectionKind.CHORUS, sectionKindOf("Припев"))
+        assertEquals(SongSectionKind.CHORUS, sectionKindOf("Приспів 2"))
+        assertEquals(SongSectionKind.BRIDGE, sectionKindOf("Мост"))
+        assertEquals(SongSectionKind.TAG, sectionKindOf("Кода"))
+        // A verse is the fallback, so it lands right whether or not its word is listed.
+        assertEquals(SongSectionKind.VERSE, sectionKindOf("Куплет 1"))
+        // Pre-chorus is not a chorus in either language — both read as a verse.
+        assertEquals(SongSectionKind.VERSE, sectionKindOf("Pre-Chorus"))
+        assertEquals(SongSectionKind.VERSE, sectionKindOf("Предприпев"))
+    }
+
     // ── Counting ────────────────────────────────────────────────────────────────
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SongsSqliteLoadingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SongsSqliteLoadingTest.kt
@@ -226,26 +226,18 @@ class SongsSqliteLoadingTest {
         )
     }
 
-    /**
-     * Documents a KNOWN GAP: a heading is recognised by prefix alone, so a sung line that happens to
-     * begin with one of the heading words is wrapped as though it were a heading.
-     *
-     * `"Chorus of angels sing"` becomes `"{Chorus of angels sing}"`, and the braces are then shown
-     * on screen as part of the lyric. Any English line opening with "Verse", "Chorus", "Refrain" or
-     * "Bridge" is affected, and the same applies to the text format (both share `wrapSectionHeader`).
-     * The fix is to require the rest of the line to be a section number or nothing at all; this
-     * expectation then becomes the line left untouched.
-     */
     @Test
-    fun `a lyric line that opens with a heading word is wrapped as a heading -- known gap`() {
+    fun `a lyric line that opens with a heading word is left alone`() {
+        // A heading names its section and stops; a line that runs on into more words is sung, not a
+        // heading. Without that rule "Chorus of angels sing" was wrapped and the braces reached the
+        // screen as part of the projected line.
         val songs = loadSqlite(
             Row(number = "1", title = "Unlucky", songText = "Verse 1\nChorus of angels sing"),
         )
 
         assertEquals(
-            listOf("[Verse 1]", "{Chorus of angels sing}"),
+            listOf("[Verse 1]", "Chorus of angels sing"),
             songs.getSongs().single().lyrics,
-            "current behaviour: the braces reach the screen as part of the projected line",
         )
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SongsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SongsTest.kt
@@ -281,13 +281,31 @@ class SongsTest {
 
     @Test
     fun `a section with an unrecognised heading is left as written`() {
-        val songs = load(row("1", "Odd", lyrics = lyrics(listOf("Intro", "spoken line"))))
+        val songs = load(row("1", "Odd", lyrics = lyrics(listOf("Tacet", "spoken line"))))
 
         assertEquals(
-            listOf("Intro", "spoken line"),
+            listOf("Tacet", "spoken line"),
             songs.getSongs().single().lyrics,
             "an unknown heading is neither a verse nor a chorus, so it is shown as it stands",
         )
+    }
+
+    @Test
+    fun `a heading written in another language is wrapped like the english one`() {
+        val songs = load(
+            row("1", "Polska", lyrics = lyrics(listOf("Zwrotka 1", "a"), listOf("Refren", "b"))),
+        )
+
+        val text = songs.getSongs().single().lyrics
+        assertTrue("[Zwrotka 1]" in text, text.toString())
+        assertTrue("{Refren}" in text, text.toString())
+    }
+
+    @Test
+    fun `an intro is a section in its own right`() {
+        val songs = load(row("1", "Lead-in", lyrics = lyrics(listOf("Intro", "spoken line"))))
+
+        assertEquals(listOf("[Intro]", "spoken line"), songs.getSongs().single().lyrics)
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SpsSectionRoundTripTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SpsSectionRoundTripTest.kt
@@ -1,0 +1,56 @@
+package org.churchpresenter.app.churchpresenter.data
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SpsSectionRoundTripTest {
+
+    private val songs = Songs()
+
+    /** Sections as SPS writes them: `@$` between sections, `@%` between lines. */
+    private fun sections(sps: String): List<List<String>> =
+        sps.split("@\$").map { it.split("@%") }
+
+    @Test
+    fun `an english song keeps its sections when written back`() {
+        val sps = songs.formatLyricsForSps(
+            listOf("[Verse 1]", "Amazing grace", "", "{Chorus}", "My chains are gone"),
+        )
+        assertEquals(
+            listOf(
+                listOf("Verse 1", "Amazing grace"),
+                listOf("Chorus", "My chains are gone"),
+            ),
+            sections(sps),
+        )
+    }
+
+    @Test
+    fun `a polish song keeps its sections when written back`() {
+        // Before the header rule was widened this wrote "[Zwrotka 1]" out as a lyric line,
+        // brackets and all, folding the whole song into one section.
+        val sps = songs.formatLyricsForSps(
+            listOf("[Zwrotka 1]", "Cudowna Boża łaska ta", "", "{Refren}", "Me więzy spadły"),
+        )
+        assertEquals(
+            listOf(
+                listOf("Zwrotka 1", "Cudowna Boża łaska ta"),
+                listOf("Refren", "Me więzy spadły"),
+            ),
+            sections(sps),
+        )
+    }
+
+    @Test
+    fun `a header this app has no word for is still a header`() {
+        // Bracket-based, so a name from a language or tradition nobody listed survives too.
+        val sps = songs.formatLyricsForSps(listOf("[Tacet]", "one", "", "[Vamp]", "two"))
+        assertEquals(listOf(listOf("Tacet", "one"), listOf("Vamp", "two")), sections(sps))
+    }
+
+    @Test
+    fun `a lyric line carrying a chord is not mistaken for a header`() {
+        val sps = songs.formatLyricsForSps(listOf("[Verse 1]", "[G]Amazing grace", "how sweet"))
+        assertEquals(listOf(listOf("Verse 1", "[G]Amazing grace", "how sweet")), sections(sps))
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabChartAndTitleSlideTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabChartAndTitleSlideTest.kt
@@ -17,7 +17,8 @@ import kotlin.test.assertTrue
  */
 class SongsTabChartAndTitleSlideTest {
 
-    private val TITLE_SLIDE = "Song Title Slide"
+    /** Upper-cased on screen: the title slide wears the same section chip a verse does. */
+    private val TITLE_SLIDE = "SONG TITLE SLIDE"
 
     private val chordedSong = listOf(
         SongFixture(

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabLyricsClickTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabLyricsClickTest.kt
@@ -36,13 +36,16 @@ class SongsTabLyricsClickTest {
 
     private val lyricLine = "a line of Amazing Grace"
 
+    /** Upper-cased on screen: the title slide wears the same section chip a verse does. */
+    private val TITLE_SLIDE = "SONG TITLE SLIDE"
+
     // ── Title slide ─────────────────────────────────────────────────────────────
 
     @Test
     fun `clicking the title slide selects it and previews it, without going live`() =
         songsTab(songSettings = SongSettings(titleSlideEnabled = true)) { _, reports ->
             clickRow("Amazing Grace")
-            onNodeWithText("Song Title Slide").performClick()
+            onNodeWithText(TITLE_SLIDE).performClick()
             waitForIdle()
 
             assertEquals(0, reports.sectionIndex)
@@ -61,9 +64,9 @@ class SongsTabLyricsClickTest {
     fun `double-clicking the title slide sends it live`() =
         songsTab(songSettings = SongSettings(titleSlideEnabled = true)) { _, reports ->
             clickRow("Amazing Grace")
-            onNodeWithText("Song Title Slide").performClick()
+            onNodeWithText(TITLE_SLIDE).performClick()
             waitForIdle()
-            onNodeWithText("Song Title Slide").performClick()
+            onNodeWithText(TITLE_SLIDE).performClick()
             waitForIdle()
 
             assertEquals(listOf(Presenting.LYRICS), reports.presenting)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/SongSectionWordsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/SongSectionWordsTest.kt
@@ -1,0 +1,100 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SongSectionWordsTest {
+
+    // ── Recognising a section across languages ──────────────────────────────────
+
+    @Test
+    fun `english section words name their group`() {
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.groupOf("Verse 1"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Chorus"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Refrain"))
+        assertEquals(SongSectionWordGroup.BRIDGE, SongSectionWords.groupOf("Bridge"))
+        assertEquals(SongSectionWordGroup.TAG, SongSectionWords.groupOf("Outro"))
+        assertEquals(SongSectionWordGroup.INTRO, SongSectionWords.groupOf("Intro"))
+    }
+
+    @Test
+    fun `a section written in its own language names the same group`() {
+        // ru / uk / be — what the format already carried
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.groupOf("Куплет 1"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Припев"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Приспів 2"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Припеў"))
+        assertEquals(SongSectionWordGroup.BRIDGE, SongSectionWords.groupOf("Мост"))
+        // pl / de / cs — new
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.groupOf("Zwrotka 1"))
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.groupOf("Strophe 2"))
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.groupOf("Sloka"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Refren"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Kehrvers"))
+        // es / pt / fr / nl
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Estribillo"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Refrão"))
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.groupOf("Couplet 3"))
+        assertEquals(SongSectionWordGroup.BRIDGE, SongSectionWords.groupOf("Puente"))
+    }
+
+    @Test
+    fun `pre-chorus is not a chorus in any language`() {
+        assertEquals(SongSectionWordGroup.PRE_CHORUS, SongSectionWords.groupOf("Pre-Chorus"))
+        assertEquals(SongSectionWordGroup.PRE_CHORUS, SongSectionWords.groupOf("Предприпев"))
+        assertFalse(SongSectionWords.isChorus("Pre-Chorus"))
+        assertTrue(SongSectionWords.isChorus("Chorus"))
+    }
+
+    // ── Not mistaking a lyric for a header ──────────────────────────────────────
+
+    @Test
+    fun `a lyric that opens with a section word is not a header`() {
+        // "most" is Polish and Czech for bridge, "slot" Dutch for ending, "final" Spanish —
+        // short words that open real English lines. The tail rule is what keeps them apart.
+        assertNull(SongSectionWords.groupOf("Most of all I love you Lord"))
+        assertNull(SongSectionWords.groupOf("Refrain from evil"))
+        assertNull(SongSectionWords.groupOf("Bridge over troubled water"))
+        assertNull(SongSectionWords.groupOf("Tag along with me"))
+        assertNull(SongSectionWords.groupOf("Version of the truth"))
+        assertNull(SongSectionWords.groupOf("Final answer to the question"))
+        assertNull(SongSectionWords.groupOf("Coronation day is here"))
+    }
+
+    @Test
+    fun `a header may carry a number, punctuation or a repeat count`() {
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.groupOf("Verse 2"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Припев:"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Chorus 2x"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.groupOf("Припев (2 раза)"))
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.groupOf("  verse 1  "))
+    }
+
+    @Test
+    fun `an unknown name and an empty line name nothing`() {
+        assertNull(SongSectionWords.groupOf("Tacet"))
+        assertNull(SongSectionWords.groupOf(""))
+        assertNull(SongSectionWords.groupOf("   "))
+        assertFalse(SongSectionWords.isKnownSection("Tacet"))
+    }
+
+    // ── The looser rule chord sheets are read by ────────────────────────────────
+
+    @Test
+    fun `a chord sheet heading is found wherever the word sits in a short line`() {
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.looseGroupOf("1 куплет:"))
+        assertEquals(SongSectionWordGroup.VERSE, SongSectionWords.looseGroupOf("2. Zwrotka"))
+        assertEquals(SongSectionWordGroup.CHORUS, SongSectionWords.looseGroupOf("CHORUS:"))
+    }
+
+    @Test
+    fun `a long line naming a section is not a chord sheet heading`() {
+        assertNull(
+            SongSectionWords.looseGroupOf("and then the chorus rang out across the whole room"),
+        )
+        assertNull(SongSectionWords.looseGroupOf(""))
+    }
+}


### PR DESCRIPTION
Add a SECTION_WORDS map and use it in sectionKindOf to recognise chorus/bridge/tag headers in other languages (Russian/Ukrainian), matching ChordSheetImporter canonicalisation. Keep unrecognised labels (and Pre-Chorus) as VERSE. Update unit tests to assert multilingual matches. Also make the SongsTab title slide use the same SectionLabelRow chip for visual consistency and remove the extra divider. This unifies parsing and presentation of section headers across localized song files.