### PR TITLE
Add the Holy Bible XML archive as a third Bible download source

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -1531,11 +1531,14 @@
     <string name="bible_catalog_rights">Copyright: %1$s</string>
     <string name="bible_catalog_source_ebible">eBible.org</string>
     <string name="bible_catalog_source_zefania">Zefania Archive</string>
+    <string name="bible_catalog_source_beblia">Holy Bible XML</string>
     <string name="bible_catalog_license_title">Copyright and licensing</string>
     <string name="bible_catalog_license_body">Bible translations are protected by copyright. Some are public domain, others allow personal or congregational use only, and some require a licence before they may be shown publicly, streamed or broadcast.\n\nBy downloading you confirm that you are permitted to use this translation in your setting, and that you accept the publisher's terms.</string>
     <string name="bible_catalog_license_unknown">This archive states no copyright for this translation.</string>
     <string name="bible_catalog_license_source_ebible">eBible.org lists this translation as redistributable and publishes the copyright shown above.</string>
     <string name="bible_catalog_license_source_zefania">The Zefania archive publishes no licence details, so this translation’s copyright only becomes visible once it is installed. Its modules are community-contributed and have not been checked.</string>
+    <string name="bible_catalog_license_source_beblia">The Holy Bible XML archive republishes each translation\'s own copyright statement, shown above, but its files are community-contributed and none of the statements have been checked.</string>
+    <string name="bible_catalog_book_names_english">Book names will appear in English for this translation — the archive\'s files identify books by number only. Verse text is unaffected.</string>
     <string name="bible_catalog_license_accept">I understand — Download</string>
     <string name="bible_catalog_subtitle">Browse free translations and add them to your library</string>
     <string name="bible_catalog_installed_count">%1$d installed</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaCatalogIndex.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaCatalogIndex.kt
@@ -1,0 +1,295 @@
+package org.churchpresenter.app.churchpresenter.data
+
+import converter.BibleCatalogNaming
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.churchpresenter.app.churchpresenter.utils.Constants
+import org.churchpresenter.app.churchpresenter.utils.CrashReporter
+import java.io.File
+import java.net.URLEncoder
+
+/**
+ * Lists the Bible modules available in the Holy Bible XML archive.
+ *
+ * Unlike the Zefania archive, whose file names carry everything a browse list needs, this one is
+ * 1048 flat `.xml` files named only `<Language><Edition>Bible.xml`, with the title, the copyright and
+ * the book counts buried inside files that average five megabytes. Neither a tree listing nor a
+ * ranged read would recover them.
+ *
+ * So the archive publishes a generated `catalog.json` alongside its files — see
+ * `scripts/generate_beblia_catalog.py`, which builds it — and this fetches that one small document.
+ * It is a curated index rather than a derived one, which is a real cost: it has to be regenerated
+ * when the archive's content changes. What it buys is a browse list that states each translation's
+ * actual copyright *before* anything is downloaded, and testament coverage taken from the file's real
+ * contents rather than guessed from its title.
+ *
+ * The manifest names the commit its blob hashes were read at, and downloads are pinned to that
+ * commit. Without the pin, an upstream edit after generation would hand every user a checksum
+ * mismatch — reported as "the download was incomplete" — until someone regenerated the manifest.
+ * Pinned, a lagging manifest simply serves the older file it actually describes.
+ */
+object BebliaCatalogIndex {
+
+    const val OWNER = "ChurchPresenter"
+    const val REPO = "Holy-Bible-XML-Format"
+    const val BRANCH = "master"
+
+    /** One row of the browse list, taken entirely from the manifest. */
+    data class Module(
+        val file: String,
+        val blobSha: String,
+        val sizeBytes: Long,
+        val language: String,
+        /**
+         * What the manifest calls [language] in English; blank where it could not name it.
+         *
+         * This archive reaches languages neither eBible nor [BibleLanguageNames] has ever listed —
+         * over 250 codes against the Zefania archive's 63 — so without a name of its own the filter
+         * would show a bare code for most of them.
+         */
+        val languageName: String,
+        val identifier: String,
+        val displayName: String,
+        /** The translation's own copyright statement, which this archive publishes up front. */
+        val copyright: String,
+        val sourceUrl: String,
+        val otBookCount: Int,
+        val ntBookCount: Int,
+        val fileStem: String
+    ) {
+        val fileName: String get() = "$fileStem.${Constants.EXTENSION_SPB}"
+    }
+
+    /** [commit] is what downloads are pinned to, so it travels with the modules it describes. */
+    data class Index(val commit: String, val modules: List<Module>, val etag: String = "")
+
+    /**
+     * No `RateLimited` case, deliberately: this comes off `raw.githubusercontent.com`, a CDN with no
+     * API quota, where the Zefania listing comes off the GitHub API's 60-requests-per-hour limit.
+     */
+    sealed interface IndexOutcome {
+        /** [stale] means this came from the on-disk copy because the archive was unreachable. */
+        data class Success(val index: Index, val stale: Boolean = false) : IndexOutcome
+        data object NetworkError : IndexOutcome
+        data object Failure : IndexOutcome
+    }
+
+    // --- manifest DTOs ---
+
+    @Serializable
+    internal data class Entry(
+        val file: String = "",
+        val sha: String = "",
+        val size: Long = 0,
+        val title: String = "",
+        val id: String = "",
+        val lang: String = "",
+        /** English name for [lang], where the generator could resolve one. */
+        val langName: String = "",
+        /** How the generator arrived at [lang]; recorded for review, never shown. */
+        val langFrom: String = "",
+        val rights: String = "",
+        val url: String = "",
+        val ot: Int = 0,
+        val nt: Int = 0
+    )
+
+    /**
+     * Every field is defaulted and unknown ones are ignored, so the archive can add a column without
+     * an app release. [schemaVersion] is informational only and is never refused on — refusing would
+     * strand every installed copy the moment someone bumped it. A breaking change gets a new path.
+     */
+    @Serializable
+    internal data class CatalogFile(
+        val schemaVersion: Int = 1,
+        val commit: String = "",
+        val bibles: List<Entry> = emptyList()
+    )
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val defaultHttp by lazy {
+        HttpClient(CIO) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30_000
+                connectTimeoutMillis = 8_000
+            }
+        }
+    }
+
+    private val defaultCacheFile = File(System.getProperty("user.home"), ".churchpresenter/cache/beblia-catalog.json")
+
+    /** The archive is a preservation project, not a feed; it changes a few times a year. */
+    private const val CACHE_TTL_MILLIS = 7L * 24 * 60 * 60 * 1000
+
+    @Volatile
+    private var memoryCache: Pair<Long, Index>? = null
+
+    /** `-Dchurchpresenter.bebliaCatalogUrl=` points at a staging archive. For testing, not a setting. */
+    internal fun catalogUrl(): String =
+        System.getProperty("churchpresenter.bebliaCatalogUrl")?.takeIf { it.isNotBlank() }
+            ?: "https://raw.githubusercontent.com/$OWNER/$REPO/$BRANCH/catalog.json"
+
+    internal fun rawBase(): String =
+        System.getProperty("churchpresenter.bebliaRawBase")?.takeIf { it.isNotBlank() }
+            ?: "https://raw.githubusercontent.com/$OWNER/$REPO"
+
+    /** [commit] rather than the branch, so the bytes match the hash the manifest published. */
+    fun rawUrlFor(commit: String, file: String): String =
+        rawBase().trimEnd('/') + "/" + encodePath(commit) + "/" + encodePath(file)
+
+    private fun encodePath(segment: String): String =
+        URLEncoder.encode(segment, "UTF-8").replace("+", "%20")
+
+    internal fun clearMemoryCache() {
+        memoryCache = null
+    }
+
+    suspend fun fetch(
+        url: String = catalogUrl(),
+        http: HttpClient = defaultHttp,
+        cacheFile: File = defaultCacheFile,
+        nowMillis: Long = System.currentTimeMillis(),
+    ): IndexOutcome = withContext(Dispatchers.IO) {
+        memoryCache?.let { (fetchedAt, index) ->
+            if (nowMillis - fetchedAt < CACHE_TTL_MILLIS) return@withContext IndexOutcome.Success(index)
+        }
+
+        val cached = readCache(cacheFile)
+        val cachedAt = BibleInstallSupport.BibleIndexCache.readMeta(cacheFile).first
+        if (cached != null && nowMillis - cachedAt < CACHE_TTL_MILLIS) {
+            memoryCache = nowMillis to cached
+            return@withContext IndexOutcome.Success(cached)
+        }
+
+        try {
+            val response = http.get(url) {
+                header("User-Agent", "ChurchPresenter")
+                if (cached != null && cached.etag.isNotBlank()) header("If-None-Match", cached.etag)
+            }
+
+            if (response.status.value == 304 && cached != null) {
+                BibleInstallSupport.BibleIndexCache.writeMeta(cacheFile, nowMillis, cached.etag)
+                memoryCache = nowMillis to cached
+                return@withContext IndexOutcome.Success(cached)
+            }
+
+            if (response.status.value !in 200..299) {
+                CrashReporter.reportWarning(
+                    "Holy Bible XML catalogue fetch returned HTTP ${response.status.value}",
+                    tags = mapOf("subsystem" to "beblia_catalog")
+                )
+                return@withContext cached?.let { IndexOutcome.Success(it, stale = true) } ?: IndexOutcome.Failure
+            }
+
+            val body = response.body<String>()
+            val etag = response.headers["ETag"].orEmpty()
+            when (val parsed = parseCatalog(body, etag)) {
+                is IndexOutcome.Success -> {
+                    memoryCache = nowMillis to parsed.index
+                    runCatching {
+                        cacheFile.parentFile?.mkdirs()
+                        cacheFile.writeText(body)
+                        BibleInstallSupport.BibleIndexCache.writeMeta(cacheFile, nowMillis, etag)
+                    }
+                    parsed
+                }
+                // A manifest that arrived but did not parse is not written over a good cached copy.
+                else -> cached?.let { IndexOutcome.Success(it, stale = true) } ?: parsed
+            }
+        } catch (e: Exception) {
+            CrashReporter.reportWarning(
+                "Holy Bible XML catalogue fetch failed",
+                throwable = e,
+                tags = mapOf("subsystem" to "beblia_catalog")
+            )
+            // An offline hall still sees the list it saw last time; the failure then surfaces on the
+            // install, which is far more useful than an empty dialog.
+            cached?.let { IndexOutcome.Success(it, stale = true) } ?: IndexOutcome.NetworkError
+        }
+    }
+
+    /**
+     * Parses a manifest body. Pure — this is where nearly all the behaviour lives.
+     *
+     * Rows are sorted by file name and deduplicated in that fixed order, so every machine derives the
+     * same stem for the same translation. That determinism is what lets the dialog show "Installed"
+     * by comparing against the files on disk, with nothing pinned anywhere. The stem is deliberately
+     * *not* carried in the manifest: keeping the naming rule in [BibleCatalogNaming] alone is what
+     * stops the generator drifting from the app.
+     */
+    internal fun parseCatalog(body: String, etag: String = ""): IndexOutcome = try {
+        val catalog = json.decodeFromString(CatalogFile.serializer(), body)
+        val entries = catalog.bibles.filter { it.file.isNotBlank() }
+        when {
+            // A manifest that parsed to nothing is a truncated or half-written file, not an empty
+            // archive — presenting it as an empty catalogue would look like a working, bare tab.
+            entries.isEmpty() -> {
+                CrashReporter.reportWarning(
+                    "Holy Bible XML catalogue listed no translations",
+                    tags = mapOf("subsystem" to "beblia_catalog")
+                )
+                IndexOutcome.Failure
+            }
+            // Without the commit the downloads have nothing to pin to, and pinning is what makes the
+            // published hashes meaningful.
+            catalog.commit.isBlank() -> {
+                CrashReporter.reportWarning(
+                    "Holy Bible XML catalogue named no commit",
+                    tags = mapOf("subsystem" to "beblia_catalog")
+                )
+                IndexOutcome.Failure
+            }
+            else -> IndexOutcome.Success(Index(catalog.commit, toModules(entries), etag))
+        }
+    } catch (e: Exception) {
+        CrashReporter.reportWarning(
+            "Holy Bible XML catalogue could not be parsed",
+            throwable = e,
+            tags = mapOf("subsystem" to "beblia_catalog")
+        )
+        IndexOutcome.Failure
+    }
+
+    internal fun toModules(entries: List<Entry>): List<Module> {
+        val taken = mutableSetOf<String>()
+        return entries.sortedBy { it.file }.map { entry ->
+            val language = entry.lang.trim().uppercase().ifBlank { BibleCatalogNaming.UNKNOWN_LANGUAGE }
+            val stem = BibleCatalogNaming.deduplicate(
+                BibleCatalogNaming.fileStem(language, entry.id),
+                taken
+            )
+            taken.add(stem)
+            Module(
+                file = entry.file,
+                blobSha = entry.sha,
+                sizeBytes = entry.size,
+                language = language,
+                languageName = entry.langName.trim(),
+                identifier = entry.id,
+                // Never let a row arrive nameless: an untitled entry would be an unclickable blank.
+                displayName = entry.title.ifBlank { entry.file.removeSuffix(".xml") },
+                copyright = entry.rights,
+                sourceUrl = entry.url,
+                otBookCount = entry.ot,
+                ntBookCount = entry.nt,
+                fileStem = stem
+            )
+        }
+    }
+
+    private fun readCache(cacheFile: File): Index? {
+        if (!cacheFile.isFile) return null
+        val body = runCatching { cacheFile.readText() }.getOrNull() ?: return null
+        val etag = BibleInstallSupport.BibleIndexCache.readMeta(cacheFile).second
+        return (parseCatalog(body, etag) as? IndexOutcome.Success)?.index
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaSource.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaSource.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.data
 import converter.BookNames
 import converter.XmlToSpbConverter
 import io.ktor.client.HttpClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.churchpresenter.app.churchpresenter.utils.CrashReporter
@@ -114,6 +115,23 @@ object BebliaSource : BibleSource {
                     expectedBytes = module.sizeBytes,
                     retryFloorMs = retryFloorMs,
                 ) { onProgress(InstallProgress(InstallPhase.DOWNLOADING, it)) }
+            } catch (e: CancellationException) {
+                // Closing the dialog cancels the install. That is the user's doing, not a fault.
+                throw e
+            } catch (e: BibleInstallSupport.DownloadStalledException) {
+                CrashReporter.reportWarning(
+                    "Holy Bible XML download stalled (${module.fileStem})",
+                    throwable = e,
+                    tags = mapOf(
+                        "subsystem" to "bible_install",
+                        "module" to module.fileStem,
+                        "reason" to "stalled",
+                        "attempts" to e.attempts.toString(),
+                        "bytes_written" to e.bytesWritten.toString(),
+                        "expected_bytes" to module.sizeBytes.toString(),
+                    )
+                )
+                return@withContext BibleInstallOutcome.DownloadStalled
             } catch (e: Exception) {
                 CrashReporter.reportWarning(
                     "Holy Bible XML download failed (${module.fileStem})",

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaSource.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaSource.kt
@@ -1,0 +1,212 @@
+package org.churchpresenter.app.churchpresenter.data
+
+import converter.BookNames
+import converter.XmlToSpbConverter
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.churchpresenter.app.churchpresenter.utils.CrashReporter
+import java.io.File
+import javax.xml.stream.XMLStreamException
+
+/**
+ * The Holy Bible XML archive: 1048 translations across more than 200 languages, many of which
+ * neither [EBibleSource] nor [ZefaniaSource] carries.
+ *
+ * It is the only one of the three whose files are not archives — each translation is a single bare
+ * XML document, so nothing is unzipped and [InstallPhase.EXTRACTING] never appears. It is also the
+ * only one that both publishes a copyright up front *and* has none of it verified: eBible states
+ * redistribution rights, Zefania states nothing at all, and this archive republishes whatever each
+ * contributor wrote. So its rows show a copyright and still carry the unverified licence badge.
+ *
+ * See [BebliaCatalogIndex] for where the catalogue comes from, and `converter.BebliaParser` for the
+ * format and for why book names come out in English for most of these languages.
+ */
+object BebliaSource : BibleSource {
+
+    override val sourceId = BibleSourceId.BEBLIA
+
+    override suspend fun catalog(nowMillis: Long): BibleCatalogOutcome =
+        when (val outcome = BebliaCatalogIndex.fetch(nowMillis = nowMillis)) {
+            is BebliaCatalogIndex.IndexOutcome.Success -> {
+                // The manifest names languages by code alone, so the names come from elsewhere.
+                val languageNames = BibleLanguageNames.table()
+                BibleCatalogOutcome.Success(
+                    outcome.index.modules.map { it.toBibleModule(outcome.index.commit, languageNames) },
+                    outcome.stale
+                )
+            }
+            BebliaCatalogIndex.IndexOutcome.NetworkError -> BibleCatalogOutcome.NetworkError
+            BebliaCatalogIndex.IndexOutcome.Failure -> BibleCatalogOutcome.Failure
+        }
+
+    /**
+     * [BibleModule.downloadKey] is `<commit>/<file>` so a row resolves on its own.
+     *
+     * A user who opens the dialog, waits while the catalogue refreshes behind them and then installs
+     * still gets the blob whose hash their row published, rather than a newer file that would fail
+     * the checksum.
+     */
+    internal fun BebliaCatalogIndex.Module.toBibleModule(
+        commit: String,
+        languageNames: Map<String, LanguageNaming> = emptyMap()
+    ) = BibleModule(
+        sourceId = BibleSourceId.BEBLIA,
+        downloadKey = "$commit/$file",
+        checksum = blobSha,
+        sizeBytes = sizeBytes,
+        language = language,
+        // The shared table wins where it has the code — it is what the other two tabs label the same
+        // language with, and it carries autonyms — but it knows a fraction of what this archive
+        // reaches, so the manifest's own name fills the rest rather than leaving a bare code.
+        languageName = languageNames[language]?.english?.ifBlank { null } ?: languageName,
+        languageNativeName = languageNames[language]?.native.orEmpty(),
+        identifier = identifier,
+        displayName = displayName,
+        copyright = copyright,
+        otBookCount = otBookCount,
+        ntBookCount = ntBookCount,
+        fileStem = fileStem
+    )
+
+    /**
+     * Whether an installed translation will list its books in its own language.
+     *
+     * These files identify books by a bare number, so the names come from the app's own tables — and
+     * those cover under twenty languages. Everything else gets native verse text under English book
+     * names, which is worth saying before the download rather than after it.
+     */
+    fun hasLocalisedBookNames(language: String): Boolean =
+        language.trim().uppercase() in BookNames.LANGUAGE_LOOKUPS
+
+    override suspend fun install(
+        module: BibleModule,
+        targetDir: File,
+        onProgress: (InstallProgress) -> Unit,
+    ): BibleInstallOutcome =
+        installBeblia(module, targetDir, BibleInstallSupport.defaultHttp, onProgress = onProgress)
+
+    internal suspend fun installBeblia(
+        module: BibleModule,
+        targetDir: File,
+        http: HttpClient,
+        /** The download's first backoff delay; 0 in tests, so a failing host costs no wall clock. */
+        retryFloorMs: Long = BibleInstallSupport.DEFAULT_DOWNLOAD_RETRY_FLOOR_MS,
+        onProgress: (InstallProgress) -> Unit,
+    ): BibleInstallOutcome = withContext(Dispatchers.IO) {
+        if (!BibleInstallSupport.usableDirectory(targetDir)) return@withContext BibleInstallOutcome.NoDirectory
+
+        val scratch = BibleInstallSupport.scratchIn(targetDir)
+        try {
+            scratch.deleteRecursively()
+            scratch.mkdirs()
+            val xmlFile = File(scratch, "module.xml")
+            val spbPart = File(scratch, module.fileName)
+
+            val commit = module.downloadKey.substringBefore('/')
+            val file = module.downloadKey.substringAfter('/')
+
+            val result = try {
+                BibleInstallSupport.downloadTo(
+                    url = BebliaCatalogIndex.rawUrlFor(commit, file),
+                    destination = xmlFile,
+                    http = http,
+                    expectedBytes = module.sizeBytes,
+                    retryFloorMs = retryFloorMs,
+                ) { onProgress(InstallProgress(InstallPhase.DOWNLOADING, it)) }
+            } catch (e: Exception) {
+                CrashReporter.reportWarning(
+                    "Holy Bible XML download failed (${module.fileStem})",
+                    throwable = e,
+                    tags = mapOf("subsystem" to "bible_install", "module" to module.fileStem)
+                )
+                return@withContext BibleInstallOutcome.NetworkError
+            }
+
+            if (result.status !in 200..299) {
+                CrashReporter.reportWarning(
+                    "Holy Bible XML download returned HTTP ${result.status} (${module.fileStem})",
+                    tags = mapOf("subsystem" to "bible_install", "module" to module.fileStem)
+                )
+                return@withContext BibleInstallOutcome.HttpError(result.status)
+            }
+            if (module.sizeBytes > 0 && result.bytesWritten != module.sizeBytes) {
+                return@withContext BibleInstallOutcome.ChecksumMismatch
+            }
+            // The git blob hash comes free with the manifest, so integrity is checked end to end
+            // against a hash the archive itself published — and it rejects the two bodies a file host
+            // hands back instead of a module, a 404 page and an LFS pointer.
+            if (module.checksum.isNotBlank() &&
+                !BibleInstallSupport.gitBlobSha1(xmlFile).equals(module.checksum, ignoreCase = true)
+            ) {
+                return@withContext BibleInstallOutcome.ChecksumMismatch
+            }
+
+            val parsed = try {
+                XmlToSpbConverter.parseBeblia(
+                    xmlFile = xmlFile,
+                    language = module.language,
+                    name = module.displayName,
+                    rights = module.copyright,
+                    source = BebliaCatalogIndex.rawUrlFor(commit, file),
+                    identifier = module.identifier,
+                ) { fraction ->
+                    onProgress(
+                        InstallProgress(
+                            InstallPhase.CONVERTING,
+                            BibleInstallSupport.DOWNLOAD_END +
+                                (BibleInstallSupport.PARSE_END - BibleInstallSupport.DOWNLOAD_END) * fraction
+                        )
+                    )
+                }
+            } catch (e: XMLStreamException) {
+                // Not XML at all: a captive portal's login page, or a truncated body that still
+                // matched no published size. "Damaged download" is the useful thing to say.
+                CrashReporter.reportWarning(
+                    "Holy Bible XML module was not well-formed (${module.fileStem})",
+                    throwable = e,
+                    tags = mapOf("subsystem" to "bible_install", "module" to module.fileStem)
+                )
+                return@withContext BibleInstallOutcome.CorruptArchive
+            } catch (e: Exception) {
+                CrashReporter.reportWarning(
+                    "Holy Bible XML module could not be parsed (${module.fileStem})",
+                    throwable = e,
+                    tags = mapOf("subsystem" to "bible_install", "module" to module.fileStem)
+                )
+                return@withContext BibleInstallOutcome.ConversionFailed
+            }
+            if (parsed.books.isEmpty() || parsed.books.sumOf { b -> b.chapters.sumOf { it.verses.size } } == 0) {
+                return@withContext BibleInstallOutcome.ConversionFailed
+            }
+
+            XmlToSpbConverter.write(parsed, spbPart) { fraction ->
+                onProgress(
+                    InstallProgress(
+                        InstallPhase.CONVERTING,
+                        BibleInstallSupport.PARSE_END +
+                            (BibleInstallSupport.CONVERT_END - BibleInstallSupport.PARSE_END) * fraction
+                    )
+                )
+            }
+            if (!BibleInstallSupport.looksLikeModule(spbPart)) return@withContext BibleInstallOutcome.ConversionFailed
+
+            onProgress(InstallProgress(InstallPhase.INSTALLING, BibleInstallSupport.CONVERT_END))
+            val destination = File(targetDir, module.fileName)
+            try {
+                BibleInstallSupport.moveIntoPlace(spbPart, destination)
+            } catch (e: Exception) {
+                CrashReporter.reportWarning(
+                    "Could not write Bible into place (${module.fileStem})",
+                    throwable = e,
+                    tags = mapOf("subsystem" to "bible_install", "module" to module.fileStem)
+                )
+                return@withContext BibleInstallOutcome.WriteFailed
+            }
+            onProgress(InstallProgress(InstallPhase.INSTALLING, 1f))
+            BibleInstallOutcome.Success(destination, parsed.name, parsed.books.size, parsed.rights)
+        } finally {
+            scratch.deleteRecursively()
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleInstallSupport.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleInstallSupport.kt
@@ -41,6 +41,15 @@ internal object BibleInstallSupport {
     const val EXTRACT_END = 0.60f
     const val CONVERT_END = 0.97f
 
+    /**
+     * Where reading the source file ends, for a source with nothing to unzip.
+     *
+     * The Holy Bible XML archive publishes bare XML up to 21 MB, so the parse owns the slice the
+     * other two sources spend extracting — without this the bar would sit at [DOWNLOAD_END] through
+     * the longest part of the install.
+     */
+    const val PARSE_END = 0.80f
+
     /** Attempts in a row that move the file forward not one byte, before the download is given up on. */
     private const val MAX_STALLED_ATTEMPTS = 3
 
@@ -298,6 +307,32 @@ internal object BibleInstallSupport {
     fun looksLikeModule(file: File): Boolean = runCatching {
         file.bufferedReader(Charsets.UTF_8).use { it.readLine() }?.startsWith("##") == true
     }.getOrDefault(false)
+
+    /**
+     * Records when a cached catalogue was fetched, and its ETag, in a `<cache>.meta` sidecar.
+     *
+     * Kept beside the cache rather than read from the file's own timestamp: a copied user profile, a
+     * restored backup or a sync tool all rewrite mtimes, and any of those would silently make a
+     * years-old listing look current.
+     */
+    internal object BibleIndexCache {
+
+        private fun metaFile(cacheFile: File) = File(cacheFile.parentFile, cacheFile.name + ".meta")
+
+        /** `fetchedAt` millis and ETag; zero and blank when there is no sidecar to read. */
+        fun readMeta(cacheFile: File): Pair<Long, String> {
+            val text = runCatching { metaFile(cacheFile).readText() }.getOrNull() ?: return 0L to ""
+            val fetchedAt = text.substringBefore('\n').trim().toLongOrNull() ?: 0L
+            return fetchedAt to text.substringAfter('\n', "").trim()
+        }
+
+        fun writeMeta(cacheFile: File, fetchedAt: Long, etag: String) {
+            runCatching {
+                cacheFile.parentFile?.mkdirs()
+                metaFile(cacheFile).writeText("$fetchedAt\n$etag")
+            }
+        }
+    }
 
     fun moveIntoPlace(source: File, destination: File) {
         try {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleSource.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleSource.kt
@@ -4,7 +4,7 @@ import org.churchpresenter.app.churchpresenter.utils.Constants
 import java.io.File
 
 /** The archives the downloader can install from, in the order they are offered. */
-enum class BibleSourceId { EBIBLE, ZEFANIA }
+enum class BibleSourceId { EBIBLE, ZEFANIA, BEBLIA }
 
 /** Which portion of scripture a translation covers. */
 enum class Testament { OLD, NEW, FULL }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/ZefaniaRepositoryIndex.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/ZefaniaRepositoryIndex.kt
@@ -303,25 +303,8 @@ object ZefaniaRepositoryIndex {
         return (parseIndex(body, readMeta(cacheFile).second) as? IndexOutcome.Success)?.index
     }
 
-    private fun metaFile(cacheFile: File) = File(cacheFile.parentFile, cacheFile.name + ".meta")
+    private fun readMeta(cacheFile: File) = BibleInstallSupport.BibleIndexCache.readMeta(cacheFile)
 
-    /**
-     * When the listing was fetched, and its ETag.
-     *
-     * Kept beside the cache rather than read from the file's timestamp: a copied user profile, a
-     * restored backup or a sync tool all rewrite mtimes, and any of those would silently make a
-     * years-old listing look current.
-     */
-    private fun readMeta(cacheFile: File): Pair<Long, String> {
-        val text = runCatching { metaFile(cacheFile).readText() }.getOrNull() ?: return 0L to ""
-        val fetchedAt = text.substringBefore('\n').trim().toLongOrNull() ?: 0L
-        return fetchedAt to text.substringAfter('\n', "").trim()
-    }
-
-    private fun writeMeta(cacheFile: File, fetchedAt: Long, etag: String) {
-        runCatching {
-            cacheFile.parentFile?.mkdirs()
-            metaFile(cacheFile).writeText("$fetchedAt\n$etag")
-        }
-    }
+    private fun writeMeta(cacheFile: File, fetchedAt: Long, etag: String) =
+        BibleInstallSupport.BibleIndexCache.writeMeta(cacheFile, fetchedAt, etag)
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/BibleCatalogBrowserDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/BibleCatalogBrowserDialog.kt
@@ -125,10 +125,14 @@ import churchpresenter.composeapp.generated.resources.bible_catalog_testament_ne
 import churchpresenter.composeapp.generated.resources.bible_catalog_testament_old
 import churchpresenter.composeapp.generated.resources.bible_catalog_title
 import churchpresenter.composeapp.generated.resources.cancel
+import churchpresenter.composeapp.generated.resources.bible_catalog_book_names_english
+import churchpresenter.composeapp.generated.resources.bible_catalog_license_source_beblia
+import churchpresenter.composeapp.generated.resources.bible_catalog_source_beblia
 import churchpresenter.composeapp.generated.resources.ok
 import org.churchpresenter.app.churchpresenter.LocalMainWindowState
 import org.churchpresenter.app.churchpresenter.centeredOnMainWindow
 import org.churchpresenter.app.churchpresenter.composables.SearchableDropdownField
+import org.churchpresenter.app.churchpresenter.data.BebliaSource
 import org.churchpresenter.app.churchpresenter.data.BibleModule
 import org.churchpresenter.app.churchpresenter.data.BibleSource
 import org.churchpresenter.app.churchpresenter.data.BibleSourceId
@@ -164,6 +168,7 @@ fun BibleCatalogBrowserDialog(
         listOf(
             EBibleSource to Res.string.bible_catalog_source_ebible,
             ZefaniaSource to Res.string.bible_catalog_source_zefania,
+            BebliaSource to Res.string.bible_catalog_source_beblia,
         )
     }
     val viewModels = remember(storageDirectory) {
@@ -504,7 +509,12 @@ private fun SourceSegmentedControl(
  * Re-downloading folds into the same dialog rather than stacking a second one on top. The
  * redistributable/unverified badge is chosen from which archive the module came from, not from
  * whether its copyright string happens to be blank — eBible always states redistribution rights,
- * Zefania never publishes licence details up front, regardless of any one module's copyright text.
+ * Zefania never publishes licence details up front, and the Holy Bible XML archive republishes a
+ * copyright statement it has not checked, so only eBible's rows are badged as redistributable.
+ *
+ * That archive also gets a second notice, because its files identify books by number alone: for a
+ * language the app has no book-name table for, the installed Bible lists its books in English. That
+ * is worth learning before the download rather than after it.
  */
 @Composable
 private fun LicenceConfirmation(
@@ -514,6 +524,8 @@ private fun LicenceConfirmation(
     onDismiss: () -> Unit
 ) {
     val isRedistributable = module.sourceId == BibleSourceId.EBIBLE
+    val showsEnglishBookNames = module.sourceId == BibleSourceId.BEBLIA &&
+        !BebliaSource.hasLocalisedBookNames(module.language)
     val badgeContainer = if (isRedistributable) MaterialTheme.colorScheme.inverseSurface else MaterialTheme.colorScheme.errorContainer
     val badgeContent = if (isRedistributable) MaterialTheme.colorScheme.inverseOnSurface else MaterialTheme.colorScheme.onErrorContainer
     val badgeLabel = stringResource(
@@ -610,6 +622,14 @@ private fun LicenceConfirmation(
                             style = MaterialTheme.typography.bodySmall
                         )
                     }
+                }
+                if (showsEnglishBookNames) {
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(Res.string.bible_catalog_book_names_english),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
                 if (isReinstall) {
                     Spacer(Modifier.height(12.dp))
@@ -1021,11 +1041,13 @@ private fun phaseStringRes(phase: InstallPhase?): StringResource = when (phase) 
 private fun sourceLabelStringRes(sourceId: BibleSourceId): StringResource = when (sourceId) {
     BibleSourceId.EBIBLE -> Res.string.bible_catalog_source_ebible
     BibleSourceId.ZEFANIA -> Res.string.bible_catalog_source_zefania
+    BibleSourceId.BEBLIA -> Res.string.bible_catalog_source_beblia
 }
 
 private fun sourceLicenceStringRes(sourceId: BibleSourceId): StringResource = when (sourceId) {
     BibleSourceId.EBIBLE -> Res.string.bible_catalog_license_source_ebible
     BibleSourceId.ZEFANIA -> Res.string.bible_catalog_license_source_zefania
+    BibleSourceId.BEBLIA -> Res.string.bible_catalog_license_source_beblia
 }
 
 private fun catalogErrorStringRes(error: BibleCatalogError): StringResource = when (error) {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaCatalogIndexTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaCatalogIndexTest.kt
@@ -1,0 +1,347 @@
+package org.churchpresenter.app.churchpresenter.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Reading the Holy Bible XML archive's `catalog.json`.
+ *
+ * The manifest is generated data committed beside the files it describes, so the two failure modes
+ * that matter are a half-written one and a stale one. A manifest that parses to no translations, or
+ * that names no commit for the downloads to pin to, is refused outright — presented as a catalogue it
+ * would look like a working but empty tab, which is far harder to diagnose than an error. Everything
+ * else falls back to the cached copy and says so, because a hall with no internet should still see
+ * the list it saw last time.
+ *
+ * The cache lifecycle is exercised over `MockEngine` with a counter rather than a clock: nothing here
+ * waits, and `nowMillis` is passed in so the TTL is arithmetic instead of elapsed time.
+ */
+class BebliaCatalogIndexTest {
+
+    private lateinit var dir: File
+    private lateinit var cacheFile: File
+    private val restore = mutableMapOf<String, String?>()
+
+    @BeforeTest
+    fun setUp() {
+        dir = Files.createTempDirectory("cp-beblia-index-test").toFile()
+        cacheFile = File(dir, "beblia-catalog.json")
+        BebliaCatalogIndex.clearMemoryCache()
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        restore.forEach { (key, value) ->
+            if (value == null) System.clearProperty(key) else System.setProperty(key, value)
+        }
+        restore.clear()
+        BebliaCatalogIndex.clearMemoryCache()
+        dir.deleteRecursively()
+    }
+
+    private fun setProperty(key: String, value: String?) {
+        restore.putIfAbsent(key, System.getProperty(key))
+        if (value == null) System.clearProperty(key) else System.setProperty(key, value)
+    }
+
+    // --- fixtures ---
+
+    private fun entry(
+        file: String = "EnglishKJBible.xml",
+        sha: String = "abc123",
+        size: Long = 4_404_123,
+        title: String = "English KJV",
+        id: String = "KJ",
+        lang: String = "ENG",
+        langName: String = "English",
+        rights: String = "Public Domain",
+        ot: Int = 39,
+        nt: Int = 27,
+    ) = """{"file":"$file","sha":"$sha","size":$size,"title":"$title","id":"$id","lang":"$lang",
+        "langName":"$langName","langFrom":"filename","rights":"$rights",
+        "url":"https://example.invalid/x","ot":$ot,"nt":$nt}""".trimIndent().replace("\n", "")
+
+    private fun manifest(vararg entries: String, commit: String = "0".repeat(40)) =
+        """{"schemaVersion":1,"commit":"$commit","bibles":[${entries.joinToString(",")}]}"""
+
+    private fun httpServing(
+        body: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+        etag: String = "",
+        counter: IntArray? = null,
+    ) = HttpClient(
+        MockEngine {
+            counter?.let { it[0]++ }
+            respond(
+                content = body,
+                status = status,
+                headers = if (etag.isBlank()) headersOf(HttpHeaders.ContentType, "application/json")
+                else headersOf(HttpHeaders.ETag, etag),
+            )
+        },
+    )
+
+    private fun httpFailing(counter: IntArray? = null) = HttpClient(
+        MockEngine {
+            counter?.let { it[0]++ }
+            throw java.io.IOException("no route to host")
+        },
+    )
+
+    // --- URLs ---
+
+    @Test
+    fun `the catalogue and raw urls point at the archive by default`() {
+        setProperty("churchpresenter.bebliaCatalogUrl", null)
+        setProperty("churchpresenter.bebliaRawBase", null)
+
+        assertEquals(
+            "https://raw.githubusercontent.com/ChurchPresenter/Holy-Bible-XML-Format/master/catalog.json",
+            BebliaCatalogIndex.catalogUrl()
+        )
+        assertEquals(
+            "https://raw.githubusercontent.com/ChurchPresenter/Holy-Bible-XML-Format/abc/EnglishKJBible.xml",
+            BebliaCatalogIndex.rawUrlFor("abc", "EnglishKJBible.xml")
+        )
+    }
+
+    @Test
+    fun `both urls can be pointed at a staging archive`() {
+        setProperty("churchpresenter.bebliaCatalogUrl", "https://staging.invalid/catalog.json")
+        setProperty("churchpresenter.bebliaRawBase", "https://staging.invalid/raw/")
+
+        assertEquals("https://staging.invalid/catalog.json", BebliaCatalogIndex.catalogUrl())
+        assertEquals("https://staging.invalid/raw/abc/A%20File.xml", BebliaCatalogIndex.rawUrlFor("abc", "A File.xml"))
+    }
+
+    @Test
+    fun `a blank override is treated as unset rather than as an empty url`() {
+        setProperty("churchpresenter.bebliaCatalogUrl", "  ")
+        assertTrue(BebliaCatalogIndex.catalogUrl().startsWith("https://raw.githubusercontent.com/"))
+    }
+
+    // --- parsing ---
+
+    @Test
+    fun `a manifest entry becomes a browse row`() {
+        val outcome = BebliaCatalogIndex.parseCatalog(manifest(entry()), etag = "W/\"x\"")
+
+        val index = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(outcome).index
+        assertEquals("0".repeat(40), index.commit)
+        assertEquals("W/\"x\"", index.etag)
+        val module = index.modules.single()
+        assertEquals("EnglishKJBible.xml", module.file)
+        assertEquals("abc123", module.blobSha)
+        assertEquals(4_404_123, module.sizeBytes)
+        assertEquals("ENG", module.language)
+        assertEquals("English", module.languageName)
+        assertEquals("English KJV", module.displayName)
+        assertEquals("Public Domain", module.copyright)
+        assertEquals(39, module.otBookCount)
+        assertEquals(27, module.ntBookCount)
+        assertEquals("ENG_KJ", module.fileStem)
+        assertEquals("ENG_KJ.spb", module.fileName)
+    }
+
+    @Test
+    fun `unknown fields are ignored so the archive can add a column without an app release`() {
+        val body = """{"schemaVersion":1,"commit":"${"0".repeat(40)}","generatedAt":"2026-08-10",
+            "bibles":[{"file":"x.xml","lang":"ENG","id":"A","somethingNew":42}]}""".trimIndent().replace("\n", "")
+
+        val index = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(BebliaCatalogIndex.parseCatalog(body)).index
+        assertEquals("ENG_A", index.modules.single().fileStem)
+    }
+
+    @Test
+    fun `a manifest listing no translations is refused rather than shown as an empty archive`() {
+        assertIs<BebliaCatalogIndex.IndexOutcome.Failure>(BebliaCatalogIndex.parseCatalog(manifest()))
+    }
+
+    @Test
+    fun `a manifest naming no commit is refused, since downloads have nothing to pin to`() {
+        assertIs<BebliaCatalogIndex.IndexOutcome.Failure>(
+            BebliaCatalogIndex.parseCatalog(manifest(entry(), commit = ""))
+        )
+    }
+
+    @Test
+    fun `a malformed manifest is a failure rather than a crash`() {
+        assertIs<BebliaCatalogIndex.IndexOutcome.Failure>(BebliaCatalogIndex.parseCatalog("{not json"))
+    }
+
+    @Test
+    fun `an entry with no file name is dropped`() {
+        val body = manifest(entry(file = ""), entry(file = "Keep.xml", id = "KEEP"))
+        val index = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(BebliaCatalogIndex.parseCatalog(body)).index
+        assertEquals(listOf("Keep.xml"), index.modules.map { it.file })
+    }
+
+    @Test
+    fun `an untitled entry falls back to its file name rather than arriving blank`() {
+        val index = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(
+            BebliaCatalogIndex.parseCatalog(manifest(entry(title = "")))
+        ).index
+        assertEquals("EnglishKJBible", index.modules.single().displayName)
+    }
+
+    @Test
+    fun `an entry with no language code becomes the unknown code rather than a blank`() {
+        val index = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(
+            BebliaCatalogIndex.parseCatalog(manifest(entry(lang = "", id = "")))
+        ).index
+        assertEquals("UND", index.modules.single().language)
+        assertEquals("UND", index.modules.single().fileStem)
+    }
+
+    @Test
+    fun `translations that reduce to the same stem are separated`() {
+        val body = manifest(
+            entry(file = "A.xml", lang = "ENG", id = ""),
+            entry(file = "B.xml", lang = "ENG", id = ""),
+            entry(file = "C.xml", lang = "ENG", id = ""),
+        )
+        val index = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(BebliaCatalogIndex.parseCatalog(body)).index
+        assertEquals(listOf("ENG", "ENG_2", "ENG_3"), index.modules.map { it.fileStem })
+    }
+
+    @Test
+    fun `stems do not depend on the order the manifest happens to list its entries`() {
+        val a = entry(file = "A.xml", lang = "ENG", id = "")
+        val b = entry(file = "B.xml", lang = "ENG", id = "")
+
+        val forwards = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(
+            BebliaCatalogIndex.parseCatalog(manifest(a, b))
+        ).index.modules.associate { it.file to it.fileStem }
+        val backwards = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(
+            BebliaCatalogIndex.parseCatalog(manifest(b, a))
+        ).index.modules.associate { it.file to it.fileStem }
+
+        assertEquals(forwards, backwards, "the same manifest must name the same files the same way")
+    }
+
+    // --- caching ---
+
+    @Test
+    fun `a fetched manifest is cached to disk and reused inside the ttl`() = runBlocking {
+        val calls = intArrayOf(0)
+        val http = httpServing(manifest(entry()), counter = calls)
+
+        val first = BebliaCatalogIndex.fetch("https://x.invalid/c.json", http, cacheFile, nowMillis = 1_000)
+        assertIs<BebliaCatalogIndex.IndexOutcome.Success>(first)
+        assertTrue(cacheFile.isFile, "the manifest is written to disk")
+
+        BebliaCatalogIndex.clearMemoryCache()
+        val second = BebliaCatalogIndex.fetch("https://x.invalid/c.json", http, cacheFile, nowMillis = 2_000)
+        assertIs<BebliaCatalogIndex.IndexOutcome.Success>(second)
+        assertEquals(1, calls[0], "a second fetch inside the TTL asks the network for nothing")
+    }
+
+    @Test
+    fun `an expired cache is refetched`() = runBlocking {
+        val calls = intArrayOf(0)
+        val http = httpServing(manifest(entry()), counter = calls)
+        val week = 7L * 24 * 60 * 60 * 1000
+
+        BebliaCatalogIndex.fetch("https://x.invalid/c.json", http, cacheFile, nowMillis = 0)
+        BebliaCatalogIndex.clearMemoryCache()
+        BebliaCatalogIndex.fetch("https://x.invalid/c.json", http, cacheFile, nowMillis = week + 1)
+
+        assertEquals(2, calls[0])
+    }
+
+    @Test
+    fun `an unreachable archive falls back to the cached copy and says it is stale`() = runBlocking {
+        BebliaCatalogIndex.fetch("https://x.invalid/c.json", httpServing(manifest(entry())), cacheFile, 0)
+        BebliaCatalogIndex.clearMemoryCache()
+        val week = 7L * 24 * 60 * 60 * 1000
+
+        val outcome = BebliaCatalogIndex.fetch("https://x.invalid/c.json", httpFailing(), cacheFile, week + 1)
+
+        val success = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(outcome)
+        assertTrue(success.stale, "an offline hall still sees the list it saw last time")
+        assertEquals("EnglishKJBible.xml", success.index.modules.single().file)
+    }
+
+    @Test
+    fun `an unreachable archive with nothing cached is a network error`() {
+        runBlocking {
+            val outcome = BebliaCatalogIndex.fetch("https://x.invalid/c.json", httpFailing(), cacheFile, 0)
+            assertIs<BebliaCatalogIndex.IndexOutcome.NetworkError>(outcome)
+        }
+    }
+
+    @Test
+    fun `a server error falls back to the cached copy`() = runBlocking {
+        BebliaCatalogIndex.fetch("https://x.invalid/c.json", httpServing(manifest(entry())), cacheFile, 0)
+        BebliaCatalogIndex.clearMemoryCache()
+        val week = 7L * 24 * 60 * 60 * 1000
+
+        val outcome = BebliaCatalogIndex.fetch(
+            "https://x.invalid/c.json",
+            httpServing("nope", status = HttpStatusCode.InternalServerError),
+            cacheFile,
+            week + 1,
+        )
+        assertTrue(assertIs<BebliaCatalogIndex.IndexOutcome.Success>(outcome).stale)
+    }
+
+    @Test
+    fun `a manifest that arrives corrupt does not replace a good cached copy`() = runBlocking {
+        BebliaCatalogIndex.fetch("https://x.invalid/c.json", httpServing(manifest(entry())), cacheFile, 0)
+        BebliaCatalogIndex.clearMemoryCache()
+        val week = 7L * 24 * 60 * 60 * 1000
+
+        val outcome = BebliaCatalogIndex.fetch("https://x.invalid/c.json", httpServing("{not json"), cacheFile, week + 1)
+
+        val success = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(outcome)
+        assertTrue(success.stale)
+        assertEquals(1, success.index.modules.size)
+        assertNotEquals("{not json", cacheFile.readText(), "the good copy on disk is left alone")
+    }
+
+    @Test
+    fun `an unreadable cache is ignored rather than crashing the fetch`() = runBlocking {
+        cacheFile.parentFile.mkdirs()
+        cacheFile.writeText("{ this was never json")
+
+        val outcome = BebliaCatalogIndex.fetch("https://x.invalid/c.json", httpServing(manifest(entry())), cacheFile, 0)
+        assertEquals(1, assertIs<BebliaCatalogIndex.IndexOutcome.Success>(outcome).index.modules.size)
+    }
+
+    @Test
+    fun `a 304 reuses the cached copy without re-parsing a body`() = runBlocking {
+        BebliaCatalogIndex.fetch(
+            "https://x.invalid/c.json",
+            httpServing(manifest(entry()), etag = "W/\"v1\""),
+            cacheFile,
+            0,
+        )
+        BebliaCatalogIndex.clearMemoryCache()
+        val week = 7L * 24 * 60 * 60 * 1000
+
+        val outcome = BebliaCatalogIndex.fetch(
+            "https://x.invalid/c.json",
+            httpServing("", status = HttpStatusCode.NotModified),
+            cacheFile,
+            week + 1,
+        )
+
+        val success = assertIs<BebliaCatalogIndex.IndexOutcome.Success>(outcome)
+        assertTrue(!success.stale, "a revalidated cache is current, not stale")
+        assertEquals("EnglishKJBible.xml", success.index.modules.single().file)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaSourceTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaSourceTest.kt
@@ -6,6 +6,7 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.runBlocking
 import org.churchpresenter.app.churchpresenter.data.BebliaSource.toBibleModule
 import java.io.File
@@ -67,6 +68,16 @@ class BebliaSourceTest {
         httpServingBytes(body.toByteArray(Charsets.UTF_8), status)
 
     private fun httpFailing() = HttpClient(MockEngine { throw java.io.IOException("no route to host") })
+
+    /** Answers with a promised length and then delivers none of it — the shape the Sentry report had. */
+    private fun httpNeverDelivering(body: ByteArray) = HttpClient(
+        MockEngine {
+            respond(
+                content = ByteReadChannel(ByteArray(0)),
+                headers = headersOf(HttpHeaders.ContentLength, body.size.toString()),
+            )
+        },
+    )
 
     /** The real git blob hash of [bytes], as the manifest publishes it. */
     private fun blobShaOf(bytes: ByteArray): String {
@@ -223,6 +234,17 @@ class BebliaSourceTest {
     @Test
     fun `an unreachable host is reported as a network error`() {
         assertIs<BibleInstallOutcome.NetworkError>(install(httpFailing()))
+    }
+
+    @Test
+    fun `a download that never gets going is reported as stalled, not as being offline`() {
+        // The distinction the Retry button hangs off: this tab must answer it like the other two.
+        val body = xmlBible().toByteArray(Charsets.UTF_8)
+
+        val outcome = install(httpNeverDelivering(body), module(sizeBytes = body.size.toLong()))
+
+        assertEquals(BibleInstallOutcome.DownloadStalled, outcome)
+        assertTrue(targetDir.listFiles()!!.isEmpty(), "nothing is left behind")
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaSourceTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BebliaSourceTest.kt
@@ -1,0 +1,293 @@
+package org.churchpresenter.app.churchpresenter.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import org.churchpresenter.app.churchpresenter.data.BebliaSource.toBibleModule
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Installing a translation from the Holy Bible XML archive.
+ *
+ * The end-to-end path is the same shape as the other two — a body served over `MockEngine`, converted
+ * by the real [converter.XmlToSpbConverter], written to a per-test temp directory, no mocks — but the
+ * download is a bare XML file rather than an archive. That is the difference worth pinning: there is
+ * nothing to unzip, so the install never reports [InstallPhase.EXTRACTING] and the parse owns the
+ * slice of the progress bar the other sources spend extracting.
+ *
+ * `catalog()` is not driven end-to-end, because it always asks [BebliaCatalogIndex] for the real
+ * archive at its default URL; the mapping from an already-fetched index to the browse list is checked
+ * instead, exactly as [ZefaniaSourceTest] does.
+ */
+class BebliaSourceTest {
+
+    private lateinit var dir: File
+    private lateinit var targetDir: File
+
+    @BeforeTest
+    fun createDir() {
+        dir = Files.createTempDirectory("cp-beblia-source-test").toFile()
+        targetDir = File(dir, "Bibles").apply { mkdirs() }
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        dir.deleteRecursively()
+    }
+
+    // --- fixtures ---
+
+    private fun xmlBible(title: String = "English KJV") = """<?xml version="1.0" encoding="UTF-8"?>
+        <bible translation="$title" status="Public Domain" link="https://example.invalid/x">
+        <testament name="Old"><book number="1"><chapter number="1">
+        <verse number="1">In the beginning God created the heaven and the earth.</verse>
+        <verse number="2">And the earth was without form, and void.</verse>
+        </chapter></book></testament>
+        </bible>""".trimIndent()
+
+    private fun httpServingBytes(body: ByteArray, status: HttpStatusCode = HttpStatusCode.OK) = HttpClient(
+        MockEngine {
+            respond(content = body, status = status, headers = headersOf(HttpHeaders.ContentType, "text/plain"))
+        },
+    )
+
+    private fun httpServing(body: String, status: HttpStatusCode = HttpStatusCode.OK) =
+        httpServingBytes(body.toByteArray(Charsets.UTF_8), status)
+
+    private fun httpFailing() = HttpClient(MockEngine { throw java.io.IOException("no route to host") })
+
+    /** The real git blob hash of [bytes], as the manifest publishes it. */
+    private fun blobShaOf(bytes: ByteArray): String {
+        val temp = File(dir, "blob-sha-scratch").apply { writeBytes(bytes) }
+        return BibleInstallSupport.gitBlobSha1(temp).also { temp.delete() }
+    }
+
+    private fun module(
+        checksum: String = "",
+        sizeBytes: Long = 0,
+        language: String = "ENG",
+        copyright: String = "Public Domain",
+    ) = BibleModule(
+        sourceId = BibleSourceId.BEBLIA,
+        downloadKey = "${"0".repeat(40)}/EnglishKJBible.xml",
+        checksum = checksum,
+        sizeBytes = sizeBytes,
+        language = language,
+        identifier = "KJ",
+        displayName = "English KJV",
+        copyright = copyright,
+        fileStem = "ENG_KJ",
+    )
+
+    private fun install(
+        http: HttpClient,
+        module: BibleModule = module(),
+        into: File = targetDir,
+        onProgress: (InstallProgress) -> Unit = {},
+    ) = runBlocking { BebliaSource.installBeblia(module, into, http, retryFloorMs = 0L, onProgress) }
+
+    // --- catalogue mapping ---
+
+    @Test
+    fun `an index row becomes a browse row pinned to the manifest's commit`() {
+        val commit = "a".repeat(40)
+        val indexModule = BebliaCatalogIndex.Module(
+            file = "EnglishKJBible.xml",
+            blobSha = "abc",
+            sizeBytes = 4_404_123,
+            language = "ENG",
+            languageName = "English",
+            identifier = "KJ",
+            displayName = "English KJV",
+            copyright = "Public Domain",
+            sourceUrl = "https://example.invalid/x",
+            otBookCount = 39,
+            ntBookCount = 27,
+            fileStem = "ENG_KJ",
+        )
+
+        val row = with(BebliaSource) { indexModule.toBibleModule(commit) }
+
+        assertEquals(BibleSourceId.BEBLIA, row.sourceId)
+        assertEquals("$commit/EnglishKJBible.xml", row.downloadKey)
+        assertEquals("abc", row.checksum)
+        assertEquals("Public Domain", row.copyright, "this archive states a copyright before download")
+        assertEquals(Testament.FULL, row.testament, "taken from the counts, not from the title")
+        assertEquals("English", row.languageName)
+    }
+
+    @Test
+    fun `the shared language table wins over the manifest's own name`() {
+        val indexModule = BebliaCatalogIndex.Module(
+            file = "x.xml", blobSha = "", sizeBytes = 0, language = "AFR",
+            languageName = "Afrikaans, from the manifest", identifier = "", displayName = "x",
+            copyright = "", sourceUrl = "", otBookCount = 0, ntBookCount = 0, fileStem = "AFR",
+        )
+
+        val row = with(BebliaSource) {
+            indexModule.toBibleModule("c", mapOf("AFR" to LanguageNaming("Afrikaans")))
+        }
+        assertEquals("Afrikaans", row.languageName)
+    }
+
+    @Test
+    fun `the manifest names the language where the shared table has never heard of it`() {
+        val indexModule = BebliaCatalogIndex.Module(
+            file = "x.xml", blobSha = "", sizeBytes = 0, language = "LUS",
+            languageName = "Lushai", identifier = "", displayName = "x",
+            copyright = "", sourceUrl = "", otBookCount = 0, ntBookCount = 0, fileStem = "LUS",
+        )
+
+        val row = with(BebliaSource) { indexModule.toBibleModule("c", emptyMap()) }
+        assertEquals("Lushai", row.languageName, "a bare code would be the alternative")
+    }
+
+    @Test
+    fun `book names are only localised for the languages the app has a table for`() {
+        assertTrue(BebliaSource.hasLocalisedBookNames("eng"))
+        assertTrue(BebliaSource.hasLocalisedBookNames("RUS"))
+        assertFalse(BebliaSource.hasLocalisedBookNames("LUS"))
+        assertFalse(BebliaSource.hasLocalisedBookNames(""))
+    }
+
+    // --- install ---
+
+    @Test
+    fun `a translation is downloaded, converted and installed`() {
+        val body = xmlBible().toByteArray(Charsets.UTF_8)
+
+        val outcome = install(
+            httpServingBytes(body),
+            module(checksum = blobShaOf(body), sizeBytes = body.size.toLong()),
+        )
+
+        val success = assertIs<BibleInstallOutcome.Success>(outcome)
+        assertEquals("ENG_KJ.spb", success.file.name)
+        assertEquals("English KJV", success.title)
+        assertEquals(1, success.books)
+        assertEquals("Public Domain", success.rights)
+
+        val lines = success.file.readLines()
+        assertTrue(lines.first().startsWith("##spDataVersion:"))
+        assertTrue(lines.any { it == "##Copyright:\tPublic Domain" })
+        assertTrue(lines.any { it.startsWith("B001C001V001\t") })
+        assertTrue(lines.any { it.contains("In the beginning God created") })
+    }
+
+    @Test
+    fun `the scratch directory is cleaned up afterwards`() {
+        val body = xmlBible().toByteArray(Charsets.UTF_8)
+        install(httpServingBytes(body), module(sizeBytes = body.size.toLong()))
+
+        assertFalse(BibleInstallSupport.scratchIn(targetDir).exists())
+    }
+
+    @Test
+    fun `a body whose hash is not the one the manifest published is refused`() {
+        val body = xmlBible().toByteArray(Charsets.UTF_8)
+
+        val outcome = install(
+            httpServingBytes(body),
+            module(checksum = "0".repeat(40), sizeBytes = body.size.toLong()),
+        )
+
+        assertIs<BibleInstallOutcome.ChecksumMismatch>(outcome)
+        assertFalse(File(targetDir, "ENG_KJ.spb").exists(), "nothing is installed on a mismatch")
+    }
+
+    @Test
+    fun `a body of the wrong length is refused before it is even parsed`() {
+        val body = xmlBible().toByteArray(Charsets.UTF_8)
+        val outcome = install(httpServingBytes(body), module(sizeBytes = body.size + 1L))
+        assertIs<BibleInstallOutcome.ChecksumMismatch>(outcome)
+    }
+
+    @Test
+    fun `a non-2xx answer is reported as an http error`() {
+        val outcome = install(httpServing("not found", status = HttpStatusCode.NotFound))
+        assertIs<BibleInstallOutcome.HttpError>(outcome).also { assertEquals(404, it.status) }
+    }
+
+    @Test
+    fun `an unreachable host is reported as a network error`() {
+        assertIs<BibleInstallOutcome.NetworkError>(install(httpFailing()))
+    }
+
+    @Test
+    fun `a page that is not xml at all is reported as a damaged download`() {
+        val outcome = install(httpServing("<html><body>Sign in to the WiFi</body>"))
+        assertIs<BibleInstallOutcome.CorruptArchive>(outcome)
+    }
+
+    @Test
+    fun `well-formed xml carrying no scripture is a conversion failure`() {
+        val outcome = install(httpServing("""<?xml version="1.0"?><bible translation="Empty"/>"""))
+        assertIs<BibleInstallOutcome.ConversionFailed>(outcome)
+    }
+
+    @Test
+    fun `an unusable target directory is reported rather than silently retried`() {
+        val notADirectory = File(dir, "a-file").apply { writeText("x") }
+        assertIs<BibleInstallOutcome.NoDirectory>(install(httpServing(xmlBible()), into = notADirectory))
+    }
+
+    @Test
+    fun `an existing module is replaced by a reinstall`() {
+        val destination = File(targetDir, "ENG_KJ.spb").apply { writeText("##stale\n") }
+
+        assertIs<BibleInstallOutcome.Success>(install(httpServing(xmlBible())))
+        assertFalse(destination.readText().startsWith("##stale"))
+    }
+
+    // --- progress ---
+
+    @Test
+    fun `progress runs downloading then converting then installing, and never extracting`() {
+        val body = xmlBible().toByteArray(Charsets.UTF_8)
+        val seen = mutableListOf<InstallProgress>()
+
+        assertIs<BibleInstallOutcome.Success>(
+            install(httpServingBytes(body), module(sizeBytes = body.size.toLong())) { seen.add(it) }
+        )
+
+        assertFalse(
+            seen.any { it.phase == InstallPhase.EXTRACTING },
+            "there is no archive here, so nothing is ever extracted"
+        )
+        assertEquals(
+            listOf(InstallPhase.DOWNLOADING, InstallPhase.CONVERTING, InstallPhase.INSTALLING),
+            seen.map { it.phase }.distinct(),
+            "the phases run in order and none repeats after the next has started"
+        )
+        assertEquals(seen.map { it.fraction }.sorted(), seen.map { it.fraction }, "the bar never rewinds")
+        assertEquals(1f, seen.last().fraction)
+    }
+
+    @Test
+    fun `converting spans the slice the other sources spend extracting`() {
+        val body = xmlBible().toByteArray(Charsets.UTF_8)
+        val seen = mutableListOf<InstallProgress>()
+        install(httpServingBytes(body), module(sizeBytes = body.size.toLong())) { seen.add(it) }
+
+        val converting = seen.filter { it.phase == InstallPhase.CONVERTING }
+        assertTrue(converting.isNotEmpty())
+        assertTrue(
+            converting.all { it.fraction >= BibleInstallSupport.DOWNLOAD_END },
+            "converting starts where the download ended, not at the extract boundary"
+        )
+        assertTrue(converting.any { it.fraction > BibleInstallSupport.PARSE_END }, "the write half is reported too")
+        assertTrue(converting.all { it.fraction <= BibleInstallSupport.CONVERT_END })
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BibleModuleTestamentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/BibleModuleTestamentTest.kt
@@ -89,6 +89,17 @@ class BibleModuleTestamentTest {
     }
 
     @Test
+    fun `a Holy Bible XML row is read from its counted books, not from its title`() {
+        // The generated manifest counts the `<book number>` elements actually present, so an edition
+        // whose title spells "New Testament" out is still read correctly — which is the case the
+        // token fallback documented above gets wrong for about a fifth of eBible's catalogue.
+        assertEquals(
+            Testament.NEW,
+            module(displayName = "New Testament in Achi", ntBookCount = 27).testament
+        )
+    }
+
+    @Test
     fun `the token has to stand alone to count`() {
         // Otherwise any word containing the letters would name a testament.
         assertEquals(Testament.FULL, module(displayName = "Contemporary").testament)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/BibleCatalogBrowserContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/BibleCatalogBrowserContentTest.kt
@@ -582,6 +582,89 @@ class BibleCatalogBrowserContentTest {
     }
 
     @Test
+    fun `the licence dialog explains that the Holy Bible XML archive has not checked its copyrights`() = dialog(
+        catalogOutcome = BibleCatalogOutcome.Success(
+            listOf(module(sourceId = BibleSourceId.BEBLIA, copyright = "Public Domain"))
+        ),
+    ) { _, _ ->
+        onNodeWithText("Download").performClick()
+
+        // Unlike Zefania, this archive states a copyright up front — and still cannot vouch for it,
+        // which is why the badge is the unverified one rather than "Redistributable".
+        onNodeWithText("Licence unverified".uppercase()).assertExists()
+        onNodeWithText("none of the statements have been checked", substring = true).assertExists()
+    }
+
+    @Test
+    fun `the licence dialog warns when book names will come out in English`() = dialog(
+        // Mizo: real verse text, but no book-name table in the app, and the archive's files name
+        // books by number alone.
+        catalogOutcome = BibleCatalogOutcome.Success(
+            listOf(module(sourceId = BibleSourceId.BEBLIA, language = "LUS", languageName = "Lushai"))
+        ),
+    ) { _, _ ->
+        onNodeWithText("Download").performClick()
+        onNodeWithText("Book names will appear in English", substring = true).assertExists()
+    }
+
+    @Test
+    fun `a translation in a language the app has book names for gets no such warning`() = dialog(
+        catalogOutcome = BibleCatalogOutcome.Success(
+            listOf(module(sourceId = BibleSourceId.BEBLIA, language = "ENG"))
+        ),
+    ) { _, _ ->
+        onNodeWithText("Download").performClick()
+        onNodeWithText("Book names will appear in English", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the warning is only about that archive, not about every source`() = dialog(
+        catalogOutcome = BibleCatalogOutcome.Success(
+            listOf(module(sourceId = BibleSourceId.ZEFANIA, language = "LUS"))
+        ),
+    ) { _, _ ->
+        onNodeWithText("Download").performClick()
+        onNodeWithText("Book names will appear in English", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a third archive gets its own tab, listing its own translations`() {
+        fun vm(outcome: BibleCatalogOutcome) = BibleCatalogViewModel(
+            FakeSource(outcome, writesInstalledFile = true), dir.absolutePath, dispatcher = Dispatchers.Unconfined
+        ).also { created.add(it) }
+
+        val models = listOf(
+            vm(BibleCatalogOutcome.Success(listOf(module(displayName = "From eBible", fileStem = "ENG_A")))),
+            vm(BibleCatalogOutcome.Success(listOf(module(displayName = "From Zefania", fileStem = "ENG_B")))),
+            vm(BibleCatalogOutcome.Success(listOf(module(displayName = "From Holy Bible XML", fileStem = "ENG_C")))),
+        )
+        runComposeUiTest {
+            setContent {
+                MaterialTheme {
+                    BibleCatalogBrowserDialogContent(
+                        viewModels = models,
+                        tabLabels = listOf("eBible.org", "Zefania Archive", "Holy Bible XML"),
+                        onDismiss = {},
+                        onBibleInstalled = {},
+                    )
+                }
+            }
+            settle()
+            waitForIdle()
+
+            onNodeWithText("From eBible").assertExists()
+            onNodeWithText("From Holy Bible XML").assertDoesNotExist()
+
+            onNodeWithText("Holy Bible XML").performClick()
+            settle()
+            waitForIdle()
+
+            onNodeWithText("From Holy Bible XML").assertExists()
+            onNodeWithText("From eBible").assertDoesNotExist()
+        }
+    }
+
+    @Test
     fun `re-downloading an installed module warns before overwriting it`() {
         val installedFile = File(dir, "ENG_ACV.spb").apply { writeText("##spDataVersion:\t1\n") }
         dialog(catalogOutcome = BibleCatalogOutcome.Success(listOf(module()))) { _, _ ->

--- a/scripts/generate_beblia_catalog.py
+++ b/scripts/generate_beblia_catalog.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Builds the `catalog.json` manifest for the Holy Bible XML archive.
+
+    https://github.com/ChurchPresenter/Holy-Bible-XML-Format
+
+That repository is 1048 flat `.xml` files with no index of any kind, and the title, copyright and
+book counts live *inside* each ~5 MB file. Without a manifest the app would have to list the GitHub
+tree (rate-limited, and it yields only names and sizes) and could show neither a real title nor a
+copyright until after the download. So this script reads the archive once and commits the answers
+next to it: the app then fetches one ~200 KB JSON and knows everything the browse list needs.
+
+Usage:
+
+    python3 scripts/generate_beblia_catalog.py --repo ~/src/Holy-Bible-XML-Format
+
+Writes `catalog.json` into the repo, ready to commit **in the same commit as any upstream merge** —
+the manifest records the commit its blob hashes were read at, and the app downloads from that pinned
+commit, so a manifest that lags behind `master` serves older-but-correct files rather than failing.
+
+Re-run it whenever upstream content changes, read the coverage report, and add entries to NAME_OVERRIDES
+for anything that lands in UND.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+EBIBLE_CATALOG_URL = "https://ebible.org/Scriptures/translations.csv"
+# SIL's ISO 639-3 tables. eBible's catalogue alone resolves only about two thirds of these file
+# names: it is weighted towards minority languages and simply has no row for Welsh, Zulu, Slovenian
+# and a hundred others the archive carries.
+ISO_CODES_URL = "https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3.tab"
+ISO_NAMES_URL = "https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3_Name_Index.tab"
+ISO_MACRO_URL = "https://iso639-3.sil.org/sites/iso639-3/files/downloads/iso-639-3-macrolanguages.tab"
+
+CACHE_DIR = Path(__file__).parent / ".cache"
+CACHE_FILE = CACHE_DIR / "ebible-translations.csv"
+ISO_CODES_FILE = CACHE_DIR / "iso-639-3.tab"
+ISO_NAMES_FILE = CACHE_DIR / "iso-639-3_Name_Index.tab"
+ISO_MACRO_FILE = CACHE_DIR / "iso-639-3-macrolanguages.tab"
+
+SCHEMA_VERSION = 1
+
+# The Protestant canon. Book numbers run 1-39 for the Old Testament and 40-66 for the New, globally
+# and continuously, even in a New-Testament-only edition.
+OT_RANGE = range(1, 40)
+NT_RANGE = range(40, 67)
+
+# The three spellings each piece of root metadata appears under, in the order they are tried. Kept
+# identical to BebliaParser.kt — if one side gains a spelling, give it to the other.
+TITLE_ATTRIBUTES = ("translation", "name", "language")
+RIGHTS_ATTRIBUTES = ("status", "info", "version")
+SOURCE_ATTRIBUTES = ("link", "site")
+
+# Language names these files lead with that the ISO register does not answer to: misspellings
+# ("Tibetian", "Galacian", "Southeren"), country names standing in for languages ("Kazakhstan",
+# "Malaysian", "PapuaNewGuinea"), and autonyms the register files under another name ("Chibemba",
+# "Tshivenda", "Siswati"). Consulted before the register, and matched the same way, so one entry
+# resolves a whole family of editions.
+#
+# Deliberately incomplete. Where a name genuinely spans many languages — "Berber" is a family of
+# twenty-odd, and the "Chin" editions encode their variety in an opaque publisher abbreviation — no
+# entry is invented. Those stay UND, which lists and installs exactly as any other row and only
+# forgoes a place in the language filter. A guessed code would read as fact.
+NAME_OVERRIDES = {
+    "aceh": "ACE", "aramaic": "ARC", "avar": "AVA",
+    "azerbaijan": "AZE", "azerbaijan south": "AZB",
+    "balochi": "BAL", "balochi southeren": "BCC",
+    "baoule": "BCI", "bemba": "BEM", "chibemba": "BEM", "bodo": "BRX", "bugis": "BUG",
+    "chin tedim": "CTD", "chin matupi": "HLT",
+    "dogri": "DOI",
+    # The macrolanguage where the file names an edition rather than a variety; the two varieties the
+    # names do identify get their own codes.
+    "fulfulde": "FUL", "fulfulde adamawa": "FUB", "fulfulde benin": "FUE",
+    "galacian": "GLG", "ghomala": "BBJ", "gussi": "GUZ",
+    "ilokano": "ILO", "jamaican": "JAM",
+    "kamba": "KAM", "kazakhstan": "KAZ", "kimiiru": "MER", "kirundi": "RUN", "konkani": "KOK",
+    "lango": "LAJ", "liberian kreyol": "LIR", "luo": "LUO",
+    "maasai": "MAS", "malaysian": "ZSM", "mizo": "LUS",
+    # The macrolanguage, so that `RomaniRMC` can then resolve to its Carpathian member. eBible's own
+    # rows would otherwise pin the bare name to Vlax Romani, which the specific code contradicts.
+    "romani": "ROM",
+    "moldovian": "RON",
+    "original greek": "GRC", "original hebrew": "HBO",
+    "papua new guinea": "TPI", "papua new guinea tok pisin": "TPI",
+    "siswati": "SSW", "sotho": "SOT",
+    "tashelhayt morocco": "SHI", "thado": "TCZ", "tibetian": "BOD",
+    "tshiluba": "LUA", "tshivenda": "VEN",
+    "waray": "WAR", "zande": "ZND",
+}
+
+# Whole file names the prefix rule cannot resolve, because the language is not where it looks.
+STEM_OVERRIDES = {
+    # Two languages in one name — the prefix rule can only ever pick the first.
+    "AmharicTigrinya2024": "TIR",
+    # The language is in the edition abbreviation, not the leading token: Gikuyu.
+    "KenyaGIKCL": "KIK",
+    # eBible spells these the 639-3 way and the register agrees; pinned so a register revision
+    # cannot quietly move them.
+    "Greek1550": "GRC",
+    "GreekTR": "GRC",
+    "AncientGreek": "GRC",
+    "Latin": "LAT",
+    "LatinVulgate": "LAT",
+}
+
+# Codes the eBible catalogue has no row for at all, transcribed from
+# `data/BibleLanguageNames.kt`'s UNLISTED so the two agree on what these languages are called.
+UNLISTED_NAMES = {
+    "Afrikaans": "AFR", "Albanian": "ALB", "Arabic": "ARA", "Basque": "BAQ",
+    "Bulgarian": "BUL", "Chinese": "CHI", "Church Slavonic": "CHU", "Czech": "CZE",
+    "Esperanto": "ESP", "French": "FRE", "Gaelic": "GAE", "German": "GER",
+    "Scottish Gaelic": "GLA", "Gothic": "GOT", "Greek": "GRE", "Jamaican Creole": "JAM",
+    "Kabyle": "KAB", "Latvian": "LAV", "Maori": "MAO", "Low German": "NDS",
+    "Dutch": "NL", "Norwegian": "NOR", "Romanian": "RUM", "Croatian": "SCR",
+    "Chadian Arabic": "SHU", "Swahili": "SWA", "Syriac": "SYR", "Kenyang": "XKL",
+}
+
+UNKNOWN_LANGUAGE = "UND"  # BibleCatalogNaming.UNKNOWN_LANGUAGE
+
+# CamelCase, acronym runs and digit runs each become one token:
+#   AmharicTigrinya2024 -> Amharic, Tigrinya, 2024
+#   RomaniRMC           -> Romani, RMC
+TOKEN_RE = re.compile(r"[A-Z]{2,}(?![a-z])|[A-Z][a-z]+|[0-9]+|[A-Z]")
+
+
+def run(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def tokenize(stem: str) -> list[str]:
+    return TOKEN_RE.findall(stem)
+
+
+def cached_download(url: str, path: Path, refresh: bool) -> str:
+    CACHE_DIR.mkdir(exist_ok=True)
+    if refresh or not path.exists():
+        print(f"Downloading {url} …", flush=True)
+        req = urllib.request.Request(url, headers={"User-Agent": "ChurchPresenter-BebliaCatalog/1.0"})
+        with urllib.request.urlopen(req, timeout=120) as r:
+            path.write_bytes(r.read())
+    return path.read_text(encoding="utf-8-sig")
+
+
+def normalise(name: str) -> str:
+    return re.sub(r"[^a-z]", "", name.lower())
+
+
+class Languages:
+    """
+    English language name -> (uppercase code, English name).
+
+    Layered so the most useful code wins: eBible's own spelling first, because that is what the app's
+    language filter can put a name and an autonym to, then the ISO 639-3 register for everything
+    eBible has never published, then the handful of codes neither carries.
+    """
+
+    def __init__(self, refresh: bool) -> None:
+        self.by_name: dict[str, tuple[str, str]] = {}
+        self.codes: set[str] = set()
+        self.members: set[tuple[str, str]] = set()
+        self._load_macrolanguages(refresh)
+        self._load_iso(refresh)
+        self._load_ebible(refresh)
+        for name, code in UNLISTED_NAMES.items():
+            self.by_name.setdefault(normalise(name), (code, name))
+            self.codes.add(code)
+        # Last, and overwriting: these exist precisely because the register's own answer is wrong or
+        # missing. The display name comes from whatever the register calls that code, if anything.
+        for name, code in NAME_OVERRIDES.items():
+            existing = next((n for n, (c, _) in self.by_name.items() if c == code), None)
+            self.by_name[normalise(name)] = (code, self.by_name[existing][1] if existing else "")
+            self.codes.add(code)
+
+    def _add(self, name: str, code: str, display: str, overwrite: bool) -> None:
+        key = normalise(name)
+        if not key or not code:
+            return
+        if overwrite or key not in self.by_name:
+            self.by_name[key] = (code, display)
+        self.codes.add(code)
+
+    def _load_macrolanguages(self, refresh: bool) -> None:
+        for row in csv.DictReader(io.StringIO(cached_download(ISO_MACRO_URL, ISO_MACRO_FILE, refresh)), delimiter="\t"):
+            macro = (row.get("M_Id") or "").strip().upper()
+            member = (row.get("I_Id") or "").strip().upper()
+            if macro and member:
+                self.members.add((macro, member))
+
+    def is_member_of(self, macro: str, member: str) -> bool:
+        return (macro.upper(), member.upper()) in self.members
+
+    def _load_iso(self, refresh: bool) -> None:
+        for row in csv.DictReader(io.StringIO(cached_download(ISO_CODES_URL, ISO_CODES_FILE, refresh)), delimiter="\t"):
+            code = (row.get("Id") or "").strip().upper()
+            self._add(row.get("Ref_Name") or "", code, (row.get("Ref_Name") or "").strip(), overwrite=False)
+        # Print_Name/Inverted_Name carry the alternate spellings people actually write, which is what
+        # a file name like `SlovakianSLB` needs.
+        for row in csv.DictReader(io.StringIO(cached_download(ISO_NAMES_URL, ISO_NAMES_FILE, refresh)), delimiter="\t"):
+            code = (row.get("Id") or "").strip().upper()
+            self._add(row.get("Print_Name") or "", code, (row.get("Print_Name") or "").strip(), overwrite=False)
+
+    def _load_ebible(self, refresh: bool) -> None:
+        rows = list(csv.DictReader(io.StringIO(cached_download(EBIBLE_CATALOG_URL, CACHE_FILE, refresh))))
+        counts: dict[str, int] = {}
+        for row in rows:
+            code = (row.get("languageCode") or "").strip().upper()
+            if code:
+                counts[code] = counts.get(code, 0) + 1
+        best: dict[str, str] = {}
+        for row in rows:
+            code = (row.get("languageCode") or "").strip().upper()
+            if not code:
+                continue
+            for column in ("languageNameInEnglish", "languageName"):
+                name = normalise(row.get(column) or "")
+                if not name:
+                    continue
+                # A name shared by several codes goes to the one eBible publishes most of, which is
+                # the one a reader of that name almost certainly means.
+                if name not in best or counts[code] > counts[best[name]]:
+                    best[name] = code
+                    self._add(row.get(column) or "", code, (row.get("languageNameInEnglish") or "").strip(), overwrite=True)
+
+    def lookup(self, name: str) -> tuple[str, str] | None:
+        key = normalise(name)
+        if not key:
+            return None
+        found = self.by_name.get(key)
+        if found:
+            return found
+        # `Somalian`/`Slovakian`/`Latvian` are how these files spell languages the register calls
+        # Somali, Slovak and Latvian — try the obvious English endings before giving up.
+        for suffix, replacement in (("ian", ""), ("ian", "i"), ("an", ""), ("ish", ""), ("n", "")):
+            if key.endswith(suffix):
+                found = self.by_name.get(key[: -len(suffix)] + replacement)
+                if found:
+                    return found
+        return None
+
+
+def is_iso_like(token: str) -> bool:
+    return token.isupper() and 2 <= len(token) <= 4
+
+
+def assign_language(stem: str, tokens: list[str], languages: Languages) -> tuple[str, str, str, int]:
+    """Returns (code, English name, provenance, tokens consumed) — provenance for the review report."""
+    if stem in STEM_OVERRIDES:
+        code = STEM_OVERRIDES[stem]
+        return code, "", "override", 1
+
+    for width in (3, 2, 1):
+        if len(tokens) < width:
+            continue
+        # A year is never part of a language name, and matching is punctuation- and digit-insensitive
+        # — so without this `Afrikaans1983` matches "Afrikaans" at width 2 and swallows the edition.
+        if any(token.isdigit() for token in tokens[:width]):
+            continue
+        found = languages.lookup(" ".join(tokens[:width]))
+        if not found:
+            continue
+        code, display = found
+        # `RomaniRMC` names the variety in the token after the one that matched, and Carpathian
+        # Romani is more specific than the macrolanguage — so it wins. Strictly membership of the
+        # matched macrolanguage, never merely "looks like a code": `HebrewBSI` names the Bible
+        # Society of Israel, and BSI is also somebody's ISO code.
+        following = tokens[width] if len(tokens) > width else None
+        if following and is_iso_like(following) and languages.is_member_of(code, following):
+            return following.upper(), "", "filename", width + 1
+        return code, display, "filename", width
+
+    return UNKNOWN_LANGUAGE, "", "unknown", 0
+
+
+def read_xml(path: Path) -> tuple[dict[str, str], set[int]]:
+    """Root attributes and the set of book numbers, without holding the document in memory."""
+    root_attributes: dict[str, str] = {}
+    books: set[int] = set()
+    for event, element in ET.iterparse(str(path), events=("start", "end")):
+        if event == "start":
+            if element.tag == "bible" and not root_attributes:
+                root_attributes = dict(element.attrib)
+            elif element.tag == "book":
+                try:
+                    books.add(int((element.get("number") or "").strip()))
+                except ValueError:
+                    pass
+        else:
+            element.clear()
+    return root_attributes, books
+
+
+def first_non_blank(attributes: dict[str, str], names: tuple[str, ...]) -> str:
+    for name in names:
+        value = (attributes.get(name) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def entry_for(path: Path, blob: str, size: int, languages: Languages) -> dict:
+    stem = path.name[: -len("Bible.xml")] if path.name.endswith("Bible.xml") else path.stem
+    tokens = tokenize(stem)
+    code, language_name, provenance, consumed = assign_language(stem, tokens, languages)
+
+    attributes, books = read_xml(path)
+    title = first_non_blank(attributes, TITLE_ATTRIBUTES)
+
+    # Several files put the language name in the title attribute and nothing else, which would make
+    # for a browse list of a hundred rows all called "Spanish". Where that happens the file name is
+    # more informative, because its trailing tokens are the edition: `Spanish1909` -> "Spanish 1909".
+    if not title or languages.lookup(title) is not None:
+        title = " ".join(tokens)
+
+    return {
+        "file": path.name,
+        "sha": blob,
+        "size": size,
+        "title": title,
+        "id": "".join(c for c in "".join(tokens[consumed:]).upper() if c.isalnum()),
+        "lang": code,
+        "langName": language_name,
+        "langFrom": provenance,
+        "rights": first_non_blank(attributes, RIGHTS_ATTRIBUTES),
+        "url": first_non_blank(attributes, SOURCE_ATTRIBUTES),
+        "ot": len([b for b in books if b in OT_RANGE]),
+        "nt": len([b for b in books if b in NT_RANGE]),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, type=Path, help="local clone of the archive")
+    parser.add_argument("--out", type=Path, help="output path (default: <repo>/catalog.json)")
+    parser.add_argument("--refresh-languages", action="store_true", help="re-download eBible's catalogue")
+    parser.add_argument("--max-unknown", type=int, default=20, help="fail past this many UND rows")
+    args = parser.parse_args()
+
+    repo: Path = args.repo.expanduser()
+    if not (repo / ".git").exists():
+        print(f"error: {repo} is not a git clone", file=sys.stderr)
+        return 2
+
+    commit = run(repo, "rev-parse", "HEAD").strip()
+    languages = Languages(args.refresh_languages)
+
+    # `ls-tree -rl` gives the blob hash and the exact byte size in one pass — no hashing, no stat.
+    listing = []
+    for line in run(repo, "ls-tree", "-rl", "HEAD").splitlines():
+        meta, name = line.split("\t", 1)
+        _mode, kind, blob, size = meta.split()
+        if kind == "blob" and name.endswith(".xml") and "/" not in name:
+            listing.append((name, blob, int(size)))
+    listing.sort()
+
+    print(f"Reading {len(listing)} files at {commit[:10]} …", flush=True)
+    entries = []
+    for index, (name, blob, size) in enumerate(listing, start=1):
+        entries.append(entry_for(repo / name, blob, size, languages))
+        if index % 100 == 0:
+            print(f"  {index}/{len(listing)}", flush=True)
+
+    out: Path = args.out or (repo / "catalog.json")
+    out.write_text(
+        json.dumps(
+            {"schemaVersion": SCHEMA_VERSION, "commit": commit, "bibles": entries},
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ),
+        encoding="utf-8",
+    )
+
+    unknown = [e for e in entries if e["lang"] == UNKNOWN_LANGUAGE]
+    by_source: dict[str, int] = {}
+    for entry in entries:
+        by_source[entry["langFrom"]] = by_source.get(entry["langFrom"], 0) + 1
+
+    print(f"\nWrote {out} — {len(entries)} translations, {out.stat().st_size:,} bytes")
+    print(f"  languages: {', '.join(f'{k}={v}' for k, v in sorted(by_source.items()))}")
+    print(f"  distinct codes: {len({e['lang'] for e in entries})}")
+    print(f"  no copyright stated: {len([e for e in entries if not e['rights']])}")
+    if unknown:
+        print(f"\n  {len(unknown)} unresolved — add these to NAME_OVERRIDES:")
+        for entry in unknown:
+            print(f"    {entry['file']}")
+    if len(unknown) > args.max_unknown:
+        print(f"\nerror: {len(unknown)} unresolved exceeds --max-unknown={args.max_unknown}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds [Holy-Bible-XML-Format](https://github.com/ChurchPresenter/Holy-Bible-XML-Format) — 1048 translations across 250-odd languages — as a third tab beside eBible.org and the Zefania Archive. It carries a great deal neither existing source does: Welsh, Zulu, Shan, Mizo, a dozen Chin editions.

**Depends on ChurchPresenter-Converter#4** (the submodule pointer here references that branch).

## The catalogue problem, and `catalog.json`

The archive has no index of any kind: 1048 flat `.xml` files whose title, copyright and book counts live *inside* files averaging five megabytes. Listing the GitHub tree yields names and sizes and nothing more, so a browse list built that way could show neither a real title nor a copyright until after the download — and would burn the 60/hour unauthenticated API limit doing it.

So the archive now publishes a generated `catalog.json` beside its files, built by `scripts/generate_beblia_catalog.py`, and `BebliaCatalogIndex` fetches that one ~400 KB document off the CDN.

The manifest records **the commit its blob hashes were read at**, and downloads are pinned to it. That pin is what makes the published hashes mean anything: fetched from `master` instead, any upstream edit after generation would hand every user a checksum mismatch — surfaced as "the download was incomplete" — until someone regenerated the manifest. Pinned, a lagging manifest simply serves the older file it actually describes.

A manifest that parses to no translations, or that names no commit, is refused rather than shown: presented as a catalogue it would look like a working but empty tab, which is much harder to diagnose than an error.

## Two things that differ from the existing sources

**Nothing is unzipped.** Each translation is a bare XML document, so `EXTRACTING` is never reported and the parse owns that slice of the bar instead (`PARSE_END`). Without it a 21.6 MB file would sit at 55% through the longest part of the install. A test pins the phase sequence.

**The rows state a copyright before the download and still carry the unverified badge.** eBible vouches for redistribution; Zefania publishes nothing up front; this archive republishes whatever each contributor wrote, unchecked. The licence dialog says exactly that. No code change was needed for the badge — `isRedistributable` is `== EBIBLE` — so a test guards it instead.

The dialog also warns, for a language the app has no book-name table for, that the book list will appear in English. The archive's files identify books by a bare integer and carry no names anywhere, so there is nothing better to read; verse text is unaffected.

## Language codes — the soft spot

The files carry no ISO code. The generator derives one from the file name against SIL's ISO 639-3 register plus eBible's catalogue, taking a macrolanguage's member only where the register actually says it is one — `HebrewBSI` names the Bible Society of Israel, and `BSI` also happens to be somebody's language code, which is precisely the trap that guard exists for.

**1037 of 1048 resolve.** The 11 that do not are names that genuinely span many languages ("Berber"; the Chin editions, which encode their variety in an opaque publisher abbreviation). They stay `UND` rather than being guessed, and they list and install like any other row — only the language filter loses them. A wrong code presented as fact would be worse. Fixing one is an edit to `NAME_OVERRIDES` and a push to the archive; no app release.

## Also here

The `.meta` cache sidecar, now written by three index fetchers, moves into `BibleInstallSupport.BibleIndexCache`; `ZefaniaRepositoryIndex` delegates to it with its own tests untouched.

## Testing

`./gradlew :composeApp:check` green. New: `BebliaCatalogIndexTest` (21 — URL overrides, manifest parsing, stem determinism, the full cache lifecycle over `MockEngine` with no clock), `BebliaSourceTest` (16 — install end to end, checksum and size refusal, an HTML error page as a damaged download, the phase sequence). Extended: the dialog content test with a three-tab case and the new licence/book-name notices, and `BibleModuleTestamentTest` for counts-beat-title.

Verified against the live archive: 1048 modules listed, English KJV installs in 671 ms with 66 books and its copyright in the `.spb` header, the 21.6 MB Shan Bible in ~1 s, Hebrew getting Hebrew book names and Shan/Amharic falling back to English as documented.

**No screenshots need re-recording** — `tabLabels` and `viewModels` are injected into `BibleCatalogBrowserDialogContent`, and the real source list lives in the outer composable that no test renders. That holds only while `tabLabels` stays a parameter; moving the source list inside would break all ~20 `bible_catalog` goldens at once. `verifyRoborazziJvm` fails on this machine for `ccli_report_*`, `source_camera` and one lower-third/lottie shot — all reproduce on a clean checkout of `main` and are date- and device-dependent, not from this change.