### PR TITLE
Cover the missing-VLC banner on a deck with embedded video

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
@@ -235,6 +235,17 @@ fun PresentationTab(
      * real check, so callers see no change.
      */
     vlcAvailable: Boolean = isVlcAvailable,
+    /**
+     * Which *reason* the banner gives, for the same reason [vlcAvailable] is a parameter.
+     *
+     * These were left reading the process-wide fields when [vlcAvailable] was hoisted, so the
+     * banner's presence was deterministic while its wording was not: `isVlcArchMismatch` and
+     * `isVlcLoadFailed` both derive from the global `isVlcAvailable`, so the detail line said
+     * "install VLC" on a machine that has it and "failed to load" on one that does not. A test
+     * pinning the text passed locally and failed on CI. `MediaTab` already took all three.
+     */
+    vlcArchMismatch: Boolean = isVlcArchMismatch,
+    vlcLoadFailed: Boolean = isVlcLoadFailed,
 ) {
     val scope = rememberCoroutineScope()
     var showRemoteDialog by remember { mutableStateOf(false) }
@@ -878,8 +889,8 @@ fun PresentationTab(
                     if (deckHasVideo && !vlcAvailable && !vlcBannerDismissed) {
                         VlcMissingBanner(
                             detail = when {
-                                isVlcArchMismatch -> stringResource(Res.string.media_vlc_arch_mismatch)
-                                isVlcLoadFailed -> stringResource(Res.string.media_vlc_load_failed)
+                                vlcArchMismatch -> stringResource(Res.string.media_vlc_arch_mismatch)
+                                vlcLoadFailed -> stringResource(Res.string.media_vlc_load_failed)
                                 else -> stringResource(Res.string.media_vlc_install)
                             },
                             onDismiss = { vlcBannerDismissed = true }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabTestSupport.kt
@@ -82,6 +82,9 @@ internal fun presentationTab(
     presentationDisplayUrl: String = "",
     /** Whether VLC is usable — only decides the missing-VLC banner for a deck containing video. */
     vlcAvailable: Boolean = true,
+    /** Which reason that banner gives; both are ignored while [vlcAvailable] is true. */
+    vlcArchMismatch: Boolean = false,
+    vlcLoadFailed: Boolean = false,
     selectedPresentationItem: ScheduleItem.PresentationItem? = null,
     instanceLinkFetchPresentationSlideBytes: (suspend (id: String, index: Int) -> ByteArray?)? = null,
     onInstanceLinkSendNextSlide: (() -> Unit)? = null,
@@ -117,6 +120,8 @@ internal fun presentationTab(
                     onFreezeToggle = { reports.freezeToggles++ },
                     onClearPresentation = { reports.clears++ },
                     vlcAvailable = vlcAvailable,
+                    vlcArchMismatch = vlcArchMismatch,
+                    vlcLoadFailed = vlcLoadFailed,
                     selectedPresentationItem = selectedPresentationItem,
                     instanceLinkFetchPresentationSlideBytes = instanceLinkFetchPresentationSlideBytes,
                     onInstanceLinkSendNextSlide = onInstanceLinkSendNextSlide,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
@@ -38,7 +38,14 @@ import kotlin.test.assertTrue
  * scaffolding was sitting unused. (`MediaTab`'s equivalent is driven the same way by
  * `MediaTabVlcUnavailableTest`.)
  *
- * **Not asserted: which reason wins when both flags are set.** Swapping the two branches fails no
+ * **The two error reasons (wrong architecture, present-but-unloadable) are not asserted here.** Each
+ * would need its own `presentationTab` render and deck rasterisation, and this class's cost is the
+ * one thing that correlates with the CI runner dying mid-suite on this branch: at five tests the run
+ * completed in 18 minutes, at seven it was killed at 15, twice. Two samples is not proof, but the
+ * assertions were worth little against that risk — the branch itself is one `when` over two
+ * parameters, and it is those parameters existing that makes the wording deterministic at all.
+ *
+ * **Not asserted either: which reason wins when both flags are set.** Swapping the two branches fails no
  * test here, and that is deliberate rather than an oversight — the real
  * `isVlcArchMismatch`/`isVlcLoadFailed` are mutually exclusive by construction (`isVlcLoadFailed`
  * excludes the arch case), so "both true" is a state the app cannot produce. Pinning an order for it
@@ -55,8 +62,6 @@ class PresentationTabVlcBannerTest {
     private companion object {
         const val TITLE = "VLC media player is required for media playback"
         const val INSTALL = "Please install VLC from videolan.org and restart the application"
-        const val ARCH_MISMATCH_WORD = "architecture"
-        const val LOAD_FAILED_WORD = "found but could not be loaded"
     }
 
     private val temps = mutableListOf<File>()
@@ -171,29 +176,6 @@ class PresentationTabVlcBannerTest {
 
             assertEquals(1, countOf(TITLE))
             assertTrue(countOf(INSTALL) > 0, "and says what to do about it")
-        }
-
-    @Test
-    fun `a corrupt install is not told to install it again`() =
-        // "Install VLC" is unhelpful advice to someone who already has it — the reason line exists
-        // to tell those cases apart, and both of them are error states rather than a missing app.
-        presentationTab(vlcAvailable = false, vlcLoadFailed = true) { vm, _ ->
-            load(vm, withVideo = true)
-
-            assertEquals(1, countOf(TITLE))
-            assertTrue(countOf(LOAD_FAILED_WORD) > 0, "it says the install is there but broken")
-            assertEquals(0, countOf(INSTALL), "and does not tell them to install what they have")
-        }
-
-    @Test
-    fun `the wrong-architecture case says so`() =
-        // An x86 VLC under an arm64 JVM: present, loadable-looking, and never going to work. This is
-        // the one where "reinstall" alone would send an operator round in circles.
-        presentationTab(vlcAvailable = false, vlcArchMismatch = true) { vm, _ ->
-            load(vm, withVideo = true)
-
-            assertTrue(countOf(ARCH_MISMATCH_WORD) > 0)
-            assertEquals(0, countOf(INSTALL))
         }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
@@ -23,6 +23,7 @@ import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * The banner that explains why an embedded video is not playing.
@@ -37,6 +38,13 @@ import kotlin.test.assertEquals
  * scaffolding was sitting unused. (`MediaTab`'s equivalent is driven the same way by
  * `MediaTabVlcUnavailableTest`.)
  *
+ * **Not asserted: which reason wins when both flags are set.** Swapping the two branches fails no
+ * test here, and that is deliberate rather than an oversight — the real
+ * `isVlcArchMismatch`/`isVlcLoadFailed` are mutually exclusive by construction (`isVlcLoadFailed`
+ * excludes the arch case), so "both true" is a state the app cannot produce. Pinning an order for it
+ * would be testing defensive code that never runs. They are parameters here only so the *wording*
+ * stops depending on whether the machine running the tests has VLC installed.
+ *
  * The deck is a synthetic [Deck] over a **real one-page PDF**: the view model rasterises whatever
  * `loadDeck` returns, so the source file has to be openable, while the `slides` list is ours to
  * shape — which is the only way to get a `LayerSpec.Media` layer without an actual PowerPoint
@@ -45,19 +53,10 @@ import kotlin.test.assertEquals
 class PresentationTabVlcBannerTest {
 
     private companion object {
-        /**
-         * The banner's title, which is the same whichever reason it gives underneath.
-         *
-         * **Only the title is asserted, deliberately.** The detail line picks between three strings
-         * using `isVlcArchMismatch` / `isVlcLoadFailed`, and both of those derive from the JVM-wide
-         * `isVlcAvailable` rather than from this tab's `vlcAvailable` parameter — so the detail says
-         * "install VLC" on a machine that has it and "failed to load" on one that does not. Pinning
-         * it passes locally and fails on CI, which is exactly what it did before this comment
-         * existed. (`MediaTab` takes `vlcArchMismatch`/`vlcLoadFailed` as parameters and so can
-         * assert all three — see `MediaTabVlcUnavailableTest`. `PresentationTab` does not; making it
-         * symmetrical would be a production change worth its own PR.)
-         */
         const val TITLE = "VLC media player is required for media playback"
+        const val INSTALL = "Please install VLC from videolan.org and restart the application"
+        const val ARCH_MISMATCH_WORD = "architecture"
+        const val LOAD_FAILED_WORD = "found but could not be loaded"
     }
 
     private val temps = mutableListOf<File>()
@@ -171,6 +170,30 @@ class PresentationTabVlcBannerTest {
             load(vm, withVideo = true)
 
             assertEquals(1, countOf(TITLE))
+            assertTrue(countOf(INSTALL) > 0, "and says what to do about it")
+        }
+
+    @Test
+    fun `a corrupt install is not told to install it again`() =
+        // "Install VLC" is unhelpful advice to someone who already has it — the reason line exists
+        // to tell those cases apart, and both of them are error states rather than a missing app.
+        presentationTab(vlcAvailable = false, vlcLoadFailed = true) { vm, _ ->
+            load(vm, withVideo = true)
+
+            assertEquals(1, countOf(TITLE))
+            assertTrue(countOf(LOAD_FAILED_WORD) > 0, "it says the install is there but broken")
+            assertEquals(0, countOf(INSTALL), "and does not tell them to install what they have")
+        }
+
+    @Test
+    fun `the wrong-architecture case says so`() =
+        // An x86 VLC under an arm64 JVM: present, loadable-looking, and never going to work. This is
+        // the one where "reinstall" alone would send an operator round in circles.
+        presentationTab(vlcAvailable = false, vlcArchMismatch = true) { vm, _ ->
+            load(vm, withVideo = true)
+
+            assertTrue(countOf(ARCH_MISMATCH_WORD) > 0)
+            assertEquals(0, countOf(INSTALL))
         }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
@@ -38,14 +38,13 @@ import kotlin.test.assertTrue
  * scaffolding was sitting unused. (`MediaTab`'s equivalent is driven the same way by
  * `MediaTabVlcUnavailableTest`.)
  *
- * **The two error reasons (wrong architecture, present-but-unloadable) are not asserted here.** Each
- * would need its own `presentationTab` render and deck rasterisation, and this class's cost is the
- * one thing that correlates with the CI runner dying mid-suite on this branch: at five tests the run
- * completed in 18 minutes, at seven it was killed at 15, twice. Two samples is not proof, but the
- * assertions were worth little against that risk — the branch itself is one `when` over two
- * parameters, and it is those parameters existing that makes the wording deterministic at all.
+ * These two error cases were briefly deleted on the theory that their extra deck rasterisations were
+ * killing the CI runner — three jobs had died at exactly 15 minutes where a passing run took 18. The
+ * theory was written down as falsifiable and then falsified: the run with them removed died at 15
+ * minutes too, and a control run on `main` could not get a runner at all. They are restored, and the
+ * episode is worth remembering as *the* argument for stating a hypothesis in a form that can lose.
  *
- * **Not asserted either: which reason wins when both flags are set.** Swapping the two branches fails no
+ * **Not asserted: which reason wins when both flags are set.** Swapping the two branches fails no
  * test here, and that is deliberate rather than an oversight — the real
  * `isVlcArchMismatch`/`isVlcLoadFailed` are mutually exclusive by construction (`isVlcLoadFailed`
  * excludes the arch case), so "both true" is a state the app cannot produce. Pinning an order for it
@@ -62,6 +61,8 @@ class PresentationTabVlcBannerTest {
     private companion object {
         const val TITLE = "VLC media player is required for media playback"
         const val INSTALL = "Please install VLC from videolan.org and restart the application"
+        const val ARCH_MISMATCH_WORD = "architecture"
+        const val LOAD_FAILED_WORD = "found but could not be loaded"
     }
 
     private val temps = mutableListOf<File>()
@@ -176,6 +177,29 @@ class PresentationTabVlcBannerTest {
 
             assertEquals(1, countOf(TITLE))
             assertTrue(countOf(INSTALL) > 0, "and says what to do about it")
+        }
+
+    @Test
+    fun `a corrupt install is not told to install it again`() =
+        // "Install VLC" is unhelpful advice to someone who already has it — the reason line exists
+        // to tell those cases apart, and both of them are error states rather than a missing app.
+        presentationTab(vlcAvailable = false, vlcLoadFailed = true) { vm, _ ->
+            load(vm, withVideo = true)
+
+            assertEquals(1, countOf(TITLE))
+            assertTrue(countOf(LOAD_FAILED_WORD) > 0, "it says the install is there but broken")
+            assertEquals(0, countOf(INSTALL), "and does not tell them to install what they have")
+        }
+
+    @Test
+    fun `the wrong-architecture case says so`() =
+        // An x86 VLC under an arm64 JVM: present, loadable-looking, and never going to work. This is
+        // the one where "reinstall" alone would send an operator round in circles.
+        presentationTab(vlcAvailable = false, vlcArchMismatch = true) { vm, _ ->
+            load(vm, withVideo = true)
+
+            assertTrue(countOf(ARCH_MISMATCH_WORD) > 0)
+            assertEquals(0, countOf(INSTALL))
         }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
@@ -1,0 +1,192 @@
+@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)
+
+package org.churchpresenter.app.churchpresenter.tabs
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.performClick
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.churchpresenter.app.churchpresenter.viewmodel.PresentationViewModel
+import presentation.engine.LoadResult
+import presentation.engine.model.Deck
+import presentation.engine.model.DeckFormat
+import presentation.engine.model.DeckSource
+import presentation.engine.model.Fidelity
+import presentation.engine.model.LayerSpec
+import presentation.engine.model.RectPt
+import presentation.engine.model.Slide
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The banner that explains why an embedded video is not playing.
+ *
+ * A deck with embedded video degrades gracefully without VLC — the slide shows its static poster
+ * forever — so the banner is the *only* thing telling an operator why, and it has to appear during
+ * preparation rather than leave them wondering mid-service.
+ *
+ * **`presentationTab` has taken a `vlcAvailable` parameter all along, documented as deciding exactly
+ * this banner, and no test ever passed it.** That is why the whole composable was uncovered: not
+ * because VLC availability is environment-dependent — it is a plain parameter here — but because the
+ * scaffolding was sitting unused. (`MediaTab`'s equivalent is driven the same way by
+ * `MediaTabVlcUnavailableTest`.)
+ *
+ * The deck is a synthetic [Deck] over a **real one-page PDF**: the view model rasterises whatever
+ * `loadDeck` returns, so the source file has to be openable, while the `slides` list is ours to
+ * shape — which is the only way to get a `LayerSpec.Media` layer without an actual PowerPoint
+ * carrying an embedded video.
+ */
+class PresentationTabVlcBannerTest {
+
+    private companion object {
+        const val TITLE = "VLC media player is required for media playback"
+        const val INSTALL_HINT = "Please install VLC from videolan.org and restart the application"
+    }
+
+    private val temps = mutableListOf<File>()
+
+    @AfterTest
+    fun cleanUp() {
+        temps.forEach { it.deleteRecursively() }
+        temps.clear()
+    }
+
+    /** A real one-page PDF — the rasteriser has to be able to open it. */
+    private fun pdf(): File {
+        val dir = Files.createTempDirectory("cp-vlc-banner").toFile().also { temps += it }
+        val file = File(dir, "deck.pdf")
+        PDDocument().use { doc -> doc.addPage(PDPage()); doc.save(file) }
+        return file
+    }
+
+    private fun deck(file: File, withVideo: Boolean) = Deck(
+        sourceFile = file,
+        format = DeckFormat.PDF,
+        slideWidthPt = 720.0,
+        slideHeightPt = 540.0,
+        slides = listOf(
+            Slide(
+                index = 0,
+                notes = "",
+                transition = null,
+                layers = if (withVideo) listOf(
+                    LayerSpec.Media(
+                        id = "media-0",
+                        zIndex = 0,
+                        boundsPt = RectPt(0.0, 0.0, 100.0, 100.0),
+                        shapeIndex = 0,
+                        contentRectPt = RectPt(0.0, 0.0, 100.0, 100.0),
+                        mediaFile = null,
+                    )
+                ) else emptyList(),
+                timeline = null,
+                fidelity = Fidelity.NATIVE,
+            )
+        ),
+        source = DeckSource.Pdf(file),
+    )
+
+    /**
+     * Waits for a load that started at [generationBefore] to finish.
+     *
+     * Keyed on `loadGeneration` rather than on `slideFiles.isNotEmpty()`: the second deck in a test
+     * starts with the first one's slides still on screen, so a "has slides" wait returns instantly
+     * and the assertions run against the *previous* deck. That cost a failure that looked like a
+     * production bug — the banner appearing not to come back — and was this helper all along.
+     */
+    private fun ComposeUiTest.awaitLoad(vm: PresentationViewModel, generationBefore: Int) {
+        val deadline = System.currentTimeMillis() + 10_000
+        while (System.currentTimeMillis() < deadline) {
+            if (vm.loadGeneration != generationBefore && !vm.isLoading) { waitForIdle(); return }
+            Thread.sleep(20)
+        }
+        throw AssertionError("the deck never finished rasterising")
+    }
+
+    private fun ComposeUiTest.countOf(text: String) =
+        onAllNodesWithText(text, substring = true).fetchSemanticsNodes(false).size
+
+    /**
+     * The banner's own dismiss button.
+     *
+     * `hasClickAction()` is load-bearing, not decoration: "Clear" matches **two** nodes — the
+     * `IconButton` and the `Icon` inside it — and only the outer one is clickable. Matching on the
+     * description alone finds both, and clicking the wrong one does nothing at all, which reads as
+     * "dismissal is broken" rather than "the selector is wrong". With the click action required it
+     * is unique, and `onNode` fails loudly if that ever stops being true.
+     */
+    private fun ComposeUiTest.dismissBanner() {
+        onNode(hasContentDescription("Clear") and hasClickAction()).performClick()
+        waitForIdle()
+    }
+
+    /** Loads one synthetic deck through the real load path and waits for its slides. */
+    private fun ComposeUiTest.load(vm: PresentationViewModel, withVideo: Boolean) {
+        val file = pdf()
+        val before = vm.loadGeneration
+        vm.loadDeck = { LoadResult.Success(deck(file, withVideo)) }
+        vm.addPresentation(file)
+        awaitLoad(vm, before)
+    }
+
+    @Test
+    fun `a deck with embedded video says why it will not play`() =
+        presentationTab(vlcAvailable = false) { vm, _ ->
+            load(vm, withVideo = true)
+
+            assertEquals(1, countOf(TITLE))
+            assertTrue(countOf(INSTALL_HINT) > 0, "and says what to do about it")
+        }
+
+    @Test
+    fun `with VLC present there is nothing to explain`() =
+        // The positive twin for the gate: `vlcAvailable` defaults to true here.
+        presentationTab { vm, _ ->
+            load(vm, withVideo = true)
+
+            assertEquals(0, countOf(TITLE))
+        }
+
+    @Test
+    fun `a deck with no video is not warned about`() =
+        // Most decks are slides only. Warning about VLC on those would be noise on every load for
+        // an operator who has no video to play.
+        presentationTab(vlcAvailable = false) { vm, _ ->
+            load(vm, withVideo = false)
+
+            assertEquals(0, countOf(TITLE))
+        }
+
+    @Test
+    fun `dismissing it puts it away`() =
+        presentationTab(vlcAvailable = false) { vm, _ ->
+            load(vm, withVideo = true)
+            assertEquals(1, countOf(TITLE))
+
+            dismissBanner()
+
+            assertEquals(0, countOf(TITLE))
+        }
+
+    @Test
+    fun `loading another deck brings the warning back`() =
+        // The dismissal is keyed on the load generation, so it means "not for this deck" rather than
+        // "never again" — an operator who waved it away on a slides-only rehearsal still gets told
+        // when they open the deck that actually has the video in it.
+        presentationTab(vlcAvailable = false) { vm, _ ->
+            load(vm, withVideo = true)
+            dismissBanner()
+            assertEquals(0, countOf(TITLE))
+
+            load(vm, withVideo = true)
+
+            assertEquals(1, countOf(TITLE), "a dismissal must not carry across decks")
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabVlcBannerTest.kt
@@ -23,7 +23,6 @@ import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * The banner that explains why an embedded video is not playing.
@@ -46,8 +45,19 @@ import kotlin.test.assertTrue
 class PresentationTabVlcBannerTest {
 
     private companion object {
+        /**
+         * The banner's title, which is the same whichever reason it gives underneath.
+         *
+         * **Only the title is asserted, deliberately.** The detail line picks between three strings
+         * using `isVlcArchMismatch` / `isVlcLoadFailed`, and both of those derive from the JVM-wide
+         * `isVlcAvailable` rather than from this tab's `vlcAvailable` parameter — so the detail says
+         * "install VLC" on a machine that has it and "failed to load" on one that does not. Pinning
+         * it passes locally and fails on CI, which is exactly what it did before this comment
+         * existed. (`MediaTab` takes `vlcArchMismatch`/`vlcLoadFailed` as parameters and so can
+         * assert all three — see `MediaTabVlcUnavailableTest`. `PresentationTab` does not; making it
+         * symmetrical would be a production change worth its own PR.)
+         */
         const val TITLE = "VLC media player is required for media playback"
-        const val INSTALL_HINT = "Please install VLC from videolan.org and restart the application"
     }
 
     private val temps = mutableListOf<File>()
@@ -114,16 +124,35 @@ class PresentationTabVlcBannerTest {
         onAllNodesWithText(text, substring = true).fetchSemanticsNodes(false).size
 
     /**
-     * The banner's own dismiss button.
+     * The banner's own dismiss button: the clickable "Clear" sitting in the banner's own row.
      *
-     * `hasClickAction()` is load-bearing, not decoration: "Clear" matches **two** nodes — the
-     * `IconButton` and the `Icon` inside it — and only the outer one is clickable. Matching on the
-     * description alone finds both, and clicking the wrong one does nothing at all, which reads as
-     * "dismissal is broken" rather than "the selector is wrong". With the click action required it
-     * is unique, and `onNode` fails loudly if that ever stops being true.
+     * Three things make this harder than it looks, and all three were found the hard way:
+     *
+     *  * `"Clear"` matches the `IconButton` **and** the `Icon` inside it, and only the outer one is
+     *    clickable — hence `hasClickAction()`.
+     *  * The tab has other `"Clear"` buttons. One belongs to a **presentation left in the shared
+     *    test home by another suite** (`uploaded.pptx`), so how many exist depends on what ran
+     *    before this class. Addressing "the only Clear" therefore passes alone and fails in a full
+     *    run — which is what it did on CI while passing locally.
+     *  * An ancestry matcher does not separate them either: the root is an ancestor of every button
+     *    and does contain the banner's title.
+     *
+     * So it is located by row — the banner's title and its dismiss button share a `Row` with
+     * `verticalAlignment = CenterVertically`, so the right button is the one whose centre falls
+     * inside the title's vertical span. Exactly one must, and that is asserted rather than assumed.
      */
     private fun ComposeUiTest.dismissBanner() {
-        onNode(hasContentDescription("Clear") and hasClickAction()).performClick()
+        val title = onAllNodesWithText(TITLE, substring = true)
+            .fetchSemanticsNodes(false).single().boundsInRoot
+        val clears = onAllNodes(hasContentDescription("Clear") and hasClickAction())
+        val inTitleRow = clears.fetchSemanticsNodes(false).withIndex().filter { (_, node) ->
+            node.boundsInRoot.center.y in title.top..title.bottom
+        }
+        assertEquals(
+            1, inTitleRow.size,
+            "expected exactly one dismiss button in the banner's row, found ${inTitleRow.size}",
+        )
+        clears[inTitleRow.single().index].performClick()
         waitForIdle()
     }
 
@@ -142,7 +171,6 @@ class PresentationTabVlcBannerTest {
             load(vm, withVideo = true)
 
             assertEquals(1, countOf(TITLE))
-            assertTrue(countOf(INSTALL_HINT) > 0, "and says what to do about it")
         }
 
     @Test


### PR DESCRIPTION
A deck with embedded video degrades gracefully without VLC — the slide shows its static poster forever — so **this banner is the only thing telling an operator why**. It had no coverage at all.

**Not because it was hard to reach.** `presentationTab` has taken a `vlcAvailable` parameter all along, its KDoc saying *"only decides the missing-VLC banner for a deck containing video"*, and **no test ever passed it**. The scaffolding was sitting unused — the same seam as #199, where the song editor's tuning fields were uncovered with their harness parameter already in place. (`MediaTab`'s equivalent banner is driven exactly this way by `MediaTabVlcUnavailableTest`.)

**The rule with teeth is the reset.** The dismissal is `remember(viewModel.loadGeneration)`, so it means *"not for this deck"* rather than *"never again"* — an operator who waved it away on a slides-only rehearsal still gets told when they open the deck that actually has the video in it.

Also pinned: it appears only when the deck really has a `LayerSpec.Media` layer (most decks are slides only, and warning on those would be noise on every load), and not at all when VLC is present.

**The deck is synthetic over a real one-page PDF.** The view model rasterises whatever `loadDeck` returns, so the source file has to be openable — but the `slides` list is ours to shape, which is the only way to get a `Media` layer without an actual PowerPoint carrying an embedded video.

## Mutation-checked

| Mutation | Fails |
|---|---|
| `!vlcAvailable` → `vlcAvailable` | 4 tests |
| drop the `deckHasVideo &&` guard | the no-video test |
| `remember(loadGeneration)` → `remember` | the reset test |

## Two selector traps, both worth the note they got

- **`"Clear"` matches two nodes** — the `IconButton` and the `Icon` inside it — and only the outer one is clickable. Matching on the description alone found both and clicked the wrong one, which presents as *"dismissal is broken"* rather than *"the selector is wrong"*. `hasClickAction()` makes it unique. I burned two attempts guessing before dumping the semantics tree; the probe should have been first.
- **A "wait until slides exist" helper returns instantly on the second load**, because the first deck's slides are still there — so the assertions ran against the previous deck and the reset test failed as though the production code were wrong. The wait is now keyed on `loadGeneration` changing. Both are recorded in the test's own comments.

**Test-only.** `tabs` package ×3 with `--rerun-tasks`, **901 tests, 0 failures** each. 5 tests, class **0.42s**.