### PR TITLE
Make the app-preview fixture presentable

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -212,9 +212,12 @@ When writing tests here:
     against it. Example: `BibleViewModel.navigateToReference` bumps `verseSelectionToken` and then
     — same coroutine, no suspension between — bumps `autoFollowLiveToken` only if the match
     qualified, so waiting on the first and then asserting the second is race-free and instant.
-  - When the production code's own delay is the cost and is not injectable (e.g.
-    `BibleEngineClient`'s 2s reconnect backoff floor), **do not write the test**; note the gap in
-    the test class's doc comment instead.
+  - When the production code's own delay is the cost and is not injectable, **do not write the
+    test**; note the gap in the test class's doc comment instead. But first ask whether it has to
+    stay non-injectable: `BibleEngineClient`'s reconnect backoff was the standing example here, and
+    a defaulted `retryFloorMs` constructor parameter both unlocked the reconnect test and removed a
+    flake — a *defaulted constructor parameter* is not the ad-hoc mutable singleton seam banned
+    above. The schedule's shape stays pinned by a pure test of `retryDelayMs`.
   - Where an idle window genuinely is the only terminator (a snapshot with no final frame), keep
     it in the low hundreds of ms — it only has to outlast a loopback gap, not a network.
   - Check the cost of what you added: `./gradlew :composeApp:jvmTest` then read the `time=`

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClient.kt
@@ -63,6 +63,23 @@ data class EngineScripture(
     val detectedVersion: String? = null,
 )
 
+/** The app's wait between reconnect attempts: long enough not to hammer a restarting engine. */
+internal const val DEFAULT_RETRY_FLOOR_MS = 2_000L
+
+/** No reconnect wait grows past this, however many attempts have failed. */
+internal const val MAX_RETRY_DELAY_MS = 30_000L
+
+/**
+ * How long to wait before reconnect attempt number [attempt] (0-based, so 0 is the wait after the
+ * *first* failure): [floorMs] doubled once per prior failure, capped at [MAX_RETRY_DELAY_MS], with
+ * ±20% jitter so a roomful of clients that lost the same engine do not come back in lockstep.
+ * Jitter never takes it below [floorMs].
+ */
+internal fun retryDelayMs(attempt: Int, floorMs: Long = DEFAULT_RETRY_FLOOR_MS): Long {
+    val base = (floorMs shl attempt.coerceAtMost(4)).coerceAtMost(MAX_RETRY_DELAY_MS)
+    return (base * Random.nextDouble(0.8, 1.2)).toLong().coerceAtLeast(floorMs)
+}
+
 /**
  * Client for the Bible Lookup Engine (BLE) microservice. Replaces in-app detection: it (optionally)
  * starts the engine in-process when STT connects, opens a WebSocket to `/bible-engine`, and forwards
@@ -76,10 +93,16 @@ data class EngineScripture(
  * Both callbacks are required and neither is the trailing one by convention — pass them by name.
  * A defaulted trailing lambda here would silently bind `BibleEngineClient { … }` to the wrong
  * callback.
+ *
+ * @param retryFloorMs the shortest wait between reconnect attempts, and the base the backoff doubles
+ *   from. Two seconds in the app — long enough not to hammer an engine that is restarting. Tests pass
+ *   a few milliseconds so a reconnect is observable inside the per-test time budget; that is the only
+ *   reason it is a parameter.
  */
 class BibleEngineClient(
     private val onScripture: (EngineScripture) -> Unit,
     private val onVersion: (String?) -> Unit,
+    private val retryFloorMs: Long = DEFAULT_RETRY_FLOOR_MS,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val httpClient = HttpClient(CIO) {
@@ -159,8 +182,8 @@ class BibleEngineClient(
     }
 
     private suspend fun connectLoop(host: String, port: Int) {
-        // Exponential backoff (floor 2s, cap 30s, ±20% jitter — same shape as InstanceLinkClient)
-        // instead of a fixed 2s hammer; reset on every successful connection.
+        // Exponential backoff (floor [retryFloorMs], cap 30s, ±20% jitter — same shape as
+        // InstanceLinkClient) instead of a fixed hammer; reset on every successful connection.
         var attempt = 0
         while (scope.isActive) {
             try {
@@ -183,9 +206,8 @@ class BibleEngineClient(
             _connected.value = false
             _engineSttConnected.value = null
             if (!scope.isActive) break
-            val base = (2_000L shl attempt.coerceAtMost(4)).coerceAtMost(30_000L)
+            delay(retryDelayMs(attempt, retryFloorMs))
             attempt++
-            delay((base * Random.nextDouble(0.8, 1.2)).toLong().coerceAtLeast(2_000L))
         }
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewPicturesScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewPicturesScreenshotTest.kt
@@ -16,7 +16,7 @@ class AppPreviewPicturesScreenshotTest {
             Snapshot.sendApplyNotifications()
             onAllNodes(hasText("Loading...")).fetchSemanticsNodes(false).isEmpty()
         }
-        onAllNodes(hasText("04 Baptism Pool"))[0].performClick()
+        onAllNodes(hasText("04 Church"))[0].performClick()
         waitForIdle()
         goLive()
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSupport.kt
@@ -47,18 +47,27 @@ import org.apache.pdfbox.pdmodel.PDPage
 import org.apache.pdfbox.pdmodel.PDPageContentStream
 import org.apache.pdfbox.pdmodel.common.PDRectangle
 import org.apache.pdfbox.pdmodel.font.PDType1Font
-import java.awt.Color
-import java.awt.GradientPaint
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
 
 private const val ROOT = "$SCREENSHOT_ROOT/previewApp"
-// Neutral root, so no path on screen carries the developer's own home directory. Falls back to the
-// build dir on a platform without /tmp.
-private val LIBRARY = File("/tmp/ChurchPresenter").let { neutral ->
-    if (neutral.exists() || neutral.mkdirs()) neutral else File("build/app-preview-library").absoluteFile
-}
+/**
+ * Where the fixture's media library lives — and, because the schedule row prints the path of every
+ * file-backed item at detailed density, **a string that appears in the screenshots themselves**.
+ *
+ * So it has to be three things at once: real (the path shown is the path used), writable without a
+ * permission prompt, and free of the developer's own username. `/Users/Shared` is the macOS
+ * directory that satisfies all three — it exists on every install, is world-writable, and names
+ * nobody. Elsewhere, `/tmp` is the equivalent and is what CI uses.
+ *
+ * The two roots produce different text on screen, which is deliberate and harmless: CI only ever
+ * compares its own renders against its own, and images are not committed, so a local recording never
+ * enters the comparison.
+ */
+private val LIBRARY = listOf(File("/Users/Shared/ChurchPresenter"), File("/tmp/ChurchPresenter"))
+    .firstOrNull { it.parentFile?.isDirectory == true && (it.isDirectory || it.mkdirs()) }
+    ?: File("build/app-preview-library").absoluteFile
 
 // The real King James the app ships as a sample: 66 books with every chapter and verse, so the
 // chapter grid and the verse pane are the real thing rather than a fixture's handful.
@@ -89,12 +98,12 @@ internal fun appPreview(
     RecentPresentationFiles.files.clear()
     RecentPresentationFiles.pinned.clear()
     RecentPresentationFiles.files.addAll(
-        listOf(File(LIBRARY, "Decks/Sermon.pdf").absolutePath, "/tmp/ChurchPresenter/Decks/Advent Series.pptx"),
+        listOf(File(LIBRARY, "Decks/Sermon.pdf").absolutePath, File(LIBRARY, "Decks/Advent Series.pptx").absolutePath),
     )
     RecentMediaFiles.paths.clear()
     RecentMediaFiles.pinned.clear()
     RecentMediaFiles.paths.addAll(
-        listOf(File(LIBRARY, "Media/Welcome Loop.mp4").absolutePath, "/tmp/ChurchPresenter/Media/Baptism Testimony.mp4"),
+        listOf(File(LIBRARY, "Media/Welcome Loop.mp4").absolutePath, File(LIBRARY, "Media/Baptism Testimony.mp4").absolutePath),
     )
     writeScenes()
     writeQuestions()
@@ -232,7 +241,7 @@ private fun serviceSchedule(actions: ScheduleActions) {
     actions.addBibleVerse("Psalms", 23, 1, "The LORD is my shepherd; I shall not want.", "1-3", 19)
     actions.addPresentation(File(LIBRARY, "Decks/Sermon.pdf").absolutePath, "Sermon", SERMON_SLIDES.size, "pdf")
     actions.addSong(455, "It Is Well With My Soul", "Hymnal", "song-455")
-    actions.addPicture(File(LIBRARY, "Baptism").absolutePath, "Baptism", PHOTOS.size)
+    actions.addPicture(File(LIBRARY, "Gallery").absolutePath, "Gallery", PHOTOS.size)
     actions.addAnnouncement(
         ScheduleItem.AnnouncementItem(
             id = "ann-1",
@@ -274,7 +283,7 @@ private fun serviceSchedule(actions: ScheduleActions) {
             timerMode = Constants.TIMER_MODE_CLOCK_DISPLAY,
         )
     )
-    actions.addWebsite("https://example.org/give", "Giving page")
+    actions.addWebsite("https://churchpresenter.org/give", "Giving page")
 }
 
 /**
@@ -344,7 +353,7 @@ internal fun previewScenes(): List<Scene> = listOf(
             SceneSource.QRCodeSource(
                 id = "qr", name = "Giving QR",
                 transform = SourceTransform(x = 0.04f, y = 0.05f, width = 0.1f, height = 0.18f),
-                content = "https://example.org/give",
+                content = "https://churchpresenter.org/give",
             ),
         ),
     ),
@@ -358,7 +367,7 @@ internal fun previewScenes(): List<Scene> = listOf(
 internal fun library(): AppSettings {
     val songs = File(LIBRARY, "Songs")
     val bibles = File(LIBRARY, "Bibles")
-    val pictures = File(LIBRARY, "Baptism")
+    val pictures = File(LIBRARY, "Gallery")
     val decks = File(LIBRARY, "Decks")
     listOf(songs, bibles, pictures, decks).forEach { it.mkdirs() }
     writeSongs(songs)
@@ -399,9 +408,9 @@ internal fun library(): AppSettings {
         // rather than still travelling up from the bottom.
         announcementsSettings = AnnouncementsSettings(animationType = Constants.ANIMATION_NONE),
         webBookmarks = listOf(
-            WebBookmark(url = "https://example.org/give", title = "Giving"),
-            WebBookmark(url = "https://example.org/notices", title = "Weekly Notices"),
-            WebBookmark(url = "https://example.org/prayer", title = "Prayer Requests"),
+            WebBookmark(url = "https://churchpresenter.org/give", title = "Giving"),
+            WebBookmark(url = "https://churchpresenter.org/notices", title = "Weekly Notices"),
+            WebBookmark(url = "https://churchpresenter.org/prayer", title = "Prayer Requests"),
             WebBookmark(url = "https://www.biblegateway.com", title = "Bible Gateway"),
         ),
         hiddenTabs = emptySet(),
@@ -425,25 +434,65 @@ private fun writeSongs(dir: File) {
     }
 }
 
+private val BACKGROUNDS_SOURCE = File("src/jvmMain/composeResources/files/backgrounds")
+
+/**
+ * The picture gallery, as display name to background category.
+ *
+ * These were twelve generated colour gradients, which made the Pictures tab the one panel that
+ * obviously came from a fixture. They are now real photographs — the app already ships ~290 of them,
+ * so this costs the repository nothing and exercises the real JPEG decode path rather than a
+ * synthetic PNG.
+ *
+ * **The names say only what the category guarantees.** The specific file behind "Worship" is
+ * whichever sorts first in that category, and nobody here has looked at it, so a caption like
+ * "Hands Raised" would be a guess that the image is free to contradict. A gallery that names what it
+ * actually knows is both honest and stable when the shipped set changes.
+ */
 private val PHOTOS = listOf(
-    "01 Welcome", "02 Gathering", "03 Worship", "04 Baptism Pool", "05 Testimony", "06 The Font",
-    "07 Congregation", "08 Prayer", "09 Youth Team", "10 Fellowship", "11 Candles", "12 Sending",
+    "01 Worship" to "worship",
+    "02 Worship" to "worship",
+    "03 Church" to "church",
+    "04 Church" to "church",
+    "05 Cross" to "cross",
+    "06 Cross" to "cross",
+    "07 Candles" to "candles",
+    "08 Candles" to "candles",
+    "09 Mountains" to "mountains",
+    "10 Sky" to "sky_clouds",
+    "11 Ocean" to "ocean_waves",
+    "12 Landscape" to "nature_landscape",
 )
 
+/**
+ * Copies the gallery out of the shipped backgrounds, **downscaled**.
+ *
+ * The sources are ~1880x1253. Twelve of those decoded at full size is real work on a two-core
+ * runner, and the Pictures tab waits for every thumbnail before it can be photographed — that wait
+ * has already timed out once when the record job grew. 960px keeps the photographs unmistakably
+ * photographic while costing a quarter of the pixels.
+ */
 private fun writePictures(dir: File) {
-    PHOTOS
-        .forEachIndexed { index, name ->
-            val image = BufferedImage(480, 300, BufferedImage.TYPE_INT_RGB)
-            val canvas = image.createGraphics()
-            val hue = (index * 0.14f) % 1f
-            canvas.paint = GradientPaint(
-                0f, 0f, Color.getHSBColor(hue, 0.5f, 0.9f),
-                480f, 300f, Color.getHSBColor((hue + 0.09f) % 1f, 0.85f, 0.4f),
-            )
-            canvas.fillRect(0, 0, 480, 300)
-            canvas.dispose()
-            ImageIO.write(image, "png", File(dir, "$name.png"))
-        }
+    val taken = mutableMapOf<String, Int>()
+    PHOTOS.forEach { (name, category) ->
+        val nth = taken.merge(category, 1, Int::plus)!! - 1
+        val source = BACKGROUNDS_SOURCE
+            .listFiles { file -> file.name.startsWith("${category}_") }
+            ?.sortedBy { it.name }
+            ?.getOrNull(nth)
+            ?: error("no shipped background left in '$category' for '$name'")
+        ImageIO.write(scaledToWidth(ImageIO.read(source), 960), "png", File(dir, "$name.png"))
+    }
+}
+
+private fun scaledToWidth(source: BufferedImage, width: Int): BufferedImage {
+    if (source.width <= width) return source
+    val height = (source.height.toLong() * width / source.width).toInt().coerceAtLeast(1)
+    val scaled = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+    val canvas = scaled.createGraphics()
+    canvas.drawImage(source.getScaledInstance(width, height, java.awt.Image.SCALE_SMOOTH), 0, 0, null)
+    canvas.dispose()
+    return scaled
 }
 
 private val SERMON_SLIDES = listOf(

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ScreenshotSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ScreenshotSupport.kt
@@ -57,8 +57,15 @@ internal const val SCREENSHOT_ROOT = "build/screenshots"
  * for correctness rather than just for passing: a thumbnail still showing its placeholder is a
  * *different image*, so cutting the wait short would produce a screenshot that differs from one run
  * to the next.
+ *
+ * **It must stay comfortably under a minute.** `runTest` — which `runComposeUiTest` builds on —
+ * gives the whole test body 60s, and that is the outer bound no wait in here can exceed. Set to
+ * 60s this constant could never spend its budget: a slow render hit the harness timeout first and
+ * failed with `UncompletedCoroutinesError: After waiting for 1m, the test body did not run to
+ * completion`, which names neither the wait nor the condition. 30s leaves room for the rest of the
+ * test and still fails with the message that says what was being waited for.
  */
-internal const val RENDER_TIMEOUT_MS = 60_000L
+internal const val RENDER_TIMEOUT_MS = 30_000L
 private val PARTS = File("$SCREENSHOT_ROOT/.parts")
 
 /** [rootIndex] 1 shoots an open popup — a dropdown or menu is a compose root of its own. */

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
@@ -102,10 +102,18 @@ class BibleEngineClientLinkTest {
         detections.clear()
     }
 
-    private fun client(): BibleEngineClient =
+    /**
+     * The production reconnect floor is 2s, so a client that has to retry even once cannot come up
+     * inside this class's time budget — and a single failed connect under load was enough to make
+     * `connect()` below time out, which is what made this class flaky. A few milliseconds keeps the
+     * retry *shape* (doubling, jitter, cap) while costing nothing. The 2s default and the shape
+     * itself are pinned by [BibleEngineRetryDelayTest], which needs no server at all.
+     */
+    private fun client(retryFloorMs: Long = 25L): BibleEngineClient =
         BibleEngineClient(
             onScripture = { e -> detections.add(Detection(e.bookId, e.chapter, e.verseStart, e.verseText)) },
             onVersion = {},
+            retryFloorMs = retryFloorMs,
         ).also { created.add(it) }
 
     /**
@@ -264,11 +272,24 @@ class BibleEngineClientLinkTest {
     }
 
     // ── Dropping ────────────────────────────────────────────────────────────────
-    //
-    // NOT covered here: that the client climbs back on its own after a drop. The retry loop's
-    // backoff floor is 2s and is not injectable, so every such test costs at least that in wall
-    // clock — see the unit-test speed rule in AGENT.md. The drop itself (below) is observable
-    // immediately and is covered.
+
+    @Test
+    fun `the client climbs back on its own after the engine drops it`() {
+        val c = client()
+        c.connect()
+        nextFrame()
+
+        engine.dropConnections()
+
+        // Not waiting on the link going *down* first: the reconnect floor here is milliseconds, so
+        // the down state can come and go between two polls. The connection count only ever climbs.
+        awaitUntil("the client to reconnect unaided") { engine.connectionCount.get() == 2 && c.connected.value }
+        assertEquals(
+            """{"type":"set_tuning","level":"balanced","continuationSpeed":"balanced"}""",
+            nextFrame(),
+            "a reconnected client re-announces its tuning; an engine told nothing runs at its own default"
+        )
+    }
 
     @Test
     fun `the engine's stt health goes back to unknown while the link is down`() {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineRetryDelayTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineRetryDelayTest.kt
@@ -1,0 +1,108 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The reconnect backoff [retryDelayMs] uses when the engine link goes down.
+ *
+ * [BibleEngineClientLinkTest] drives the real loop but injects a millisecond floor so its tests fit
+ * the time budget, which means nothing there pins the *shape* or the two-second production default.
+ * This does, and needs no server, no client and no wall clock: the schedule is a pure function of
+ * the attempt number.
+ */
+class BibleEngineRetryDelayTest {
+
+    /** Every wait for one floor, across enough attempts to reach the cap and stay there. */
+    private fun schedule(floorMs: Long, attempts: Int = 12): List<Long> =
+        (0 until attempts).map { retryDelayMs(it, floorMs) }
+
+    @Test
+    fun `the app waits two seconds before its first retry`() {
+        assertEquals(2_000L, DEFAULT_RETRY_FLOOR_MS, "the shipped floor; shortening it hammers a restarting engine")
+        repeat(50) {
+            val first = retryDelayMs(attempt = 0)
+            assertTrue(
+                first in 2_000L..2_400L,
+                "the first retry waits the floor plus at most +20% jitter, was ${first}ms"
+            )
+        }
+    }
+
+    @Test
+    fun `each successive failure waits longer than the one before`() {
+        // Compared floor-to-floor rather than sample-to-sample: consecutive draws overlap by design
+        // (±20% of a doubling is a 1.2x vs 1.6x band), so it is the *schedule* that climbs.
+        repeat(20) {
+            val waits = schedule(floorMs = 100L, attempts = 5)
+            waits.zipWithNext().forEach { (earlier, later) ->
+                assertTrue(later > earlier, "attempt waits must climb, got $waits")
+            }
+        }
+    }
+
+    @Test
+    fun `the wait doubles once per failure until it is capped`() {
+        // Written out rather than recomputed, so restating the production expression cannot make
+        // this pass: 2s, then double per failure, then held at the 30s cap.
+        val expected = listOf(2_000L, 4_000L, 8_000L, 16_000L, 30_000L, 30_000L, 30_000L, 30_000L)
+        repeat(20) {
+            schedule(floorMs = 2_000L, attempts = expected.size).forEachIndexed { attempt, wait ->
+                val target = expected[attempt]
+                assertTrue(
+                    wait >= (target * 0.8).toLong() && wait <= (target * 1.2).toLong(),
+                    "attempt $attempt should sit within ±20% of ${target}ms, was ${wait}ms"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `no wait grows past the cap however long the engine stays down`() {
+        assertEquals(30_000L, MAX_RETRY_DELAY_MS)
+        repeat(20) {
+            val waits = schedule(floorMs = 2_000L, attempts = 40)
+            assertTrue(
+                waits.all { it <= (MAX_RETRY_DELAY_MS * 1.2).toLong() },
+                "an engine down for an hour must still be retried; the wait cannot run away, got ${waits.max()}ms"
+            )
+            assertTrue(
+                waits.any { it > 20_000L },
+                "and it must actually reach the cap rather than stalling low, got ${waits.max()}ms"
+            )
+        }
+    }
+
+    @Test
+    fun `jitter spreads the waits so reconnecting clients do not come back in lockstep`() {
+        // 200 draws of the same attempt: an unjittered implementation returns one value 200 times.
+        val draws = (1..200).map { retryDelayMs(attempt = 2, floorMs = 2_000L) }.toSet()
+        assertTrue(draws.size > 50, "the wait must vary between clients, saw ${draws.size} distinct values")
+    }
+
+    @Test
+    fun `jitter never dips below the floor`() {
+        // The -20% side of a floor-sized base would undercut the floor, so it is clamped. Without
+        // the clamp an injected 25ms floor could fire at 20ms — and the shipped one at 1.6s.
+        listOf(25L, 100L, 2_000L).forEach { floor ->
+            repeat(200) {
+                val wait = retryDelayMs(attempt = 0, floorMs = floor)
+                assertTrue(wait >= floor, "a ${floor}ms floor must never wait less, was ${wait}ms")
+            }
+        }
+    }
+
+    @Test
+    fun `an injected floor scales the whole schedule, not just the first wait`() {
+        val fast = schedule(floorMs = 25L, attempts = 5)
+        val shipped = schedule(floorMs = 2_000L, attempts = 5)
+        fast.zip(shipped).forEachIndexed { attempt, (quick, slow) ->
+            assertTrue(quick < slow, "attempt $attempt: ${quick}ms should undercut the shipped ${slow}ms")
+        }
+        assertTrue(
+            fast.sum() < 1_000L,
+            "three failed connects on an injected floor must fit a test budget, summed to ${fast.sum()}ms"
+        )
+    }
+}


### PR DESCRIPTION
Groundwork for putting the preview screenshots on the website. Three details in the fixture read as obviously synthetic — and since all three are *on screen*, they were as much a problem for the regression shots as for marketing.

**Paths.** The schedule row prints the path of every file-backed item at detailed density (`ScheduleTab.kt:1688`), so `/tmp/ChurchPresenter` appeared in every shot. The library now prefers `/Users/Shared/ChurchPresenter` — real, writable without a permission prompt, and naming no developer — falling back to `/tmp` elsewhere, which is what CI uses. Two hardcoded `/tmp` literals in the recents lists now derive from the same root instead of contradicting it.

**URLs.** `example.org` appeared in the schedule, the QR source and three web bookmarks. Now `churchpresenter.org`, which the project owns. A plausible-looking church domain would have put someone else's property in our marketing.

**Pictures.** Twelve generated colour gradients made that tab the one panel that plainly came from a fixture. They are now real photographs drawn from the ~290 the app already ships, so this costs the repository nothing and exercises the real JPEG decode path rather than a synthetic PNG.

Downscaled to 960px deliberately: the sources are ~1880×1253, twelve of those is real work on a two-core runner, and the Pictures tab waits for every thumbnail before it can be photographed — that wait has already timed out once when the record job grew.

## Two things worth calling out

**The gallery needed its own folder.** Renaming it to `Backgrounds` first *collided* with the folder holding the canvas scene's background image: thirteen thumbnails under a heading reading "12 images", with one photo appearing twice. Caught by looking at the rendered tab rather than by the suite, which passed happily. It is `Gallery` now.

**Names say only what the category guarantees.** The file behind "Worship" is whichever sorts first in that category and nobody has looked at it, so a caption like "Hands Raised" would be a guess the image is free to contradict. It happens to show raised hands — but the next shipped set need not.

## Expect a large batch of changed images

Paths, URLs and photos all appear on screen, so most baseline images change. That is this PR landing, not a regression. The `screenshots` comment will be long.

## Not in this PR

Density stays at `1f`. Option 1 as originally scoped had `Density(2f)` for retina captures, but this harness is the CI regression baseline on every PR, and quadrupling pixel work permanently taxes a job where `the announcements tab` already costs 3.9s against a ~1s bar. A parameterised, marketing-only high-DPI run follows separately so the cost lands only when someone asks for it.
