### PR TITLE
Retry the render warm-up instead of failing the class on a refused connection

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerPresentationRenderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerPresentationRenderTest.kt
@@ -87,18 +87,30 @@ class CompanionServerPresentationRenderTest {
                     )
                 )
             )
+            // A refused connection is retried, not thrown. `isRunning` flips as soon as the engine
+            // has started, which is not the same instant Netty begins accepting on the socket, so a
+            // request issued in that gap comes back as ConnectException rather than as a status.
+            // The loop is already shaped to poll — it has a deadline and a sleep — but an unguarded
+            // `get()` escapes it on the very first refusal, so the deadline never got to do its job
+            // and @BeforeClass failed the whole class with "Connection refused". Seen on CI
+            // 2026-08-07 (run 31140371736).
             val deadline = System.currentTimeMillis() + 60_000
+            var warmed = false
             HttpClient(CIO).use { warmClient ->
-                while (System.currentTimeMillis() < deadline) {
-                    val status = runBlocking {
-                        warmClient.get(
-                            "http://127.0.0.1:$PORT${org.churchpresenter.app.churchpresenter.utils.Constants.ENDPOINT_PRESENTATIONS}/warm-up"
-                        ).status
-                    }
-                    if (status == HttpStatusCode.OK) break
-                    Thread.sleep(50)
+                while (!warmed && System.currentTimeMillis() < deadline) {
+                    val status = runCatching {
+                        runBlocking {
+                            warmClient.get(
+                                "http://127.0.0.1:$PORT${org.churchpresenter.app.churchpresenter.utils.Constants.ENDPOINT_PRESENTATIONS}/warm-up"
+                            ).status
+                        }
+                    }.getOrNull()
+                    if (status == HttpStatusCode.OK) warmed = true else Thread.sleep(50)
                 }
             }
+            // Previously the loop simply fell out after 60s and the class carried on against a
+            // server that had never answered, so the real failure surfaced later and somewhere else.
+            check(warmed) { "the companion server never served the warm-up deck on port $PORT" }
             server.updateSchedule(emptyList())
         }
 


### PR DESCRIPTION
`CompanionServerPresentationRenderTest` failed on CI tonight and took an unrelated PR's required check down with it (#225, run `31140371736`):

```
CompanionServerPresentationRenderTest[jvm] > classMethod[jvm] FAILED
    java.net.ConnectException: Connection refused
        at ...CompanionServerPresentationRenderTest$Companion$startServer$2$status$1.invokeSuspend(:272)
```

**The cause.** `@BeforeClass` polls the server until it serves the warm-up deck, and the loop is already shaped for that — it has a 60s deadline and a 50ms sleep. But the request was an unguarded `warmClient.get()`, and a refused connection *throws* instead of returning a status. So the very first refusal escaped the loop and failed the class, and the deadline never got to do its job.

The gap is real: `server.isRunning` flips when the engine has started, which is not the same instant Netty begins accepting on the socket. A request issued in between is refused.

**The fix** wraps the request so a connection error retries, which is what the loop always meant to do.

It also now asserts the outcome. Previously, if the server never answered, the loop just fell out after 60 seconds and the class carried on against a server that had never responded — so the real failure surfaced later, in some other test, looking like something else.

**Verification.** Pointed the warm-up at a port nothing listens on and shortened the deadline: the failure is now `IllegalStateException: the companion server never served the warm-up deck on port 39890` after the deadline, where before the same scenario threw `ConnectException` immediately. That exercises both halves — errors are retried, and exhaustion is loud. Full suite green.

**Not changed, but worth knowing:** the port is a hard-coded `39_890`. If anything else on the machine holds it, this now waits 60s and then fails with a clear message rather than failing instantly with a confusing one — but binding port 0 and reading the resolved port back (as `BibleEngineClientLinkTest`'s fake engine does) would remove the assumption entirely. That felt like a separate change from fixing the crash.