### PR TITLE
Wait for the signal each test actually asserts on

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabScheduleItemTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTabScheduleItemTest.kt
@@ -41,16 +41,30 @@ class PresentationTabScheduleItemTest {
         return out.toByteArray()
     }
 
-    private fun ComposeUiTest.awaitLoaded(vm: PresentationViewModel, timeoutMs: Long = 5_000) {
+    /**
+     * Waits for [slides] slides to be loaded — the count the caller is about to assert on, not
+     * merely "some".
+     *
+     * Both load paths append one slide at a time, so `slideFiles.isNotEmpty()` is true from the
+     * first one onwards. Returning on that let a caller assert the total against a load still in
+     * progress, which is what made this class fail on a loaded runner and pass everywhere else.
+     * `isLoading` does not close the gap either: it goes false in the loader's `finally`, which also
+     * runs when a slide was skipped, so the pair could settle on a short list and stay there.
+     *
+     * The timeout only fails the test — it is never the success path.
+     */
+    private fun ComposeUiTest.awaitLoaded(vm: PresentationViewModel, slides: Int, timeoutMs: Long = 5_000) {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (System.currentTimeMillis() < deadline) {
-            if (!vm.isLoading && vm.slideFiles.isNotEmpty()) {
+            if (!vm.isLoading && vm.slideFiles.size == slides) {
                 waitForIdle()
                 return
             }
             Thread.sleep(20)
         }
-        throw AssertionError("timed out waiting for the schedule item to load")
+        throw AssertionError(
+            "timed out waiting for $slides slides: loaded ${vm.slideFiles.size}, isLoading=${vm.isLoading}"
+        )
     }
 
     @Test
@@ -61,7 +75,7 @@ class PresentationTabScheduleItemTest {
                 id = "item-1", filePath = file.absolutePath, fileName = file.nameWithoutExtension, slideCount = 2, fileType = "pdf",
             ),
         ) { vm, _ ->
-            awaitLoaded(vm)
+            awaitLoaded(vm, slides = 2)
 
             assertEquals(file.absolutePath, vm.selectedPresentation?.absolutePath)
             assertEquals(2, vm.slideFiles.size)
@@ -88,7 +102,7 @@ class PresentationTabScheduleItemTest {
             ),
             instanceLinkFetchPresentationSlideBytes = { _, _ -> jpegBytes() },
         ) { vm, _ ->
-            awaitLoaded(vm)
+            awaitLoaded(vm, slides = 2)
 
             assertEquals(2, vm.slideFiles.size)
             assertEquals("mirrored-deck.pdf", vm.selectedPresentation?.name)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
@@ -205,8 +205,15 @@ class BibleEngineClientLinkTest {
     @Test
     fun `the client connects to a running engine`() {
         val c = client()
+
         c.connect()
-        assertEquals(1, engine.connectionCount.get())
+
+        // The live session, not the running total: this class sets a 25ms retry floor precisely so a
+        // connect that loses a race retries instead of failing, and a retried attempt leaves a
+        // second entry in that total for ever. What must hold is that the client ends up holding one
+        // link — a dead attempt's session is removed when its handler unwinds, so this settles at 1
+        // and would never settle if the client stacked links.
+        awaitUntil("the client to be holding exactly one link") { engine.sessions.size == 1 }
         assertFalse(c.startFailed.value, "connecting to a remote engine never starts one in-process")
     }
 


### PR DESCRIPTION
Two tests failed CI during the #269–#271 merge sequence, neither related to what those PRs changed. Both passed on re-run and pass repeatedly here, which is the definition of the flake AGENT.md refuses to keep: the failure trains you to re-run instead of to read it. Each cost a ~26 minute CI cycle.

## `PresentationTabScheduleItemTest`

```
a schedule item whose file is missing falls back to Instance Link fetch FAILED
    java.lang.AssertionError: expected:<2> but was:<1>
```

`awaitLoaded` returned as soon as `slideFiles.isNotEmpty()`, and the callers then asserted the total was 2. Both load paths append **one slide at a time** — `loadPresentationFromRemote` inside its fetch loop, `renderSlides` inside its rasterise loop — so that condition is satisfied by the first slide, and everything after it is a race the loaded runner loses.

`isLoading` did not close the gap. It goes false in the loader's `finally`, which also runs when a slide was skipped: a fetch returning null `continue`s, a failed `renameTo` `continue`s, and a throw mid-loop leaves the list short on the way out. So the pair `!isLoading && isNotEmpty()` can settle on a one-slide list and stay there — the exact `<2> but was:<1>` observed.

`awaitLoaded` now takes the count the caller is about to assert on and waits for it. The wait ends on the positive signal; the timeout only fails the test, and now says what was loaded instead of leaving the next reader to guess.

## `BibleEngineClientLinkTest`

```
the client connects to a running engine FAILED
    java.lang.AssertionError: expected:<1> but was:<2>
```

This one was asserting against its own fixture. The class sets a 25 ms retry floor deliberately — the comment on `client()` explains that the production 2 s floor makes a single lost race blow the class's time budget — so a connect that loses a race is *designed* to retry here. `connectionCount` is cumulative and never forgets that retry, so the assertion forbade the very thing the fixture was built to absorb.

What the test means to establish is that the client ends up holding one link, which is what `sessions` shows: a dead attempt's entry is removed when its handler unwinds. It now waits for `sessions.size == 1` — a condition a client that stacked links would never satisfy, so this is the stronger claim as well as the stable one. It is also already the shape the neighbouring "drops the previous link rather than stacking a second one" test uses to make the same point.

The two remaining `connectionCount` uses are untouched: both wait for a monotonic counter to reach a value rather than asserting an exact total, which is the sound use of it.

## Verification

`./gradlew :composeApp:jvmTest --tests '*PresentationTabScheduleItemTest*' --tests '*BibleEngineClientLinkTest*' --rerun-tasks`, three consecutive runs, all green. No production code changes.

One note on cost: `a schedule item whose file exists locally loads it directly` now takes ~1.3 s, because it waits for both slides to render rather than returning after the first. That is real work rather than a pause, but it is over the ~1 s guideline and worth knowing about.