### PR TITLE
Cover the Q&A admin connection handshake

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerQaTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerQaTest.kt
@@ -27,6 +27,7 @@ import org.churchpresenter.app.churchpresenter.viewmodel.QAManager
 import java.io.File
 import org.junit.AfterClass
 import org.junit.BeforeClass
+import org.churchpresenter.app.churchpresenter.utils.Constants
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -168,11 +169,39 @@ class CompanionServerQaTest {
         client.get(url(path)) { password?.let { p -> header("X-QA-Password", p) } }
     }
 
-    private fun post(path: String, body: String = "", password: String? = null): HttpResponse = runBlocking {
+    private fun post(
+        path: String,
+        body: String = "",
+        password: String? = null,
+        deviceId: String? = null,
+    ): HttpResponse = runBlocking {
         client.post(url(path)) {
             password?.let { p -> header("X-QA-Password", p) }
+            deviceId?.let { d -> header(Constants.HEADER_DEVICE_ID, d) }
             setBody(body)
         }
+    }
+
+    /**
+     * Answers the *connection* prompt raised by `/api/qa/auth`, with [allow].
+     *
+     * A different flow from [playOperator]: that one answers a moderation action, this one answers
+     * the one-off handshake a device performs before it can moderate at all. Shares the same scope
+     * so a test can play both, and waits on the subscription for the same reason.
+     */
+    private fun playConnectOperator(allow: Boolean = true): MutableList<PendingConnectionRequest> {
+        val seen = mutableListOf<PendingConnectionRequest>()
+        val scope = operatorScope ?: CoroutineScope(Dispatchers.IO).also { operatorScope = it }
+        scope.launch {
+            server.onQaAdminConnect.collect { pending ->
+                seen.add(pending)
+                pending.decision.complete(allow)
+            }
+        }
+        runBlocking {
+            withTimeout(5_000) { server.onQaAdminConnect.subscriptionCount.first { it > 0 } }
+        }
+        return seen
     }
 
     private fun HttpResponse.text(): String = runBlocking { bodyAsText() }
@@ -515,5 +544,84 @@ class CompanionServerQaTest {
 
         assertEquals(HttpStatusCode.Unauthorized, response.status)
         assertEquals("PENDING", qa.findQuestion(id)?.status?.name, "and the question must be left as it was")
+    }
+
+    // ── The admin connection handshake ──────────────────────────────────────────
+
+    @Test
+    fun `an approved device is let into the admin panel`() {
+        server.qaAdminPassword = "let-me-in"
+        playConnectOperator(allow = true)
+
+        val response = post("/api/qa/auth", password = "let-me-in", deviceId = "moderator-phone")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("true", response.obj().str("ok"))
+    }
+
+    @Test
+    fun `a denied device is told so, not left waiting`() {
+        server.qaAdminPassword = "let-me-in"
+        playConnectOperator(allow = false)
+
+        val response = post("/api/qa/auth", password = "let-me-in", deviceId = "someones-phone")
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals("connection denied", response.obj().str("error"))
+    }
+
+    @Test
+    fun `the prompt names the device asking to moderate`() {
+        // The operator is approving a device, not a request — the id is the only thing on the
+        // prompt that distinguishes "the moderator's phone" from anyone else on the wifi.
+        server.qaAdminPassword = "let-me-in"
+        val prompts = playConnectOperator()
+
+        post("/api/qa/auth", password = "let-me-in", deviceId = "moderator-phone")
+
+        assertEquals("moderator-phone", prompts.single().clientId)
+    }
+
+    @Test
+    fun `a wrong password never raises a prompt on the desktop`() {
+        // The password gate runs first for a reason. If a bad password still asked the operator,
+        // anyone on the church wifi could put a dialog on the desktop during a service, repeatedly,
+        // without ever knowing the password.
+        server.qaAdminPassword = "let-me-in"
+        val prompts = playConnectOperator()
+
+        val response = post("/api/qa/auth", password = "guess", deviceId = "someones-phone")
+
+        // The 401 is the positive signal that the route ran to completion: the prompt would have
+        // had to be raised before the response, and was not. Nothing here waits on a duration.
+        assertEquals(HttpStatusCode.Unauthorized, response.status)
+        assertTrue(prompts.isEmpty(), "the operator must not be shown a device that failed the gate")
+    }
+
+    @Test
+    fun `with no password set the operator is still asked`() {
+        // An unset password is the default, and it makes `checkQaAdmin` a no-op — so on this path
+        // the operator's approval is the *only* thing standing between a stranger's phone and the
+        // moderation queue.
+        server.qaAdminPassword = ""
+        val prompts = playConnectOperator()
+
+        val response = post("/api/qa/auth", deviceId = "a-stranger")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("a-stranger", prompts.single().clientId, "approval is the whole gate here")
+    }
+
+    @Test
+    fun `a device that sends no id is still put to the operator`() {
+        // Older clients send no device header. Refusing outright would lock them out; the prompt
+        // just cannot name them, and the operator decides on that basis.
+        server.qaAdminPassword = ""
+        val prompts = playConnectOperator()
+
+        val response = post("/api/qa/auth")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("", prompts.single().clientId)
     }
 }


### PR DESCRIPTION
`POST /api/qa/auth` had **no test at all** — so neither of the two gates in front of the moderation queue was covered: `checkQaAdmin` (the password) and `checkQaAdminConnect` (the operator approving the device).

**The one worth having is that a wrong password never raises a prompt on the desktop.** The gates run in that order deliberately: if a bad password still asked the operator, anyone on the church wifi could put a dialog on the desktop during a service, repeatedly, without ever knowing the password. The 401 is the positive signal that the route ran to completion — the prompt would have had to be raised *before* the response — so asserting that no prompt appeared is race-free rather than a pause-and-hope.

**Also pinned:** approval → `200 {"ok":true}`; denial → `403 connection denied` (told, not left waiting); the prompt carries the device id, since that is the only thing distinguishing the moderator's phone from anyone else's; **with no password set the operator's approval is the entire gate**, which is the default configuration; and a client sending no device header is still put to the operator rather than refused outright, because older clients send none.

**Mutation-checked** — and the first attempt was wrong in a way worth reporting.

| Mutation | Fails |
|---|---|
| the two gates swapped in order | the wrong-password test |
| `PendingConnectionRequest(clientId)` → `("")` | both device-id tests |
| `403 Forbidden` → `401 Unauthorized` | the denied test |

**My first run caught only 1 of 3, because two of the three mutated the wrong function.** `PendingConnectionRequest(clientId)` and the `connection denied` respond are **character-identical** in the presentation-remote handshake 90 lines above, so a first-occurrence string replace hit that one instead. Re-applied by line index, all three land. (This is the same trap as #205, where the singular and batch schedule handlers shared identical text — worth treating as standing practice in this file: **mutate by line range, never by string match**.)

**A free finding from the mistake, checked rather than left hanging:** those two mutations sat on the presentation-remote handshake, so I ran *its* suite against them — `a first connection asks the operator to approve the device` and `a device the operator refuses is turned away` both fail. That sibling is genuinely covered; there is no gap there.

**Test-only** — `server` package ×3 with `--rerun-tasks`, **735 tests, 0 failures** each. Class 28 → 34 tests, still under 1s total.