### PR TITLE
Stop handing out the interlinear index's own mutable list

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/InterlinearRepository.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/InterlinearRepository.kt
@@ -89,9 +89,21 @@ class InterlinearRepository {
         }
     }
 
+    /**
+     * The verses for one Strong's number, **as a copy**.
+     *
+     * The index holds `MutableList`s that loading appends to, so returning one directly handed the
+     * caller a live view of a list this class goes on mutating. `DictionaryViewModel` keeps it in
+     * `interlinearVerses`, and `cardAvailableBooks` iterates it during composition — so a load
+     * finishing while the Dictionary tab recomposed threw `ConcurrentModificationException` out of
+     * the composition and took the tab down. Seen on CI 2026-08-07.
+     *
+     * A copy is cheap next to the load that produced it, and it is what every caller already
+     * assumed it was getting from a `List` return type.
+     */
     fun getVersesForEntry(number: String): List<InterlinearVerse> {
         val index = if (number.startsWith("G")) greekIndex else hebrewIndex
-        return index[number] ?: emptyList()
+        return index[number]?.toList() ?: emptyList()
     }
 
     fun getBooksWithGreekData(): List<Int>  = greekBookIndex.keys.sorted()

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/InterlinearRepositoryTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/InterlinearRepositoryTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
 
 /**
@@ -240,5 +241,28 @@ class InterlinearRepositoryTest {
             repository.getVersesForEntry("G26").isEmpty(),
             "current behaviour: the retry returns without reading, and the index stays empty",
         )
+    }
+
+    /**
+     * The caller must not be handed the index's own list.
+     *
+     * The index stores `MutableList`s and loading appends to them, so returning one directly gave
+     * the caller a live view of a list this class goes on mutating. `DictionaryViewModel` holds the
+     * result in `interlinearVerses` and `cardAvailableBooks` iterates it during composition, so a
+     * load completing mid-recomposition threw `ConcurrentModificationException` out of the
+     * composition and took the Dictionary tab down with it. Seen on CI 2026-08-07.
+     *
+     * Asserting on identity rather than contents is the point: equal contents held either before or
+     * after the fix, and it is the sharing that does the damage.
+     */
+    @Test
+    fun `the verses for an entry are a copy, not the index's own list`() {
+        val repository = loaded()
+
+        val first = repository.getVersesForEntry("G26")
+        val second = repository.getVersesForEntry("G26")
+
+        assertEquals(first, second, "the same entry must still answer with the same verses")
+        assertNotSame(first, second, "callers were handed the index's own mutable list")
     }
 }


### PR DESCRIPTION
A real crash in the Dictionary tab, found by CI rather than by a user.

```
java.util.ConcurrentModificationException
    at DictionaryViewModel.getCardAvailableBooks(DictionaryViewModel.kt:436)
    at DictionaryTabKt.DictionaryTab(DictionaryTab.kt:194)
    at androidx.compose.runtime.RecomposeScopeImpl.compose(...)
```

`InterlinearRepository.getVersesForEntry` returned `index[number]` **directly**. The index stores `MutableList`s that loading appends to (`InterlinearRepository.kt:61`), so the caller was handed a live view of a list the repository goes on mutating.

`DictionaryViewModel` keeps it in `interlinearVerses`, and `cardAvailableBooks` iterates it (`.map{}.distinct().sorted()`) during composition. A load finishing mid-recomposition therefore throws out of the composition and takes the tab down.

Returning a copy is cheap next to the load that produced it, and it is what every caller already assumed a `List` return type meant.

## How it was found

It failed the `test` check on #232 — a PR that only adds a density knob defaulting to the existing value. The trace initially looked impossible: `getCardAvailableBooks` appears nowhere in the repository, on any branch, in any commit. It is the JVM getter for the Kotlin property `cardAvailableBooks`, which is why searching for the method name found nothing. Worth remembering next time a stack trace names a symbol that "doesn't exist".

## Verification

The test asserts **identity**, not contents — the contents matched before and after, and it is the sharing that does the damage. Mutation-checked: reverting the copy fails the test by name. Full suite green.

## Note

This is pre-existing and unrelated to #231/#232; those merely render the Dictionary tab often enough to hit the race. It is intermittent, so a green run does not mean absence — #231 passed the same check while #232 failed it.
