### PR TITLE
Cover the Strong's reference links in a definition

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTab.kt
@@ -1039,7 +1039,9 @@ private fun DetailRow(label: String, value: String) {
 
 private val strongsPattern = Regex("[HGhg]\\d+")
 
-private fun buildStrongsAnnotatedString(text: String, onClick: (String) -> Unit) = buildAnnotatedString {
+// `internal` so the link-splitting can be tested directly: it is a pure function over the text, and
+// driving it through the composable would assert on a rendered tree instead of on the ranges.
+internal fun buildStrongsAnnotatedString(text: String, onClick: (String) -> Unit) = buildAnnotatedString {
     var lastEnd = 0
     for (match in strongsPattern.findAll(text)) {
         append(text.substring(lastEnd, match.range.first))

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryStrongsLinksTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryStrongsLinksTest.kt
@@ -1,0 +1,144 @@
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * `buildStrongsAnnotatedString` — the pass that turns the `H1234`/`G5678` references inside a
+ * Strong's definition into the links the operator clicks to follow a word.
+ *
+ * The definitions come from the dictionary data as plain prose with references embedded in it, and
+ * this walks them with a regex, appending the text between matches by index. **The arithmetic is the
+ * risk.** A wrong `lastEnd` does not throw and does not look wrong in a screenshot — it silently
+ * duplicates or drops words in the middle of a definition somebody is reading aloud. So the first
+ * thing asserted throughout is that the flattened text still equals the input exactly.
+ *
+ * Tested directly rather than through `DictionaryTab`: it is a pure function over a string, and
+ * driving it through the composable would assert on a rendered tree instead of on the ranges it
+ * actually produces.
+ */
+class DictionaryStrongsLinksTest {
+
+    /** Hebrew links are amber, Greek blue — the literal is pinned once, here. */
+    private val hebrew = Color(0xFFB45309)
+
+    private fun build(text: String, onClick: (String) -> Unit = {}): AnnotatedString =
+        buildStrongsAnnotatedString(text, onClick)
+
+    private fun AnnotatedString.links(): List<AnnotatedString.Range<LinkAnnotation>> =
+        getLinkAnnotations(0, length)
+
+    private fun AnnotatedString.tags(): List<String> =
+        links().map { (it.item as LinkAnnotation.Clickable).tag }
+
+    private fun AnnotatedString.colorOf(index: Int): Color? =
+        (links()[index].item as LinkAnnotation.Clickable).styles?.style?.color
+
+    // ── The text must survive the walk ────────────────────────────────────────
+
+    @Test
+    fun `the whole definition survives, references and all`() {
+        val source = "from H1234 in the sense of G5678 covering"
+
+        assertEquals(source, build(source).text, "no word may be dropped or repeated by the split")
+    }
+
+    @Test
+    fun `text before the first reference and after the last is kept`() {
+        // The two ends are what the index arithmetic gets wrong: the head is appended from the
+        // previous match's end, and the tail only after the loop has finished.
+        val source = "H1234 and G5678"
+
+        val built = build(source)
+
+        assertEquals(source, built.text)
+        assertContentEquals(listOf("H1234", "G5678"), built.tags())
+    }
+
+    @Test
+    fun `a definition with no references is passed through untouched`() {
+        val source = "a primitive root; to cover, to atone"
+
+        val built = build(source)
+
+        assertEquals(source, built.text)
+        assertTrue(built.links().isEmpty(), "nothing here is clickable")
+    }
+
+    @Test
+    fun `an empty definition produces nothing rather than throwing`() {
+        val built = build("")
+
+        assertEquals("", built.text)
+        assertTrue(built.links().isEmpty())
+    }
+
+    @Test
+    fun `adjacent references keep the separator between them`() {
+        val source = "H1 H2 H3"
+
+        val built = build(source)
+
+        assertEquals(source, built.text, "the spaces between references are text and must be kept")
+        assertContentEquals(listOf("H1", "H2", "H3"), built.tags())
+    }
+
+    // ── What each link carries ────────────────────────────────────────────────
+
+    @Test
+    fun `the link is only the reference, not the words around it`() {
+        val source = "from H1234 in the sense"
+        val built = build(source)
+
+        val range = built.links().single()
+
+        assertEquals("H1234", built.text.substring(range.start, range.end))
+    }
+
+    @Test
+    fun `a lowercase reference is looked up in uppercase`() {
+        // The data is not consistently cased, and the tag is what the lookup is keyed on — so a
+        // lowercase `h1234` left as-is would be a link that finds nothing when clicked.
+        val built = build("see h1234 and g5678")
+
+        assertContentEquals(listOf("H1234", "G5678"), built.tags())
+        assertEquals("see h1234 and g5678", built.text, "only the tag is uppercased, not the text")
+    }
+
+    @Test
+    fun `clicking a link reports the reference it stands for`() {
+        var clicked: String? = null
+        val built = build("see h1234", onClick = { clicked = it })
+
+        val link = built.links().single().item as LinkAnnotation.Clickable
+        link.linkInteractionListener?.onClick(link)
+
+        assertEquals("H1234", clicked, "the uppercased tag is what the lookup needs")
+    }
+
+    // ── Hebrew and Greek are told apart ───────────────────────────────────────
+
+    @Test
+    fun `hebrew and greek references are coloured differently`() {
+        // The colour is the only thing distinguishing the two languages inline. If the ternary were
+        // inverted every reference would still be clickable and still go to the right entry, so
+        // nothing else in the app would complain.
+        val built = build("H1234 and G5678")
+
+        assertEquals(hebrew, built.colorOf(0), "Hebrew is the amber one")
+        assertNotEquals(built.colorOf(0), built.colorOf(1), "Greek must not share Hebrew's colour")
+    }
+
+    @Test
+    fun `a lowercase hebrew reference is still coloured as hebrew`() {
+        // The branch tests the *uppercased* value, so this would regress the moment someone tested
+        // `match.value` instead.
+        assertEquals(hebrew, build("h1234").colorOf(0))
+    }
+}


### PR DESCRIPTION
`buildStrongsAnnotatedString` is the pass that turns the `H1234`/`G5678` references inside a Strong's definition into the links the operator clicks to follow a word. It had no coverage.

**The index arithmetic is the real risk.** It walks the text with a regex and appends the spans between matches by index. A wrong `lastEnd` does not throw and does not look wrong in a screenshot — it silently duplicates or drops words in the middle of a definition somebody may be reading aloud. So every test here first asserts that the flattened text still equals the input exactly, and the boundary cases (a reference first, a reference last, adjacent references, no references at all, empty string) are each their own test.

**Also pinned:**

- **The tag is uppercased.** The dictionary data is not consistently cased and the lookup is keyed on the tag, so a lowercase `h1234` left as-is is a link that finds nothing when clicked. Asserted alongside the text staying lowercase — only the tag is uppercased, not what the reader sees.
- **The link covers only the reference**, not the words around it.
- **Hebrew and Greek are coloured differently.** That colour is the only thing distinguishing the two languages inline; if the ternary were inverted every reference would still be clickable and still resolve to the right entry, so nothing else in the app would complain. One test also pins *which* is which.
- **The click reports the uppercased tag**, driven through the real `linkInteractionListener`.

**Mutation-checked**, four mutations, all caught:

| Mutation | Fails |
|---|---|
| `lastEnd = match.range.last + 1` → `match.range.last` | the four text-preservation tests |
| colours swapped in the ternary | both colour tests |
| `match.value.uppercase()` → `match.value` | the lowercase-tag, click and lowercase-colour tests |
| final `append(text.substring(lastEnd))` dropped | the no-references, whole-definition and click tests |

The last one is why *"a definition with no references is passed through untouched"* earns its place: with no matches, the entire output comes from that trailing append.

**Production change is one word** — `private` → `internal` on the function, so it can be tested as the pure function it is. Driving it through `DictionaryTab` would assert on a rendered tree instead of on the ranges actually produced, and the tooltip and dialog around it are window-bound.

**Validation.** 10 tests, **0.083s**. Full suite ×3 (**8,353 tests**, 0 failures) because this touches production code. `DictionaryTab.kt` 83.1% → **84.9%**.