### PR TITLE
PROBE — DO NOT MERGE — red-path check for #241

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: App unit tests
+        id: unit_tests
         # Tighter than the job's own deadline so a hang here is attributed to this step and the
         # submodule suites below (`if: always()`) and the report upload still get to run. Runs land
         # around 11-14 minutes; one run was killed at a 25-minute budget with no diagnosis that
@@ -94,14 +95,28 @@ jobs:
               print(f'{t:>8.1f}s  {n:>5}  {name}')
           PY
 
-      # The 75% line-coverage floor, off the execution data the tests above just produced (so this
-      # adds no test time). Its denominator excludes the app-entry wiring that only runs under a real
-      # display -- see jacocoTestCoverageVerification in composeApp/build.gradle.kts. `if: always()`
-      # so a coverage regression is reported alongside test failures rather than hidden behind them.
+      # The 75% line-coverage floor, off the execution data the tests above just produced. Its
+      # denominator excludes the app-entry wiring that only runs under a real display -- see
+      # jacocoTestCoverageVerification in composeApp/build.gradle.kts. `if: always()` so a coverage
+      # regression is reported alongside test failures rather than hidden behind them.
+      #
+      # `-x jvmTest` is load-bearing. The Gradle task `dependsOn("jvmTest")`, which is right for a
+      # developer running it directly, but here the suite has already run in the step above. When it
+      # PASSED that task is up to date and the dependency costs nothing -- which is why this looked
+      # fine for as long as the suite was green. When it FAILED it is not up to date, so this step
+      # started the whole 21-minute suite again inside a 10-minute budget: a guaranteed timeout.
+      # Observed on run 31232339922 (main, 2026-08-08) -- jvmTest failed at 01:40:44, this step
+      # relaunched it at 01:41:20, killed at 01:50:57. Every red run paid an extra ten minutes and
+      # reported a second failure that said "Coverage floor timed out" and meant nothing.
+      #
+      # Advisory when the suite failed: the exec data is then from a run that did not finish, so the
+      # number is understated and a floor breach would be an artefact. The build is already red for a
+      # better reason. When the suite passed this gates exactly as before, in seconds.
       - name: Coverage floor
         if: always()
+        continue-on-error: ${{ steps.unit_tests.outcome == 'failure' }}
         timeout-minutes: 10
-        run: ./gradlew :composeApp:jacocoTestCoverageVerification
+        run: ./gradlew :composeApp:jacocoTestCoverageVerification -x jvmTest
 
       # Each submodule is its own Gradle build with its own wrapper, so they cannot be reached
       # from the root build and are invoked individually. `if: always()` keeps a failure in one

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/DeliberateFailureProbeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/DeliberateFailureProbeTest.kt
@@ -1,0 +1,15 @@
+package org.churchpresenter.app.churchpresenter
+
+import kotlin.test.Test
+import kotlin.test.fail
+
+/**
+ * TEMPORARY. Fails on purpose so CI exercises the red path of the Coverage floor step.
+ * This branch is a throwaway probe for PR #241 and must never be merged.
+ */
+class DeliberateFailureProbeTest {
+    @Test
+    fun `fails on purpose so the coverage floor step meets a failed suite`() {
+        fail("deliberate probe failure for PR #241 — this branch is not for merging")
+    }
+}


### PR DESCRIPTION
Throwaway. One deliberately failing test, so CI exercises the path #241 actually changes: the Coverage floor step meeting a failed suite. Closing as soon as the log is read.