### PR TITLE
Cover the interlinear word tooltip

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTabTestSupport.kt
@@ -87,9 +87,11 @@ internal fun dictionaryTab(
     strongsForBookChapter: Map<Int, Set<String>> = emptyMap(),
     withOnAddToSchedule: Boolean = true,
     withOnGoLive: Boolean = true,
+    /** Extra Greek entries, for a test needing a shape the standing corpus does not have. */
+    extraEntries: List<StrongsEntry> = emptyList(),
     block: ComposeUiTest.(vm: DictionaryViewModel, reports: DictionaryReports) -> Unit,
 ) {
-    DictionaryFixture.stubResources()
+    DictionaryFixture.stubResources(extraEntries)
     mockkConstructor(InterlinearRepository::class)
     coEvery { anyConstructed<InterlinearRepository>().ensureGreekLoaded() } returns Unit
     coEvery { anyConstructed<InterlinearRepository>().ensureHebrewLoaded() } returns Unit

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTabWordTooltipTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTabWordTooltipTest.kt
@@ -1,0 +1,164 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import org.churchpresenter.app.churchpresenter.data.InterlinearVerse
+import org.churchpresenter.app.churchpresenter.data.InterlinearWord
+import org.churchpresenter.app.churchpresenter.data.StrongsEntry
+import org.churchpresenter.app.churchpresenter.viewmodel.DictionaryFixture
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The hover tooltip on an interlinear word chip — how an operator reads what a word in the verse
+ * means without leaving the entry they are already on.
+ *
+ * **A `TooltipArea` body does compose under `runComposeUiTest`**, which is what makes this suite
+ * possible: hovering the chip with `performMouseInput { moveTo(center) }` draws it. Roughly two
+ * dozen files here have a `TooltipArea` and none of their bodies had ever been driven.
+ * `CanvasTabTestSupport` had in fact recorded the behaviour from the other side — a tooltip
+ * lingering after a click and swallowing the next one — which is the same fact, written down as an
+ * obstacle.
+ *
+ * **Every assertion is differential — a count before the hover against a count after.** The tooltip
+ * repeats the number, word and transliteration that the detail pane is *already* showing for the
+ * selected entry, so `assertExists` on any of them passes just as well with no tooltip at all. Only
+ * the count going up is evidence that this control drew anything.
+ */
+class DictionaryTabWordTooltipTest {
+
+    private val agape = DictionaryFixture.agape
+
+    /** A Greek entry whose definition is past the tooltip's 200-character cut. */
+    private val verbose = StrongsEntry(
+        number = "G9001",
+        word = "μακρολογία",
+        transliteration = "makrologia",
+        pronunciation = "mak-rol-og-ee'-ah",
+        definition = "an account at length, " + "spun out with many words ".repeat(12),
+        kjvUsage = "long speech",
+    )
+
+    private fun verseOf(entry: StrongsEntry, wordText: String) = InterlinearVerse(
+        ref = "043003016",
+        words = listOf(InterlinearWord(text = wordText, strongsNumber = entry.number)),
+    )
+
+    /** Selects [entry] in the list, which is what draws its "In Scripture" chips. */
+    private fun ComposeUiTest.open(entry: StrongsEntry) {
+        onAllNodesWithText(entry.number)[0].performClick()
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.countOf(text: String, substring: Boolean = false) =
+        onAllNodesWithText(text, substring = substring).fetchSemanticsNodes(false).size
+
+    /** Hovers the chip labelled [wordText] and settles the tooltip's own delay. */
+    private fun ComposeUiTest.hoverChip(wordText: String) {
+        onAllNodesWithText(wordText)[0].performMouseInput { moveTo(center) }
+        waitForIdle()
+        mainClock.advanceTimeBy(2_000)
+        waitForIdle()
+    }
+
+    @Test
+    fun `hovering a word chip shows what it means`() {
+        dictionaryTab(verses = mapOf(agape.number to listOf(verseOf(agape, "αγαπη")))) { _, _ ->
+            open(agape)
+            val before = countOf(agape.number)
+
+            hoverChip("αγαπη")
+
+            assertEquals(
+                before + 1, countOf(agape.number),
+                "the tooltip adds a second place the entry's number is shown",
+            )
+            assertTrue(
+                countOf(agape.transliteration) > 0,
+                "and it names the transliteration, which is how the word is pronounced",
+            )
+        }
+    }
+
+    @Test
+    fun `the tooltip carries the definition, not just the label`() {
+        // The number and transliteration alone would not tell an operator what the word means, which
+        // is the only reason to hover it mid-service.
+        dictionaryTab(verses = mapOf(agape.number to listOf(verseOf(agape, "αγαπη")))) { _, _ ->
+            open(agape)
+            val before = countOf(agape.definition)
+
+            hoverChip("αγαπη")
+
+            assertEquals(before + 1, countOf(agape.definition))
+        }
+    }
+
+    @Test
+    fun `a long definition is cut short with an ellipsis`() {
+        // Untruncated, a wordy entry's tooltip grows down the window and covers the verse the
+        // operator is reading — the thing they hovered it from.
+        dictionaryTab(
+            verses = mapOf(verbose.number to listOf(verseOf(verbose, "μακρολογια"))),
+            extraEntries = listOf(verbose),
+        ) { _, _ ->
+            open(verbose)
+            // The detail pane already shows this entry's definition in full, so the count of the
+            // whole text starts at one and the assertion below has to be that the hover does not
+            // add a second — not that it is absent.
+            val fullBefore = countOf(verbose.definition)
+
+            hoverChip("μακρολογια")
+
+            val expected = verbose.definition.take(200) + "…"
+            assertTrue(countOf(expected) > 0, "the tooltip shows exactly 200 characters and an ellipsis")
+            assertEquals(
+                fullBefore, countOf(verbose.definition),
+                "and never the whole thing — the detail pane is where that belongs",
+            )
+        }
+    }
+
+    @Test
+    fun `a definition that fits is shown whole, with no ellipsis`() {
+        // The positive twin of the test above: without it, a truncation that fired on every
+        // definition would still pass there.
+        dictionaryTab(verses = mapOf(agape.number to listOf(verseOf(agape, "αγαπη")))) { _, _ ->
+            open(agape)
+
+            hoverChip("αγαπη")
+
+            assertEquals(0, countOf("${agape.definition}…"), "nothing to cut, so nothing is cut")
+        }
+    }
+
+    @Test
+    fun `a word the dictionary does not know gets no tooltip`() {
+        // The chip is still drawn — the verse has to render whether or not every word is tagged with
+        // a number this build has an entry for. It just has nothing to say about it.
+        val unknown = "G9999"
+        dictionaryTab(
+            verses = mapOf(
+                agape.number to listOf(
+                    InterlinearVerse(
+                        ref = "043003016",
+                        words = listOf(InterlinearWord(text = "ξενον", strongsNumber = unknown)),
+                    )
+                )
+            )
+        ) { _, _ ->
+            open(agape)
+            assertTrue(countOf("ξενον") > 0, "the untagged word is still part of the verse")
+            val before = countOf(unknown)
+
+            hoverChip("ξενον")
+
+            assertEquals(before, countOf(unknown), "no entry means no tooltip to draw")
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/DictionaryFixture.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/DictionaryFixture.kt
@@ -79,11 +79,16 @@ object DictionaryFixture {
     /**
      * Points `Res.readBytes` at the fixture for all four dictionary files. Callers are responsible
      * for `unmockkObject(Res)` in teardown.
+     *
+     * [extraGreek] appends entries to the Greek side for a test that needs a shape the standing
+     * corpus does not have — a definition long enough to be truncated, for instance. The corpus is
+     * deliberately tiny and every other suite asserts against it by name, so this adds rather than
+     * replaces, and defaults to empty.
      */
-    fun stubResources() {
+    fun stubResources(extraGreek: List<StrongsEntry> = emptyList()) {
         mockkObject(Res)
         coEvery { Res.readBytes(HEBREW_EN) } returns bytes(hebrewEntries)
-        coEvery { Res.readBytes(GREEK_EN) } returns bytes(greekEntries)
+        coEvery { Res.readBytes(GREEK_EN) } returns bytes(greekEntries + extraGreek)
         coEvery { Res.readBytes(HEBREW_RU) } returns bytes(hebrewEntriesRu)
         coEvery { Res.readBytes(GREEK_RU) } returns bytes(greekEntriesRu)
     }


### PR DESCRIPTION
The hover tooltip on an interlinear word chip — how an operator reads what a word in the verse means without leaving the entry they are on. At **38 lines it is the largest single tooltip body in the app**, and it had no coverage.

## The reason this was reachable all along

**A `TooltipArea` body does compose under `runComposeUiTest`.** Hovering the chip with `performMouseInput { moveTo(center) }` draws it. Roughly **two dozen files** here have a `TooltipArea` — `BibleTab` alone has 10, `CanvasTab` 9 — and none of their bodies had ever been driven. This is the first.

Worth noting where the evidence was: `CanvasTabTestSupport.kt:147` already documents the same fact *from the other side* — a hover tooltip lingering after a click and swallowing the next one, which is why `addSourceOfType` is marked "usable once per test". The behaviour had been observed and written down as an obstacle.

## Every assertion is differential, and it has to be

The tooltip repeats the number, word and transliteration that the **detail pane is already showing** for the selected entry. So `assertExists` on any of them passes just as well with no tooltip at all — the same vacuous-assertion trap as the `TEMPO` and `Recent:` cases before it. Each test counts matching nodes before the hover and after.

That caught a mistake of mine while writing it: I first asserted the full untruncated definition was *absent* after hovering a wordy entry, and it is not — the detail pane legitimately shows it. The correct assertion is that the hover does not add a **second** copy.

## What is pinned

- Hovering shows the entry's number and transliteration.
- **The definition is in it** — number and transliteration alone would not tell an operator what the word means, which is the only reason to hover mid-service.
- **A long definition is cut at 200 characters with an ellipsis.** Untruncated, a wordy entry's tooltip grows down the window and covers the verse the operator hovered it from.
- **A definition that fits is shown whole, with no ellipsis** — the positive twin, without which a truncation that fired on every definition would still pass.
- **A word the dictionary does not know gets no tooltip**, while the chip itself still renders: the verse has to draw whether or not every word is tagged with a number this build has an entry for.

## Mutation-checked

| Mutation | Fails |
|---|---|
| gate never true (tooltip never drawn) | 3 tests |
| `take(200)` → `take(500)` | the long-definition test |
| ellipsis appended unconditionally | the short-definition twin, and the definition test |

**One mutation was thrown away rather than counted:** replacing the gate with `if (false)` **does not compile** — the `entry` smart cast goes with it, exactly as in #184's `webSnapshot` case. A mutation that fails to build proves nothing; it was re-expressed as `entry != null && entry.number.isEmpty()`, which keeps the cast. Caught by checking `^e:` and the missing result XML rather than reading a stale one.

## Fixture change

`DictionaryFixture.stubResources` and the `dictionaryTab` harness gain a defaulted `extraGreek`/`extraEntries` parameter. The standing corpus has **no definition longer than 42 characters**, so the 200-character cut had no case to exercise it. It appends rather than replaces — every other suite asserts against that corpus by name — and every existing call site is unchanged.

**Test-only.** `tabs` package ×3 with `--rerun-tasks` (**886 tests**, 0 failures each) plus the `viewmodel` package once (**1,479**, 0 failures) since the fixture is shared. 5 tests; class **0.93s** in package context, slowest test 0.19s.