### PR TITLE
Say why a Planning Center download failed, not just that it did

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClient.kt
@@ -605,6 +605,13 @@ object PlanningCenterClient {
             destination.writeBytes(bytes)
             FileDownloadOutcome.Success(destination)
         } catch (e: Exception) {
+            // Also on stderr, the same way BibleEngineClient reports a failed connect. The Sentry
+            // warning below carries the exception, but `reportWarning` returns immediately when
+            // Sentry is not enabled — which is every test run, and every operator who has not opted
+            // in. Without this line the only surviving evidence is the word `NetworkError`, which
+            // says neither what failed nor why: a refused connection, a timeout and a closed client
+            // are indistinguishable, and each wants a different answer.
+            System.err.println("planning-center: download of $url failed — ${e.javaClass.simpleName}: ${e.message}")
             CrashReporter.reportWarning(
                 "Planning Center attachment download failed",
                 throwable = e,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterDownloadTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterDownloadTest.kt
@@ -9,7 +9,9 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.runBlocking
+import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.PrintStream
 import java.net.ServerSocket
 import java.nio.file.Files
 import kotlin.test.AfterTest
@@ -126,6 +128,49 @@ class PlanningCenterDownloadTest {
         assertTrue(outcome is PlanningCenterClient.FileDownloadOutcome.Success, "got $outcome")
         assertEquals(target, (outcome as PlanningCenterClient.FileDownloadOutcome.Success).file)
         assertTrue(target.exists())
+    }
+
+    /**
+     * A download that fails has to say *why* somewhere a human can reach.
+     *
+     * `NetworkError` on its own does not distinguish a refused connection from a timeout from a
+     * closed client, and each wants a different answer. The `CrashReporter.reportWarning` alongside
+     * carries the exception but returns immediately when Sentry is not enabled — which is every test
+     * run, and every operator who has not opted in. This class's own
+     * `an attachment is written where it was asked for` failed once in a full suite with nothing but
+     * the word `NetworkError` recorded, which is what prompted this.
+     *
+     * `System.setErr` is JVM-wide, so it is restored in a `finally` rather than after the assertions.
+     *
+     * Points at port 1 rather than stopping [server]. Stopping the fixture mid-test frees its port,
+     * and the next test binds port 0 and can be handed the same number back — which showed up
+     * immediately as a sibling test downloading from a server that 404s its route. Port 1 is
+     * privileged, never bound, and refuses instantly.
+     */
+    @Test
+    fun `a failed download reports the reason, not just that it failed`() {
+        val deadUrl = "http://127.0.0.1:1/attachment.pdf"
+        val captured = ByteArrayOutputStream()
+        val realErr = System.err
+
+        val outcome = try {
+            System.setErr(PrintStream(captured, true))
+            runBlocking { PlanningCenterClient.downloadFile(deadUrl, File(dir, "plan.pdf")) }
+        } finally {
+            System.setErr(realErr)
+        }
+
+        assertEquals(PlanningCenterClient.FileDownloadOutcome.NetworkError, outcome)
+        val reported = captured.toString()
+        assertTrue(reported.contains("planning-center"), "nothing was reported at all: '$reported'")
+        assertTrue(
+            reported.contains(deadUrl),
+            "the URL that failed has to be in it, or it names no target: '$reported'"
+        )
+        assertTrue(
+            reported.substringAfter("failed — ").trim().isNotEmpty(),
+            "and the exception, or it says no more than the outcome already did: '$reported'"
+        )
     }
 
     @Test


### PR DESCRIPTION
## What happened

`PlanningCenterDownloadTest > an attachment is written where it was asked for` failed once during a full suite on unmodified `main` (found while re-measuring coverage). Everything it left behind was:

```
java.lang.AssertionError: got NetworkError
```

`NetworkError` is the same outcome for a refused connection, a timeout and a closed client — three problems wanting three different answers. There was nothing else to go on.

`downloadFile` *does* hand the exception to `CrashReporter.reportWarning`, but that returns immediately when Sentry is not enabled — which is every test run, and every operator who has not opted in. So the cause was reaching nobody.

## The change

One `System.err.println` alongside the Sentry warning, the same way `BibleEngineClient` reports a failed connect (an established pattern here — `DEVELOPMENT_GUIDE.md` records `System.err.println` for error diagnostics as deliberate).

**It has already paid for itself.** With the line in place the flake reproduced and named itself:

```
planning-center: download of http://127.0.0.1:57098/attachment.pdf failed
    — ConnectException: Connection refused
```

Refused — against a fixture the test had *already probed and seen accepting a TCP connection*. That is the fact this flake family has been missing.

### What it points at (not fixed here)

Same shape as the `BibleEngineClientLinkTest` flake and the `CompanionServerPresentationRenderTest` one fixed in #226: connect to a just-started local server, get refused. The new evidence narrows it — `PlanningCenterClient.defaultHttp` is a **lazy, JVM-wide `HttpClient(CIO)`**, and every test in the class binds a fresh port 0. A pooled keep-alive connection to a port a previous fixture has since closed, later handed by the OS to a new fixture, would produce exactly this: instant, intermittent, only in multi-test runs.

**I am not claiming to have fixed the flake.** This makes the next occurrence diagnosable, and it makes a real download failure explicable for an operator who can only send a console log.

## About the test

It drives **port 1** rather than stopping the fixture server.

My first version called `server.stop()` to get a refused connection. That is wrong here and it showed immediately: stopping the fixture frees its port, the next test binds port 0, and the OS can hand back the same number — a sibling test then downloaded from a server that 404s its route (`got Failure`, an outcome the original flake never produced). Port 1 is privileged, never bound, and refuses instantly.

`System.setErr` is JVM-wide, so it is restored in a `finally`.

## Validation

- **Mutation:** deleting the stderr line fails `a failed download reports the reason, not just that it failed` — and nothing else.
- `*PlanningCenter*` suites, **6 consecutive runs** with `--rerun-tasks`, results preserved per run: clean every time. The new test failed in none of them.
- Full suite `--rerun-tasks --no-build-cache`: **green, 8m23s** — required, since the test redirects `System.err`.

**One honest gap:** in an earlier batch of 5 runs, run 4 failed and its XML was overwritten before I read it, so I cannot attribute it. Across the 11 runs in total there was that single failure, which matches the pre-existing rate; every run I preserved was clean.
