### PR TITLE
Stop an undecodable picture claiming to be loading for ever

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -634,6 +634,7 @@
     <string name="auto_scroll_interval">Auto-scroll interval:</string>
     <string name="seconds_suffix">s</string>
     <string name="loading">Loading...</string>
+    <string name="picture_thumbnail_unreadable">Unreadable image</string>
     <string name="select_folder_to_view">Select a folder to view images</string>
     <string name="select_image_folder_dialog">Select Image Folder</string>
     <string name="loop">Loop</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
@@ -115,6 +115,7 @@ import churchpresenter.composeapp.generated.resources.ic_skip_next
 import churchpresenter.composeapp.generated.resources.ic_skip_previous
 import churchpresenter.composeapp.generated.resources.image_counter
 import churchpresenter.composeapp.generated.resources.loading
+import churchpresenter.composeapp.generated.resources.picture_thumbnail_unreadable
 import churchpresenter.composeapp.generated.resources.loop_off
 import churchpresenter.composeapp.generated.resources.loop_on
 import churchpresenter.composeapp.generated.resources.next_image
@@ -935,18 +936,28 @@ fun PicturesTab(
                                     .background(MaterialTheme.colorScheme.surfaceVariant),
                                 contentAlignment = Alignment.Center
                             ) {
-                                viewModel.thumbnails[imageFile]?.let { bitmap ->
-                                    Image(
-                                        bitmap = bitmap,
+                                val thumbnail = viewModel.thumbnails[imageFile]
+                                when {
+                                    thumbnail != null -> Image(
+                                        bitmap = thumbnail,
                                         contentDescription = imageFile.name,
                                         modifier = Modifier.fillMaxSize(),
                                         contentScale = ContentScale.Crop
                                     )
-                                } ?: Text(
-                                    text = stringResource(Res.string.loading),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
+                                    // A decode that failed used to leave "Loading..." on the tile for
+                                    // the rest of the session, so a corrupt file looked like a slow
+                                    // one for ever. Say so instead.
+                                    imageFile in viewModel.thumbnailFailures -> Text(
+                                        text = stringResource(Res.string.picture_thumbnail_unreadable),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.error
+                                    )
+                                    else -> Text(
+                                        text = stringResource(Res.string.loading),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
                             }
                             // Nameplate below image
                             Box(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
@@ -19,6 +20,7 @@ import org.churchpresenter.app.churchpresenter.models.AnimationType
 import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.utils.CrashReporter
 import org.churchpresenter.app.churchpresenter.utils.HeicDecoder
 import org.jetbrains.skia.Image
 import java.io.File
@@ -26,6 +28,17 @@ import java.nio.file.FileSystems
 import java.nio.file.StandardWatchEventKinds
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
+
+/** How long to wait before re-reading a file whose first decode failed. */
+private const val THUMBNAIL_RETRY_MS = 120L
+
+/**
+ * How many times the folder watcher re-reads a newly created file before giving up on it.
+ *
+ * Three tries spanning ~240ms: enough to outlast a local copy finishing its write, short enough that
+ * a genuinely corrupt file is reported almost immediately rather than sitting on "Loading…".
+ */
+private const val THUMBNAIL_RETRY_ATTEMPTS = 3
 
 class PicturesViewModel(
     appSettings: AppSettings? = null
@@ -41,6 +54,48 @@ class PicturesViewModel(
 
     private val _thumbnails: SnapshotStateMap<File, ImageBitmap> = SnapshotStateMap()
     val thumbnails: Map<File, ImageBitmap> get() = _thumbnails
+
+    /**
+     * Files whose thumbnail could not be decoded, against the reason.
+     *
+     * The grid draws "Loading…" for any file with no entry in [thumbnails], so before this existed a
+     * decode that threw was indistinguishable from one still running — and since the failure was
+     * swallowed, the tile said "Loading…" for the rest of the session. A corrupt or truncated image
+     * meant a permanent placeholder and no error anywhere.
+     *
+     * Every file therefore ends up in exactly one of [thumbnails] or here, which is also what lets a
+     * test wait for a positive signal instead of for the absence of a label.
+     */
+    private val _thumbnailFailures: SnapshotStateMap<File, String> = SnapshotStateMap()
+    val thumbnailFailures: Map<File, String> get() = _thumbnailFailures
+
+    /**
+     * Decodes [file] into [thumbnails], or records why it could not be in [thumbnailFailures].
+     *
+     * [attempts] exists for the folder watcher: a file being copied into a watched folder is
+     * routinely seen the instant it is created and long before it is complete, so the first decode
+     * of a half-written file legitimately fails and the same read succeeds moments later. The
+     * initial folder load reads files that were already there and needs no retry.
+     */
+    private suspend fun decodeThumbnail(file: File, attempts: Int = 1) {
+        var lastError: Exception? = null
+        repeat(attempts) { attempt ->
+            try {
+                _thumbnails[file] = loadImageBitmap(file)
+                _thumbnailFailures.remove(file)
+                return
+            } catch (e: Exception) {
+                lastError = e
+                if (attempt < attempts - 1) delay(THUMBNAIL_RETRY_MS)
+            }
+        }
+        val reason = lastError?.message ?: lastError?.toString() ?: "unknown"
+        _thumbnailFailures[file] = reason
+        CrashReporter.reportWarning(
+            "Pictures: thumbnail for ${file.name} could not be decoded — $reason",
+            tags = mapOf("subsystem" to "pictures")
+        )
+    }
 
     private val _selectedImageIndex = mutableStateOf(0)
     var selectedImageIndex: Int
@@ -120,14 +175,7 @@ class PicturesViewModel(
 
         // Load thumbnails in background
         scope.launch {
-            imageFiles.forEach { file ->
-                try {
-                    val bitmap = loadImageBitmap(file)
-                    _thumbnails[file] = bitmap
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
+            imageFiles.forEach { file -> decodeThumbnail(file) }
         }
     }
 
@@ -166,11 +214,7 @@ class PicturesViewModel(
                     if (!tmp.renameTo(cacheFile)) { tmp.delete(); continue }
                 }
                 _images.add(cacheFile)
-                try {
-                    _thumbnails[cacheFile] = loadImageBitmap(cacheFile)
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
+                decodeThumbnail(cacheFile)
                 presenterManager?.let { syncWithPresenter(it) }
             }
         }
@@ -181,6 +225,7 @@ class PicturesViewModel(
         watchJob = null
         _images.clear()
         _thumbnails.clear()
+        _thumbnailFailures.clear()
         _selectedImageIndex.value = 0
         _isPlaying.value = false
     }
@@ -413,11 +458,10 @@ class PicturesViewModel(
                                         _images.add(file)
                                     }
                                     // Load thumbnail
-                                    launch {
-                                        try {
-                                            _thumbnails[file] = loadImageBitmap(file)
-                                        } catch (_: Exception) {}
-                                    }
+                                    // A file copied into a watched folder is seen the moment it
+                                    // is created, usually before it is fully written, so the first
+                                    // decode of it legitimately fails.
+                                    launch { decodeThumbnail(file, attempts = THUMBNAIL_RETRY_ATTEMPTS) }
                                     changed = true
                                 }
                             }
@@ -426,6 +470,7 @@ class PicturesViewModel(
                                 if (idx >= 0) {
                                     _images.removeAt(idx)
                                     _thumbnails.remove(file)
+                                    _thumbnailFailures.remove(file)
                                     if (idx < _selectedImageIndex.value) {
                                         _selectedImageIndex.value--
                                     } else if (_selectedImageIndex.value >= _images.size && _images.isNotEmpty()) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/PicturesTabScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/PicturesTabScreenshotTest.kt
@@ -15,7 +15,6 @@ import org.churchpresenter.app.churchpresenter.tabs.openIntervalEditor
 import org.churchpresenter.app.churchpresenter.tabs.openTransitionEditor
 import org.churchpresenter.app.churchpresenter.tabs.pictureButton
 import org.churchpresenter.app.churchpresenter.tabs.picturesTab
-import org.churchpresenter.app.churchpresenter.tabs.showsExactly
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.viewmodel.PicturesViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
@@ -27,6 +26,7 @@ import javax.imageio.ImageIO
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class PicturesTabScreenshotTest {
 
@@ -76,15 +76,33 @@ class PicturesTabScreenshotTest {
         }
     }
 
+    /**
+     * Waits for every thumbnail to have resolved, one way or the other.
+     *
+     * The condition is deliberately **not** "the Loading… label is gone". That is the absence of a
+     * label, which a decode that failed satisfies never rather than late: the view model used to
+     * swallow the exception, so the tile kept saying "Loading…" for the rest of the run and this
+     * wait could only end by spending its whole budget. That is what took `main` red on CI run
+     * 31232339922 — 30s exhausted on five 480x300 gradients, which was never a decode speed problem.
+     *
+     * Now each file lands in either `thumbnails` or `thumbnailFailures`, so this ends on a positive
+     * signal, and a failure is reported immediately, naming the file and the reason, instead of
+     * thirty seconds later naming nothing.
+     */
     private fun ComposeUiTest.awaitAll(vm: PicturesViewModel) {
         if (vm.images.isEmpty()) return
-        waitUntil("no thumbnail still loading", RENDER_TIMEOUT_MS) {
+        waitUntil("every thumbnail to finish decoding", RENDER_TIMEOUT_MS) {
             // Thumbnails are decoded on Dispatchers.IO and written into a SnapshotStateMap from
             // there. Without this the write can sit in the global snapshot unapplied while this
             // loop spins, and the placeholder never goes away.
             Snapshot.sendApplyNotifications()
-            !showsExactly(PictureLabel.LOADING)
+            vm.images.all { it in vm.thumbnails || it in vm.thumbnailFailures }
         }
+        assertTrue(
+            vm.thumbnailFailures.isEmpty(),
+            "every fixture is a gradient this test just wrote, so none of them should fail to " +
+                "decode: ${vm.thumbnailFailures}"
+        )
         waitForIdle()
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesThumbnailFailureTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesThumbnailFailureTest.kt
@@ -1,0 +1,156 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What happens to a picture the app cannot decode.
+ *
+ * The grid draws "Loading…" for any file with no thumbnail, and the decode used to swallow its
+ * exception — so a corrupt or truncated image sat on "Loading…" for the rest of the session, with no
+ * error shown, logged or recorded anywhere. It also made every wait for "no thumbnail still loading"
+ * unsatisfiable, which is what took `main` red on CI run 31232339922: thirty seconds spent on five
+ * 480x300 gradients, a timeout that could never have been fixed by making it longer.
+ *
+ * The contract now is that **every file ends up in exactly one of `thumbnails` or
+ * `thumbnailFailures`** — never neither, which is what "still loading, for ever" was.
+ *
+ * **Not covered here: the folder watcher's retry.** A file copied into a watched folder is seen the
+ * instant it is created and usually before it is fully written, so the watcher re-reads it a few
+ * times before giving up — without that, marking it unreadable on the first attempt would turn the
+ * ordinary "drop some photos in" flow into a grid of permanent errors, which is worse than the bug
+ * being fixed. Proving it would mean winning a race against a real write, and a test that has to be
+ * timed to land inside a 240ms window is exactly the flake AGENT.md forbids. The retry is a bounded
+ * loop around [PicturesViewModel]'s decode, which the cases below do cover.
+ */
+class PicturesThumbnailFailureTest {
+
+    private lateinit var folder: File
+    private val created = mutableListOf<PicturesViewModel>()
+
+    @BeforeTest
+    fun createFolder() {
+        folder = Files.createTempDirectory("cp-thumb-failure").toFile()
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        created.forEach { runCatching { it.dispose() } }
+        created.clear()
+        folder.deleteRecursively()
+    }
+
+    private fun viewModel() = PicturesViewModel().also { created.add(it) }
+
+    private fun writeReadable(name: String) {
+        ImageIO.write(BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB), "png", File(folder, name))
+    }
+
+    /** A file with a picture extension that is not a picture — what a truncated copy looks like. */
+    private fun writeUndecodable(name: String) {
+        File(folder, name).writeText("this is not a PNG")
+    }
+
+    /**
+     * Polls until every image has resolved. Ends on the positive signal itself, so a pass costs
+     * milliseconds; the deadline only exists so a regression fails instead of hanging.
+     */
+    private fun PicturesViewModel.awaitResolved(timeoutMs: Long = 5_000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (images.isNotEmpty() && images.all { it in thumbnails || it in thumbnailFailures }) return
+            Thread.sleep(10)
+        }
+        throw AssertionError(
+            "thumbnails never resolved: ${images.size} images, ${thumbnails.size} decoded, " +
+                "${thumbnailFailures.size} failed — a file in none of them is the 'Loading… for ever' bug"
+        )
+    }
+
+    @Test
+    fun `a picture that cannot be decoded is recorded as failed rather than left loading`() {
+        writeUndecodable("broken.png")
+        val vm = viewModel()
+        vm.selectFolder(folder)
+        vm.awaitResolved()
+
+        val broken = File(folder, "broken.png")
+        assertFalse(broken in vm.thumbnails, "it did not decode, so there is no bitmap for it")
+        assertContains(vm.thumbnailFailures, broken, "and the failure must be recorded, not swallowed")
+        assertTrue(
+            vm.thumbnailFailures.getValue(broken).isNotEmpty(),
+            "with a reason, so the tile and the log can say what went wrong"
+        )
+    }
+
+    @Test
+    fun `a readable picture decodes and is not marked as failed`() {
+        writeReadable("fine.png")
+        val vm = viewModel()
+        vm.selectFolder(folder)
+        vm.awaitResolved()
+
+        assertContains(vm.thumbnails, File(folder, "fine.png"))
+        assertTrue(vm.thumbnailFailures.isEmpty(), "nothing failed: ${vm.thumbnailFailures}")
+    }
+
+    @Test
+    fun `one unreadable picture does not stop the others decoding`() {
+        // The decode loop is sequential, so an exception escaping it would abandon every later file
+        // and leave the rest of the grid on "Loading…" too.
+        writeUndecodable("2 broken.png")
+        writeReadable("1 first.png")
+        writeReadable("3 last.png")
+        val vm = viewModel()
+        vm.selectFolder(folder)
+        vm.awaitResolved()
+
+        assertEquals(3, vm.images.size)
+        assertContains(vm.thumbnails, File(folder, "1 first.png"))
+        assertContains(vm.thumbnails, File(folder, "3 last.png"), "the file after the broken one still loads")
+        assertEquals(setOf(File(folder, "2 broken.png")), vm.thumbnailFailures.keys)
+    }
+
+    @Test
+    fun `every picture resolves one way or the other`() {
+        // The invariant PicturesTabScreenshotTest's wait now depends on. Without it that wait is on
+        // the absence of a label, which an unreadable file satisfies never rather than late.
+        listOf("a.png", "c.png").forEach { writeReadable(it) }
+        listOf("b.png", "d.png").forEach { writeUndecodable(it) }
+        val vm = viewModel()
+        vm.selectFolder(folder)
+        vm.awaitResolved()
+
+        assertEquals(4, vm.images.size)
+        vm.images.forEach { file ->
+            val decoded = file in vm.thumbnails
+            val failed = file in vm.thumbnailFailures
+            assertTrue(decoded != failed, "$file must be in exactly one of the two, not $decoded/$failed")
+        }
+    }
+
+    @Test
+    fun `clearing the folder forgets the failures too`() {
+        writeUndecodable("broken.png")
+        val vm = viewModel()
+        vm.selectFolder(folder)
+        vm.awaitResolved()
+        assertTrue(vm.thumbnailFailures.isNotEmpty(), "precondition: something failed")
+
+        vm.clearImages()
+
+        assertTrue(
+            vm.thumbnailFailures.isEmpty(),
+            "a stale failure would mark the next folder's file unreadable: ${vm.thumbnailFailures}"
+        )
+    }
+}


### PR DESCRIPTION
## It was never a timeout problem

`PicturesTabScreenshotTest > the slideshow running` failed CI run [31232339922](https://github.com/ChurchPresenter/ChurchPresenter/actions/runs/31232339922) on `main` with:

```
Condition (no thumbnail still loading) still not satisfied after 30000 ms
```

The fixtures that wait is watching are **five 480×300 synthetic gradients**, written by the test itself moments earlier. Nothing decodes those in thirty seconds on any hardware. The premise behind the earlier 5s → 30s raise of `RENDER_TIMEOUT_MS` — that a loaded two-core runner makes the decode slow — does not survive contact with the fixture size, and a third widening would not have worked either.

## What was actually wrong

The grid draws:

```kotlin
viewModel.thumbnails[imageFile]?.let { Image(...) } ?: Text(stringResource(Res.string.loading))
```

"Loading…" is shown for *any* file with no map entry. And `PicturesViewModel` swallowed the decode exception at all three sites — `printStackTrace()` twice, and a bare `catch (_: Exception) {}` in the folder watcher. So a file that failed to decode **never got an entry, and the tile said "Loading…" for the rest of the session**, with nothing shown to the operator and nothing recorded anywhere.

Two consequences:

1. **A user-facing bug.** One corrupt or truncated photo in a folder is a tile that claims, permanently, to be loading.
2. **A test that could only fail by timing out.** The wait is on the *absence* of a label, which a failed decode satisfies never rather than late. AGENT.md's rule is that a wait must end on a positive signal and never by the timeout expiring; this one structurally could not.

## The change

Every file now ends in **exactly one** of `thumbnails` or `thumbnailFailures` — never neither, which is what "loading, for ever" was.

- the tile says `Unreadable image` instead of a false "Loading…";
- the failure goes to `CrashReporter` rather than stdout, with the file and reason;
- the wait becomes `images.all { it in thumbnails || it in thumbnailFailures }`, then asserts nothing failed. A decode failure now fails in **milliseconds naming the file**, instead of thirty seconds later naming nothing.

`RENDER_TIMEOUT_MS` is untouched.

### The watcher retry, and why it is here

The watcher re-reads a newly created file 3× over ~240ms before giving up. A file copied into a watched folder is seen the instant it is created and usually *before it is fully written*, so its first decode legitimately fails. Without the retry, this PR would convert the ordinary "drop some photos in" flow into a grid of permanent errors — worse than the bug being fixed. The initial folder load reads files that were already there and takes one attempt, so no test pays for this.

## Validation

- **Mutation:** reverting just the failure-recording line (back to the old swallow) fails **4 of the 5** new cases. Verified against the mutated source, not assumed.
- 3 consecutive runs of every `*Pictures*` suite with `--rerun-tasks`: green.
- Full suite `--rerun-tasks --no-build-cache`: **green, 8m44s.**
- `PicturesThumbnailFailureTest` costs **0.069s**; `PicturesTabScreenshotTest` is 1.874s for 16 states.

## Known gap

**The watcher retry is not covered by a test.** Proving it means winning a race against a real write inside a 240ms window, which is exactly the flake AGENT.md forbids, so it is recorded in the test class's doc comment instead. The retry is a bounded loop around the decode the other cases do cover.
