### PR TITLE
Cover the last two uncovered tooltips

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabToolTooltipTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabToolTooltipTest.kt
@@ -1,0 +1,83 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.performMouseInput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The drawing toolbar's tooltips — which are the **only** name those buttons have.
+ *
+ * Each tool is an `IconButton` whose entire visible content is one glyph (`◆`, `□`, `○`, `∕`, `→`,
+ * `✎`). Nothing else on screen says which is which, and the glyphs for line and freehand in
+ * particular are not self-explanatory, so a tooltip that stopped drawing would leave an operator
+ * guessing at six identical-looking buttons rather than merely losing a convenience.
+ *
+ * Assertions are **differential** — a count before the hover against a count after. Unlike most
+ * tooltips these names appear nowhere else, so a bare `assertExists` would in fact detect them; the
+ * differential form is kept anyway because it also proves the tooltip belongs to *the button that
+ * was hovered*, which is the part that would break if the loop that builds them lost its binding.
+ *
+ * The glyph is what a test can address the button by, and that is a symptom rather than a
+ * convenience: `AGENT.md` forbids text-as-icon (`Text("⏸")`) precisely here. Reported with the PR;
+ * not changed by it, since real icon assets are a production change of their own.
+ */
+class CanvasTabToolTooltipTest {
+
+    /** Glyph on the button, and the name only its tooltip gives. */
+    private val tools = listOf(
+        "◆" to "Select",
+        "□" to "Rectangle",
+        "○" to "Ellipse",
+        "∕" to "Line",
+        "→" to "Arrow",
+        "✎" to "Freehand",
+    )
+
+    private fun ComposeUiTest.countOf(text: String) =
+        onAllNodesWithText(text, substring = true).fetchSemanticsNodes(false).size
+
+    private fun ComposeUiTest.hover(glyph: String) {
+        onAllNodesWithText(glyph)[0].performMouseInput { moveTo(center) }
+        waitForIdle()
+        mainClock.advanceTimeBy(2_000)
+        waitForIdle()
+    }
+
+    @Test
+    fun `every drawing tool is named by its tooltip`() {
+        // One test per tool would be six near-identical bodies; the loop that builds them is one
+        // site, so the thing worth asserting is that each glyph carries its *own* name.
+        tools.forEach { (glyph, name) ->
+            canvasTab(seed = { addScene("Tools") }) { _, _ ->
+                assertTrue(countOf(glyph) > 0, "the $name button should be on the toolbar")
+                val before = countOf(name)
+
+                hover(glyph)
+
+                assertEquals(before + 1, countOf(name), "hovering $glyph should name it '$name'")
+            }
+        }
+    }
+
+    @Test
+    fun `hovering one tool does not name another`() {
+        // The names come from a list zipped against the buttons by position. An off-by-one there
+        // would label every tool as its neighbour, and each tool would still show *a* tooltip — so
+        // the test above passes only because it checks the pairing, and this one states why.
+        canvasTab(seed = { addScene("Tools") }) { _, _ ->
+            val beforeRectangle = countOf("Rectangle")
+
+            hover("◆") // Select
+
+            assertEquals(
+                beforeRectangle, countOf("Rectangle"),
+                "only the hovered tool's tooltip should be drawn",
+            )
+        }
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabExtraTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabExtraTest.kt
@@ -27,9 +27,13 @@ import kotlin.test.assertTrue
  *
  * Left uncovered: the shift+drag reorder gesture (a test cannot set `keyboardModifiers` on an
  * injected pointer event — see `ScheduleTabReorderDragTest`'s doc comment, which records this same
- * tab as one of the two places that blocks); the loop toggle button, whose icon carries neither text
- * nor a content description to address it by; and anything that reaches `RecentPictureFolders` — see
+ * tab as one of the two places that blocks); and anything that reaches `RecentPictureFolders` — see
  * `PicturesTabTestSupport.kt`'s doc comment for why.
+ *
+ * The loop toggle used to be listed here too — "neither text nor a content description to address it
+ * by" — which was true of the usual selectors and not of the tree: it is the *only* clickable node
+ * carrying neither, and that is a selector. See `PicturesTabLoopTooltipTest`, which addresses it that
+ * way and asserts the uniqueness rather than assuming it.
  *
  * See `PicturesTabTestSupport.kt` for the harness.
  */

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabLoopTooltipTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabLoopTooltipTest.kt
@@ -1,0 +1,87 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.performMouseInput
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The slideshow loop toggle's tooltip, which is the only thing on screen that says whether looping
+ * is on.
+ *
+ * The button is an icon with no label, and its two states differ only by container colour — so the
+ * tooltip is not a convenience here, it is the readout. One stuck on `Loop On` would tell the
+ * operator the opposite of the truth, and the failure is silent until a slideshow dead-ends at the
+ * last picture mid-service.
+ *
+ * **`PicturesTabExtraTest` records this button as unreachable** — "whose icon carries neither text
+ * nor a content description to address it by". That is true of the usual selectors and not of the
+ * tree: it is the *only* clickable node with neither, which is a selector in itself. [loopButton]
+ * asserts that uniqueness rather than assuming it, so if a second unlabelled button ever appears
+ * this fails loudly instead of silently addressing the wrong one — the approach `CanvasTab`'s
+ * rename tick already uses.
+ */
+class PicturesTabLoopTooltipTest {
+
+    /** The one clickable node carrying neither text nor a content description. */
+    private fun ComposeUiTest.loopButton(): SemanticsNodeInteraction {
+        val all = onAllNodes(hasClickAction())
+        val nodes = all.fetchSemanticsNodes(atLeastOneRootRequired = false)
+        val bare = nodes.indices.filter { i ->
+            nodes[i].config.getOrNull(SemanticsProperties.ContentDescription) == null &&
+                nodes[i].config.getOrNull(SemanticsProperties.Text) == null
+        }
+        assertEquals(
+            1, bare.size,
+            "the loop toggle is addressed as the only unlabelled button; found ${bare.size}",
+        )
+        return all[bare.single()]
+    }
+
+    private fun ComposeUiTest.countOf(text: String) =
+        onAllNodesWithText(text, substring = true).fetchSemanticsNodes(false).size
+
+    private fun ComposeUiTest.hoverLoop() {
+        loopButton().performMouseInput { moveTo(center) }
+        waitForIdle()
+        mainClock.advanceTimeBy(2_000)
+        waitForIdle()
+    }
+
+    @Test
+    fun `with looping on the tooltip says so`() = picturesTab { vm, _ ->
+        // Looping is the default, so this is what an operator sees without touching anything.
+        assertEquals(true, vm.isLooping)
+        val before = countOf("Loop On")
+
+        hoverLoop()
+
+        assertEquals(before + 1, countOf("Loop On"))
+    }
+
+    @Test
+    fun `with looping off it says the other thing`() {
+        // The readout has to follow the state. The two buttons differ only by container colour, so
+        // a tooltip stuck on one string is invisible until the slideshow dead-ends at the last
+        // picture — and by then the operator is mid-service wondering why it stopped.
+        picturesTab(
+            settings = { it.copy(pictureSettings = it.pictureSettings.copy(isLooping = false)) },
+        ) { vm, _ ->
+            assertEquals(false, vm.isLooping)
+            val beforeOff = countOf("Loop Off")
+            val beforeOn = countOf("Loop On")
+
+            hoverLoop()
+
+            assertEquals(beforeOff + 1, countOf("Loop Off"))
+            assertEquals(beforeOn, countOf("Loop On"), "and must not still claim looping is on")
+        }
+    }
+}


### PR DESCRIPTION
The two remaining `TooltipArea` bodies with no coverage. **Surveyed all four remaining clusters to find them** — `CanvasTab` (9 tooltips), `MediaTab` (6), `PicturesTab` (5), `PresentationTab` (5) — and only these two had gaps. The rest were already covered incidentally, because a test that clicks a control leaves the pointer hovering it. With these, the category is closed.

## 1. The Canvas drawing toolbar

Six tool buttons, each an `IconButton` whose entire visible content is **one glyph** — `◆ □ ○ ∕ → ✎`. **The tooltip is the only name the button has**; the line and freehand glyphs are not self-explanatory, so a tooltip that stopped drawing would leave an operator guessing at six near-identical buttons rather than merely losing a convenience.

**The second test is the one that earns its place.** The names are zipped against the buttons by position, so an off-by-one gives every tool its *neighbour's* name — and each would still show *a* tooltip, so a presence check stays green. It asserts that hovering Select does not name Rectangle. Mutating the tooltip to `tools[(i + 1) % size].label` fails **both** tests, which is the result that justifies writing it.

## 2. The slideshow loop toggle

**`PicturesTabExtraTest` recorded this one as unreachable** — *"whose icon carries neither text nor a content description to address it by"*. True of the usual selectors, and not of the tree: it is the **only clickable node carrying neither**, and that is a selector. A semantics probe confirmed it (9 clickable nodes, exactly one bare). The helper **asserts that uniqueness** rather than assuming it, so if a second unlabelled button ever appears this fails loudly instead of silently addressing the wrong one — the approach `CanvasTab`'s rename tick already uses. The stale deferral is corrected in place rather than deleted.

Worth reaching because **the tooltip is the readout, not a convenience**: the two states differ only by container colour, so one stuck on `Loop On` tells the operator the opposite of the truth, and the failure stays silent until a slideshow dead-ends at the last picture mid-service. Inverting the condition fails both tests.

## Found, not fixed — an `AGENT.md` "UI icons" violation

`AGENT.md` says: *"**NEVER** use text/emoji as icons (`Text("⏸")`). Use `painterResource()` with real icon assets."* `CanvasTab.kt:771-781` does exactly that, six times.

**The tell was that the test could address those buttons at all** — a real `painterResource` icon would carry a `contentDescription`, giving them a name in the semantics tree instead of leaving the tooltip to carry it alone. Not changed here: real icon assets are a production change of their own and would rewrite this suite's selectors, so the tests would need updating alongside.

**Test-only.** `tabs` package ×3 with `--rerun-tasks`, **896 tests, 0 failures** each. 4 tests; both classes well under a second in package context (0.32s and 0.18s).