### PR TITLE
Stop rendering Browser Source frames nobody asked for

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BrowserSourceVideoRenderer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BrowserSourceVideoRenderer.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.sp
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
 import io.github.alexzhirkevich.compottie.rememberLottieComposition
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
@@ -98,7 +99,7 @@ data class BrowserSourceFrame(
     val png: ByteArray,
 )
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalCoroutinesApi::class)
 class BrowserSourceVideoRenderer(
     private val presenterManager: PresenterManager,
     private val appSettingsState: State<AppSettings>,
@@ -317,6 +318,11 @@ class BrowserSourceVideoRenderer(
      * Dropping a *dirty-rect* frame this way is only safe because of [FULL_FRAME_RESEED_MS] —
      * each delta is only valid applied on top of the state the previous one produced, so on its
      * own a dropped delta would leave a client permanently wrong in that region.
+     *
+     * That the replayed frame is usually a delta is also why the render loop clears this cache
+     * when it parks (see [shouldRenderTick]): with no subscribers left there is no canvas for the
+     * next client to apply it to, so replaying it would paint a fragment of the old content until
+     * the wake-up full frame arrives.
      */
     val frames = MutableSharedFlow<BrowserSourceFrame>(
         replay = 1,
@@ -355,19 +361,25 @@ class BrowserSourceVideoRenderer(
                 var hasPrevious = false
                 var lastSeenSubscriberCount = 0
                 var lastFullFrameAtMs = 0L
+                var parked = false
                 while (true) {
-                    // A newly-attached HTTP client (OBS/vMix reconnect, or a debug tab opened
-                    // mid-service) must be seeded with a full frame before any dirty-rect delta
-                    // means anything to it, so force one whenever the subscriber count rises —
-                    // even on a tick where content didn't otherwise change.
                     val subscriberCount = frames.subscriptionCount.value
 
                     if (!shouldRenderTick(screenAssignmentState.value.browserSourceEnabled, subscriberCount)) {
-                        // Forget the baseline: whoever connects next has an empty canvas, so the
-                        // next rendered frame has to be a full one regardless. Dropping it here
-                        // means that happens via decideTick's existing first-frame path rather
-                        // than by diffing against pixels no client ever received.
-                        hasPrevious = false
+                        if (!parked) {
+                            parked = true
+                            // Forget the baseline: whoever connects next has an empty canvas, so
+                            // the next rendered frame has to be a full one regardless. Dropping it
+                            // here means that happens via decideTick's existing first-frame path
+                            // rather than by diffing against pixels no client ever received.
+                            hasPrevious = false
+                            // And drop what [frames] would replay. The last thing emitted before
+                            // parking is usually a dirty-rect delta, which only means anything
+                            // applied on top of the canvas the client before it had built up — so
+                            // replaying it to the *next* client paints a fragment of old content
+                            // at that rectangle until the wake-up full frame lands a poll later.
+                            frames.resetReplayCache()
+                        }
                         lastSeenSubscriberCount = subscriberCount
                         // Keep the virtual animation clock on real time so a client that connects
                         // after a long park doesn't resume mid-animation at a stale timestamp.
@@ -376,6 +388,7 @@ class BrowserSourceVideoRenderer(
                         continue
                     }
 
+                    parked = false
                     timeNanos += frameNanos
                     Snapshot.sendApplyNotifications()
                     val img = scene.render(timeNanos)
@@ -385,6 +398,10 @@ class BrowserSourceVideoRenderer(
                         img.close()
                     }
 
+                    // A newly-attached HTTP client (OBS/vMix reconnect, or a debug tab opened
+                    // mid-service) must be seeded with a full frame before any dirty-rect delta
+                    // means anything to it, so force one whenever the subscriber count rises —
+                    // even on a tick where content didn't otherwise change.
                     val newSubscriberJoined = subscriberCount > lastSeenSubscriberCount
                     lastSeenSubscriberCount = subscriberCount
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BrowserSourceVideoRenderer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BrowserSourceVideoRenderer.kt
@@ -72,7 +72,10 @@ import javax.imageio.ImageIO
  * Only encodes and emits a frame when the rendered pixels actually changed since the last
  * tick, so a static slide costs one encode, not continuous encoding — this is what keeps a
  * per-output stream far cheaper than NDI (which encodes continuously regardless of change
- * or of whether anyone is even watching). The one exception is a periodic full-frame
+ * or of whether anyone is even watching). The "whether anyone is watching" half of that is
+ * [shouldRenderTick]'s job: the loop parks entirely while the output is switched off or has
+ * no subscriber, because until it did, the render and pixel readback were still paid in full
+ * on every tick just to discover the frame was redundant. The one exception is a periodic full-frame
  * recapture (see [FULL_FRAME_RESEED_MS]) that fires on its own schedule regardless of
  * whether content changed, to bound how long a client can stay desynced from a dropped
  * dirty-rect delta (see [frames]'s KDoc for why that can happen).
@@ -123,6 +126,38 @@ class BrowserSourceVideoRenderer(
         // with no way to detect it. Forcing a fresh full-frame recapture on this schedule (not
         // just on new-subscriber) bounds how long that drift can persist.
         private const val FULL_FRAME_RESEED_MS = 5_000L
+
+        /**
+         * How often to re-check for work while parked. Only a subscription-count read, so this
+         * costs nothing measurable; it just bounds how long a connecting client waits for its
+         * first frame. Deliberately slower than any tick rate — the reseed path gives that client
+         * a full frame the moment the loop wakes, so a quarter second of latency on connect buys
+         * back a permanently idle output.
+         */
+        internal const val IDLE_POLL_MS = 250L
+
+        /**
+         * Whether this tick is worth rendering at all.
+         *
+         * Rendering a Browser Source frame is the single most expensive thing this app does per
+         * unit time — a full off-screen [ImageComposeScene] render plus a full-resolution pixel
+         * readback, ~16 MB of allocation per frame at 1920x1080 — and until this gate existed the
+         * loop paid it unconditionally, from app launch, for every configured output, whether or
+         * not an OBS/vMix client was connected and whether or not the output was even switched on.
+         * Measured on an idle app with two 1080p30 outputs configured and nothing connected: 57.5%
+         * of a core and 98% of all allocation, versus 24.6% and near-zero with the outputs removed.
+         *
+         * [enabled] is the per-output `browserSourceEnabled` switch. It gated *serving* frames in
+         * BrowserSourceRoutes but never gated *producing* them, so switching an output off in
+         * settings left this loop running at full rate — which is exactly the state a user who
+         * turned it off would assume costs nothing.
+         *
+         * Note the emit path was always change-gated ([decideTick] returns null for an unchanged
+         * frame), so a static slide never re-encoded. The cost this removes is the render and
+         * readback done *before* that decision — the work of discovering the frame was redundant.
+         */
+        internal fun shouldRenderTick(enabled: Boolean, subscriberCount: Int): Boolean =
+            enabled && subscriberCount > 0
 
         /**
          * Pure per-tick decision of whether this frame is worth sending and, if so, which
@@ -311,10 +346,36 @@ class BrowserSourceVideoRenderer(
             try {
                 var timeNanos = 0L
                 val intBuf = IntArray(width * height)
-                var lastBuf: IntArray? = null
+                // The previous frame's pixels, reused rather than reallocated. This used to be
+                // `lastBuf = intBuf.copyOf()` per changed frame — a fresh width*height IntArray
+                // (8.3 MB at 1080p) every time, and 34% of the app's total allocation. The
+                // contents are only ever read by decideTick/computeDirtyRect before being
+                // overwritten, so one buffer for the lifetime of the loop is enough.
+                val previousBuf = IntArray(width * height)
+                var hasPrevious = false
                 var lastSeenSubscriberCount = 0
                 var lastFullFrameAtMs = 0L
                 while (true) {
+                    // A newly-attached HTTP client (OBS/vMix reconnect, or a debug tab opened
+                    // mid-service) must be seeded with a full frame before any dirty-rect delta
+                    // means anything to it, so force one whenever the subscriber count rises —
+                    // even on a tick where content didn't otherwise change.
+                    val subscriberCount = frames.subscriptionCount.value
+
+                    if (!shouldRenderTick(screenAssignmentState.value.browserSourceEnabled, subscriberCount)) {
+                        // Forget the baseline: whoever connects next has an empty canvas, so the
+                        // next rendered frame has to be a full one regardless. Dropping it here
+                        // means that happens via decideTick's existing first-frame path rather
+                        // than by diffing against pixels no client ever received.
+                        hasPrevious = false
+                        lastSeenSubscriberCount = subscriberCount
+                        // Keep the virtual animation clock on real time so a client that connects
+                        // after a long park doesn't resume mid-animation at a stale timestamp.
+                        timeNanos += IDLE_POLL_MS * 1_000_000L
+                        delay(IDLE_POLL_MS)
+                        continue
+                    }
+
                     timeNanos += frameNanos
                     Snapshot.sendApplyNotifications()
                     val img = scene.render(timeNanos)
@@ -324,15 +385,11 @@ class BrowserSourceVideoRenderer(
                         img.close()
                     }
 
-                    // A newly-attached HTTP client (OBS/vMix reconnect, or a debug tab opened
-                    // mid-service) must be seeded with a full frame before any dirty-rect delta
-                    // means anything to it, so force one whenever the subscriber count rises —
-                    // even on a tick where content didn't otherwise change.
-                    val subscriberCount = frames.subscriptionCount.value
                     val newSubscriberJoined = subscriberCount > lastSeenSubscriberCount
                     lastSeenSubscriberCount = subscriberCount
 
                     val elapsedMs = timeNanos / 1_000_000
+                    val lastBuf = if (hasPrevious) previousBuf else null
                     val decision = decideTick(intBuf, lastBuf, width, height, newSubscriberJoined, elapsedMs, lastFullFrameAtMs)
 
                     if (decision != null) {
@@ -348,7 +405,10 @@ class BrowserSourceVideoRenderer(
                         }
                         frames.emit(frame)
                         if (decision.forceFullFrame) lastFullFrameAtMs = elapsedMs
-                        if (decision.contentChanged) lastBuf = intBuf.copyOf()
+                        if (decision.contentChanged) {
+                            System.arraycopy(intBuf, 0, previousBuf, 0, intBuf.size)
+                            hasPrevious = true
+                        }
                     }
                     delay(tickDelayMs)
                 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BrowserSourceVideoRendererTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/BrowserSourceVideoRendererTest.kt
@@ -26,6 +26,60 @@ class BrowserSourceVideoRendererTest {
     private fun solid(width: Int, height: Int, argb: Int) = IntArray(width * height) { argb }
 
     @Test
+    fun `shouldRenderTick is false when nothing is connected`() {
+        // The case that cost 57.5% of a core: outputs configured, app launched, no OBS client.
+        assertFalse(BrowserSourceVideoRenderer.shouldRenderTick(enabled = true, subscriberCount = 0))
+    }
+
+    @Test
+    fun `shouldRenderTick is false when the output is switched off`() {
+        // browserSourceEnabled gated serving but never production, so a disabled output used to
+        // render at full rate for a client that would have been refused anyway.
+        assertFalse(BrowserSourceVideoRenderer.shouldRenderTick(enabled = false, subscriberCount = 3))
+    }
+
+    @Test
+    fun `shouldRenderTick is false when disabled even with no subscribers`() {
+        assertFalse(BrowserSourceVideoRenderer.shouldRenderTick(enabled = false, subscriberCount = 0))
+    }
+
+    @Test
+    fun `shouldRenderTick is true only for an enabled output with a subscriber`() {
+        assertTrue(BrowserSourceVideoRenderer.shouldRenderTick(enabled = true, subscriberCount = 1))
+        assertTrue(BrowserSourceVideoRenderer.shouldRenderTick(enabled = true, subscriberCount = 12))
+    }
+
+    @Test
+    fun `the idle poll is slower than the fastest tick rate`() {
+        // Parking has to be cheaper than ticking or it defeats the point; 60fps is the ceiling
+        // tickDelayMs can reach (16ms), so the poll must be well above it.
+        assertTrue(BrowserSourceVideoRenderer.IDLE_POLL_MS > renderer(fps = 60).tickDelayMs)
+    }
+
+    @Test
+    fun `a client connecting after an idle park is reseeded with a full frame`() {
+        // The loop drops its baseline while parked, so the first tick after waking takes
+        // decideTick's previous == null path — a full frame, not a delta against pixels the
+        // new client never received.
+        val frame = solid(4, 4, 0xFF00FF00.toInt())
+        val decision = BrowserSourceVideoRenderer.decideTick(
+            intBuf = frame,
+            previous = null,
+            width = 4,
+            height = 4,
+            newSubscriberJoined = true,
+            elapsedMs = 10_000L,
+            lastFullFrameAtMs = 10_000L,
+        )
+        assertNotNull(decision)
+        assertTrue(decision.forceFullFrame)
+        assertEquals(0, decision.rect.x)
+        assertEquals(0, decision.rect.y)
+        assertEquals(4, decision.rect.w)
+        assertEquals(4, decision.rect.h)
+    }
+
+    @Test
     fun `BrowserSourceFrame equality is reference-based on the png bytes`() {
         val a = BrowserSourceFrame(0, 0, 4, 4, 4, 4, byteArrayOf(1, 2, 3))
         val b = BrowserSourceFrame(0, 0, 4, 4, 4, 4, byteArrayOf(1, 2, 3))


### PR DESCRIPTION
## What was wrong

A Browser Source output rendered a full off-screen `ImageComposeScene` and read back every pixel **on every tick from app launch onwards**, for each configured output — whether or not an OBS/vMix client was connected, and whether or not the output was even switched on. `browserSourceEnabled` gated *serving* frames in `BrowserSourceRoutes` but never gated *producing* them, so turning an output off in settings changed nothing about its cost.

The emit path was already change-gated (`decideTick` returns null for an unchanged frame), so a static slide never re-encoded. What was paid unconditionally was the render and readback done to *discover* the frame was redundant — ~16 MB of allocation per frame at 1080p.

## How it was found

JFR profile of an idle app (nothing loaded, nothing live, nobody touching it) with two 1080p30 outputs configured and nothing connected:

- **57.5% of a core**, sustained
- **98% of all allocation** in two call sites: `toComposeImageBitmap()` 63.7%, `lastBuf = intBuf.copyOf()` 34.2% — 2567 of ~2600 samples on one line
- RSS sawtoothing **1.6 GB → 5.2 GB** against a **130 MB** live heap, i.e. churn, not a leak

Confirmed by A/B: two runs of the same JVM with identical flags, differing only in `projectionSettings.browserSourceOutputs`.

## The change

1. `shouldRenderTick(enabled, subscriberCount)` — park the loop on a 250 ms poll instead of rendering when the output is disabled or has no subscriber. The baseline is dropped while parked, so the first frame after waking takes `decideTick`'s existing first-frame path and a connecting client gets a full frame. `timeNanos` keeps advancing on real time so a client connecting after a long park doesn't resume at a stale animation timestamp.
2. Reuse the previous-frame buffer rather than allocating a fresh `IntArray(width*height)` per changed frame.

`shouldRenderTick` is a pure function and tested directly, matching `decideTick`/`computeDirtyRect` alongside it.

## Result

| 45 s idle, 2×1080p30 configured, nothing connected | before | after | no outputs at all |
|---|---|---|---|
| CPU (% of one core) | 57.5% | **23.6%** | 24.6% |
| allocation samples | 2893 | **67** | 51 |
| young GCs | 18 | **0** | 0 |

A two-output configuration now costs the same as not having the feature. `skia.Bitmap.readPixels` is gone from the allocation profile; what tops it now is `MetalRedrawer.draw` (native window compositing).

## Verification

Streaming still works — connected a real WebSocket client to `/api/browser-source/1/ws`:

```
PARKED (no client connected): 27.8% of one core
handshake: HTTP/1.1 101 Switching Protocols
frames=2 bytes=66582
CONNECTED (client streaming):  31.8% of one core
AFTER DISCONNECT:              19.8% of one core
```

The gate opens and closes with the connection. Two frames over 12 s of *static* content is the designed behaviour: the new-subscriber full frame plus one 5 s periodic reseed.

6 new tests (class now 30 tests, 0.048 s). Full `jvmTest` green with `--rerun-tasks`; `cleanup_check.sh` clean.

## Not addressed here

- `toComposeImageBitmap()` still allocates 8.3 MB per frame **while a client is actively streaming**. Removing that means rendering into a reusable Skia `Surface` rather than `scene.render()` → `toComposeImageBitmap()` → `readPixels`, which needs skiko APIs worth verifying properly, and it only helps when the work is at least useful.
- The same per-frame-allocation pattern likely applies to `SharedCameraFrameCache` and `DeckLinkComposeOutput`. That is a hypothesis from reading the code, not something measured.

## Unrelated flake seen along the way

`LowerThirdTabTest > choosing a preset opens it and enables the actions` failed once (Go Live asserted enabled, found disabled). Not from this change: full suite green on base, full suite green with the fix, and that class green alone on both — four of five runs green including both full-suite runs. Flagging it since it is intermittent.