### PR TITLE
Make the Bible engine's reconnect backoff injectable, and test the reconnect

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -212,9 +212,12 @@ When writing tests here:
     against it. Example: `BibleViewModel.navigateToReference` bumps `verseSelectionToken` and then
     — same coroutine, no suspension between — bumps `autoFollowLiveToken` only if the match
     qualified, so waiting on the first and then asserting the second is race-free and instant.
-  - When the production code's own delay is the cost and is not injectable (e.g.
-    `BibleEngineClient`'s 2s reconnect backoff floor), **do not write the test**; note the gap in
-    the test class's doc comment instead.
+  - When the production code's own delay is the cost and is not injectable, **do not write the
+    test**; note the gap in the test class's doc comment instead. But first ask whether it has to
+    stay non-injectable: `BibleEngineClient`'s reconnect backoff was the standing example here, and
+    a defaulted `retryFloorMs` constructor parameter both unlocked the reconnect test and removed a
+    flake — a *defaulted constructor parameter* is not the ad-hoc mutable singleton seam banned
+    above. The schedule's shape stays pinned by a pure test of `retryDelayMs`.
   - Where an idle window genuinely is the only terminator (a snapshot with no final frame), keep
     it in the low hundreds of ms — it only has to outlast a loopback gap, not a network.
   - Check the cost of what you added: `./gradlew :composeApp:jvmTest` then read the `time=`

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClient.kt
@@ -63,6 +63,23 @@ data class EngineScripture(
     val detectedVersion: String? = null,
 )
 
+/** The app's wait between reconnect attempts: long enough not to hammer a restarting engine. */
+internal const val DEFAULT_RETRY_FLOOR_MS = 2_000L
+
+/** No reconnect wait grows past this, however many attempts have failed. */
+internal const val MAX_RETRY_DELAY_MS = 30_000L
+
+/**
+ * How long to wait before reconnect attempt number [attempt] (0-based, so 0 is the wait after the
+ * *first* failure): [floorMs] doubled once per prior failure, capped at [MAX_RETRY_DELAY_MS], with
+ * ±20% jitter so a roomful of clients that lost the same engine do not come back in lockstep.
+ * Jitter never takes it below [floorMs].
+ */
+internal fun retryDelayMs(attempt: Int, floorMs: Long = DEFAULT_RETRY_FLOOR_MS): Long {
+    val base = (floorMs shl attempt.coerceAtMost(4)).coerceAtMost(MAX_RETRY_DELAY_MS)
+    return (base * Random.nextDouble(0.8, 1.2)).toLong().coerceAtLeast(floorMs)
+}
+
 /**
  * Client for the Bible Lookup Engine (BLE) microservice. Replaces in-app detection: it (optionally)
  * starts the engine in-process when STT connects, opens a WebSocket to `/bible-engine`, and forwards
@@ -76,10 +93,16 @@ data class EngineScripture(
  * Both callbacks are required and neither is the trailing one by convention — pass them by name.
  * A defaulted trailing lambda here would silently bind `BibleEngineClient { … }` to the wrong
  * callback.
+ *
+ * @param retryFloorMs the shortest wait between reconnect attempts, and the base the backoff doubles
+ *   from. Two seconds in the app — long enough not to hammer an engine that is restarting. Tests pass
+ *   a few milliseconds so a reconnect is observable inside the per-test time budget; that is the only
+ *   reason it is a parameter.
  */
 class BibleEngineClient(
     private val onScripture: (EngineScripture) -> Unit,
     private val onVersion: (String?) -> Unit,
+    private val retryFloorMs: Long = DEFAULT_RETRY_FLOOR_MS,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val httpClient = HttpClient(CIO) {
@@ -159,8 +182,8 @@ class BibleEngineClient(
     }
 
     private suspend fun connectLoop(host: String, port: Int) {
-        // Exponential backoff (floor 2s, cap 30s, ±20% jitter — same shape as InstanceLinkClient)
-        // instead of a fixed 2s hammer; reset on every successful connection.
+        // Exponential backoff (floor [retryFloorMs], cap 30s, ±20% jitter — same shape as
+        // InstanceLinkClient) instead of a fixed hammer; reset on every successful connection.
         var attempt = 0
         while (scope.isActive) {
             try {
@@ -183,9 +206,8 @@ class BibleEngineClient(
             _connected.value = false
             _engineSttConnected.value = null
             if (!scope.isActive) break
-            val base = (2_000L shl attempt.coerceAtMost(4)).coerceAtMost(30_000L)
+            delay(retryDelayMs(attempt, retryFloorMs))
             attempt++
-            delay((base * Random.nextDouble(0.8, 1.2)).toLong().coerceAtLeast(2_000L))
         }
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
@@ -102,10 +102,18 @@ class BibleEngineClientLinkTest {
         detections.clear()
     }
 
-    private fun client(): BibleEngineClient =
+    /**
+     * The production reconnect floor is 2s, so a client that has to retry even once cannot come up
+     * inside this class's time budget — and a single failed connect under load was enough to make
+     * `connect()` below time out, which is what made this class flaky. A few milliseconds keeps the
+     * retry *shape* (doubling, jitter, cap) while costing nothing. The 2s default and the shape
+     * itself are pinned by [BibleEngineRetryDelayTest], which needs no server at all.
+     */
+    private fun client(retryFloorMs: Long = 25L): BibleEngineClient =
         BibleEngineClient(
             onScripture = { e -> detections.add(Detection(e.bookId, e.chapter, e.verseStart, e.verseText)) },
             onVersion = {},
+            retryFloorMs = retryFloorMs,
         ).also { created.add(it) }
 
     /**
@@ -264,11 +272,24 @@ class BibleEngineClientLinkTest {
     }
 
     // ── Dropping ────────────────────────────────────────────────────────────────
-    //
-    // NOT covered here: that the client climbs back on its own after a drop. The retry loop's
-    // backoff floor is 2s and is not injectable, so every such test costs at least that in wall
-    // clock — see the unit-test speed rule in AGENT.md. The drop itself (below) is observable
-    // immediately and is covered.
+
+    @Test
+    fun `the client climbs back on its own after the engine drops it`() {
+        val c = client()
+        c.connect()
+        nextFrame()
+
+        engine.dropConnections()
+
+        // Not waiting on the link going *down* first: the reconnect floor here is milliseconds, so
+        // the down state can come and go between two polls. The connection count only ever climbs.
+        awaitUntil("the client to reconnect unaided") { engine.connectionCount.get() == 2 && c.connected.value }
+        assertEquals(
+            """{"type":"set_tuning","level":"balanced","continuationSpeed":"balanced"}""",
+            nextFrame(),
+            "a reconnected client re-announces its tuning; an engine told nothing runs at its own default"
+        )
+    }
 
     @Test
     fun `the engine's stt health goes back to unknown while the link is down`() {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineRetryDelayTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineRetryDelayTest.kt
@@ -1,0 +1,108 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The reconnect backoff [retryDelayMs] uses when the engine link goes down.
+ *
+ * [BibleEngineClientLinkTest] drives the real loop but injects a millisecond floor so its tests fit
+ * the time budget, which means nothing there pins the *shape* or the two-second production default.
+ * This does, and needs no server, no client and no wall clock: the schedule is a pure function of
+ * the attempt number.
+ */
+class BibleEngineRetryDelayTest {
+
+    /** Every wait for one floor, across enough attempts to reach the cap and stay there. */
+    private fun schedule(floorMs: Long, attempts: Int = 12): List<Long> =
+        (0 until attempts).map { retryDelayMs(it, floorMs) }
+
+    @Test
+    fun `the app waits two seconds before its first retry`() {
+        assertEquals(2_000L, DEFAULT_RETRY_FLOOR_MS, "the shipped floor; shortening it hammers a restarting engine")
+        repeat(50) {
+            val first = retryDelayMs(attempt = 0)
+            assertTrue(
+                first in 2_000L..2_400L,
+                "the first retry waits the floor plus at most +20% jitter, was ${first}ms"
+            )
+        }
+    }
+
+    @Test
+    fun `each successive failure waits longer than the one before`() {
+        // Compared floor-to-floor rather than sample-to-sample: consecutive draws overlap by design
+        // (±20% of a doubling is a 1.2x vs 1.6x band), so it is the *schedule* that climbs.
+        repeat(20) {
+            val waits = schedule(floorMs = 100L, attempts = 5)
+            waits.zipWithNext().forEach { (earlier, later) ->
+                assertTrue(later > earlier, "attempt waits must climb, got $waits")
+            }
+        }
+    }
+
+    @Test
+    fun `the wait doubles once per failure until it is capped`() {
+        // Written out rather than recomputed, so restating the production expression cannot make
+        // this pass: 2s, then double per failure, then held at the 30s cap.
+        val expected = listOf(2_000L, 4_000L, 8_000L, 16_000L, 30_000L, 30_000L, 30_000L, 30_000L)
+        repeat(20) {
+            schedule(floorMs = 2_000L, attempts = expected.size).forEachIndexed { attempt, wait ->
+                val target = expected[attempt]
+                assertTrue(
+                    wait >= (target * 0.8).toLong() && wait <= (target * 1.2).toLong(),
+                    "attempt $attempt should sit within ±20% of ${target}ms, was ${wait}ms"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `no wait grows past the cap however long the engine stays down`() {
+        assertEquals(30_000L, MAX_RETRY_DELAY_MS)
+        repeat(20) {
+            val waits = schedule(floorMs = 2_000L, attempts = 40)
+            assertTrue(
+                waits.all { it <= (MAX_RETRY_DELAY_MS * 1.2).toLong() },
+                "an engine down for an hour must still be retried; the wait cannot run away, got ${waits.max()}ms"
+            )
+            assertTrue(
+                waits.any { it > 20_000L },
+                "and it must actually reach the cap rather than stalling low, got ${waits.max()}ms"
+            )
+        }
+    }
+
+    @Test
+    fun `jitter spreads the waits so reconnecting clients do not come back in lockstep`() {
+        // 200 draws of the same attempt: an unjittered implementation returns one value 200 times.
+        val draws = (1..200).map { retryDelayMs(attempt = 2, floorMs = 2_000L) }.toSet()
+        assertTrue(draws.size > 50, "the wait must vary between clients, saw ${draws.size} distinct values")
+    }
+
+    @Test
+    fun `jitter never dips below the floor`() {
+        // The -20% side of a floor-sized base would undercut the floor, so it is clamped. Without
+        // the clamp an injected 25ms floor could fire at 20ms — and the shipped one at 1.6s.
+        listOf(25L, 100L, 2_000L).forEach { floor ->
+            repeat(200) {
+                val wait = retryDelayMs(attempt = 0, floorMs = floor)
+                assertTrue(wait >= floor, "a ${floor}ms floor must never wait less, was ${wait}ms")
+            }
+        }
+    }
+
+    @Test
+    fun `an injected floor scales the whole schedule, not just the first wait`() {
+        val fast = schedule(floorMs = 25L, attempts = 5)
+        val shipped = schedule(floorMs = 2_000L, attempts = 5)
+        fast.zip(shipped).forEachIndexed { attempt, (quick, slow) ->
+            assertTrue(quick < slow, "attempt $attempt: ${quick}ms should undercut the shipped ${slow}ms")
+        }
+        assertTrue(
+            fast.sum() < 1_000L,
+            "three failed connects on an injected floor must fit a test budget, summed to ${fast.sum()}ms"
+        )
+    }
+}


### PR DESCRIPTION
## The flake

`BibleEngineClientLinkTest` failed roughly **1 full-suite run in 8** on a loaded machine. Its signature was always the same: the class cost **15.69s instead of 0.68s** — the whole `awaitUntil` budget. The client had not connected *slowly*, it had **never connected**.

`connectLoop`'s backoff is not a fixed 2s hammer; it doubles from a 2s floor with ±20% jitter:

| failed connects | cumulative wait | vs the test's 15s budget |
|---|---|---|
| 1 | 2.0 – 2.4s | fine |
| 2 | 5.2 – 7.2s | fine (a 5.05s partial was observed) |
| 3 | **11.6 – 16.8s** | **straddles it — jitter decides** |
| 4 | 24.4 – 36.0s | always fails |

So a single failed connect under load puts the test one more failure away from a cliff whose outcome is a coin toss.

## The fix

Widening the 15s timeout is the forbidden move and would only push the cliff from three failures to four. What makes a retry unaffordable in a test is the **floor**, so it becomes a parameter:

- `BibleEngineClient(…, retryFloorMs: Long = DEFAULT_RETRY_FLOOR_MS)` — a defaulted constructor parameter, not a mutable singleton seam. The app is byte-for-byte unchanged at the default.
- The link test injects **25ms**. Three failed connects now cost ~0.2s instead of ~14s.

This does not explain *why* an individual connect fails — that fact is still unknown. It removes the mechanism that turns one failure into a 15s stall.

## What now pins the shape

The injected floor means the link test no longer exercises the real schedule, so the schedule moved into `internal fun retryDelayMs(attempt, floorMs)` and **`BibleEngineRetryDelayTest`** covers it with no server, no client and no wall clock (7 cases, 0.006s): the 2s shipped default, the doubling, the 30s cap, the jitter spread, and the clamp that stops jitter dipping below the floor.

Each was mutated in the production source and the matching case failed — nothing else caught any of them:

| mutation | caught by |
|---|---|
| jitter removed | `jitter spreads the waits…` |
| floor clamp removed | `jitter never dips below the floor` (+ the 2s case) |
| 30s cap removed | `no wait grows past the cap…` (+ the doubling case) |
| default floor → 500ms | `the app waits two seconds before its first retry` |
| retry loop removed (`break`) | `the client climbs back on its own after the engine drops it` |

## The coverage gap this closes

The class doc carried this:

> NOT covered here: that the client climbs back on its own after a drop. The retry loop's backoff floor is 2s and is not injectable, so every such test costs at least that in wall clock.

That is the headline claim in the class's own header — "climb back on its own when the engine restarts, without the operator touching anything" — and it was untested. It is now a test, it costs **0.09s**, and mutation E above shows it is the only thing standing behind the retry loop.

`AGENT.md` cited this floor as its standing example of a non-injectable delay; that paragraph is updated to say a defaulted constructor parameter is worth reaching for first.

## Validation

- Full suite `--rerun-tasks --no-build-cache` on unmodified `main` as a control: green, link class 0.661s. Machine healthy, no build-cache corruption.
- Bible + viewmodel packages, `--rerun-tasks`, **3 consecutive runs**: green, link class 1.375 / 1.375 / 1.54s.
- Same configuration **before** the change measured 1.272s, so the delta is the new reconnect test and nothing else.
- Slowest case in the class, excluding the first-test warm-up, is 0.09s.
