### PR TITLE
Extract and cover the update download's copy loop

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/UpdateAvailableDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/UpdateAvailableDialog.kt
@@ -79,6 +79,8 @@ import org.churchpresenter.app.churchpresenter.utils.UpdateChecker
 import org.jetbrains.compose.resources.stringResource
 import java.awt.Desktop
 import java.io.File
+import java.io.OutputStream
+import java.io.InputStream
 import java.net.HttpURLConnection
 import java.net.URI
 import kotlin.system.exitProcess
@@ -106,6 +108,34 @@ internal fun installerSuffixFor(downloadUrl: String): String = when {
  * Fraction of the download complete, or -1f (indeterminate) when the server didn't report a
  * content length to measure against.
  */
+/**
+ * Copies [input] to [output], reporting progress as each chunk lands, and returns the bytes copied.
+ *
+ * Split out of the update download so it can be tested without a server: what it has to get right is
+ * that **every byte arrives** — a short copy produces an installer that fails to run, minutes after
+ * the operator started the update — and that progress is reported often enough for the bar to move
+ * rather than only at the end.
+ *
+ * [onProgress] is suspending so the caller can hop to the UI dispatcher per chunk; this function
+ * itself touches no dispatcher, which is what keeps it drivable from a plain test.
+ */
+internal suspend fun copyReportingProgress(
+    input: InputStream,
+    output: OutputStream,
+    contentLength: Long,
+    onProgress: suspend (Float) -> Unit,
+): Long {
+    val buffer = ByteArray(8 * 1024)
+    var bytesRead = 0L
+    var read: Int
+    while (input.read(buffer).also { read = it } != -1) {
+        output.write(buffer, 0, read)
+        bytesRead += read
+        onProgress(downloadProgressFraction(bytesRead, contentLength))
+    }
+    return bytesRead
+}
+
 internal fun downloadProgressFraction(bytesRead: Long, contentLength: Long): Float =
     if (contentLength > 0) (bytesRead.toFloat() / contentLength.toFloat()).coerceIn(0f, 1f) else -1f
 
@@ -246,13 +276,7 @@ fun UpdateAvailableDialog(
 
                 connection.inputStream.use { input ->
                     tempFile.outputStream().use { output ->
-                        val buffer = ByteArray(8 * 1024)
-                        var bytesRead = 0L
-                        var read: Int
-                        while (input.read(buffer).also { read = it } != -1) {
-                            output.write(buffer, 0, read)
-                            bytesRead += read
-                            val progress = downloadProgressFraction(bytesRead, contentLength)
+                        copyReportingProgress(input, output, contentLength) { progress ->
                             withContext(Dispatchers.Main) {
                                 downloadState = DownloadState.Downloading(progress)
                             }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/DownloadCopyProgressTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/DownloadCopyProgressTest.kt
@@ -1,0 +1,113 @@
+package org.churchpresenter.app.churchpresenter.dialogs
+
+import kotlinx.coroutines.runBlocking
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The copy loop behind the in-app update download.
+ *
+ * It used to sit inline inside the `DialogWindow` that shows the update, where nothing could run it.
+ * Two things it has to get right, and both fail late and confusingly:
+ *
+ *  * **Every byte arrives.** A short copy produces an installer that fails to run — minutes after
+ *    the operator started an update, with the app already asking to restart.
+ *  * **Progress is reported as it goes**, not once at the end. The bar is the only sign the download
+ *    is alive over what may be a 100 MB file on church wifi.
+ *
+ * `downloadProgressFraction` already had its own coverage; this is the loop around it.
+ */
+class DownloadCopyProgressTest {
+
+    private fun copy(
+        bytes: ByteArray,
+        contentLength: Long = bytes.size.toLong(),
+        input: InputStream = ByteArrayInputStream(bytes),
+    ): Triple<Long, ByteArray, List<Float>> {
+        val out = ByteArrayOutputStream()
+        val seen = mutableListOf<Float>()
+        val copied = runBlocking { copyReportingProgress(input, out, contentLength) { seen += it } }
+        return Triple(copied, out.toByteArray(), seen)
+    }
+
+    /** Larger than the 8 KB buffer, so the loop runs several times rather than once. */
+    private fun payload(size: Int) = ByteArray(size) { (it % 251).toByte() }
+
+    @Test
+    fun `every byte reaches the other side`() {
+        val bytes = payload(20_000)
+
+        val (copied, written, _) = copy(bytes)
+
+        assertEquals(bytes.size.toLong(), copied)
+        assertContentEquals(bytes, written, "a short copy is an installer that will not run")
+    }
+
+    @Test
+    fun `progress is reported during the copy, not once at the end`() {
+        val (_, _, seen) = copy(payload(20_000))
+
+        // Deliberately not asserting the exact number of reports: that follows the buffer size,
+        // which anyone may tune without changing behaviour. What has to hold is that the bar moves
+        // *while* a large file downloads and ends at full.
+        assertTrue(seen.size > 1, "the bar has to move during the download, not just at the end")
+        assertTrue(seen.first() < 1f, "the first report must come before the copy finishes: $seen")
+        assertEquals(1f, seen.last(), "and it must finish at full")
+    }
+
+    @Test
+    fun `progress only ever climbs`() {
+        val (_, _, seen) = copy(payload(40_000))
+
+        assertEquals(seen.sorted(), seen, "a bar that jumps backwards reads as a stall: $seen")
+        assertTrue(seen.all { it in 0f..1f }, "and stays in range: $seen")
+    }
+
+    @Test
+    fun `an empty body copies nothing and reports nothing`() {
+        // A zero-length response is a server or proxy problem, not a crash: the caller sees zero
+        // bytes and can say the download failed rather than launching an empty installer.
+        val (copied, written, seen) = copy(ByteArray(0))
+
+        assertEquals(0L, copied)
+        assertEquals(0, written.size)
+        assertTrue(seen.isEmpty())
+    }
+
+    @Test
+    fun `an unknown content length still copies, reporting the indeterminate fraction`() {
+        // Servers that stream without a Content-Length give -1, which is the signal for an
+        // indeterminate bar. The copy itself must not depend on knowing the size.
+        val bytes = payload(12_000)
+
+        val (copied, written, seen) = copy(bytes, contentLength = -1)
+
+        assertEquals(bytes.size.toLong(), copied)
+        assertContentEquals(bytes, written)
+        assertTrue(seen.all { it == -1f }, "unknown length means an indeterminate bar throughout: $seen")
+    }
+
+    @Test
+    fun `a stream that dies mid-download propagates rather than truncating silently`() {
+        // The caller turns this into a visible error state. Swallowing it would leave a half-written
+        // temp file being handed to the installer.
+        val failing = object : InputStream() {
+            private var served = 0
+            override fun read() = throw UnsupportedOperationException()
+            override fun read(b: ByteArray, off: Int, len: Int): Int {
+                if (served > 0) throw IOException("connection reset")
+                served++
+                return len.coerceAtMost(4_096).also { b.fill(1, off, off + it) }
+            }
+        }
+
+        assertFailsWith<IOException> { copy(ByteArray(0), contentLength = 9_000, input = failing) }
+    }
+}


### PR DESCRIPTION
The copy loop behind the in-app update download. It sat inline inside the `DialogWindow` that shows an available update, where nothing could run it — the second instance of the pattern #216 turned up: **the wrapper is untestable, the logic inside its coroutine is not.**

Extracted to `internal suspend fun copyReportingProgress(input, output, contentLength, onProgress)`. `onProgress` is suspending so the caller keeps its per-chunk hop to the UI dispatcher; **the extracted function touches no dispatcher itself**, which is what makes it drivable from a plain test rather than needing a Compose clock.

## Two things it has to get right, and both fail late

- **Every byte arrives.** A short copy produces an installer that fails to run — minutes after the operator started an update, with the app already asking to restart.
- **Progress is reported as it goes**, not once at the end. The bar is the only sign the download is alive over what may be a 100 MB file on church wifi.

Also pinned: progress only ever climbs and stays in range (a bar that jumps backwards reads as a stall); an empty body copies nothing rather than crashing; an **unknown `Content-Length`** still copies correctly while reporting the indeterminate `-1f` throughout, since servers that stream without one are ordinary; and a stream that dies mid-download **propagates** rather than truncating silently, because swallowing it would hand a half-written temp file to the installer.

## One assertion deliberately weakened

My first version asserted the progress callback fired **exactly 3 times** — true for 20,000 bytes over an 8 KB buffer. That pins the buffer size, which anyone may tune without changing behaviour, so the test would have failed for a non-reason. It now asserts the properties that actually matter: more than one report, the first one before completion, the last one at full.

## Mutation-checked

| Mutation | Fails |
|---|---|
| `bytesRead += buffer.size` instead of `+= read` | the every-byte and unknown-length tests |
| `output.write(buffer)` instead of `write(buffer, 0, read)` | the every-byte and unknown-length tests |
| report progress once after the loop | the during-the-copy and empty-body tests |

## Also checked and still rejected

`PlanningCenterImportDialog`'s 107-line block was re-read under the same lens and stays rejected: it is the `DialogWindow` plus `PlanningCenterConnectDialogContent`, which is **already extracted and covered**, plus an OAuth call that opens a browser. No inline logic hiding in it.

**Validation.** Full suite ×3 with `--rerun-tasks` (**8,387 tests**, 0 failures each) because this touches live production code. 6 tests, class **0.10s**.