### PR TITLE
Give each slide cache entry one owner

### DIFF
--- a/composeApp/src/jvmMain/appResources/common/ChurchPresenter-PresentationEngine/src/main/kotlin/presentation/engine/cache/SlideDiskCache.kt
+++ b/composeApp/src/jvmMain/appResources/common/ChurchPresenter-PresentationEngine/src/main/kotlin/presentation/engine/cache/SlideDiskCache.kt
@@ -7,7 +7,17 @@ import presentation.engine.model.DeckFormat
 import presentation.engine.model.Fidelity
 import java.awt.image.BufferedImage
 import java.io.File
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
 import javax.imageio.ImageIO
+
+/**
+ * Thrown when a [SlideDiskCache.Writer] is asked to keep writing an entry that another writer (or
+ * an invalidate) has since taken over. The render that raised it must stop and not commit; the
+ * writer that superseded it owns the files now.
+ */
+class SlideCacheSupersededException(dir: File) :
+    IOException("Slide cache entry ${dir.absolutePath} was taken over by another writer")
 
 /**
  * Disk cache of rendered final-frame slides, shared by the Presentation tab and the companion
@@ -30,6 +40,25 @@ class SlideDiskCache(
 
         /** Stable id per source path — same derivation the companion API has always used. */
         fun idFor(absolutePath: String): String = absolutePath.hashCode().toUInt().toString(16)
+
+        /**
+         * The writer that currently owns each entry directory, keyed by its absolute path.
+         *
+         * An entry dir is keyed on the source path alone, so several renders can target the same
+         * one: the tab and the companion server render the same deck, and re-selecting a file
+         * starts a new render while the cancelled one is still in its loop. Every deletion path
+         * ([Writer.init], [Writer.abort], [invalidate], [cleanupOrphaned]) used to wipe the dir
+         * unconditionally, so whichever render lost the race carried on writing into a directory
+         * that no longer existed — `ImageIO.write` then failed with "Can't create an
+         * ImageOutputStream!" from the middle of the deck onwards.
+         *
+         * Ownership is process-wide because every [SlideDiskCache] instance shares one base dir.
+         */
+        private val activeWriters = ConcurrentHashMap<String, Writer>()
+
+        /** Why a write could not happen, for the exception message. */
+        private fun diagnose(dir: File): String =
+            "dir exists=${dir.isDirectory}, writable=${dir.canWrite()}, usableBytes=${dir.usableSpace}"
     }
 
     @Serializable
@@ -81,22 +110,33 @@ class SlideDiskCache(
         return CachedSlides(manifest, slideFiles, notes)
     }
 
+    /**
+     * Deletes the entry for [file]. An in-flight render of that file is disowned rather than left
+     * writing into a deleted directory: its next `putSlide` throws [SlideCacheSupersededException].
+     */
     fun invalidate(file: File) {
-        dirFor(file).deleteRecursively()
+        val dir = dirFor(file)
+        activeWriters.remove(dir.absolutePath)
+        dir.deleteRecursively()
     }
 
     /**
      * Deletes cache entries whose source path is not in [keepPaths]. Session-scoped entries
      * (`remote_*`, used for instance-link mirrored slides) are always deleted — they are
-     * re-downloaded on demand.
+     * re-downloaded on demand. An entry a render is currently writing is left alone; it is
+     * cleaned up by the next call once that render has finished.
      */
     fun cleanupOrphaned(keepPaths: Collection<String>) {
         if (!baseDir.exists()) return
         val keepIds = keepPaths.map { idFor(it) }.toSet()
         baseDir.listFiles()?.forEach { dir ->
-            if (dir.isDirectory && dir.name !in keepIds) dir.deleteRecursively()
+            val busy = activeWriters.containsKey(dir.absolutePath)
+            if (dir.isDirectory && dir.name !in keepIds && !busy) dir.deleteRecursively()
         }
     }
+
+    /** True while some render owns [file]'s entry — a second render should wait rather than start. */
+    fun isWriting(file: File): Boolean = activeWriters.containsKey(dirFor(file).absolutePath)
 
     fun beginWrite(file: File, format: DeckFormat, renderWidthPx: Int): Writer =
         Writer(dirFor(file), file, format, renderWidthPx)
@@ -108,6 +148,11 @@ class SlideDiskCache(
      * Incremental cache writer: slides are written as they render so a consumer can stream them,
      * and the manifest lands last as the commit marker. [abort] (or a crash) leaves an invalid,
      * self-healing entry.
+     *
+     * Creating a writer takes ownership of the entry directory (see [activeWriters]): a writer
+     * that has been superseded stops at its next [putSlide] or [commit] with a
+     * [SlideCacheSupersededException], and its [abort] no longer deletes the files that now
+     * belong to the newer writer.
      */
     inner class Writer internal constructor(
         val dir: File,
@@ -116,10 +161,27 @@ class SlideDiskCache(
         private val renderWidthPx: Int
     ) {
         private val entries = mutableListOf<SlideEntry>()
+        private val key = dir.absolutePath
 
         init {
-            dir.deleteRecursively()
-            dir.mkdirs()
+            activeWriters[key] = this
+            try {
+                dir.deleteRecursively()
+                ensureDir()
+            } catch (e: Throwable) {
+                activeWriters.remove(key, this)
+                throw e
+            }
+        }
+
+        private fun isCurrent(): Boolean = activeWriters[key] === this
+
+        /** Creates the entry directory, failing loudly (and once) instead of per slide. */
+        private fun ensureDir() {
+            if (dir.isDirectory) return
+            if (!dir.mkdirs() && !dir.isDirectory) {
+                throw IOException("Cannot create slide cache directory $key (${diagnose(dir)})")
+            }
         }
 
         /** Writes one slide; returns the JPEG file. Alpha is flattened onto white for JPEG. */
@@ -130,14 +192,24 @@ class SlideDiskCache(
             fidelity: Fidelity,
             hasTimeline: Boolean
         ): File {
+            if (!isCurrent()) throw SlideCacheSupersededException(dir)
+            ensureDir()
             val slideFile = File(dir, slideName(index))
-            ImageIO.write(DeckRasterizer.flattenToRgb(image), "jpg", slideFile)
+            val written = try {
+                ImageIO.write(DeckRasterizer.flattenToRgb(image), "jpg", slideFile)
+            } catch (e: IOException) {
+                // The bare ImageIO message ("Can't create an ImageOutputStream!") names neither the
+                // file nor why it could not be opened; say both.
+                throw IOException("Failed to write slide $index to $slideFile (${diagnose(dir)})", e)
+            }
+            if (!written) throw IOException("No JPEG writer accepted slide $index for $slideFile")
             if (note.isNotBlank()) File(dir, noteName(index)).writeText(note)
             entries.add(SlideEntry(fidelity, hasTimeline))
             return slideFile
         }
 
         fun commit() {
+            if (!activeWriters.remove(key, this)) throw SlideCacheSupersededException(dir)
             val manifest = Manifest(
                 schemaVersion = SCHEMA_VERSION,
                 sourcePath = sourceFile.absolutePath,
@@ -150,8 +222,9 @@ class SlideDiskCache(
             File(dir, "manifest.json").writeText(json.encodeToString(Manifest.serializer(), manifest))
         }
 
+        /** Discards this writer's entry — unless another writer owns it now, which leaves it alone. */
         fun abort() {
-            dir.deleteRecursively()
+            if (activeWriters.remove(key, this)) dir.deleteRecursively()
         }
     }
 }

--- a/composeApp/src/jvmMain/appResources/common/ChurchPresenter-PresentationEngine/src/test/kotlin/presentation/engine/SlideDiskCacheTest.kt
+++ b/composeApp/src/jvmMain/appResources/common/ChurchPresenter-PresentationEngine/src/test/kotlin/presentation/engine/SlideDiskCacheTest.kt
@@ -1,14 +1,18 @@
 package presentation.engine
 
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import presentation.engine.cache.SlideCacheSupersededException
 import presentation.engine.cache.SlideDiskCache
 import presentation.engine.model.DeckFormat
 import presentation.engine.model.Fidelity
 import java.awt.Color
 import java.awt.image.BufferedImage
 import java.io.File
+import java.io.IOException
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -84,6 +88,90 @@ class SlideDiskCacheTest {
         File(dir, "slide_0000.jpg").writeBytes(Fixtures.jpegBytes(64, 36, Color.RED))
         File(dir, "mtime.txt").writeText(source.lastModified().toString())
         assertNull(cache.lookup(source, 1920))
+    }
+
+    @Test
+    fun `a superseded writer cannot write or delete the newer entry`() {
+        val cache = newCache()
+        val source = sourceFile()
+        val first = cache.beginWrite(source, DeckFormat.PPTX, 1920)
+        first.putSlide(0, image(Color.RED), "", Fidelity.NATIVE, false)
+
+        val second = cache.beginWrite(source, DeckFormat.PPTX, 1920)
+        second.putSlide(0, image(Color.BLUE), "", Fidelity.NATIVE, false)
+
+        assertFailsWith<SlideCacheSupersededException> {
+            first.putSlide(1, image(Color.RED), "", Fidelity.NATIVE, false)
+        }
+        assertFailsWith<SlideCacheSupersededException> { first.commit() }
+        first.abort()
+
+        second.putSlide(1, image(Color.BLUE), "", Fidelity.NATIVE, false)
+        second.commit()
+
+        val cached = assertNotNull(cache.lookup(source, 1920))
+        assertEquals(2, cached.slideFiles.size)
+        assertTrue(cached.slideFiles.all { it.isFile })
+    }
+
+    @Test
+    fun `invalidate during a render disowns the writer instead of leaving it writing into nothing`() {
+        val cache = newCache()
+        val source = sourceFile()
+        val writer = cache.beginWrite(source, DeckFormat.PPTX, 1920)
+        writer.putSlide(0, image(Color.RED), "", Fidelity.NATIVE, false)
+
+        cache.invalidate(source)
+
+        assertFailsWith<SlideCacheSupersededException> {
+            writer.putSlide(1, image(Color.RED), "", Fidelity.NATIVE, false)
+        }
+        assertNull(cache.lookup(source, 1920))
+    }
+
+    @Test
+    fun `cleanupOrphaned leaves an in-flight render alone`() {
+        val cache = newCache()
+        val source = sourceFile()
+        val writer = cache.beginWrite(source, DeckFormat.PPTX, 1920)
+        writer.putSlide(0, image(Color.RED), "", Fidelity.NATIVE, false)
+
+        cache.cleanupOrphaned(emptyList())
+
+        writer.putSlide(1, image(Color.RED), "", Fidelity.NATIVE, false)
+        writer.commit()
+        assertEquals(2, assertNotNull(cache.lookup(source, 1920)).slideFiles.size)
+    }
+
+    @Test
+    fun `putSlide recreates an entry directory deleted underneath it`() {
+        val cache = newCache()
+        val source = sourceFile()
+        val writer = cache.beginWrite(source, DeckFormat.PPTX, 1920)
+        writer.putSlide(0, image(Color.RED), "", Fidelity.NATIVE, false)
+        cache.dirFor(source).deleteRecursively()
+
+        val slide = writer.putSlide(1, image(Color.BLUE), "", Fidelity.NATIVE, false)
+        assertTrue(slide.isFile)
+    }
+
+    @Test
+    fun `an entry directory that cannot be created fails naming it`() {
+        val base = File(tempDir, "readonly-cache").apply { mkdirs() }
+        val probe = File(base, "probe")
+        // Root, and some Windows setups, ignore the read-only bit — then there is nothing to test.
+        assumeTrue(base.setWritable(false) && !probe.mkdir(), "cache dir stayed writable here")
+        try {
+            val cache = SlideDiskCache(base)
+            val source = sourceFile()
+            val failure = assertFailsWith<IOException> { cache.beginWrite(source, DeckFormat.PPTX, 1920) }
+            assertTrue(
+                cache.dirFor(source).absolutePath in (failure.message ?: ""),
+                "message was: ${failure.message}"
+            )
+        } finally {
+            base.setWritable(true)
+        }
     }
 
     @Test

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationStore.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationStore.kt
@@ -17,6 +17,7 @@ import org.churchpresenter.app.churchpresenter.utils.CrashReporter
 import presentation.engine.DeckRasterizer
 import presentation.engine.LoadResult
 import presentation.engine.PresentationLoader
+import presentation.engine.cache.SlideCacheSupersededException
 import presentation.engine.cache.SlideDiskCache
 
 /**
@@ -136,6 +137,10 @@ internal class PresentationStore(
                 jpegSlides = cached.slideFiles.map { it.readBytes() }
                 notes = cached.notes
             } else {
+                // The Presentation tab is rendering this very deck into the shared entry. Starting
+                // a second render here would take the entry away from it mid-deck, so leave it be:
+                // the client's 404-retry path comes back once the tab's render has committed.
+                if (slideDiskCache.isWriting(file)) return
                 val deck = when (val result = PresentationLoader.load(file)) {
                     is LoadResult.Failure -> {
                         CrashReporter.reportWarning(
@@ -170,6 +175,9 @@ internal class PresentationStore(
                     }
                     writer.commit()
                     committed = true
+                } catch (superseded: SlideCacheSupersededException) {
+                    // A tab render took the entry over after this one started; it finishes the job.
+                    return
                 } finally {
                     if (!committed) writer.abort()
                 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModel.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.viewmodel
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -18,6 +19,7 @@ import org.churchpresenter.app.churchpresenter.utils.CrashReporter
 import presentation.engine.DeckRasterizer
 import presentation.engine.LoadResult
 import presentation.engine.PresentationLoader
+import presentation.engine.cache.SlideCacheSupersededException
 import presentation.engine.cache.SlideDiskCache
 import presentation.engine.model.Deck
 import presentation.engine.model.DeckFormat
@@ -379,6 +381,7 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
             }
             val cacheWriter = diskCache.beginWrite(file, deck.format, renderWidth)
             writer = cacheWriter
+            var reportedSlideFailure = false
             DeckRasterizer(deck, renderWidth).use { rasterizer ->
                 for (slide in deck.slides) {
                     try {
@@ -394,9 +397,24 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
                             _slideFiles.add(slideFile)
                             _slideNotes.add(slide.notes)
                         }
+                    } catch (e: CancellationException) {
+                        // This render was superseded by a newer selectPresentation. Let it die here
+                        // instead of rendering (and reporting) the rest of a deck nobody wants.
+                        throw e
+                    } catch (e: SlideCacheSupersededException) {
+                        // Another render of the same deck — the companion server, or a re-select
+                        // whose cancellation we haven't reached yet — owns the cache entry now.
+                        // Stop quietly and leave the files to it.
+                        return@use
                     } catch (e: Exception) {
-                        // One bad slide must not kill the deck; the slide is simply skipped.
-                        CrashReporter.reportException(e, "Rendering slide ${slide.index} of ${file.name}")
+                        // One bad slide must not kill the deck; the slide is simply skipped. Only
+                        // the first failure is reported: whatever breaks one slide (a full or
+                        // read-only cache dir) breaks every slide after it, and forty identical
+                        // events say nothing the first one didn't.
+                        if (!reportedSlideFailure) {
+                            reportedSlideFailure = true
+                            CrashReporter.reportException(e, "Rendering slide ${slide.index} of ${file.name}")
+                        }
                     }
                 }
             }
@@ -415,6 +433,11 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
                     )
                 )
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: SlideCacheSupersededException) {
+            // Lost the entry to a newer render of the same deck between the last slide and the
+            // commit. That render owns the result; this one is not a failure and shows no error.
         } catch (e: Exception) {
             if (_loadError.value == null) {
                 withContext(Dispatchers.Main) { _loadError.value = PresentationLoadError.RENDER_FAILED }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModelDeckSwitchingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModelDeckSwitchingTest.kt
@@ -6,6 +6,9 @@ import org.apache.pdfbox.pdmodel.PDPageContentStream
 import org.apache.pdfbox.pdmodel.font.PDType1Font
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -201,6 +204,39 @@ class PresentationViewModelDeckSwitchingTest {
         vm.switchTo(first, slides = 2)
 
         assertTrue(vm.isPlaying)
+    }
+
+    @Test
+    fun `re-selecting a deck while it is still rendering still ends with every slide`() {
+        // Both renders of the same deck target one cache directory. The cancelled one used to
+        // delete it in its `finally` — while the restarted one was writing into it — so every
+        // remaining slide died with "Can't create an ImageOutputStream!" and the deck came up
+        // short. The overlap is forced rather than raced: the first render is held at slide 1
+        // until the second has started, and released only then.
+        val slides = 8
+        val file = pdf(pages = slides)
+        val vm = viewModel()
+        val reachedSlideOne = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val held = AtomicBoolean(false)
+        vm.renderSlideFrame = { rasterizer, index ->
+            if (index == 1 && held.compareAndSet(false, true)) {
+                reachedSlideOne.countDown()
+                assertTrue(release.await(5, TimeUnit.SECONDS), "the second render never started")
+            }
+            rasterizer.renderFinalFrame(index)
+        }
+
+        vm.addPresentation(file)
+        assertTrue(reachedSlideOne.await(10, TimeUnit.SECONDS), "the first render never reached slide 1")
+        vm.selectPresentation(file)
+        release.countDown()
+
+        awaitUntil("the restarted render to finish") { !vm.isLoading && vm.slideFiles.size >= slides }
+
+        assertEquals(slides, vm.slideFiles.size)
+        assertNull(vm.loadError)
+        assertTrue(vm.slideFiles.all { it.exists() }, "every rendered slide must still be on disk")
     }
 
     // ── Closing a deck and its rendered slides ──────────────────────────────────


### PR DESCRIPTION
Fixes the Sentry issue `IIOException: Can't create an ImageOutputStream!` in `SlideDiskCache.putSlide` (release 26.4.203), reported mid-deck ("Rendering slide 10 of …").

## Cause

A cache entry directory is keyed on the source path alone, so several renders can target the same one:

- the Presentation tab and the companion server render the same deck (`PresentationStore.renderPresentationForServer`);
- re-selecting a file cancels `activeLoadJob` and starts a new render, while the cancelled one is still inside its slide loop.

Every deletion path — `Writer.init`, `Writer.abort`, `invalidate`, `cleanupOrphaned` — wiped that directory unconditionally. The render that lost the race kept writing into a directory that no longer existed, and `ImageIO.write` could not open the file: the deck came up short from that slide onwards, with one Sentry event per remaining slide.

The cancelled-render case is the likely source of the report: the old job's `finally { writer.abort() }` deletes the directory the restarted job is by then writing into.

## Fix

- A `Writer` takes ownership of its entry directory (process-wide, since every `SlideDiskCache` instance shares one base dir). A superseded writer stops with `SlideCacheSupersededException` at its next `putSlide`/`commit`, and its `abort()` no longer deletes files that now belong to another writer.
- `invalidate` disowns an in-flight render rather than deleting under it; `cleanupOrphaned` skips a busy entry and collects it next time.
- The companion server skips a deck the tab is already rendering; the client's existing 404-retry path covers it.
- Real write failures (full disk, read-only home) now name the file and report `dir exists/writable/usableBytes`, and a failed `mkdirs()` fails once up front instead of being ignored and failing per slide.
- `renderSlides` rethrows `CancellationException` — the per-slide `catch (Exception)` used to swallow it, so a cancelled render rendered and reported the rest of the deck — and reports only the first genuine per-slide failure.

## Tests

- `SlideDiskCacheTest`: superseded writer can neither write nor delete the newer entry; `invalidate` disowns the writer; `cleanupOrphaned` spares an in-flight render; `putSlide` recreates a directory deleted underneath it; an uncreatable directory fails naming itself.
- `PresentationViewModelDeckSwitchingTest`: re-selecting a deck mid-render still ends with every slide. The overlap is forced with latches through the existing `renderSlideFrame` seam rather than raced — no sleeps, 0.4s. It fails on the pre-fix code with `loadError = RENDER_FAILED` and passes with the fix, three consecutive `--rerun-tasks` runs.
- `./gradlew :composeApp:check` (9815 tests) and the Presentation Engine's own `sh gradlew build` are both green.