### PR TITLE
Assert the two screenshot rules that fail silently, and fix the doc that contradicts them

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ScreenshotInvariantsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ScreenshotInvariantsTest.kt
@@ -1,0 +1,141 @@
+package org.churchpresenter.app.churchpresenter.screenshot
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * The two rules that decide whether a screenshot is compared in CI at all.
+ *
+ * Both fail **silently**. `.github/workflows/screenshots.yml` records with `--tests
+ * '*ScreenshotTest*'` and matches images between the two sides of the comparison by their path
+ * relative to [SCREENSHOT_ROOT], so a class named something else is simply never rendered, and an
+ * image written outside that root simply has no counterpart. Neither produces a failure, a warning,
+ * or a missing-file error — the image just stops being looked at, and stays that way for as long as
+ * nobody thinks to check. Each has already happened: a batch of 63 images was dead on arrival for
+ * the naming rule, and four files plus [PresenterScreenshotTest] had their own path literal.
+ *
+ * So these are asserted here rather than left to review. Reading the sources is the only way: what
+ * the record task picks up is decided by a class *name*, and where an image lands is decided by a
+ * path *literal*, neither of which exists as a value at runtime.
+ *
+ * Sources resolve relative to the module directory, the same way [AppPreviewSupport]'s fixtures do.
+ */
+class ScreenshotInvariantsTest {
+
+    private val packageDir =
+        File("src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot")
+
+    /** Every `.kt` in the screenshot package, paired with its text. */
+    private fun sources(): List<Pair<File, String>> {
+        val files = packageDir.listFiles { f: File -> f.extension == "kt" }?.sortedBy { it.name }
+        if (files.isNullOrEmpty()) {
+            // A moved package or a changed working directory would otherwise leave every assertion
+            // below vacuously true — the exact silence this class exists to end.
+            fail("no sources found at ${packageDir.absolutePath}; this test can no longer see what it checks")
+        }
+        return files.map { it to it.readText() }
+    }
+
+    @Test
+    fun `the screenshot package is where this test thinks it is`() {
+        val names = sources().map { (file, _) -> file.name }
+        assertTrue(names.size > 20, "expected the whole screenshot package, saw ${names.size} files")
+        assertTrue("ScreenshotSupport.kt" in names, "saw $names")
+    }
+
+    @Test
+    fun `every class that takes a screenshot is named so CI renders it`() {
+        val offenders = sources().mapNotNull { (file, text) ->
+            if (!text.contains("@Test")) return@mapNotNull null
+            val declared = CLASS_DECLARATION.find(text)?.groupValues?.get(1) ?: return@mapNotNull null
+            // This class itself asserts about sources rather than rendering any; it needs no images
+            // in CI and deliberately sits outside the record filter.
+            if (declared == this::class.simpleName) return@mapNotNull null
+            if (declared.endsWith("ScreenshotTest")) null else "${file.name}: class $declared"
+        }
+        assertEquals(
+            emptyList(), offenders,
+            "the record job runs --tests '*ScreenshotTest*'; a class outside that pattern is never " +
+                "rendered in CI and its images are never compared"
+        )
+    }
+
+    /**
+     * `SCREENSHOT_ROOT` plus every constant in the package defined *from* it — `ROOT` in
+     * [AppPreviewSupport] is `"$SCREENSHOT_ROOT/previewApp"`, and a capture through that is under
+     * the root just as surely as one naming it outright. Resolved rather than allow-listed, so a new
+     * sub-root is accepted the moment it is derived correctly and never when it is not.
+     */
+    private fun rootDerivedNames(): Set<String> {
+        val derived = sources().flatMap { (_, text) ->
+            ROOT_DERIVED_CONSTANT.findAll(text).map { it.groupValues[1] }
+        }
+        return derived.toSet() + "SCREENSHOT_ROOT"
+    }
+
+    @Test
+    fun `every capture is written under the screenshot root`() {
+        val roots = rootDerivedNames()
+        val offenders = sources().flatMap { (file, text) ->
+            text.lineSequence().withIndex()
+                .filter { (_, line) -> CAPTURE_CALL.containsMatchIn(line) }
+                // A capture either builds its path from a root or takes a File the caller built;
+                // only a path literal spelled out on the spot can miss it.
+                .filter { (_, line) -> line.contains(".png\"") && roots.none { it in line } }
+                .map { (i, line) -> "${file.name}:${i + 1}: ${line.trim()}" }
+        }
+        assertEquals(
+            emptyList(), offenders,
+            "images are matched between the two sides of the comparison by their path relative to " +
+                "SCREENSHOT_ROOT, so one written elsewhere is not reported as differing — it has no " +
+                "counterpart and silently stops being compared"
+        )
+    }
+
+    @Test
+    fun `every path that names the root derives it rather than restating it`() {
+        val literal = Regex(""""[^"]*build/screenshots""")
+        val offenders = sources()
+            // This file spells the path out to search for it; matching itself would be noise.
+            .filterNot { (file, _) -> file.name == "${this::class.simpleName}.kt" }
+            .flatMap { (file, text) ->
+                text.lineSequence().withIndex()
+                    .filter { (_, line) -> literal.containsMatchIn(line) }
+                    .filterNot { (_, line) -> line.contains("SCREENSHOT_ROOT =") }
+                    .map { (i, line) -> "${file.name}:${i + 1}: ${line.trim()}" }
+            }
+        assertEquals(
+            emptyList(), offenders,
+            "SCREENSHOT_ROOT is the single definition of that path; a second copy moves out of step " +
+                "with it without anything noticing"
+        )
+    }
+
+    @Test
+    fun `no screenshot is committed`() {
+        // Under build/, and the old committed location stays empty. A recorded image reaching a
+        // commit is how 15-of-16 platform churn got into the history before 2026-08-07.
+        assertTrue(
+            SCREENSHOT_ROOT.startsWith("build/"),
+            "screenshots must land under build/ so they cannot be added to a commit, was $SCREENSHOT_ROOT"
+        )
+        val abandoned = File("screenshots")
+        assertTrue(
+            !abandoned.exists() || abandoned.walkTopDown().none { it.extension == "png" },
+            "${abandoned.absolutePath} holds recorded images again; nothing reads them and git keeps " +
+                "every version of a binary for ever"
+        )
+    }
+
+    private companion object {
+        val CLASS_DECLARATION = Regex("""^(?:internal |private )?class (\w+)""", RegexOption.MULTILINE)
+        val CAPTURE_CALL = Regex("""captureRoboImage\(|captureTo\(""")
+
+        /** e.g. `private const val ROOT = "$SCREENSHOT_ROOT/previewApp"` — captures `ROOT`. */
+        val ROOT_DERIVED_CONSTANT =
+            Regex("""val (\w+)\s*=\s*(?:File\()?"[^"]*\$\{?SCREENSHOT_ROOT""")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ScreenshotSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ScreenshotSupport.kt
@@ -25,15 +25,27 @@ internal val THEMES = listOf("light" to ThemeMode.LIGHT, "dark" to ThemeMode.DAR
 /**
  * Where every screenshot is written, relative to the module directory a Gradle test task runs in.
  *
- * **Committed**, so that what is on screen can be reviewed and approved before it is merged, and so
- * a change to it shows up in the diff of a pull request. `.github/workflows/screenshots.yml` still
- * records both sides on one runner and posts the visual difference as a PR comment; the committed
- * copies are what a human looks at and signs off, which the comment alone cannot be relied on for.
+ * **Nothing here is committed.** It is under `build/`, and `.github/workflows/screenshots.yml`
+ * renders *both* sides of the comparison on one runner and posts the visual difference as a PR
+ * comment. Recording locally is for looking at the images yourself: nothing you record is read by
+ * anything else, so there is no need to re-record before pushing and no reason to add an image to a
+ * commit.
  *
- * The cost is real and worth knowing: Skia rasterises text per platform, so re-recording the same
- * *unchanged* states on a different OS rewrites nearly every file (15 of 16, measured), and git
- * keeps every version of a binary for ever. **Record on one platform per branch** and do not
- * re-record just to re-record — only when a state actually changed.
+ * They were committed until 2026-08-07, so that a change on screen appeared in the diff. That cost
+ * more than it bought. Skia rasterises text per platform, so re-recording the same *unchanged*
+ * states on a different OS rewrote nearly every file — 15 of 16, measured — and git keeps every
+ * version of a binary for ever. The comparison comment shows before and after side by side, which is
+ * what a reviewer actually wants; two opaque PNG blobs in a diff cannot be compared by eye anyway.
+ *
+ * Two invariants follow from CI being the only consumer, and both have already been broken once:
+ *
+ * - **A capture must be written under this root.** Images are matched between the two sides **by
+ *   their path relative to it**, so one written elsewhere is not reported as *differing* — it has no
+ *   counterpart and silently stops being compared. Go through [stackedThemes]/[captureComponent] and
+ *   this is handled.
+ * - **A class must be named `…ScreenshotTest`.** The workflow records with `--tests
+ *   '*ScreenshotTest*'`; a class outside that pattern is never rendered in CI and its images are
+ *   never compared.
  */
 internal const val SCREENSHOT_ROOT = "build/screenshots"
 


### PR DESCRIPTION
## The stale doc

`SCREENSHOT_ROOT`'s own KDoc still described the regime #236 introduced and #239 took back out:

> **Committed**, so that what is on screen can be reviewed and approved before it is merged […] the committed copies are what a human looks at and signs off.

Nothing is committed any more. The path is under `build/`, `.gitignore` says so, `screenshots.yml` says so, `AGENT.md` says so, and `PresenterScreenshotTest` and `AppPreviewSupport` in the same package say so. The one place a contributor is most likely to read said the opposite — and "record on one platform per branch" is advice for a workflow that no longer exists.

## The rules it should have been stating

Both decide whether a screenshot is compared **at all**, and both fail **silently**:

| rule | what happens when it is broken | already happened |
|---|---|---|
| a class must be named `…ScreenshotTest` | the record job's `--tests '*ScreenshotTest*'` never renders it | #228 — 63 images dead on arrival |
| a capture must land under `SCREENSHOT_ROOT` | the two sides are matched **by path relative to that root**, so it has no counterpart | #228 + `PresenterScreenshotTest` — five own literals |

Neither produces a failure, a warning, or a missing-file error. The image just stops being looked at, and stays that way until somebody thinks to check. That is a poor thing to leave to review, so `ScreenshotInvariantsTest` asserts them.

## Why it reads sources

Because there is nothing else to read. What the record task picks up is decided by a class *name*; where an image lands is decided by a path *literal*. Neither exists as a value at runtime. `AppPreviewSupport` already resolves `src/jvmTest/...` relative to the module directory for its fixtures, so the approach is established here.

Sub-roots are **resolved, not allow-listed**: `AppPreviewSupport`'s `ROOT` passes because it is `"$SCREENSHOT_ROOT/previewApp"`, and a new sub-root passes the moment it derives correctly and never when it does not. I got this wrong first — my initial check flagged `ROOT` as a violation, which is precisely the false positive an allow-list would have papered over.

It also **fails loudly if it cannot find the package**, because a moved package or a changed working directory would otherwise make every assertion vacuously true — the same silence the class exists to end.

## Validation

Two mutations, each caught by exactly one case:

| mutation | caught by |
|---|---|
| `DropdownSelectorScreenshotTest` → `DropdownSelectorShotsTest` | `every class that takes a screenshot is named so CI renders it` |
| a capture repointed at `build/marketing/…` | `every capture is written under the screenshot root` |

The first attempt at the second mutation **did not apply** — my `perl` pattern missed and the run went green, which proves nothing. Re-applied and verified against the actual mutated line before believing it.

3 consecutive runs with `--rerun-tasks`, green. 5 tests, **0.115s**, no rendering.
