### PR TITLE
Give every icon-only button a name

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -2255,4 +2255,18 @@
     <string name="planning_center_import_matched">✓ Matched</string>
     <string name="planning_center_import_button">Import Selected</string>
     <string name="planning_center_import_file_count">%1$d file(s)</string>
+
+    <!-- Names for buttons whose only content is an icon. These are read by assistive technology
+         and are never drawn, so a button that already shows a text label does not need one. -->
+    <string name="web_clear_url">Clear address</string>
+    <string name="web_clear_typed_text">Clear text</string>
+    <string name="recent_pin">Pin</string>
+    <string name="recent_unpin">Unpin</string>
+    <string name="canvas_rename_confirm">Confirm rename</string>
+    <string name="crossword_prev_level">Previous level</string>
+    <string name="crossword_next_level">Next level</string>
+    <string name="tab_strip_scroll_back">Scroll tabs back</string>
+    <string name="tab_strip_scroll_forward">Scroll tabs forward</string>
+    <string name="stock_photo_show_key">Show API key</string>
+    <string name="stock_photo_hide_key">Hide API key</string>
 </resources>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -2263,6 +2263,7 @@
     <string name="recent_pin">Pin</string>
     <string name="recent_unpin">Unpin</string>
     <string name="canvas_rename_confirm">Confirm rename</string>
+    <string name="qa_clear_question_text">Clear question text</string>
     <string name="crossword_prev_level">Previous level</string>
     <string name="crossword_next_level">Next level</string>
     <string name="tab_strip_scroll_back">Scroll tabs back</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/TabStripArrows.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/TabStripArrows.kt
@@ -14,10 +14,14 @@ import androidx.compose.ui.unit.dp
 import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.ic_arrow_left
 import churchpresenter.composeapp.generated.resources.ic_arrow_right
+import churchpresenter.composeapp.generated.resources.tab_strip_scroll_back
+import churchpresenter.composeapp.generated.resources.tab_strip_scroll_forward
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
 
 internal const val TAB_STRIP_ARROW_BACK_TAG = "tabStripArrowBack"
 internal const val TAB_STRIP_ARROW_FORWARD_TAG = "tabStripArrowForward"
@@ -49,7 +53,7 @@ fun TabStripBackArrow(scrollState: ScrollState) {
     // cancelled at that moment — killing the animation that was still finishing the move.
     val coroutineScope = rememberCoroutineScope()
     if (scrollState.maxValue > 0 && scrollState.value > 0) {
-        TabStripArrow(Res.drawable.ic_arrow_left, TAB_STRIP_ARROW_BACK_TAG, coroutineScope, scrollState) {
+        TabStripArrow(Res.drawable.ic_arrow_left, Res.string.tab_strip_scroll_back, TAB_STRIP_ARROW_BACK_TAG, coroutineScope, scrollState) {
             (scrollState.value - TAB_SCROLL_STEP).coerceAtLeast(0)
         }
     }
@@ -60,16 +64,20 @@ fun TabStripBackArrow(scrollState: ScrollState) {
 fun TabStripForwardArrow(scrollState: ScrollState) {
     val coroutineScope = rememberCoroutineScope()
     if (scrollState.maxValue > 0 && scrollState.value < scrollState.maxValue) {
-        TabStripArrow(Res.drawable.ic_arrow_right, TAB_STRIP_ARROW_FORWARD_TAG, coroutineScope, scrollState) {
+        TabStripArrow(Res.drawable.ic_arrow_right, Res.string.tab_strip_scroll_forward, TAB_STRIP_ARROW_FORWARD_TAG, coroutineScope, scrollState) {
             (scrollState.value + TAB_SCROLL_STEP).coerceAtMost(scrollState.maxValue)
         }
     }
 }
 
-/** @param target where to scroll to, read at click time rather than at composition. */
+/**
+ * @param description the button's name for assistive technology; the arrow itself carries no text.
+ * @param target where to scroll to, read at click time rather than at composition.
+ */
 @Composable
 private fun TabStripArrow(
     icon: DrawableResource,
+    description: StringResource,
     tag: String,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
@@ -84,7 +92,7 @@ private fun TabStripArrow(
     ) {
         Icon(
             painter = painterResource(icon),
-            contentDescription = null,
+            contentDescription = stringResource(description),
             modifier = Modifier.size(ARROW_ICON_SIZE),
         )
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/EditSongDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/EditSongDialog.kt
@@ -642,7 +642,7 @@ private fun RowScope.SongbookCard(
                     onClick = { onSongbookChange(originalSongbook); isAddingNew = false },
                     modifier = Modifier.size(20.dp),
                 ) {
-                    Icon(Icons.Default.Close, contentDescription = null, modifier = Modifier.size(14.dp))
+                    Icon(Icons.Default.Close, contentDescription = stringResource(Res.string.cancel), modifier = Modifier.size(14.dp))
                 }
             }
         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/RemoteActivityToast.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/RemoteActivityToast.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import churchpresenter.composeapp.generated.resources.Res
+import churchpresenter.composeapp.generated.resources.block_for_session
 import churchpresenter.composeapp.generated.resources.remote_activity_added_to_schedule
 import churchpresenter.composeapp.generated.resources.remote_activity_removed_from_schedule
 import churchpresenter.composeapp.generated.resources.remote_activity_by
@@ -270,7 +271,7 @@ private fun RemoteActivityToast(
                 OutlinedButton(shape = RoundedCornerShape(6.dp), onClick = onBlockForSession) {
                     Icon(
                         Icons.Filled.RemoveCircle,
-                        contentDescription = null,
+                        contentDescription = stringResource(Res.string.block_for_session),
                         tint = MaterialTheme.colorScheme.error
                     )
                 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/StockMediaBrowserDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/StockMediaBrowserDialog.kt
@@ -73,6 +73,7 @@ import churchpresenter.composeapp.generated.resources.stock_photo_error_network
 import churchpresenter.composeapp.generated.resources.stock_photo_error_rate_limited
 import churchpresenter.composeapp.generated.resources.stock_photo_get_key
 import churchpresenter.composeapp.generated.resources.stock_photo_get_key_hint
+import churchpresenter.composeapp.generated.resources.stock_photo_hide_key
 import churchpresenter.composeapp.generated.resources.stock_photo_key_required_hint
 import churchpresenter.composeapp.generated.resources.stock_photo_load_more
 import churchpresenter.composeapp.generated.resources.stock_photo_no_results
@@ -80,6 +81,7 @@ import churchpresenter.composeapp.generated.resources.stock_photo_pexels_key_lab
 import churchpresenter.composeapp.generated.resources.stock_photo_pixabay_key_label
 import churchpresenter.composeapp.generated.resources.stock_photo_search_placeholder_photo
 import churchpresenter.composeapp.generated.resources.stock_photo_search_placeholder_video
+import churchpresenter.composeapp.generated.resources.stock_photo_show_key
 import churchpresenter.composeapp.generated.resources.stock_photo_source_pexels
 import churchpresenter.composeapp.generated.resources.stock_photo_source_pixabay
 import org.churchpresenter.app.churchpresenter.LocalMainWindowState
@@ -466,7 +468,9 @@ private fun ApiKeyField(
                 IconButton(onClick = { showKey = !showKey }) {
                     Icon(
                         imageVector = if (showKey) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                        contentDescription = null
+                        contentDescription = stringResource(
+                            if (showKey) Res.string.stock_photo_hide_key else Res.string.stock_photo_show_key
+                        )
                     )
                 }
             }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -214,6 +214,7 @@ import churchpresenter.composeapp.generated.resources.no_results_found
 import churchpresenter.composeapp.generated.resources.primary_bible
 import churchpresenter.composeapp.generated.resources.scope
 import churchpresenter.composeapp.generated.resources.search
+import churchpresenter.composeapp.generated.resources.search_clear
 import churchpresenter.composeapp.generated.resources.secondary_bible
 import churchpresenter.composeapp.generated.resources.stt_connect
 import churchpresenter.composeapp.generated.resources.stt_disconnect
@@ -3003,10 +3004,11 @@ private fun BibleSearchField(
         if (value.isNotEmpty()) {
             IconButton(
                 onClick = onClear,
-                // Tagged for tests: the icon is decorative, so there is no label to address it by.
+                // Tagged as well as labelled: this tab has other content descriptions in play, and
+                // the tag keeps the existing test selector exact.
                 modifier = Modifier.size(30.dp).testTag("bible_searchClear")
             ) {
-                Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = stringResource(Res.string.search_clear), modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
         Box(modifier = Modifier.padding(end = 6.dp)) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
@@ -125,6 +125,7 @@ import churchpresenter.composeapp.generated.resources.canvas_tool_ellipse
 import churchpresenter.composeapp.generated.resources.canvas_tool_line
 import churchpresenter.composeapp.generated.resources.canvas_tool_arrow
 import churchpresenter.composeapp.generated.resources.canvas_tool_freehand
+import churchpresenter.composeapp.generated.resources.canvas_rename_confirm
 import churchpresenter.composeapp.generated.resources.canvas_rename_scene
 import churchpresenter.composeapp.generated.resources.canvas_remove_scene
 import churchpresenter.composeapp.generated.resources.canvas_add_source
@@ -302,7 +303,7 @@ fun CanvasTab(
                                 },
                                 modifier = Modifier.size(20.dp)
                             ) {
-                                Icon(Icons.Filled.Check, contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
+                                Icon(Icons.Filled.Check, contentDescription = stringResource(Res.string.canvas_rename_confirm), modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.primary)
                             }
                         } else {
                             Text(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CrosswordTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CrosswordTab.kt
@@ -60,6 +60,8 @@ import churchpresenter.composeapp.generated.resources.crossword_ask_more
 import churchpresenter.composeapp.generated.resources.crossword_check
 import churchpresenter.composeapp.generated.resources.crossword_correct
 import churchpresenter.composeapp.generated.resources.crossword_down
+import churchpresenter.composeapp.generated.resources.crossword_next_level
+import churchpresenter.composeapp.generated.resources.crossword_prev_level
 import churchpresenter.composeapp.generated.resources.crossword_wrong
 import churchpresenter.composeapp.generated.resources.crossword_level_label
 import churchpresenter.composeapp.generated.resources.crossword_loading
@@ -197,7 +199,7 @@ fun CrosswordTab(
                     ) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = null,
+                            contentDescription = stringResource(Res.string.crossword_prev_level),
                             tint = if (canGoBack)
                                 MaterialTheme.colorScheme.onSurface
                             else
@@ -218,7 +220,7 @@ fun CrosswordTab(
                     ) {
                         Icon(
                             Icons.AutoMirrored.Filled.ArrowForward,
-                            contentDescription = null,
+                            contentDescription = stringResource(Res.string.crossword_next_level),
                             tint = if (canGoForward)
                                 MaterialTheme.colorScheme.onSurface
                             else

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/DictionaryTab.kt
@@ -106,6 +106,7 @@ import churchpresenter.composeapp.generated.resources.book
 import churchpresenter.composeapp.generated.resources.chapter
 import churchpresenter.composeapp.generated.resources.ic_close
 import churchpresenter.composeapp.generated.resources.ic_search
+import churchpresenter.composeapp.generated.resources.search_clear
 import churchpresenter.composeapp.generated.resources.verse
 import java.awt.Cursor
 import org.churchpresenter.app.churchpresenter.composables.ActionIconButton
@@ -1008,7 +1009,7 @@ private fun DictionarySearchField(
             IconButton(onClick = onClear, modifier = Modifier.size(30.dp)) {
                 Icon(
                     painter = painterResource(Res.drawable.ic_close),
-                    contentDescription = null,
+                    contentDescription = stringResource(Res.string.search_clear),
                     modifier = Modifier.size(14.dp),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant
                 )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThird.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/LowerThird.kt
@@ -912,7 +912,9 @@ fun LowerThirdTab(
                     )
                     val unreachableTooltip = stringResource(Res.string.atem_unreachable, appSettings.atemSettings.host)
                     val goLiveKey = appSettings.atemSettings.goLiveKey
-                    Tooltip(stringResource(Res.string.atem_golive_key)) {
+                    // One string for the tooltip and the button's name, so they cannot drift apart.
+                    val goLiveKeyLabel = stringResource(Res.string.atem_golive_key)
+                    Tooltip(goLiveKeyLabel) {
                         FilledIconButton(
                             onClick = { onSettingsChangeState.value { s -> s.copy(atemSettings = s.atemSettings.copy(goLiveKey = !s.atemSettings.goLiveKey)) } },
                             modifier = Modifier.size(34.dp),
@@ -922,7 +924,7 @@ fun LowerThirdTab(
                                 contentColor = if (goLiveKey) MaterialTheme.colorScheme.onTertiary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
                             )
                         ) {
-                            Icon(painterResource(Res.drawable.ic_key), contentDescription = null, modifier = Modifier.size(16.dp))
+                            Icon(painterResource(Res.drawable.ic_key), contentDescription = goLiveKeyLabel, modifier = Modifier.size(16.dp))
                         }
                     }
 
@@ -934,14 +936,16 @@ fun LowerThirdTab(
                         val quickClipCapacity = appSettings.atemSettings.detectedClipMaxFrames.getOrNull(clipSlot)
                         val quickClipTooLong = quickClipVariant != null && quickClipCapacity != null && quickClipVariant.frameCount > quickClipCapacity
 
-                        Tooltip(if (!atemReachable) unreachableTooltip else stringResource(Res.string.atem_quick_still_tooltip, stillSlot + 1)) {
+                        val quickStillLabel = if (!atemReachable) unreachableTooltip else stringResource(Res.string.atem_quick_still_tooltip, stillSlot + 1)
+                        Tooltip(quickStillLabel) {
                             FilledIconButton(onClick = { startAtemUpload(atemVariant(isClip = false, useDetectedFps = false), stillSlot, closeDialogOnSuccess = false) }, enabled = quickEnabled, modifier = Modifier.size(34.dp), shape = RoundedCornerShape(8.dp), colors = atemButtonColors) {
-                                Icon(Icons.Filled.Image, contentDescription = null, modifier = Modifier.size(16.dp))
+                                Icon(Icons.Filled.Image, contentDescription = quickStillLabel, modifier = Modifier.size(16.dp))
                             }
                         }
-                        Tooltip(when { !atemReachable -> unreachableTooltip; quickClipTooLong -> { val secs = String.format(java.util.Locale.US, "%.1f", quickClipCapacity / quickClipVariant.fps); stringResource(Res.string.atem_clip_too_long, quickClipVariant.frameCount, clipSlot + 1, quickClipCapacity, secs) }; else -> stringResource(Res.string.atem_quick_clip_tooltip, clipSlot + 1) }) {
+                        val quickClipLabel = when { !atemReachable -> unreachableTooltip; quickClipTooLong -> { val secs = String.format(java.util.Locale.US, "%.1f", quickClipCapacity / quickClipVariant.fps); stringResource(Res.string.atem_clip_too_long, quickClipVariant.frameCount, clipSlot + 1, quickClipCapacity, secs) }; else -> stringResource(Res.string.atem_quick_clip_tooltip, clipSlot + 1) }
+                        Tooltip(quickClipLabel) {
                             FilledIconButton(onClick = { quickClipVariant?.let { startAtemUpload(it, clipSlot, closeDialogOnSuccess = false) } }, enabled = quickEnabled && !quickClipTooLong, modifier = Modifier.size(34.dp), shape = RoundedCornerShape(8.dp), colors = atemButtonColors) {
-                                Icon(Icons.Filled.Movie, contentDescription = null, modifier = Modifier.size(16.dp))
+                                Icon(Icons.Filled.Movie, contentDescription = quickClipLabel, modifier = Modifier.size(16.dp))
                             }
                         }
                     } else {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
@@ -117,6 +117,8 @@ import churchpresenter.composeapp.generated.resources.media_vlc_required
 import churchpresenter.composeapp.generated.resources.pause
 import churchpresenter.composeapp.generated.resources.play
 import churchpresenter.composeapp.generated.resources.recent
+import churchpresenter.composeapp.generated.resources.recent_pin
+import churchpresenter.composeapp.generated.resources.recent_unpin
 import churchpresenter.composeapp.generated.resources.stop
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Movie
@@ -485,7 +487,7 @@ fun MediaTab(
                                 Text(displayName, style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Medium), color = if (isActive) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.75f), maxLines = 1)
                             }
                             IconButton(onClick = { RecentMediaFiles.togglePin(path) }, modifier = Modifier.size(20.dp)) {
-                                Icon(painterResource(if (isPinned) Res.drawable.ic_star_filled else Res.drawable.ic_star), contentDescription = null, modifier = Modifier.size(12.dp), tint = if (isPinned) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f))
+                                Icon(painterResource(if (isPinned) Res.drawable.ic_star_filled else Res.drawable.ic_star), contentDescription = stringResource(if (isPinned) Res.string.recent_unpin else Res.string.recent_pin), modifier = Modifier.size(12.dp), tint = if (isPinned) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f))
                             }
                         }
                     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
@@ -123,6 +123,8 @@ import churchpresenter.composeapp.generated.resources.no_folder_selected
 import churchpresenter.composeapp.generated.resources.pause
 import churchpresenter.composeapp.generated.resources.play
 import churchpresenter.composeapp.generated.resources.previous_image
+import churchpresenter.composeapp.generated.resources.recent_pin
+import churchpresenter.composeapp.generated.resources.recent_unpin
 import churchpresenter.composeapp.generated.resources.select_folder
 import churchpresenter.composeapp.generated.resources.tab_focus_lost
 import churchpresenter.composeapp.generated.resources.select_folder_to_view
@@ -493,7 +495,7 @@ fun PicturesTab(
                             IconButton(onClick = { RecentPictureFolders.togglePin(path) }, modifier = Modifier.size(20.dp)) {
                                 Icon(
                                     painter = painterResource(if (isPinned) Res.drawable.ic_star_filled else Res.drawable.ic_star),
-                                    contentDescription = null,
+                                    contentDescription = stringResource(if (isPinned) Res.string.recent_unpin else Res.string.recent_pin),
                                     modifier = Modifier.size(12.dp),
                                     tint = if (isPinned) MaterialTheme.colorScheme.primary
                                            else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
@@ -607,7 +609,9 @@ fun PicturesTab(
                         contentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
                     )
                 ) {
-                    Icon(painterResource(Res.drawable.ic_refresh), contentDescription = null, modifier = Modifier.size(16.dp))
+                    // Same text the tooltip shows: TooltipArea is a hover popup and contributes no
+                    // semantics, so without this the button has no name at all.
+                    Icon(painterResource(Res.drawable.ic_refresh), contentDescription = stringResource(if (viewModel.isLooping) Res.string.loop_on else Res.string.loop_off), modifier = Modifier.size(16.dp))
                 }
             }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
@@ -91,6 +91,8 @@ import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.add_to_schedule
 import churchpresenter.composeapp.generated.resources.ic_folder
 import churchpresenter.composeapp.generated.resources.ic_stop
+import churchpresenter.composeapp.generated.resources.recent_pin
+import churchpresenter.composeapp.generated.resources.recent_unpin
 import churchpresenter.composeapp.generated.resources.tooltip_presentation_remote
 import churchpresenter.composeapp.generated.resources.animation_crossfade
 import churchpresenter.composeapp.generated.resources.animation_fade
@@ -651,7 +653,7 @@ fun PresentationTab(
                             IconButton(onClick = { RecentPresentationFiles.togglePin(path) }, modifier = Modifier.size(20.dp)) {
                                 Icon(
                                     painter = painterResource(if (isPinned) Res.drawable.ic_star_filled else Res.drawable.ic_star),
-                                    contentDescription = null,
+                                    contentDescription = stringResource(if (isPinned) Res.string.recent_unpin else Res.string.recent_pin),
                                     modifier = Modifier.size(12.dp),
                                     tint = if (isPinned) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
                                 )

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/QATab.kt
@@ -75,6 +75,7 @@ import churchpresenter.composeapp.generated.resources.qa_add_question_hint
 import churchpresenter.composeapp.generated.resources.qa_approve
 import churchpresenter.composeapp.generated.resources.qa_back_to_incoming
 import churchpresenter.composeapp.generated.resources.qa_clear_all_questions
+import churchpresenter.composeapp.generated.resources.qa_clear_question_text
 import churchpresenter.composeapp.generated.resources.qa_confirm_go_live
 import churchpresenter.composeapp.generated.resources.qa_confirm_go_live_prompt
 import churchpresenter.composeapp.generated.resources.qa_delete_all_history
@@ -426,7 +427,7 @@ fun QATab(
                         }
                         if (addQuestionText.isNotEmpty()) {
                             FilledIconButton(onClick = { addQuestionText = "" }, modifier = Modifier.size(30.dp), shape = RoundedCornerShape(5.dp), colors = IconButtonDefaults.filledIconButtonColors(containerColor = Color.Transparent, contentColor = MaterialTheme.colorScheme.onSurfaceVariant)) {
-                                Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = null, modifier = Modifier.size(14.dp))
+                                Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = stringResource(Res.string.qa_clear_question_text), modifier = Modifier.size(14.dp))
                             }
                         }
                     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
@@ -159,6 +159,7 @@ import churchpresenter.composeapp.generated.resources.song_play_count
 import churchpresenter.composeapp.generated.resources.song_columns
 import churchpresenter.composeapp.generated.resources.number
 import churchpresenter.composeapp.generated.resources.search
+import churchpresenter.composeapp.generated.resources.search_clear
 import churchpresenter.composeapp.generated.resources.search_songs
 import churchpresenter.composeapp.generated.resources.song_book
 import churchpresenter.composeapp.generated.resources.song_title_slide
@@ -696,7 +697,7 @@ fun SongsTab(
                     }
                     if (searchQuery.isNotEmpty()) {
                         IconButton(onClick = { viewModel.updateSearchQuery("") }, modifier = Modifier.size(30.dp)) {
-                            Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = stringResource(Res.string.search_clear), modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                         }
                     }
                 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
@@ -107,6 +107,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import java.awt.Cursor
 import java.awt.Window as AwtWindow
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.style.TextAlign
@@ -204,6 +205,9 @@ import org.churchpresenter.app.churchpresenter.viewmodel.SongsViewModel
 import org.churchpresenter.app.churchpresenter.ui.theme.semantic
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+
+/** The toolbar button that adds the *selected* song, as opposed to any other "Add to Schedule". */
+internal const val SONGS_ADD_SELECTED_TAG = "songs_addSelectedToSchedule"
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -847,6 +851,10 @@ fun SongsTab(
                             contentAlignment = Alignment.Center
                         ) {
                             Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+                                // Deliberately unlabelled: this is a column header whose click
+                                // SORTS, so naming it "Add to Schedule" would name it after an
+                                // action it does not perform. Giving a sortable header its proper
+                                // name is a semantics question for the whole table, not this icon.
                                 Icon(
                                     painter = painterResource(
                                         if (colId == "favorites") Res.drawable.ic_star else Res.drawable.ic_playlist_add
@@ -1129,7 +1137,7 @@ fun SongsTab(
                                         ) {
                                             Icon(
                                                 painter = painterResource(Res.drawable.ic_playlist_add),
-                                                contentDescription = null,
+                                                contentDescription = stringResource(Res.string.add_to_schedule),
                                                 modifier = Modifier.size(16.dp),
                                                 tint = MaterialTheme.colorScheme.secondary
                                             )
@@ -1475,7 +1483,12 @@ fun SongsTab(
                             }
                             tabFocusRequester.requestFocus()
                         },
-                        tooltipText = addScheduleStr
+                        tooltipText = addScheduleStr,
+                        // Tagged because "Add to Schedule" is the right name for several controls
+                        // here — this one, the per-row buttons and the favourites panel's — and only
+                        // this one adds the *selected* song. The name is shared on purpose; the tag
+                        // is how a test says which of them it means.
+                        modifier = Modifier.testTag(SONGS_ADD_SELECTED_TAG)
                     )
                 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/WebTab.kt
@@ -70,6 +70,8 @@ import churchpresenter.composeapp.generated.resources.web_bookmark_add
 import churchpresenter.composeapp.generated.resources.web_bookmark_remove
 import churchpresenter.composeapp.generated.resources.web_add_to_schedule
 import churchpresenter.composeapp.generated.resources.web_back
+import churchpresenter.composeapp.generated.resources.web_clear_typed_text
+import churchpresenter.composeapp.generated.resources.web_clear_url
 import churchpresenter.composeapp.generated.resources.web_engine_unavailable_body
 import churchpresenter.composeapp.generated.resources.web_engine_unavailable_title
 import churchpresenter.composeapp.generated.resources.web_engine_unavailable_macos_body
@@ -327,7 +329,7 @@ fun WebTab(
                     ) {
                         Icon(
                             painter = painterResource(Res.drawable.ic_close),
-                            contentDescription = null,
+                            contentDescription = stringResource(Res.string.web_clear_url),
                             modifier = Modifier.size(14.dp),
                             tint = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -587,7 +589,7 @@ fun WebTab(
                         }
                         if (typeBuffer.isNotEmpty()) {
                             IconButton(onClick = { typeBuffer = "" }, modifier = Modifier.size(30.dp)) {
-                                Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = null, modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                                Icon(painter = painterResource(Res.drawable.ic_close), contentDescription = stringResource(Res.string.web_clear_typed_text), modifier = Modifier.size(14.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
                             }
                         }
                     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabSceneRenameTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTabSceneRenameTest.kt
@@ -24,34 +24,34 @@ import kotlin.test.assertEquals
  * leaves the operator looking at the name they typed while the scene, the schedule and the saved
  * `scenes.json` all still hold the old one. That divergence is what these tests are for.
  *
- * **Locating the tick.** Its icon is declared with `contentDescription = null`, so it cannot be
- * addressed by label. While the editor is open it is the only button in the tab carrying neither text
- * nor a content description — every other one has a label ("Add source", "Go Live") or is a glyph
- * button whose symbol is its text. [confirmRenameButton] asserts that uniqueness rather than assuming
- * it, so if another unlabelled button ever appears the test says so instead of clicking the wrong
- * thing.
+ * **Locating the tick.** It carries its own content description, `canvas_rename_confirm` — a name
+ * distinct from the rename pencil's `canvas_rename_scene`, so the control that *opens* the editor and
+ * the one that *commits* it cannot be confused for one another.
+ *
+ * This test used to address the tick as the only button in the tab carrying neither text nor a content
+ * description. That worked, but it selected on the absence of a label, so labelling the button — an
+ * accessibility fix — broke it. Addressing it by its name is both the accessible behaviour and the
+ * stabler selector.
  */
 class CanvasTabSceneRenameTest {
 
     private companion object {
         /** The rename pencil's tooltip and content description — `canvas_rename_scene`. */
         const val RENAME = "Rename"
+
+        /** The tick that commits the rename — `canvas_rename_confirm`. */
+        const val CONFIRM_RENAME = "Confirm rename"
     }
 
-    /** The unlabelled tick that commits the rename. Fails loudly if it is no longer the only one. */
+    /** The tick that commits the rename. Fails loudly if it is not on screen exactly once. */
     private fun ComposeUiTest.confirmRenameButton(): SemanticsNodeInteraction {
-        val unlabelled = onAllNodes(
-            hasClickAction() and
-                SemanticsMatcher.keyNotDefined(SemanticsProperties.Text) and
-                SemanticsMatcher.keyNotDefined(SemanticsProperties.ContentDescription) and
-                SemanticsMatcher.keyNotDefined(SemanticsProperties.EditableText)
-        )
+        val ticks = onAllNodesWithContentDescription(CONFIRM_RENAME)
         assertEquals(
             1,
-            unlabelled.fetchSemanticsNodes().size,
-            "the confirm tick is identified by being the only unlabelled button while renaming",
+            ticks.fetchSemanticsNodes().size,
+            "the confirm tick is addressed by its content description while renaming",
         )
-        return unlabelled[0]
+        return ticks[0]
     }
 
     private fun ComposeUiTest.editorText(): String =

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabExtraTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabExtraTest.kt
@@ -31,9 +31,8 @@ import kotlin.test.assertTrue
  * `PicturesTabTestSupport.kt`'s doc comment for why.
  *
  * The loop toggle used to be listed here too — "neither text nor a content description to address it
- * by" — which was true of the usual selectors and not of the tree: it is the *only* clickable node
- * carrying neither, and that is a selector. See `PicturesTabLoopTooltipTest`, which addresses it that
- * way and asserts the uniqueness rather than assuming it.
+ * by". It now has one, matching its tooltip, so it is addressable by name like any other button. See
+ * `PicturesTabLoopTooltipTest`.
  *
  * See `PicturesTabTestSupport.kt` for the harness.
  */

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabLoopTooltipTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabLoopTooltipTest.kt
@@ -2,11 +2,10 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.performMouseInput
 import kotlin.test.Test
@@ -21,28 +20,27 @@ import kotlin.test.assertEquals
  * operator the opposite of the truth, and the failure is silent until a slideshow dead-ends at the
  * last picture mid-service.
  *
- * **`PicturesTabExtraTest` records this button as unreachable** — "whose icon carries neither text
- * nor a content description to address it by". That is true of the usual selectors and not of the
- * tree: it is the *only* clickable node with neither, which is a selector in itself. [loopButton]
- * asserts that uniqueness rather than assuming it, so if a second unlabelled button ever appears
- * this fails loudly instead of silently addressing the wrong one — the approach `CanvasTab`'s
- * rename tick already uses.
+ * The button now carries the same `Loop On`/`Loop Off` string as its content description, so it is
+ * addressable by name. It used to be addressed as the only clickable node carrying neither text nor
+ * a description — a selector that worked, but one that selected on the *absence* of a label and so
+ * broke the moment the button was given one.
+ *
+ * The tooltip is still what this tests: [countOf] matches `Text` semantics only, which the content
+ * description does not contribute to, so hovering must still raise the count by one.
  */
 class PicturesTabLoopTooltipTest {
 
-    /** The one clickable node carrying neither text nor a content description. */
+    /** The loop toggle, by the name it now carries in whichever state it is in. */
     private fun ComposeUiTest.loopButton(): SemanticsNodeInteraction {
-        val all = onAllNodes(hasClickAction())
-        val nodes = all.fetchSemanticsNodes(atLeastOneRootRequired = false)
-        val bare = nodes.indices.filter { i ->
-            nodes[i].config.getOrNull(SemanticsProperties.ContentDescription) == null &&
-                nodes[i].config.getOrNull(SemanticsProperties.Text) == null
-        }
-        assertEquals(
-            1, bare.size,
-            "the loop toggle is addressed as the only unlabelled button; found ${bare.size}",
+        val matches = onAllNodes(
+            hasClickAction() and
+                (hasContentDescription("Loop On") or hasContentDescription("Loop Off"))
         )
-        return all[bare.single()]
+        assertEquals(
+            1, matches.fetchSemanticsNodes(atLeastOneRootRequired = false).size,
+            "the loop toggle is addressed by its content description",
+        )
+        return matches[0]
     }
 
     private fun ComposeUiTest.countOf(text: String) =

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabSelectionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabSelectionTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import org.churchpresenter.app.churchpresenter.data.settings.SongSettings
 import kotlin.test.Test
@@ -226,7 +227,10 @@ class SongsTabSelectionTest {
     @Test
     fun `the add-to-schedule action sends the selected song to the schedule`() = songsTab { _, reports ->
         clickRow("Amazing Love")
-        onAllNodes(hasContentDescription("Add to Schedule"))[0].performClick()
+        // By tag, not by label: several controls are correctly named "Add to Schedule" — the toolbar
+        // button, one per table row, one per favourites entry — and only the tagged one adds the
+        // song that is *selected*, which is what this asserts.
+        onNodeWithTag(SONGS_ADD_SELECTED_TAG).performClick()
         waitForIdle()
 
         assertEquals(


### PR DESCRIPTION
Stacked on #275 — review that one first; this PR's diff is against its branch.

#275 labelled the three search clear buttons. Auditing for the same defect turned up **13 more** icon-only buttons drawn with `contentDescription = null` and nothing else: assistive technology meets an unlabelled button, and a test has no name to address one by.

| Pattern | Sites | Label |
|---|---|---|
| Pin/unpin star in recents | `MediaTab`, `PicturesTab`, `PresentationTab` | new `recent_pin`/`recent_unpin` |
| Clear-field buttons | `WebTab` ×2 (URL, type buffer) | new `web_clear_url`/`web_clear_typed_text` |
| Nav arrows | `CrosswordTab` ×2, `TabStripArrows` | new, 4 strings |
| Show/hide API key | `StockMediaBrowserDialog` | new, 2 strings |
| Add to schedule (row) | `SongsTab` | existing `add_to_schedule` |
| Cancel / confirm inline edit | `EditSongDialog`, `CanvasTab` | existing `cancel`; new `canvas_rename_confirm` |
| Loop toggle | `PicturesTab` | existing `loop_on`/`loop_off` |

The **pin toggles are the worst three**: a filled star and an outline star are the only thing separating pinned from unpinned, so without a description the *state* is unreachable, not merely the name — and it is the same copy-pasted code in three tabs.

Eleven new strings in `values/strings.xml` only; no other locale touched. Roughly half the sites reuse strings that already existed.

### Three tests selected on the absence of a label

`CanvasTabSceneRenameTest`, `PicturesTabLoopTooltipTest` and `SongsTabSelectionTest` addressed their button as *"the only unlabelled button"* — a deliberate, documented selector that asserted its own uniqueness. Labelling the buttons broke all three, loudly and exactly as those tests were designed to fail.

The selector is what was wrong, not the label. Each now addresses its button by name, which is both what an assistive-technology user gets and the more stable choice. Doc comments that recorded these buttons as unreachable are updated rather than left to mislead.

`canvas_rename_confirm` is a **new** string rather than a reuse of the pencil's `canvas_rename_scene` ("Rename"), so the control that *opens* the rename editor and the one that *commits* it stay distinguishable.

### Two deliberate exceptions

**The Songs table's action-column header keeps `contentDescription = null`.** Its click *sorts*, so naming it "Add to Schedule" would name it after an action it does not perform. Giving a sortable header its proper accessible name is a semantics question for the whole table, not for this icon — left alone on purpose, with a comment saying so.

**"Add to Schedule" is now correctly the name of several controls** — the toolbar button, one per table row, one per favourites entry. `SongsTabSelectionTest` used `onAllNodes(...)[0]`, which the new row buttons displaced. The shared name is right and stays; the toolbar button gets a test tag so the test can say which control it means instead of relying on tree order.

### Verification

- `./gradlew compileKotlinJvm` — green.
- `./gradlew :composeApp:jvmTest` — full suite green (9,814 tests).
- `./gradlew :composeApp:verifyRoborazziJvm` — no tab image moved. A content description draws nothing.
- A scanner for both shapes of this defect (`IconButton`, and clickable `Box`/`Row`/`Column`/`Surface`/`Card` containers) now reports **0** across `jvmMain`. It was validated against the pre-#275 tree, where it finds exactly the three buttons that PR fixes.

The same 5 pre-existing screenshot reds as #275 remain, unchanged and unrelated: `previewApp/ccli_report_{,bible_,activity_}light` (date-filtered), `canvasTab/source_camera` (enumerates real cameras), `lottieGen/section_shape` (order-dependent).

### Not included

Custom wrappers that already take a name — `TooltipIconButton`, `ActionIconButton` — were excluded because they supply their own description. I did not separately audit whether every *caller* passes a sensible one.
