### PR TITLE
Make the fully-qualified-name check countable, and fix the 21 it was hiding

### DIFF
--- a/cleanup_check.sh
+++ b/cleanup_check.sh
@@ -38,10 +38,24 @@ else
     echo "   ✅ PASS"
 fi
 
-# Count fully qualified type names used inline (e.g. in a function signature) — import statements
-# are excluded since they're the correct, required way to reference a type, not a violation of the
-# "no fully-qualified names when an import exists" rule
-QUALIFIED=$(grep -rE 'androidx\.compose\.[a-z]*\.[a-zA-Z]*\.[A-Z]' --include='*.kt' composeApp/src/ 2>/dev/null | grep -vE '^\S*:\s*import\b' | wc -l | tr -d ' ')
+# Count fully qualified type names used inline (e.g. in a function signature). Three kinds of line
+# are excluded, because none of them is the thing the rule forbids — writing the long form where an
+# import already binds the name:
+#
+#   import ...                  the correct, required way to reference a type
+#   @file:OptIn(...::class)     a file-level annotation, which sits above the import block and is
+#                               conventionally written out in full; 283 of these alone, so leaving
+#                               them in made the count permanently non-zero
+#   * / // / /*                 KDoc links like [androidx.compose.ui.test.ComposeUiTest], which need
+#                               the full path precisely when the type is NOT imported
+#
+# Without those exclusions this reported 306 against a documented target of 0 — a check that cannot
+# pass is a check nobody reads, and it was hiding 21 real violations in the noise.
+QUALIFIED=$(grep -rE 'androidx\.compose\.[a-z]*\.[a-zA-Z]*\.[A-Z]' --include='*.kt' composeApp/src/ 2>/dev/null \
+    | grep -vE '^\S*:\s*import\b' \
+    | grep -vE '@file:OptIn|@OptIn' \
+    | grep -vE '^\S*:\s*(\*|//|/\*)' \
+    | wc -l | tr -d ' ')
 echo "📝 Fully qualified type names: $QUALIFIED"
 if [ "$QUALIFIED" -gt 0 ]; then
     echo "   ⚠️  WARN - Should be 0"

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardContentTest.kt
@@ -5,6 +5,7 @@ package org.churchpresenter.app.churchpresenter.dialogs
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.onNodeWithText
@@ -227,7 +228,7 @@ class SetupWizardContentTest {
         assertEquals(0, choices.dismissed, "walking to the end must not close the wizard on its own")
     }
 
-    private fun ComposeUiTest.onAllNodesCount(matcher: androidx.compose.ui.test.SemanticsMatcher): Int =
+    private fun ComposeUiTest.onAllNodesCount(matcher: SemanticsMatcher): Int =
         onAllNodes(matcher).fetchSemanticsNodes(atLeastOneRootRequired = false).size
 
     private fun ComposeUiTest.onAllNodesWithTextCount(text: String): Int =

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundSettingsTabRecompositionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundSettingsTabRecompositionTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onAllNodesWithContentDescription
@@ -208,7 +209,7 @@ class BackgroundSettingsTabRecompositionTest {
         )
     }
 
-    private fun assertEveryRowKindIsIntact(test: androidx.compose.ui.test.ComposeUiTest) = with(test) {
+    private fun assertEveryRowKindIsIntact(test: ComposeUiTest) = with(test) {
         onAllNodesWithText("Background Image:").assertCountEquals(2)
         onAllNodesWithText("Background Video:").assertCountEquals(2)
         onAllNodesWithContentDescription("Browse downloaded library").assertCountEquals(4)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundSettingsTabTooltipTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundSettingsTabTooltipTest.kt
@@ -2,6 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.dialogs.tabs
 
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -30,7 +31,7 @@ class BackgroundSettingsTabTooltipTest {
         AppSettings().let { it.copy(backgroundSettings = it.backgroundSettings.change()) }
 
     /** Hovers the button described by [description] and waits for its tooltip to be composed. */
-    private fun androidx.compose.ui.test.ComposeUiTest.hoverAndAwaitTooltip(description: String) {
+    private fun ComposeUiTest.hoverAndAwaitTooltip(description: String) {
         onNodeWithContentDescription(description).performScrollTo()
         waitForIdle()
         onNodeWithContentDescription(description).performMouseInput { moveTo(center) }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/OBSSettingsTabScenesTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/OBSSettingsTabScenesTest.kt
@@ -2,6 +2,8 @@
 
 package org.churchpresenter.app.churchpresenter.dialogs.tabs
 
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
@@ -92,10 +94,10 @@ class OBSSettingsTabScenesTest {
     }
 
     /** The default scene box sits directly under the "Default Scene" caption, above the mode rows. */
-    private fun androidx.compose.ui.test.ComposeUiTest.sceneOrDefaultBox() =
+    private fun ComposeUiTest.sceneOrDefaultBox() =
         onNode(
             androidx.compose.ui.test.hasSetTextAction() and
-                androidx.compose.ui.test.SemanticsMatcher("is the default-scene box") { node ->
+                SemanticsMatcher("is the default-scene box") { node ->
                     val caption = onAllNodesWithText(ObsLabel.DEFAULT_SCENE)
                         .fetchSemanticsNodes(atLeastOneRootRequired = false)
                         .minByOrNull { it.boundsInRoot.top } ?: return@SemanticsMatcher false

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabExclusivityTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ProjectionSettingsTabExclusivityTest.kt
@@ -2,6 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.dialogs.tabs
 
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.onAllNodesWithText
@@ -349,7 +350,7 @@ class ProjectionSettingsTabExclusivityTest {
     }
 }
 
-private fun androidx.compose.ui.test.SemanticsNodeInteractionCollection.assertCountAtLeast(n: Int) {
+private fun SemanticsNodeInteractionCollection.assertCountAtLeast(n: Int) {
     val found = fetchSemanticsNodes(atLeastOneRootRequired = false).size
     kotlin.test.assertTrue(found >= n, "expected at least $n nodes but found $found")
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTabTestSupport.kt
@@ -7,10 +7,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.test.hasClickAction
@@ -181,9 +183,9 @@ internal object Switch {
 
 internal fun ComposeUiTest.serverSwitches(): SemanticsNodeInteractionCollection =
     onAllNodes(
-        androidx.compose.ui.test.SemanticsMatcher.expectValue(
+        SemanticsMatcher.expectValue(
             SemanticsProperties.Role,
-            androidx.compose.ui.semantics.Role.Switch,
+            Role.Switch,
         ),
     )
 
@@ -218,7 +220,7 @@ internal fun ComposeUiTest.retypeField(showing: String, to: String) {
  * displayed text is what is searched instead.
  */
 internal fun ComposeUiTest.assertFieldShows(value: String, what: String) {
-    val shown = onAllNodes(androidx.compose.ui.test.SemanticsMatcher.keyIsDefined(SemanticsProperties.EditableText))
+    val shown = onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.EditableText))
         .fetchSemanticsNodes(atLeastOneRootRequired = false)
         .mapNotNull { it.config.getOrNull(SemanticsProperties.EditableText)?.text }
     assertEquals(true, value in shown, "$what must display \"$value\" — fields show $shown")
@@ -226,7 +228,7 @@ internal fun ComposeUiTest.assertFieldShows(value: String, what: String) {
 
 /** Any text box displaying [value], whether or not it is editable. */
 internal fun ComposeUiTest.boxShowing(value: String): SemanticsNodeInteraction =
-    onNode(androidx.compose.ui.test.SemanticsMatcher.keyIsDefined(SemanticsProperties.EditableText) and hasText(value))
+    onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.EditableText) and hasText(value))
 
 /** How many times [text] is rendered. */
 internal fun ComposeUiTest.countOf(text: String): Int =

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTabPreviewTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTabPreviewTest.kt
@@ -4,6 +4,7 @@ package org.churchpresenter.app.churchpresenter.dialogs.tabs
 
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
@@ -30,7 +31,7 @@ import kotlin.test.assertTrue
 class StageMonitorSettingsTabPreviewTest {
 
     /** The text of every non-clickable node, which is what the preview is built from. */
-    private fun androidx.compose.ui.test.ComposeUiTest.previewTexts(): List<String> =
+    private fun ComposeUiTest.previewTexts(): List<String> =
         onAllNodes(!hasClickAction()).fetchSemanticsNodes(atLeastOneRootRequired = false)
             .mapNotNull { it.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { t -> t.text } }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTabStructureTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StageMonitorSettingsTabStructureTest.kt
@@ -2,6 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.dialogs.tabs
 
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasText
@@ -141,7 +142,7 @@ class StageMonitorSettingsTabStructureTest {
                 assertEquals(
                     marker.toString(),
                     numberFields()[index * 3].fetchSemanticsNode().config
-                        .let { c -> c[androidx.compose.ui.semantics.SemanticsProperties.EditableText].text },
+                        .let { c -> c[SemanticsProperties.EditableText].text },
                     "the font size at ordinal $index must belong to $zone",
                 )
                 assertEquals(index, ZoneOrdinal.of(zone), "ZoneOrdinal.of($zone) must agree")

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StatisticsTabRecompositionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StatisticsTabRecompositionTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
@@ -33,7 +34,7 @@ class StatisticsTabRecompositionTest {
     /** Renders the tab over [stats] with a recomposition trigger the test controls. */
     private fun rerenderable(
         stats: StatisticsManager,
-        block: androidx.compose.ui.test.ComposeUiTest.(recompose: () -> Unit) -> Unit,
+        block: ComposeUiTest.(recompose: () -> Unit) -> Unit,
     ) = runComposeUiTest {
         var tick by mutableStateOf(0)
         setContent {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StatisticsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/StatisticsTabTestSupport.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.runComposeUiTest
 import org.churchpresenter.app.churchpresenter.data.StatisticsManager
@@ -101,7 +102,7 @@ internal object StatsLabel {
 
 /** Every string the tab renders, in traversal order. */
 internal fun ComposeUiTest.renderedLines(): List<String> =
-    onAllNodes(androidx.compose.ui.test.SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
+    onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
         .fetchSemanticsNodes(atLeastOneRootRequired = false)
         .mapNotNull { it.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { t -> t.text } }
 
@@ -113,7 +114,7 @@ internal fun ComposeUiTest.renderedLines(): List<String> =
  * belongs to one row, and the bands below a heading and above the next one belong to that section.
  */
 internal fun ComposeUiTest.rowsUnder(heading: String): List<Triple<String, String, String>> {
-    val all = onAllNodes(androidx.compose.ui.test.SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
+    val all = onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Text))
         .fetchSemanticsNodes(atLeastOneRootRequired = false)
         .map { it.boundsInRoot to (it.config.getOrNull(SemanticsProperties.Text)?.joinToString("") { t -> t.text } ?: "") }
     val headings = all.filter { it.second.startsWith(StatsLabel.TOP_SONGS) || it.second.startsWith(StatsLabel.TOP_VERSES) }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/DictionaryPresenterRenderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/DictionaryPresenterRenderTest.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.presenter
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
@@ -36,7 +37,7 @@ class DictionaryPresenterRenderTest {
     private fun runDict(
         entry: StrongsEntry?,
         settings: DictionarySettings = DictionarySettings(),
-        body: androidx.compose.ui.test.ComposeUiTest.() -> Unit,
+        body: ComposeUiTest.() -> Unit,
     ) = runComposeUiTest {
         setContent {
             Box(screen) { DictionaryPresenter(entry = entry, dictionarySettings = settings) }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenterRenderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenterRenderTest.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.presenter
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
@@ -41,7 +42,7 @@ class STTPresenterRenderTest {
         settings: STTSettings,
         transcription: List<STTSegment> = emptyList(),
         translation: List<STTSegment> = emptyList(),
-        body: androidx.compose.ui.test.ComposeUiTest.() -> Unit,
+        body: ComposeUiTest.() -> Unit,
     ) = runComposeUiTest {
         setContent {
             Box(screen) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/DropdownSelectorScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/DropdownSelectorScreenshotTest.kt
@@ -3,6 +3,7 @@
 package org.churchpresenter.app.churchpresenter.screenshot
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
@@ -72,7 +73,7 @@ class DropdownSelectorScreenshotTest {
             modifier = box,
             itemTrailingContent = { _, index ->
                 Modifier.size(10.dp).let { modifier ->
-                    androidx.compose.foundation.layout.Box(
+                    Box(
                         modifier
                             .background(
                                 if (index == 0) MaterialTheme.colorScheme.primary

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabLyricsClickTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabLyricsClickTest.kt
@@ -2,6 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -29,7 +30,7 @@ import kotlin.test.assertTrue
  */
 class SongsTabLyricsClickTest {
 
-    private fun androidx.compose.ui.test.ComposeUiTest.clickRow(title: String) {
+    private fun ComposeUiTest.clickRow(title: String) {
         onAllNodes(hasText(title))[0].performClick()
         waitForIdle()
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabSelectionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabSelectionTest.kt
@@ -2,6 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasContentDescription
@@ -27,7 +28,7 @@ import kotlin.test.assertTrue
 class SongsTabSelectionTest {
 
     /** Clicks the row showing [title]. Rows are addressed by the title they display. */
-    private fun androidx.compose.ui.test.ComposeUiTest.clickRow(title: String) {
+    private fun ComposeUiTest.clickRow(title: String) {
         onAllNodes(hasText(title))[0].performClick()
         waitForIdle()
     }
@@ -40,7 +41,7 @@ class SongsTabSelectionTest {
      * (Note the capital L — `PrimaryActionButtonsTest` uses "Go live" because it passes its own
      * tooltip text; here the description comes from the `go_live` string resource.)
      */
-    private fun androidx.compose.ui.test.ComposeUiTest.goLive() {
+    private fun ComposeUiTest.goLive() {
         onAllNodes(hasContentDescription("Go Live"))[0].performClick()
         waitForIdle()
     }


### PR DESCRIPTION
## A gate that could never pass

`cleanup_check.sh` has been reporting **306** fully-qualified type names against a documented target of **0**, on every run. A check that cannot pass is a check nobody reads — and this one was hiding real violations inside its own noise.

## 285 of the 306 were not violations

| kind | count |
|---|---|
| `@file:OptIn(androidx.compose.ui.test.ExperimentalTestApi::class)` | **283** |
| KDoc links such as `[androidx.compose.ui.test.ComposeUiTest]` | the rest |

A file-level annotation sits *above* the import block and is conventionally written out in full. A KDoc link needs the full path **precisely when the type is not imported**. Neither is "writing the long form where an import already binds the name", which is what `DEVELOPMENT_GUIDE.md` actually forbids.

Both are now excluded, with the reasoning written at the grep so the next person does not have to re-derive it.

## The 21 it was hiding

All in test sources, across 15 files — receivers and parameter types spelled out in full:

```kotlin
private fun androidx.compose.ui.test.ComposeUiTest.clickRow(title: String) { … }
private fun ComposeUiTest.onAllNodesCount(matcher: androidx.compose.ui.test.SemanticsMatcher): Int
```

Each now imports the type and uses the simple name: `ComposeUiTest`, `SemanticsMatcher`, `SemanticsNodeInteractionCollection`, `SemanticsProperties`, `Role`, `Box`.

## Validation

- The check now reports **0** and **PASSES**; the whole report is green.
- **Mutation:** putting one fully-qualified receiver back takes it to `1` / `WARN`. It still catches what it exists for — the exclusions narrow it, they do not blind it.
- `compileTestKotlinJvm` clean, with no new unused-import warnings.
- Full suite `--rerun-tasks --no-build-cache`: **green, 8m22s**.

No production code is touched.
