### PR TITLE
Fix three screenshots the website exports

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewRemotePermissionScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewRemotePermissionScreenshotTest.kt
@@ -2,9 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.screenshot
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
@@ -32,12 +30,16 @@ class AppPreviewRemotePermissionScreenshotTest {
             setContent {
                 ChurchPresenterTheme(themeMode = mode) {
                     Box(
-                        Modifier
-                            .background(MaterialTheme.colorScheme.surfaceVariant)
-                            .padding(24.dp)
-                            // The size the real DialogWindow opens at (DialogSizes.kt); without a
-                            // height the content stretches and leaves a gap the operator never sees.
-                            .size(500.dp, 290.dp)
+                        // The size the real DialogWindow opens at (DialogSizes.kt); without a
+                        // height the content stretches and leaves a gap the operator never sees.
+                        //
+                        // No backdrop behind it, and no padding around it: this shot is exported to
+                        // the website, which frames it itself. A painted margin inside the image
+                        // fought that frame — 24dp of surfaceVariant on all four sides, invisible
+                        // against the dark page and an obvious grey slab against the light one.
+                        // Safe to sit flush because the content is an opaque Surface with no shape
+                        // (RemoteEventDialog.kt), so there are no rounded corners to expose.
+                        Modifier.size(500.dp, 290.dp)
                     ) {
                         RemoteEventDialogContent(
                             event = event,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewStatisticsScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewStatisticsScreenshotTest.kt
@@ -86,8 +86,23 @@ class AppPreviewStatisticsScreenshotTest {
         waitForIdle()
     }
 
+    /**
+     * 1200dp because the table needs it, and shrinking — the intuitive fix for a cramped
+     * screenshot — makes it worse.
+     *
+     * The summary panel down the left is a fixed `width(300.dp)` and the table takes `weight(1f)`
+     * of what is left. Inside the table only title, author and songbook flex (weights 2, 1.5, 1);
+     * rank, CCLI number, count and the two dates are fixed, ~386dp once gaps and row padding are
+     * counted. At 940 that left the three flexible columns 253dp between them, so the songbook
+     * header rendered as "SONGBO" and titles and authors were ellipsised mid-word — which is what
+     * the website was publishing. 1200 gives them ~513dp and they fit.
+     *
+     * Not fixed by this, and not a capture problem: each row reserves `end = 20.dp` for the
+     * scrollbar overlaid at CenterEnd, and the date columns are wider than the dates. That gutter
+     * on the right is the dialog's own layout at any window size.
+     */
     private fun ccli(name: String, drive: ComposeUiTest.() -> Unit = {}) =
-        dialog(name, 940.dp, 700.dp, drive) { mode ->
+        dialog(name, 1200.dp, 700.dp, drive) { mode ->
             CCLIReportContent(
                 theme = mode,
                 statisticsManager = StatisticsManager(),

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ScheduleTabScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ScheduleTabScreenshotTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.dp
 import org.churchpresenter.app.churchpresenter.tabs.scheduleTab
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.viewmodel.ScheduleViewModel
+import java.io.File
 import kotlin.test.Test
 
 class ScheduleTabScreenshotTest {
@@ -176,6 +177,38 @@ class ScheduleTabScreenshotTest {
 
     @Test
     fun `a narrow panel wraps the toolbar`() = shoot("narrow_panel", width = 240.dp)
+
+    /**
+     * The schedule image the website's homepage uses, written straight into `previewApp/` — beside
+     * the app-preview captures it sits next to on the page.
+     *
+     * Every other shot in this class renders into the harness's full 1024dp window, because a
+     * layout test wants the panel given room and then observed. That is nearly three times the
+     * width an operator's panel actually has: `AppPreviewSupport.library()` settles on
+     * `schedulePanelWidthDp = 360`. So the rows come out with their text against the left edge and
+     * most of each row empty — fine for a regression diff, but on a marketing page it reads as a
+     * stretched, broken screenshot, which is what shipped. 400dp is a panel someone would really
+     * use, so the rows fill their width.
+     *
+     * Written unstacked, one file per theme, unlike everything else here. The website needs the two
+     * themes as separate images and was cutting them out of the stacked pair by hand — which is how
+     * it came to ship a crop of a *stale* render for a release. [stackedThemes] is still right for
+     * the regression shots; it is the wrong shape for an export.
+     */
+    @Test
+    fun `the schedule panel at the width an operator uses`() {
+        val dir = File("$SCREENSHOT_ROOT/previewApp").apply { mkdirs() }
+        THEMES.forEach { (suffix, mode) ->
+            scheduleTab(
+                width = 400.dp,
+                seed = { everyItemType() },
+                themeMode = mode,
+                density = PREVIEW_DENSITY,
+            ) { _, _ ->
+                captureTo(File(dir, "schedule_$suffix.png"))
+            }
+        }
+    }
 
     @Test
     fun `density extra compact`() = shoot("density_extra_compact", itemZoomPercent = 55)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleTabTestSupport.kt
@@ -17,7 +17,10 @@ import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.serialization.builtins.ListSerializer
@@ -45,6 +48,13 @@ import java.nio.file.Files
  */
 
 // ── Harness ─────────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The window [runComposeUiTest] composes into when it is not told otherwise, which is why every
+ * capture from this harness comes out 1024x768. Stated here only so the density branch below can
+ * hand the Skiko runner the same size instead of silently rendering into a different one.
+ */
+private val DEFAULT_TEST_WINDOW = Size(1024f, 768f)
 
 /** What the tab reported back, so a test asserts on the choice rather than on a stub. */
 internal class ScheduleReports {
@@ -80,6 +90,16 @@ internal fun scheduleTab(
     seed: ScheduleViewModel.() -> Unit = {},
     /** Null keeps the plain MaterialTheme every other test composes under; set to shoot a theme. */
     themeMode: ThemeMode? = null,
+    /**
+     * Null renders at the default 1 dp = 1 px, which every test here wants: they assert on layout,
+     * and more pixels of the same layout tells them nothing.
+     *
+     * Set only by the capture the website exports, which needs the same dp at more pixels to stay
+     * crisp on a retina display. It switches to the Skiko runner because [runComposeUiTest] has no
+     * density hook, and that runner needs its window size stated rather than defaulted — hence
+     * [DEFAULT_TEST_WINDOW], which is the size the other branch gets for free.
+     */
+    density: Float? = null,
     block: ComposeUiTest.(vm: ScheduleViewModel, reports: ScheduleReports) -> Unit,
 ) {
     TestSingletons.latchToTestHome()
@@ -90,7 +110,7 @@ internal fun scheduleTab(
     try {
         vm.seed()
         val reports = ScheduleReports()
-        runComposeUiTest {
+        val body: ComposeUiTest.() -> Unit = {
             setContent {
                 ThemedForTest(themeMode) {
                     Box(modifier = if (width != null) Modifier.width(width) else Modifier) {
@@ -117,6 +137,12 @@ internal fun scheduleTab(
                 }
             }
             block(vm, reports)
+        }
+        if (density == null) {
+            runComposeUiTest(block = body)
+        } else {
+            val window = Size(width?.value ?: DEFAULT_TEST_WINDOW.width, DEFAULT_TEST_WINDOW.height)
+            runSkikoComposeUiTest(size = window * density, density = Density(density), block = body)
         }
     } finally {
         runCatching { vm.dispose() }


### PR DESCRIPTION
Three captures in `previewApp/` are exported to churchpresenter.org, and all three were
publishing something the app does not actually look like. Found while re-importing the
site's screenshots.

### The schedule panel had no export shot at all

The website was using a hand-cut half of the stacked `scheduleTab/density_detailed.png`.
That fixture renders the panel at the full 1024dp test window against the 360dp an operator
really gives it (`AppPreviewSupport.library()`), so every row carried its text against the
left edge with most of the row empty — it read as a stretched, broken screenshot on the
homepage.

Worse, cutting it by hand meant nobody noticed it had been cut from a render taken *before*
#237 removed the fixture's placeholder paths. `/decks/sermon.pptx` and
`https://example.org/notices` were live on the marketing site while the app itself had been
fixed for a release.

So: one shot at 400dp, written straight into `previewApp/` beside the app-preview captures
it sits next to on the page, and written **unstacked** — the site needs the two themes as
separate files, and hand-cropping a stacked pair is what let a stale image through.

`scheduleTab()` grows an optional `density` for it, since `runComposeUiTest` has no density
hook and the site wants the same dp at more pixels. Null keeps the existing runner, so no
existing capture changes and reg-actions has nothing new to diff.

### The CCLI report was too narrow for its own table

Rendered at 940dp. The summary panel is a fixed `width(300.dp)` and the table takes
`weight(1f)` of the rest, but inside the table only title, author and songbook flex — rank,
CCLI number, count and the two dates are fixed, ~386dp once gaps and row padding are counted.
That left the three flexible columns 253dp between them:

| | at 940dp | at 1200dp |
|---|---|---|
| title | ~112dp — `Come Thou Foun…` | ~228dp |
| author | ~84dp — `Robert Robi…` | ~171dp |
| songbook | ~56dp — header read `SONGBO` | ~114dp |

Widening rather than shrinking, which is the intuitive move for a cramped screenshot and the
wrong one here.

The gutter still visible on the right is the row's own `end = 20.dp` scrollbar reserve plus
date columns wider than the dates — the dialog's layout at any window size, not something the
capture can fix. Left alone deliberately.

### The permission prompt carried a painted margin

`.background(surfaceVariant).padding(24.dp)` outside `.size(500.dp, 290.dp)`, so the PNG came
out 548x338 around a 500x290 dialog. Invisible against the dark site and an obvious grey slab
against the light one, fighting the frame the page already draws around it. Sitting flush is
safe because the content is an opaque `Surface` with no `shape`.

---

Test-only; no production code touched. Expect a visual difference on the CCLI and permission
shots — that is reg-actions working, not a regression.