### PR TITLE
Delete the dead SongItem.toDto, and record why not to re-add it

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
@@ -109,8 +109,19 @@ import java.util.concurrent.atomic.AtomicReference
 
 // ── API DTOs ─────────────────────────────────────────────────────────────────
 
+/**
+ * A song as the companion API serves it.
+ *
+ * **Built inline by `CompanionServer.buildCatalog`, deliberately, and there is no
+ * `SongItem.toDto()`.** One existed and was deleted as dead code, having never had a caller. It set
+ * every field *except* [id], which defaults to 0 — so anything that adopted it would have given
+ * every song the same id, and [id] is how a phone asks for one. The catalogue assigns it from the
+ * song's position in the list, which a mapper over a single [SongItem] cannot know. Add a mapper
+ * only if it takes that position as a parameter.
+ */
 @Serializable
 data class SongDto(
+    /** Position in the server's song list; how a client addresses a song. Not stable across reloads. */
     val id: Int = 0,
     val number: String,
     val title: String,
@@ -4948,9 +4959,3 @@ connect();
 
 // ── Extension mappers ─────────────────────────────────────────────────────────
 
-fun SongItem.toDto() = SongDto(
-    number = number,
-    title = title,
-    tune = tune,
-    author = author
-)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
@@ -768,6 +768,12 @@ fun CanvasTab(
                                         else MaterialTheme.colorScheme.onSurface
                                     )
                                 ) {
+                                    // Geometric glyphs, not `painterResource` icons, and kept that
+                                    // way deliberately: AGENT.md's "no text as icons" rule is about
+                                    // letters and emoji standing in for artwork, and these are the
+                                    // shapes the tools draw. Their names live in the TooltipArea
+                                    // above — see CanvasTabToolTooltipTest, which addresses the
+                                    // buttons by these glyphs.
                                     Text(
                                         when (tool.id) {
                                             "select" -> "\u25C6"


### PR DESCRIPTION
Two owner decisions, both small, both about not re-litigating a question later.

## 1. `SongItem.toDto()` deleted

**Zero callers anywhere** — production or test. The songs catalogue builds `SongDto` inline in `CompanionServer.buildCatalog`. Verified again before deleting: the other `.toDto()` call sites in that file are `Question.toDto()`, on the QA routes.

**Re-adding a mapper of that shape would be a trap rather than a tidy-up**, which is the part worth writing down. It set every field *except* `id`, which defaults to `0` — so anything that adopted it would have given **every song the same id**, and `id` is how a phone asks for one. The catalogue assigns it from the song's **position in the list**, which a mapper over a single `SongItem` cannot know. It is exactly the sort of dead helper that looks like an obvious cleanup opportunity and is a bug waiting to be adopted.

So the note goes on `SongDto` itself — where anyone tempted to add a mapper would look — rather than in a commit message nobody will find, and `id` gains a doc line saying what it is for and that it is not stable across reloads. Same shape as #198, which deleted `FileManager.deleteFile` and left a note saying it had been removed rather than never written.

## 2. The Canvas tool glyphs are deliberate, and the code now says so

I had flagged `CanvasTab.kt:771-781` as an `AGENT.md` **"UI icons"** violation — `Text("◆")`, `Text("□")`, `Text("○")`, `Text("∕")`, `Text("→")`, `Text("✎")` as the tool buttons' only content.

**The owner's call is that these are fine**, and the reasoning holds: that rule is about *letters and emoji* standing in for artwork, and these are the shapes the tools actually draw — a rectangle tool showing `□` is not a letter pretending to be an icon. A comment at the site records it, so the next person auditing against that rule (or the next `/loop` iteration) does not re-raise it. It also points at `CanvasTabToolTooltipTest`, which addresses those buttons *by* these glyphs and would need rewriting if they ever became `painterResource` icons.

**Validation.** Full suite ×3 with `--rerun-tasks`, **8,393 tests, 0 failures** each — the rule for live production code, and warranted here since removing a public function can break callers a compile alone would not surface in every module. Net −1 function, +11 lines of explanation.