### PR TITLE
Keep the song section selection inside the song it points at

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
@@ -199,6 +199,9 @@ class SongsViewModel(
             _filteredSongItems.value = _filteredSongItems.value.replaced()
             _allSongItems.value = _allSongItems.value.replaced()
             _songsData.value = Songs().also { it.addSongs(_allSongItems.value) }
+            // The fetched lyrics are the first sections this song has had; an index carried over from
+            // whatever was selected before must not survive past their end.
+            clampSectionSelection()
             // Only nudge the presenter if this song is still the one selected — the operator may
             // have already moved on to a different song by the time this fetch resolves.
             val currentIdx = _selectedSongIndex.value
@@ -376,8 +379,30 @@ class SongsViewModel(
     fun selectSongById(songId: String): Boolean = selectSongByDetails(0, "", "", songId)
 
     fun selectSection(index: Int) {
-        _selectedSectionIndex.value = index
+        // Clamped, because the index does not always come from the rendered list: a phone pushes one
+        // through MainDesktop's songDisplaySectionIndex collector, and Back-to-Live replays one
+        // remembered from an earlier — possibly longer — version of the song.
+        _selectedSectionIndex.value = index.coerceAtMost(getLyricSections().lastIndex)
         _selectedLineIndex.value = 0
+    }
+
+    /**
+     * Keeps the section selection inside the song it now points at.
+     *
+     * There is no stored section list — [getLyricSections] recomputes from the selected song on every
+     * call — so the list changes under the index whenever the song does: a filter or sort change puts
+     * a different song at the same row, an edit or a folder-watcher reload can drop a verse, and an
+     * Instance Link catalog arrives with no lyrics at all. An index left past the end presented the
+     * wrong slide, and walking down from it crashed [navigatePreviousSection].
+     *
+     * `-1` is a real value — the whole-song/title slide — and is preserved.
+     */
+    private fun clampSectionSelection() {
+        val last = getLyricSections().lastIndex
+        if (_selectedSectionIndex.value > last) {
+            _selectedSectionIndex.value = last // -1 when the song has no sections at all
+            _selectedLineIndex.value = 0
+        }
     }
 
     fun setLineIndex(index: Int) {
@@ -578,7 +603,9 @@ class SongsViewModel(
     fun navigatePreviousSection(): Boolean {
         _selectedLineIndex.value = 0
         val sections = getLyricSections()
-        var prevIdx = _selectedSectionIndex.value - 1
+        // Start from the end of what actually exists: the selection can outlive the list it indexes
+        // (see [clampSectionSelection]), and this walk only guards its lower bound.
+        var prevIdx = (_selectedSectionIndex.value - 1).coerceAtMost(sections.lastIndex)
         while (prevIdx >= 0) {
             if (sections[prevIdx].lines.isNotEmpty()) {
                 _selectedSectionIndex.value = prevIdx
@@ -633,7 +660,9 @@ class SongsViewModel(
         }
         // Move to previous section with content lines (skip empty sections)
         val sections = getLyricSections()
-        var prevIdx = _selectedSectionIndex.value - 1
+        // Clamped for the same reason as [navigatePreviousSection] — a stale index would index past
+        // the end on the very first step.
+        var prevIdx = (_selectedSectionIndex.value - 1).coerceAtMost(sections.lastIndex)
         while (prevIdx >= 0) {
             if (sections[prevIdx].lines.isNotEmpty()) {
                 _selectedSectionIndex.value = prevIdx
@@ -701,6 +730,9 @@ class SongsViewModel(
             if (idx >= 0) {
                 _selectedSongIndex.value = idx
                 _pendingSelectSourceFile = null
+                // The re-select moved the song after [refreshFilteredSongItems] clamped, so the
+                // section index has to be checked against this song too.
+                clampSectionSelection()
             }
         }
     }
@@ -762,6 +794,9 @@ class SongsViewModel(
         }
 
         _filteredSongItems.value = items
+        // A re-sort leaves _selectedSongIndex where it was, so a different song — with a different
+        // number of sections — now sits under it.
+        clampSectionSelection()
     }
 
     private fun buildSongFileName(number: String, title: String): String {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelNavigationEdgeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModelNavigationEdgeTest.kt
@@ -6,6 +6,7 @@ import org.churchpresenter.app.churchpresenter.data.SongFileParser
 import org.churchpresenter.app.churchpresenter.data.SongItem
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
+import org.churchpresenter.app.churchpresenter.utils.Constants
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest
@@ -40,6 +41,11 @@ class SongsViewModelNavigationEdgeTest {
                 "[Verse 2]", "V2 line one",
             ),
         )
+        // Five sections, so a selection late in this song is out of range in the one above.
+        writeSong(
+            songbook = "Hymnal", number = "0002", title = "Long Song",
+            lyrics = (1..5).flatMap { listOf("[Verse $it]", "V$it line one") },
+        )
     }
 
     @AfterTest
@@ -62,8 +68,15 @@ class SongsViewModelNavigationEdgeTest {
         created.add(vm)
         // Immediate dispatchers, so the load is done by the time the constructor returns.
         if (vm.filteredSongItems.value.isEmpty()) throw AssertionError("songs did not load synchronously")
-        vm.selectSong(0)
+        vm.selectByTitle("Empty Middle")
         return vm
+    }
+
+    /** Selects by title — the order the two songs load in is not guaranteed. */
+    private fun SongsViewModel.selectByTitle(title: String) {
+        val index = filteredSongItems.value.indexOfFirst { it.title == title }
+        assertTrue(index >= 0, "no song titled $title")
+        selectSong(index)
     }
 
     @Test
@@ -114,5 +127,88 @@ class SongsViewModelNavigationEdgeTest {
 
         assertEquals(0, vm.selectedSectionIndex.value, "the empty Bridge is skipped, landing on Verse 1")
         assertEquals(1, vm.selectedLineIndex.value, "and resumes at the last line of that section")
+    }
+
+    // ── A section selection that outlives the song it indexes ───────────────────
+    //
+    // The section list is recomputed from the selected song on every call, so anything that puts a
+    // different — shorter — song under the same row leaves the index pointing past the end. Walking
+    // *down* from such an index used to read past the end of the list on its very first step and
+    // kill the app (Sentry 042c9c37: "Index 3 out of bounds for length 3", released 26.4.203).
+
+    /** Leaves only the three-section song, with the selection on section 4 of the five-section one. */
+    private fun SongsViewModel.selectLateThenFilterToShortSong() {
+        selectByTitle("Long Song")
+        selectSection(4)
+        assertEquals(4, selectedSectionIndex.value, "the long song really does reach section 4")
+
+        updateSearchQuery("Empty")
+
+        assertEquals(1, filteredSongItems.value.size, "only the short song survives the search")
+        assertEquals(3, getLyricSections().size, "and it is the three-section song")
+    }
+
+    @Test
+    fun `stepping a section back after a shorter song takes the row does not read past the end`() {
+        val vm = viewModel()
+        vm.selectLateThenFilterToShortSong()
+
+        vm.navigatePreviousSection() // threw IndexOutOfBoundsException before the selection was clamped
+
+        assertTrue(
+            vm.selectedSectionIndex.value in vm.getLyricSections().indices,
+            "the selection lands inside the song that is actually selected",
+        )
+    }
+
+    @Test
+    fun `stepping a line back after a shorter song takes the row does not read past the end`() {
+        val vm = viewModel()
+        vm.selectLateThenFilterToShortSong()
+
+        vm.navigatePreviousLine()
+
+        assertTrue(vm.selectedSectionIndex.value in vm.getLyricSections().indices)
+    }
+
+    @Test
+    fun `a search that swaps in a shorter song pulls the section selection back into it`() {
+        val vm = viewModel()
+
+        vm.selectLateThenFilterToShortSong()
+
+        assertEquals(2, vm.selectedSectionIndex.value, "clamped to the last section of the short song")
+        assertEquals(0, vm.selectedLineIndex.value, "and to that section's first line")
+    }
+
+    @Test
+    fun `a re-sort that puts a shorter song under the selection re-clamps it`() {
+        val vm = viewModel()
+        vm.updateSort(Constants.SORT_TITLE) // ascending: Empty Middle, Long Song
+        vm.selectByTitle("Long Song")
+        vm.selectSection(4)
+
+        vm.updateSort(Constants.SORT_TITLE) // same column again -> descending, the songs swap rows
+
+        assertEquals("Empty Middle", vm.filteredSongItems.value[vm.selectedSongIndex.value].title)
+        assertEquals(2, vm.selectedSectionIndex.value)
+    }
+
+    @Test
+    fun `selecting a section past the end lands on the last real section`() {
+        val vm = viewModel() // the three-section song
+
+        vm.selectSection(9) // e.g. a stale index replayed by Back-to-Live or pushed from a phone
+
+        assertEquals(2, vm.selectedSectionIndex.value)
+    }
+
+    @Test
+    fun `selecting section -1 still selects the whole-song slide`() {
+        val vm = viewModel()
+
+        vm.selectSection(-1)
+
+        assertEquals(-1, vm.selectedSectionIndex.value, "-1 is the title slide, not an out-of-range index")
     }
 }


### PR DESCRIPTION
Fixes the fatal `IndexOutOfBoundsException: Index 3 out of bounds for length 3` reported from release 26.4.203 (Sentry `042c9c37a03440e58dd67756179437a2`) — the operator was on the Songs tab and pressed the previous-section shortcut, and the app died.

## The bug

`navigatePreviousSection` starts at `selectedSectionIndex - 1` and walks **down**, so its only loop guard, `prevIdx >= 0`, never bounded the upper end. With the selection on section 4 of a song that parses to three sections, the very first `sections[prevIdx]` read out of range. `navigatePreviousLine` walked down the same way. The two `next*` walks loop on `nextIdx < sections.size` and were already safe.

The index went stale because there is no stored section list — `getLyricSections()` recomputes from `_filteredSongItems[_selectedSongIndex]` on every call — and nothing reconciled the index when the song underneath it changed. `applyFilters()` clamped the *song* index and never the section index, so a search, a songbook change, a re-sort, a folder-watcher reload, a song edit, or an Instance Link catalog swap could all leave the selection pointing past the end of whatever song now sat under that row. `getSelectedLyricSection()` is range-checked and falls back to the whole-song slide, which is why this mostly showed up as the wrong slide rather than a crash.

## The fix

Two layers:

- Both downward walks now start at `(index - 1).coerceAtMost(sections.lastIndex)`. `lastIndex` is `-1` for an empty list, so it falls straight out of the `prevIdx >= 0` guard and the empty-song case still returns `false`.
- New `clampSectionSelection()` pulls the selection back into the current song, called wherever the list is replaced: `refreshFilteredSongItems()` (covers every filter and sort path), the pending `sourceFile` re-select in `applyFilters()`, and the async Instance Link lyric fetch. `selectSection()` clamps its argument too — it also takes indices pushed from a phone (`MainDesktop.kt:530`) and replayed by Back-to-Live (`SongsTab.kt:1500`), both captured from a possibly longer earlier version of the song.

`-1` — the whole-song/title slide — is a real value and is preserved everywhere.

This follows `BibleViewModel`'s existing idiom: `coerceIn` after the backing list is replaced, plus a range guard on the public selector.

## Tests

Five cases added to `SongsViewModelNavigationEdgeTest`, whose fixture song already parses to exactly three sections. Reverting only the production change makes two of them fail with the reported `Index 3 out of bounds for length 3`; the other three cover the clamp on search, on re-sort, and on an out-of-range `selectSection`, plus that `selectSection(-1)` still selects the title slide.

`:composeApp:check` green; the Songs suites run three consecutive times clean, each new test ~1ms. No UI touched, so no screenshot re-record.