### PR TITLE
Move the verse-selection hint into strings.xml

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="bible_search_mode_reference">Reference</string>
     <string name="bible_search_mode_text">Text</string>
     <string name="bible_search_mode_tooltip">Tap to switch — Auto: jump to references, search everything else. Reference: navigate only. Text: always search verse text.</string>
+    <string name="bible_verse_selection_hint">Ctrl+Click to toggle, Shift+Click for range</string>
     <string name="replace">Replace with</string>
     <string name="search_songs">Search songs...</string>
     <string name="song_book">Song Book</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -210,6 +210,7 @@ import churchpresenter.composeapp.generated.resources.bible_translation_order_mo
 import churchpresenter.composeapp.generated.resources.bible_translation_order_panel_subtitle
 import churchpresenter.composeapp.generated.resources.bible_translation_order_panel_title
 import churchpresenter.composeapp.generated.resources.drag_to_reorder_translation
+import churchpresenter.composeapp.generated.resources.bible_verse_selection_hint
 import churchpresenter.composeapp.generated.resources.hold_live
 import churchpresenter.composeapp.generated.resources.ic_drag_dots
 import churchpresenter.composeapp.generated.resources.move_translation_down
@@ -1422,6 +1423,7 @@ fun BibleTab(
             }
         } else {
             val holdLiveStr = stringResource(Res.string.hold_live)
+            val verseSelectionHint = stringResource(Res.string.bible_verse_selection_hint)
             val swapBiblesStr = stringResource(Res.string.swap_bibles)
             val translationOrderStr = stringResource(Res.string.bible_translation_order)
             val goLiveStr = stringResource(Res.string.go_live)
@@ -1475,7 +1477,7 @@ fun BibleTab(
                         tooltip = {
                             Surface(color = MaterialTheme.colorScheme.inverseSurface, shape = MaterialTheme.shapes.extraSmall) {
                                 Text(
-                                    if (holdPillActive) holdLiveStr else "Ctrl+Click to toggle, Shift+Click for range",
+                                    if (holdPillActive) holdLiveStr else verseSelectionHint,
                                     color = MaterialTheme.colorScheme.inverseOnSurface,
                                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                                     style = MaterialTheme.typography.bodySmall

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabHoldPillTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabHoldPillTest.kt
@@ -6,7 +6,9 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -66,5 +68,56 @@ class BibleTabHoldPillTest {
 
             assertTrue(presenter.bibleHold.value)
         }
+    }
+
+    // ── What the pill says it is for ────────────────────────────────────────────
+
+    private fun ComposeUiTest.countOf(text: String) =
+        onAllNodesWithText(text, substring = true).fetchSemanticsNodes(false).size
+
+    /** The tooltip body only composes while the pointer is over the pill. */
+    private fun ComposeUiTest.hoverPill() {
+        onNodeWithText("⌘/Ctrl Shift").performMouseInput { moveTo(center) }
+        waitForIdle()
+        mainClock.advanceTimeBy(2_000)
+        waitForIdle()
+    }
+
+    @Test
+    fun `without a presenter the pill explains the keyboard selection instead`() {
+        // The pill does double duty: with an output attached it is the Hold Live toggle, and without
+        // one it is nothing but a legend for Ctrl/Shift click — which is the only place multi-verse
+        // selection is explained at all.
+        bibleTab { _, _ ->
+            val before = countOf(SELECTION_HINT)
+
+            hoverPill()
+
+            assertEquals(before + 1, countOf(SELECTION_HINT))
+        }
+    }
+
+    @Test
+    fun `with a presenter it names the hold instead of the shortcut`() {
+        // The positive twin: the two branches share one tooltip, so a pill stuck on either string
+        // would still pass the other test on its own.
+        bibleTab(presenter = PresenterManager()) { _, _ ->
+            val beforeHold = countOf("Hold Live")
+            val beforeHint = countOf(SELECTION_HINT)
+
+            hoverPill()
+
+            assertEquals(beforeHold + 1, countOf("Hold Live"))
+            assertEquals(beforeHint, countOf(SELECTION_HINT), "the shortcut legend belongs to the other state")
+        }
+    }
+
+    private companion object {
+        /**
+         * Asserted as a literal, deliberately. It was a hardcoded English string in `BibleTab` until
+         * this change moved it into `strings.xml`, and spelling it out here is what proves the
+         * resource still renders the same words rather than an empty or mangled lookup.
+         */
+        const val SELECTION_HINT = "Ctrl+Click to toggle, Shift+Click for range"
     }
 }


### PR DESCRIPTION
`BibleTab.kt` rendered **`"Ctrl+Click to toggle, Shift+Click for range"`** as a hardcoded English literal — a `DEVELOPMENT_GUIDE.md` zero-tolerance item, found while covering the tooltips in #212.

**It is the one that matters most in that file.** It is the *only* place multi-verse selection is explained anywhere in the UI, and it lives in a tooltip on a pill an operator has to go looking for. So an operator running the app in Ukrainian or Polish got the single instruction they most needed in a language they may not read. Same shape as the WebTab literals found in #184 and fixed in #185 — including that one being the macOS hint, i.e. also the only explanation of its kind.

**English `values/strings.xml` only. No other locale touched**, per `AGENT.md`.

## The tests come with it, and they are the point

The tooltip body had **no coverage**, so nothing would have noticed if the extraction had rendered an empty or mangled lookup. The pill does double duty — *Hold Live* with an output attached, this legend without one — and **both branches share a single `Text`**, so a pill stuck on either string would have gone unnoticed. Two tests, one per branch, each asserting **differentially** (count before hover vs after), since the tooltip body only composes while the pointer is over the pill.

`SELECTION_HINT` is asserted as a **literal in the test**, deliberately. That is what proves the resource still renders the same words — an assertion against `Res.string.bible_verse_selection_hint` would pass against any value, including an empty one.

## Mutation-checked

| Mutation | Fails |
|---|---|
| the hint points at `Res.string.hold_live` instead | the no-presenter test |
| `if (holdPillActive) holdLiveStr else …` → always the legend | the with-presenter twin |

## Also confirms a stale note, for the second time

`DEVELOPMENT_GUIDE.md`'s decision log still records a 2026-07-13 investigation where a *new* string resource reproducibly failed to compile in this environment, and reverts a `"%"` extraction because of it. #185 already showed that was stale; this resource compiled and ran green first try as well. **Two independent data points now — the entry should be retired**, but that is a doc change and does not belong in this PR.

**Validation.** Full suite ×3 with `--rerun-tasks` (**8,373 tests**, 0 failures each) because this is live production code, per the rule #176 set and #185 followed. Class 4 → 6 tests, 1.51s.