### PR TITLE
Cover the pictures catalogue endpoint

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerPictureCatalogTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerPictureCatalogTest.kt
@@ -1,0 +1,173 @@
+package org.churchpresenter.app.churchpresenter.server
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `GET /api/pictures` — the folder the desktop currently has open, which is what a phone asks for
+ * when it opens its Pictures tab with no folder id to go on.
+ *
+ * **Its two siblings were covered and this one was not**, which is why it is worth its own suite.
+ * `/api/pictures/{id}` and `/api/pictures/{id}/images/{index}` each have their key gate, their 404s
+ * and their success path asserted elsewhere; the unparameterised route had none of the three. It is
+ * also the only one of the three that can answer *"there is nothing to show yet"*, because it is the
+ * only one not addressed by an id the caller already holds.
+ *
+ * **One shared server, plus a throwaway one for the empty case.** `CompanionServer` exposes no way
+ * to *unload* a picture folder — `updatePictures` only ever sets it — so on the shared server the
+ * "no folder open" case would depend on running before the others. That is the execution-order
+ * dependency the project's test rules call out, so that one test stands up its own server instead
+ * of assuming an order. The other two share the class's, because starting a Ktor engine is the
+ * whole cost here (~1s) and neither of them needs a clean one.
+ */
+class CompanionServerPictureCatalogTest {
+
+    private lateinit var client: HttpClient
+
+    companion object {
+        private val json = Json { ignoreUnknownKeys = true }
+        private lateinit var pictureDir: File
+        private lateinit var server: CompanionServer
+        private var port: Int = 0
+
+        /** Distinct port each time, so a just-stopped listener cannot refuse the next bind. */
+        private val nextPort = AtomicInteger(39_861)
+
+        /** Starts a server and waits until it is actually listening, returning its port. */
+        private fun startServer(target: CompanionServer): Int {
+            target.start(port = nextPort.getAndIncrement())
+            return runBlocking {
+                withTimeoutOrNull(10_000) {
+                    while (!target.isRunning.value || target.serverUrl.value.isBlank()) {
+                        kotlinx.coroutines.delay(25)
+                    }
+                    target.serverUrl.value.substringAfterLast(':').toInt()
+                }
+            } ?: error("server did not start")
+        }
+
+        @JvmStatic
+        @BeforeClass
+        fun startSharedServer() {
+            TestSingletons.latchToTestHome()
+            pictureDir = Files.createTempDirectory("cp-picture-catalog").toFile()
+            server = CompanionServer()
+            port = startServer(server)
+        }
+
+        @JvmStatic
+        @AfterClass
+        fun stopSharedServer() {
+            runCatching { server.stop() }
+            runCatching { pictureDir.deleteRecursively() }
+        }
+    }
+
+    @BeforeTest
+    fun openClient() {
+        client = HttpClient(CIO)
+        server.updateApiKey(enabled = false, key = "")
+    }
+
+    @AfterTest
+    fun closeClient() {
+        runCatching { client.close() }
+    }
+
+    private fun getPictures(apiKey: String? = null, atPort: Int = port): HttpResponse = runBlocking {
+        client.get("http://127.0.0.1:$atPort${Constants.ENDPOINT_PICTURES}") {
+            apiKey?.let { header(Constants.HEADER_API_KEY, it) }
+        }
+    }
+
+    private fun HttpResponse.obj(): JsonObject =
+        json.parseToJsonElement(runBlocking { bodyAsText() }).jsonObject
+
+    /** Puts a folder of [names] on the server as the open one. */
+    private fun loadFolder(vararg names: String) {
+        val files = names.map { name -> File(pictureDir, name).apply { writeBytes(byteArrayOf(1)) } }
+        server.updatePictures(
+            folderId = "folder-1",
+            folderName = "Advent",
+            folderPath = pictureDir.absolutePath,
+            imageFiles = files,
+        )
+    }
+
+    @Test
+    fun `with no folder open the phone is told so, rather than given an empty folder`() {
+        // The distinction the phone acts on: 503 means "the operator has not opened one yet", so it
+        // keeps asking. An empty 200 would read as "the folder is open and has nothing in it" —
+        // a different thing, and it would stop asking.
+        val fresh = CompanionServer()
+        val freshPort = startServer(fresh)
+        try {
+            assertEquals(HttpStatusCode.ServiceUnavailable, getPictures(atPort = freshPort).status)
+        } finally {
+            runCatching { fresh.stop() }
+        }
+    }
+
+    @Test
+    fun `the open folder is served with every image addressable`() {
+        loadFolder("advent-01.jpg", "advent-02.jpg")
+
+        val body = getPictures().obj()
+
+        // The wire names are kebab-case and differ from the Kotlin properties, so they are asserted
+        // as the phone sees them: renaming a property without its @SerialName would break the app.
+        assertEquals("folder-1", body.getValue("folder-id").jsonPrimitive.content)
+        assertEquals("Advent", body.getValue("folder-name").jsonPrimitive.content)
+        assertEquals(2, body.getValue("image-total").jsonPrimitive.int)
+
+        val images = body.getValue("images").jsonArray
+        assertEquals(2, images.size)
+        // The url is what the phone fetches next, so it has to carry this folder's own id — a
+        // catalogue whose entries point elsewhere shows the wrong pictures, not none.
+        assertTrue(
+            images.all { "/folder-1/images/" in it.jsonObject.getValue("thumbnail-url").jsonPrimitive.content },
+            "each entry must address this folder: $images",
+        )
+        assertEquals(
+            listOf(0, 1),
+            images.map { it.jsonObject.getValue("index").jsonPrimitive.int },
+            "index is how the phone asks for an image, so it has to match the position served",
+        )
+    }
+
+    @Test
+    fun `the catalogue is behind the api key like the rest of the api`() {
+        // Without this the folder path and every file name in it are readable by anyone on the
+        // church wifi, whatever the operator set the key to.
+        loadFolder("advent-01.jpg")
+        server.updateApiKey(enabled = true, key = "s3cret")
+
+        assertEquals(HttpStatusCode.Unauthorized, getPictures().status)
+        assertEquals(HttpStatusCode.OK, getPictures(apiKey = "s3cret").status)
+    }
+}


### PR DESCRIPTION
`GET /api/pictures` — the folder the desktop currently has open — had **no coverage at all**, while both of its parameterised siblings are covered thoroughly. `/api/pictures/{id}` and `/api/pictures/{id}/images/{index}` each have their key gate, their 404s and their success path asserted; the unparameterised route had none of the three.

It is also **the only one of the three that can say "there is nothing to show yet"**, because it is the only one not addressed by an id the caller already holds. That distinction is what the phone acts on: `503` means the operator has not opened a folder yet, so it keeps asking. An empty `200` would read as "the folder is open and has nothing in it" — a different thing, and it would stop asking.

**What is pinned:**

- The **503** when no folder is open.
- The **catalogue itself**, asserted by its **wire names** (`folder-id`, `image-total`, `thumbnail-url`) rather than the Kotlin property names, which differ — renaming a property without its `@SerialName` would break the mobile app while every Kotlin-side test kept passing.
- Each entry's **thumbnail url carries this folder's own id**. A catalogue whose entries point elsewhere shows the *wrong* pictures rather than none, which is the harder failure to notice.
- The **API key gate**, without which the folder path and every file name in it are readable by anyone on the church wifi.

**A server per test would have been the wrong shape, and the reason is worth stating.** `CompanionServer` exposes no way to *unload* a picture folder — `updatePictures` only ever sets it — so on a shared server the "no folder open" case would depend on running before the others, which is exactly the execution-order dependency the project's test rules call out. First attempt gave every test its own server; that removed the dependency but cost **~1s each**, since starting a Ktor engine is the entire cost here. Final shape: the two tests that load a folder share the class's server (0.004s and 0.005s), and only the empty case stands up a throwaway one. **Class cost 3.15s → 1.06s.**

The remaining ~1.05s is one Ktor engine start, measured inside the package rather than alone — running the class by itself charges it an extra 0.8s of first-server warm-up that the sibling suites otherwise pay. It ends on a positive signal (`isRunning`), not a wait.

**Mutation-checked**, three mutations, each caught by exactly one test:

| Mutation | Fails |
|---|---|
| drop `if (!checkApiKey(call)) return@get` | the key-gate test |
| `503 "No picture folder loaded"` → `200 ""` | the empty-folder test |
| thumbnail url loses its `$folderId` segment | the catalogue test |

**Test-only** — `server` package ×3 with `--rerun-tasks`, **725 tests, 0 failures** each run.