### PR TITLE
Cover the batch add-to-schedule approval path

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerRemoteControlTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerRemoteControlTest.kt
@@ -730,6 +730,76 @@ class CompanionServerRemoteControlTest {
     }
 
     @Test
+    fun `a batch reaches the operator as one prompt carrying every item`() {
+        // "Add the whole set" from a phone. It is one approval for the lot, not one per item — the
+        // operator would otherwise face six dialogs while the service is running.
+        val asked = playOperator()
+
+        val ack = sendOverWebSocket(
+            command(
+                Constants.WS_CMD_ADD_BATCH_TO_SCHEDULE,
+                """{"items":[{"songNumber":42,"title":"Amazing Grace"},""" +
+                    """{"bookName":"John","chapter":3,"verseNumber":16},""" +
+                    """{"url":"https://example.org"}]}""",
+                commandId = "cmd-batch",
+            ),
+        ).ackFor("cmd-batch")
+
+        assertEquals(3, asked.size, "every item in the batch has to reach the prompt: $asked")
+        assertIs<ScheduleItem.SongItem>(asked[0])
+        assertIs<ScheduleItem.BibleVerseItem>(asked[1])
+        assertEquals(true, assertNotNull(ack).ok)
+        assertEquals(
+            "pending_approval",
+            ack.reason,
+            "the ack goes back before the operator has answered, so it cannot claim the items landed",
+        )
+    }
+
+    @Test
+    fun `an approved batch tells the phone it went through`() {
+        playOperator(allow = true)
+
+        val replies = sendOverWebSocket(
+            command(Constants.WS_CMD_ADD_BATCH_TO_SCHEDULE, """{"items":[{"songNumber":42}]}"""),
+        )
+
+        assertTrue(replies.any { """"ok":true""" in it }, "the mobile app watches for this reply: $replies")
+    }
+
+    @Test
+    fun `a refused batch tells the phone it was refused`() {
+        // Without this the phone cannot tell refusal from a lost connection, and the volunteer
+        // presses Add again.
+        collecting(server.onAddBatchToSchedule) { it.decision.complete(false) }
+
+        val replies = sendOverWebSocket(
+            command(Constants.WS_CMD_ADD_BATCH_TO_SCHEDULE, """{"items":[{"songNumber":42}]}"""),
+        )
+
+        assertTrue(replies.any { """"reason":"denied"""" in it }, "$replies")
+    }
+
+    @Test
+    fun `entries the desktop cannot place are dropped and the rest of the batch still goes`() {
+        // A newer phone can send an item type this desktop has no mapping for. Dropping the batch
+        // wholesale would lose five good items to one unknown one; dropping only what cannot be
+        // placed is the behaviour, and the operator sees what survived rather than a silent refusal.
+        val asked = playOperator()
+
+        sendOverWebSocket(
+            command(
+                Constants.WS_CMD_ADD_BATCH_TO_SCHEDULE,
+                """{"items":[{"displayText":"something this build has never heard of"},""" +
+                    """{"songNumber":7,"title":"Be Thou My Vision"}]}""",
+            ),
+        )
+
+        assertEquals(1, asked.size, "the unplaceable entry should be dropped, not the batch: $asked")
+        assertEquals(7, assertIs<ScheduleItem.SongItem>(asked.single()).songNumber)
+    }
+
+    @Test
     fun `removing a schedule item asks the operator, naming the row`() {
         server.updateSchedule(
             listOf(ScheduleItem.SongItem(id = "row-1", songNumber = 42, title = "Amazing Grace", songbook = "Hymnal")),


### PR DESCRIPTION
The `WS_CMD_ADD_BATCH_TO_SCHEDULE` handler has two branches. The `invalid_payload` one was already covered by `a batch with nothing recognisable in it is refused rather than queued`. **The branch that runs when the payload does parse was not covered at all** — the prompt, the operator's answer, and both replies to the phone.

**What is pinned:**

- **The whole batch reaches the operator as one prompt**, not one per item. "Add the whole set" from a phone would otherwise put six dialogs in front of the operator mid-service. The test asserts all three items arrive *and* that they arrive as the right `ScheduleItem` subtypes.
- **The ack is `pending_approval`, and goes back before the operator has answered.** It cannot claim the items landed — approval can take minutes, and the outcome arrives later via `schedule_updated`.
- **Both replies to the phone**: `{"ok":true}` on approval, `"reason":"denied"` on refusal. Without the refusal reply the phone cannot tell a refusal from a lost connection, and the volunteer presses Add again.
- **Partial acceptance.** `mapNotNull { it.toScheduleItem() }` drops only the entries this build cannot place, and the rest of the batch still goes. That matters when a newer phone sends an item type this desktop has no mapping for: dropping the batch wholesale would lose five good items to one unknown one.

**Mutation-checked — five mutations, each caught by exactly the intended test and nothing else.** All were applied to the batch block alone, since the singular add/project handlers alongside it contain identical text:

| Mutation | Fails |
|---|---|
| ack reason `pending_approval` → `queued` | the one-prompt test |
| `PendingBatchRequest(items, …)` → `items.take(1)` | the one-prompt test |
| reply always `{"ok":true}` | the refused test |
| reply always `denied` | the approved test |
| `mapNotNull` → all-or-nothing when any entry fails to convert | the partial-acceptance test |

The last two are complements of each other on purpose: with only the "always ok" mutation, the approved-reply test passes vacuously, so the opposite mutation was run to show it bites.

**Test-only** — no production change, so the `server` package ×3 with `--rerun-tasks` is the validation rather than the full suite: **716 tests, 0 failures** each run. The four new tests cost ~0.55s each, within the suite's existing `sendOverWebSocket` idle-window pattern (reused, not added). Class 86 → 90 tests.