### PR TITLE
Add a density knob for retina marketing captures

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -644,6 +644,16 @@ kotlin {
 tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
     systemProperty("java.awt.headless", "true")
 
+    // Pixel density for the app-preview screenshots, for exporting retina-sized captures:
+    //   ./gradlew :composeApp:recordRoborazziJvm --tests '*AppPreview*' -PpreviewDensity=2
+    // Left at 1 by default and NOT raised for CI: this harness is the visual-regression baseline on
+    // every pull request, and doubling density quadruples the pixel work. See PREVIEW_DENSITY in
+    // AppPreviewSupport.kt.
+    systemProperty(
+        "churchpresenter.previewDensity",
+        providers.gradleProperty("previewDensity").getOrElse("1"),
+    )
+
     // Point the whole test JVM at a throwaway home directory. Several singletons resolve
     // ~/.churchpresenter paths in a `by lazy` or a constructor -- captured ONCE per JVM -- so
     // without this a test could permanently latch onto (and write into, or delete from) the

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewOutputScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewOutputScreenshotTest.kt
@@ -48,7 +48,7 @@ class AppPreviewOutputScreenshotTest {
     }
 
     private fun output(name: String, settings: AppSettings = settings(), content: @Composable () -> Unit) =
-        runSkikoComposeUiTest(size = Size(1920f, 1080f), density = Density(1f)) {
+        runSkikoComposeUiTest(size = Size(1920f, 1080f) * PREVIEW_DENSITY, density = Density(PREVIEW_DENSITY)) {
             setContent {
                 Box(screen) {
                     PresenterScreen(appSettings = settings) { content() }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSupport.kt
@@ -83,6 +83,34 @@ private val LOWER_THIRD_SOURCE = File("src/jvmTest/resources/app-preview/lower-t
 
 private val KJV_SOURCE = File("src/jvmMain/composeResources/files/bible_samples/kjv1769.spb")
 
+/**
+ * The pixel density every app-preview render is captured at. `1f` unless overridden.
+ *
+ * The preview shots are the ones used for the website, where they want to be crisp on a retina
+ * display — but this same harness is the CI visual-regression baseline that runs on **every** pull
+ * request, and doubling the density quadruples the pixel work. `the announcements tab` already costs
+ * ~3.9s against AGENT.md's ~1s bar, so making 2x the default would tax every push for a benefit only
+ * a marketing export ever collects.
+ *
+ * So it is a knob rather than a new default. Recording high-DPI captures:
+ *
+ * ```
+ * ./gradlew :composeApp:recordRoborazziJvm --tests '*AppPreview*' -PpreviewDensity=2
+ * ```
+ *
+ * **The canvas has to grow with it.** `runSkikoComposeUiTest`'s `size` is in *pixels*, not dp, so
+ * raising density alone does not render the same layout more finely — it scales the UI up inside an
+ * unchanged canvas and crops it. Done that way the fourth thumbnail simply falls off the window and
+ * the test fails looking for it. Multiplying the size by the density keeps the layout identical in
+ * dp and renders it at more pixels, which is what "retina" means here.
+ *
+ * At 2 the whole-app shots come out 3200x2000 and the output shots 3840x2160. **Do not commit a
+ * baseline recorded this way** — every image would differ from CI's and the next comparison would
+ * report the lot as changed.
+ */
+internal val PREVIEW_DENSITY: Float =
+    System.getProperty("churchpresenter.previewDensity")?.toFloatOrNull()?.takeIf { it > 0f } ?: 1f
+
 internal val WINDOW = Size(1600f, 1000f)
 
 internal fun appPreview(
@@ -108,7 +136,7 @@ internal fun appPreview(
     writeScenes()
     writeQuestions()
     THEMES.forEach { (suffix, mode) ->
-        runSkikoComposeUiTest(size = WINDOW, density = Density(1f)) {
+        runSkikoComposeUiTest(size = WINDOW * PREVIEW_DENSITY, density = Density(PREVIEW_DENSITY)) {
             var actions = ScheduleActions()
             val presenterManager = PresenterManager()
             setContent {


### PR DESCRIPTION
Stacked on #231 — review that one first.

Adds a density knob so the preview screenshots can be exported at retina size for the website:

```
./gradlew :composeApp:recordRoborazziJvm --tests '*AppPreview*' -PpreviewDensity=2
```

At 2 the whole-app shots come out **3200×2000** and the output shots **3840×2160**. Default stays `1`, and default output is byte-identical to before, so CI's baseline is untouched.

## Why a knob and not a new default

This harness is the visual-regression baseline on **every** pull request, and doubling density quadruples the pixel work. `the announcements tab` already costs ~3.9s against AGENT.md's ~1s bar. Making 2× the default would tax every push for a benefit only a marketing export ever collects.

## The part worth knowing: density alone does not do what it sounds like

The original plan was simply "`Density(2f)` for retina-crisp 3200×2000 captures". That does not work, and it fails in a way that looks like a broken test rather than a wrong setting.

`runSkikoComposeUiTest`'s `size` is in **pixels**, not dp. Raising density alone therefore does not render the same layout more finely — it scales the UI up inside an unchanged canvas and crops it. Measured, with the size left alone:

- the output shot stayed **1920×1080** instead of doubling
- `AppPreviewPicturesScreenshotTest` **failed**, because the fourth thumbnail had fallen off the window: `Can't retrieve node at index '0' … '04 Church'`

Multiplying the size by the density keeps the layout identical in dp and renders it at more pixels, which is what "retina" means here. Verified by eye at 2× as well as by the assertion passing — same twelve thumbnails, same schedule, no zoom or crop.

## Caution

**Do not commit a baseline recorded at 2×.** Every image would differ from CI's and the next comparison would report the lot as changed. That is written at the constant too.
