### PR TITLE
Announce the search clear button on every tab

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -214,6 +214,7 @@ import churchpresenter.composeapp.generated.resources.no_results_found
 import churchpresenter.composeapp.generated.resources.primary_bible
 import churchpresenter.composeapp.generated.resources.scope
 import churchpresenter.composeapp.generated.resources.search
+import churchpresenter.composeapp.generated.resources.search_clear
 import churchpresenter.composeapp.generated.resources.secondary_bible
 import churchpresenter.composeapp.generated.resources.stt_connect
 import churchpresenter.composeapp.generated.resources.stt_disconnect
@@ -3003,10 +3004,11 @@ private fun BibleSearchField(
         if (value.isNotEmpty()) {
             IconButton(
                 onClick = onClear,
-                // Tagged for tests: the icon is decorative, so there is no label to address it by.
+                // Tagged as well as labelled: this tab has other content descriptions in play, and
+                // the tag keeps the existing test selector exact.
                 modifier = Modifier.size(30.dp).testTag("bible_searchClear")
             ) {
-                Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = stringResource(Res.string.search_clear), modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
         Box(modifier = Modifier.padding(end = 6.dp)) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTab.kt
@@ -106,6 +106,7 @@ import churchpresenter.composeapp.generated.resources.book
 import churchpresenter.composeapp.generated.resources.chapter
 import churchpresenter.composeapp.generated.resources.ic_close
 import churchpresenter.composeapp.generated.resources.ic_search
+import churchpresenter.composeapp.generated.resources.search_clear
 import churchpresenter.composeapp.generated.resources.verse
 import java.awt.Cursor
 import org.churchpresenter.app.churchpresenter.composables.ActionIconButton
@@ -1008,7 +1009,7 @@ private fun DictionarySearchField(
             IconButton(onClick = onClear, modifier = Modifier.size(30.dp)) {
                 Icon(
                     painter = painterResource(Res.drawable.ic_close),
-                    contentDescription = null,
+                    contentDescription = stringResource(Res.string.search_clear),
                     modifier = Modifier.size(14.dp),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
@@ -159,6 +159,7 @@ import churchpresenter.composeapp.generated.resources.song_play_count
 import churchpresenter.composeapp.generated.resources.song_columns
 import churchpresenter.composeapp.generated.resources.number
 import churchpresenter.composeapp.generated.resources.search
+import churchpresenter.composeapp.generated.resources.search_clear
 import churchpresenter.composeapp.generated.resources.search_songs
 import churchpresenter.composeapp.generated.resources.song_book
 import churchpresenter.composeapp.generated.resources.song_title_slide
@@ -696,7 +697,7 @@ fun SongsTab(
                     }
                     if (searchQuery.isNotEmpty()) {
                         IconButton(onClick = { viewModel.updateSearchQuery("") }, modifier = Modifier.size(30.dp)) {
-                            Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = stringResource(Res.string.search_clear), modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     }
                 }


### PR DESCRIPTION
The Songs, Bible and Dictionary search boxes each drew their clear button with `contentDescription = null`. A screen reader meets an unlabelled button, and a test has no name to address it by — `BibleTab` worked around its half of this with `testTag("bible_searchClear")`, while Songs and Dictionary had no handle at all.

The shared `SearchField` (`composables/SearchField.kt`) already labels its clear button with the `search_clear` string. This uses that same existing string in all three copies. No new strings, no locale files touched.

Six lines, three files:

| File | Site |
|---|---|
| `tabs/SongsTab.kt` | inline clear `IconButton` in the search block |
| `tabs/BibleTab.kt` | `BibleSearchField` |
| `tabs/DictionaryTab.kt` | `DictionarySearchField` |

The tag on the Bible button stays — it keeps the existing selector in `BibleTabTestSupport` exact, and a tag and a label coexist fine. Its comment claimed the icon was decorative and unlabelled, so that is updated too.

### Why not consolidate the copies instead

This came out of asking whether the duplicated search chrome was worth merging onto the shared component. It isn't, and `SearchField.kt:37-41` already records why: each copy is embedded in a large tab whose committed screenshots would all be rewritten for no visual change. They are also not interchangeable — `BibleSearchField` carries an Enter-key handler, focus reporting and a trailing `modeChip()` slot, which would become three single-caller parameters on the shared component. The accessibility gap is the part that was worth fixing on its own.

`BibleCatalogBrowserDialog`'s own private `SearchField` is untouched: it is a deliberately different visual (documented at line 753) and has no clear button to label.

### Verification

- `./gradlew compileKotlinJvm` — green.
- `./gradlew :composeApp:jvmTest` — full suite green.
- `./gradlew :composeApp:verifyRoborazziJvm` for the three edited tabs — green. A content description draws nothing, so no images move and none are re-recorded.

Unrelated pre-existing screenshot reds on this machine, confirmed by stashing the change and reproducing them on a clean tree: `previewApp/ccli_report_{,bible_,activity_}light` (date-filtered reports) and `canvasTab/source_camera` (enumerates real camera devices). `lottieGen/section_shape` also failed once and passed on re-run — order-dependent, and in a module this change does not touch.

### Not included

`DictionaryTabTestSupport.kt:202` addresses the search *input* positionally (`onAllNodes(hasSetTextAction())[0]`). This change does not fix that — it labels the clear button, not the input, which no copy labels. It works today because that tab has one text field, and would break if a second were added. Fixing it needs a `testTag` on the Dictionary `BasicTextField`; left for a separate change.
