### PR TITLE
Extract and cover the connection QR's bitmap

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTab.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.material3.Surface
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.luminance
 import org.churchpresenter.app.churchpresenter.ui.theme.AppThemeWrapper
 import org.churchpresenter.app.churchpresenter.ui.theme.ThemeMode
@@ -935,28 +936,7 @@ private fun ConnectionQrDialog(serverUrl: String, apiKey: String?, onDismiss: ()
     val (parsedHost, parsedPort) = remember(serverUrl) { parseServerUrlHostPort(serverUrl) }
 
     val qrContent = connectionQrContent(parsedHost, parsedPort, apiKey)
-    val qrBitmap = remember(qrContent) {
-        try {
-            val hints = mapOf(
-                EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M,
-                EncodeHintType.MARGIN to 1
-            )
-            val matrix = QRCodeWriter().encode(qrContent, BarcodeFormat.QR_CODE, 512, 512, hints)
-            val w = matrix.width
-            val h = matrix.height
-            val img = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
-            val black = 0xFF000000.toInt()
-            val white = 0xFFFFFFFF.toInt()
-            for (y in 0 until h) {
-                for (x in 0 until w) {
-                    img.setRGB(x, y, if (matrix.get(x, y)) black else white)
-                }
-            }
-            SkiaImage.makeFromEncoded(
-                ByteArrayOutputStream().also { ImageIO.write(img, "PNG", it) }.toByteArray()
-            ).toComposeImageBitmap()
-        } catch (_: Exception) { null }
-    }
+    val qrBitmap = remember(qrContent) { connectionQrBitmap(qrContent) }
 
     val isDark = MaterialTheme.colorScheme.background.luminance() < 0.5f
     val mainWindowState = LocalMainWindowState.current
@@ -1080,6 +1060,38 @@ internal fun atemKeyTarget(atem: AtemSettings): String =
     } else {
         "keytype=usk&me=${atem.keyMixEffect + 1}&key=${atem.keyIndex + 1}"
     }
+
+/**
+ * Encodes [content] as a QR bitmap, or null when it cannot be encoded.
+ *
+ * Null rather than an exception is the point: this is called from inside the connection dialog's
+ * composition, so a throw would take the dialog down instead of merely leaving it without a code —
+ * and ZXing does throw on content it cannot represent, an empty string included.
+ *
+ * Error correction is left at M and the quiet-zone margin at 1: a phone camera a metre from a laptop
+ * screen has a clean, well-lit target, and a wider margin would shrink the modules inside a fixed
+ * 512px square for no gain.
+ */
+internal fun connectionQrBitmap(content: String, sizePx: Int = 512): ImageBitmap? = try {
+    val hints = mapOf(
+        EncodeHintType.ERROR_CORRECTION to ErrorCorrectionLevel.M,
+        EncodeHintType.MARGIN to 1
+    )
+    val matrix = QRCodeWriter().encode(content, BarcodeFormat.QR_CODE, sizePx, sizePx, hints)
+    val img = BufferedImage(matrix.width, matrix.height, BufferedImage.TYPE_INT_ARGB)
+    val black = 0xFF000000.toInt()
+    val white = 0xFFFFFFFF.toInt()
+    for (y in 0 until matrix.height) {
+        for (x in 0 until matrix.width) {
+            img.setRGB(x, y, if (matrix.get(x, y)) black else white)
+        }
+    }
+    SkiaImage.makeFromEncoded(
+        ByteArrayOutputStream().also { ImageIO.write(img, "PNG", it) }.toByteArray()
+    ).toComposeImageBitmap()
+} catch (_: Exception) {
+    null
+}
 
 /** The `churchpresenter://connect` deep link the connection QR encodes. */
 internal fun connectionQrContent(host: String, port: String, apiKey: String?): String = buildString {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ConnectionQrBitmapTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ConnectionQrBitmapTest.kt
@@ -1,0 +1,99 @@
+package org.churchpresenter.app.churchpresenter.dialogs.tabs
+
+import androidx.compose.ui.graphics.ImageBitmap
+import org.churchpresenter.app.churchpresenter.TestSingletons
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The connection QR's bitmap — the thing an operator points a phone at to join the companion server.
+ *
+ * `connectionQrContent` (what the code says) already has a suite of its own; this is the other half,
+ * whether that content becomes a scannable image. It used to sit inline inside `ConnectionQrDialog`'s
+ * `remember`, inside a `DialogWindow` that no test can open, so nothing exercised it at all.
+ *
+ * **The null return is the behaviour worth having, not a tidy default.** ZXing throws on content it
+ * cannot represent, and this is called during composition — so an exception would take the whole
+ * dialog down rather than leave it without a code. That is why the catch exists and why an empty
+ * string is tested here rather than assumed impossible.
+ */
+class ConnectionQrBitmapTest {
+
+    @BeforeTest
+    fun loadSkiko() {
+        // Decoding the PNG goes through Skia; without the native library this throws on first use.
+        TestSingletons.latchSkikoNativeLibrary()
+    }
+
+    private val realContent = "churchpresenter://connect?host=192.168.1.50&port=8765"
+
+    @Test
+    fun `a connection link becomes a bitmap of the size asked for`() {
+        val bitmap = assertNotNull(connectionQrBitmap(realContent, sizePx = 256))
+
+        assertEquals(256, bitmap.width)
+        assertEquals(256, bitmap.height)
+    }
+
+    @Test
+    fun `the image encodes the content, rather than being the same picture every time`() {
+        // The one failure a size check cannot see: a code that renders beautifully and sends every
+        // phone to the same wrong host. Two different links must not produce identical pixels.
+        val a = assertNotNull(connectionQrBitmap(realContent))
+        val b = assertNotNull(connectionQrBitmap("churchpresenter://connect?host=10.0.0.9&port=8765"))
+
+        assertNotEquals(a.toPixels(), b.toPixels(), "different links must not encode identically")
+    }
+
+    @Test
+    fun `the same link always encodes the same way`() {
+        // The dialog re-renders on every recomposition; a code that shifted between renders would
+        // be a moving target for a camera.
+        assertEquals(
+            assertNotNull(connectionQrBitmap(realContent)).toPixels(),
+            assertNotNull(connectionQrBitmap(realContent)).toPixels(),
+        )
+    }
+
+    @Test
+    fun `an api key changes the code`() {
+        // A key in the link is what a phone needs to be let in at all, so it has to reach the image.
+        val without = assertNotNull(connectionQrBitmap(realContent))
+        val with = assertNotNull(connectionQrBitmap("$realContent&apikey=s3cret"))
+
+        assertNotEquals(without.toPixels(), with.toPixels())
+    }
+
+    @Test
+    fun `the code is dark on light, not inverted`() {
+        // Every other assertion here survives swapping black and white — the sizes match, the codes
+        // still differ from each other and still repeat — while an inverted code is one most phone
+        // cameras will not read at all. The quiet zone is the tell: with MARGIN = 1 the outer edge
+        // is background, so the corner pixel must be the light one.
+        val pixels = assertNotNull(connectionQrBitmap(realContent)).toPixels()
+        val white = 0xFFFFFFFF.toInt()
+        val black = 0xFF000000.toInt()
+
+        assertEquals(white, pixels.first(), "the quiet zone around the code has to be the light one")
+        assertTrue(pixels.any { it == black }, "and there has to be a code inside it")
+    }
+
+    @Test
+    fun `content that cannot be encoded gives null instead of throwing`() {
+        // ZXing rejects empty content. Reached from inside composition, a throw here would take the
+        // dialog down; null leaves it able to say it has no code.
+        assertNull(connectionQrBitmap(""))
+    }
+
+    /** A stable digest of the pixels, so two bitmaps can be compared by content. */
+    private fun ImageBitmap.toPixels(): List<Int> {
+        val buffer = IntArray(width * height)
+        readPixels(buffer)
+        return buffer.toList()
+    }
+}


### PR DESCRIPTION
The connection QR is what an operator points a phone at to join the companion server. `connectionQrContent` — *what the code says* — already has a suite of its own. This is the other half: **whether that content becomes a scannable image**, which had no coverage at all.

It sat inline inside `ConnectionQrDialog`'s `remember`, inside a `DialogWindow` no test can open. Extracted to `internal fun connectionQrBitmap(content, sizePx)` — the refactor `AGENT.md` describes for exactly this shape, where the untestable wrapper is hiding ordinary logic. It takes no function parameters, so it adds no lambdas to the coverage denominator.

## What is pinned

- The bitmap comes back at **the size asked for**.
- **The image encodes the content** — two different links must not produce identical pixels. That is the failure a size check cannot see: a code that renders beautifully and sends every phone to the same wrong host.
- **The same link always encodes the same way** — the dialog re-renders on every recomposition, and a code that shifted between renders is a moving target for a camera.
- **An API key changes the code**, since it is what lets a phone in at all.
- **Null instead of throwing** on content ZXing cannot represent. This is behaviour, not a tidy default: it runs *during composition*, so an exception would take the whole dialog down rather than leave it without a code.

## The assertion that earned its place

**Every other test here survives swapping black and white** — the sizes still match, the codes still differ from each other, and they still repeat — while an inverted QR is one most phone cameras will not read. So there is a test for it, and the quiet zone is the tell: with `MARGIN = 1` the outer edge is background, so the corner pixel must be the light one.

I wrote it *because* I expected the inversion mutation to survive the other five. It did exactly that — the mutation fails only this test.

## Mutation-checked

| Mutation | Fails |
|---|---|
| black/white inverted | the dark-on-light test **only** |
| `sizePx` ignored (hardcoded 512) | the size test |
| `catch (Exception)` narrowed to `IOException` | the cannot-encode test |

**Validation.** Full suite ×3 with `--rerun-tasks` (**8,387 tests**, 0 failures each) because this touches live production code. 6 tests, class **0.34s**. `ServerSettingsTab.kt` 85.9% → **88.5%**; overall 85.60% → **85.63%**.