### PR TITLE
Stop the coverage floor re-running the whole suite when the tests fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: App unit tests
+        id: unit_tests
         # Tighter than the job's own deadline so a hang here is attributed to this step and the
         # submodule suites below (`if: always()`) and the report upload still get to run. Runs land
         # around 11-14 minutes; one run was killed at a 25-minute budget with no diagnosis that
@@ -94,14 +95,28 @@ jobs:
               print(f'{t:>8.1f}s  {n:>5}  {name}')
           PY
 
-      # The 75% line-coverage floor, off the execution data the tests above just produced (so this
-      # adds no test time). Its denominator excludes the app-entry wiring that only runs under a real
-      # display -- see jacocoTestCoverageVerification in composeApp/build.gradle.kts. `if: always()`
-      # so a coverage regression is reported alongside test failures rather than hidden behind them.
+      # The 75% line-coverage floor, off the execution data the tests above just produced. Its
+      # denominator excludes the app-entry wiring that only runs under a real display -- see
+      # jacocoTestCoverageVerification in composeApp/build.gradle.kts. `if: always()` so a coverage
+      # regression is reported alongside test failures rather than hidden behind them.
+      #
+      # `-x jvmTest` is load-bearing. The Gradle task `dependsOn("jvmTest")`, which is right for a
+      # developer running it directly, but here the suite has already run in the step above. When it
+      # PASSED that task is up to date and the dependency costs nothing -- which is why this looked
+      # fine for as long as the suite was green. When it FAILED it is not up to date, so this step
+      # started the whole 21-minute suite again inside a 10-minute budget: a guaranteed timeout.
+      # Observed on run 31232339922 (main, 2026-08-08) -- jvmTest failed at 01:40:44, this step
+      # relaunched it at 01:41:20, killed at 01:50:57. Every red run paid an extra ten minutes and
+      # reported a second failure that said "Coverage floor timed out" and meant nothing.
+      #
+      # Advisory when the suite failed: the exec data is then from a run that did not finish, so the
+      # number is understated and a floor breach would be an artefact. The build is already red for a
+      # better reason. When the suite passed this gates exactly as before, in seconds.
       - name: Coverage floor
         if: always()
+        continue-on-error: ${{ steps.unit_tests.outcome == 'failure' }}
         timeout-minutes: 10
-        run: ./gradlew :composeApp:jacocoTestCoverageVerification
+        run: ./gradlew :composeApp:jacocoTestCoverageVerification -x jvmTest
 
       # Each submodule is its own Gradle build with its own wrapper, so they cannot be reached
       # from the root build and are invoked individually. `if: always()` keeps a failure in one


### PR DESCRIPTION
## What happens today

`jacocoTestCoverageVerification` declares `dependsOn("jvmTest")`. That is right for a developer running the task directly. In CI the suite has already run in the step above, so:

- **suite green** → `jvmTest` is up to date, the dependency costs nothing, the step takes seconds. This is why the wiring looked fine for as long as the build was green.
- **suite red** → `jvmTest` is *not* up to date, so the Coverage floor step **starts the entire 21-minute suite again inside its 10-minute budget**. It cannot finish. Ever.

Observed on run [31232339922](https://github.com/ChurchPresenter/ChurchPresenter/actions/runs/31232339922) (`main`, 2026-08-08) — from the log, not from reasoning:

```
01:40:42  8844 tests completed, 1 failed, 4 skipped
01:40:44  > Task :composeApp:jvmTest FAILED
01:41:20  > Task :composeApp:jvmTest          <- the Coverage floor step, starting it again
01:50:57  ##[error]The action 'Coverage floor' has timed out after 10 minutes
```

So every red run pays **an extra ten minutes** and ends with a second failure reading *"Coverage floor timed out after 10 minutes"*, which carries no information about coverage. Whoever reads that log has to work out that the real failure was one test, twelve minutes earlier.

## The change

`-x jvmTest`, so the step can never re-run the suite. The verification reads `jvmTest.exec`, which the step above has already written.

Measured locally against existing exec data: **2 seconds**, and `:composeApp:jvmTest` does not appear in the executed task list.

It is also **advisory when the suite failed** (`continue-on-error` keyed off the test step's outcome). With a run that did not finish, the exec data is incomplete, so coverage is understated and a floor breach would be an artefact of the failure rather than a regression — and the build is already red for a better reason. When the suite passes, this gates exactly as before, and a coverage regression still fails the build.

The step keeps `if: always()`, so a genuine coverage regression is still reported alongside test failures rather than hidden behind them — which was the original intent, and is now actually achievable.

## Scope

`jacocoTestReport` has the same `dependsOn("jvmTest")` but is not invoked by this workflow, and no other workflow runs a task that depends on `jvmTest`. Checked rather than assumed. The Gradle task keeps its `dependsOn` so running it locally still does the right thing.

## What is NOT proven yet

CI on this PR exercises the **green** path only — which is precisely the path that always looked fine. The red path is what the change is for, so I am running a separate throwaway PR with a deliberately failing test to confirm from its log that the Coverage floor step does not relaunch the suite. I will post the result here before merging.
