### PR TITLE
Treat a Swing dialog that throws as a cancel

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/SwingFileChooser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/SwingFileChooser.kt
@@ -1,6 +1,8 @@
 package org.churchpresenter.app.churchpresenter.dialogs.filechooser
 
+import org.churchpresenter.app.churchpresenter.utils.CrashReporter
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 import java.nio.file.Path
 import javax.imageio.ImageIO
 import javax.swing.JFileChooser
@@ -227,6 +229,28 @@ object SwingFileChooser : FileChooser() {
         }
     }
 
+    /** The real cause of a failure inside [onEventDispatchThread], which reports it wrapped. */
+    internal fun unwrapDialogFault(failure: Exception): Throwable =
+        (failure as? InvocationTargetException)?.targetException ?: failure
+
+    /**
+     * Runs a dialog, treating one that throws as a cancel.
+     *
+     * This chooser is the last resort — every other implementation falls back to it, and it has
+     * nowhere to fall back to itself — so a fault here would otherwise leave the coroutine that
+     * asked for a file dying with it. The faults are not all ours to prevent: `JFileChooser`
+     * throws out of its own focus handling when Swing's `FilePane` repaints the selection with a
+     * null rectangle (JDK-6561072, open since 2007). An operator who cannot open a file is a
+     * problem; an operator whose app dies because they clicked Open is a worse one.
+     */
+    internal fun <T> dialogOrCancelled(context: String, show: () -> T?): T? =
+        try {
+            show()
+        } catch (e: Exception) {
+            CrashReporter.reportException(unwrapDialogFault(e), context = context)
+            null
+        }
+
     @Suppress("BlockingMethodInNonBlockingContext")
     override suspend fun chooseImpl(
         path: Path,
@@ -234,8 +258,10 @@ object SwingFileChooser : FileChooser() {
         title: String,
         selectDirectory: Boolean,
         multiple: Boolean
-    ): List<Path>? = runOpen(path, filters, title, selectDirectory, multiple, ownerFrame) { chooser, frame ->
-        chooser.showOpenDialog(frame)
+    ): List<Path>? = dialogOrCancelled("SwingFileChooser.chooseImpl") {
+        runOpen(path, filters, title, selectDirectory, multiple, ownerFrame) { chooser, frame ->
+            chooser.showOpenDialog(frame)
+        }
     }
 
     @Suppress("BlockingMethodInNonBlockingContext")
@@ -244,7 +270,9 @@ object SwingFileChooser : FileChooser() {
         suggestedName: String,
         filters: List<FileNameExtensionFilter>,
         title: String
-    ): Path? = runSave(location, suggestedName, filters, title, ownerFrame) { chooser, frame ->
-        chooser.showSaveDialog(frame)
+    ): Path? = dialogOrCancelled("SwingFileChooser.saveImpl") {
+        runSave(location, suggestedName, filters, title, ownerFrame) { chooser, frame ->
+            chooser.showSaveDialog(frame)
+        }
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/PlatformFileChooserTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/PlatformFileChooserTest.kt
@@ -26,6 +26,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -1163,5 +1164,43 @@ class PlatformFileChooserTest {
 
         assertFalse(fellBack, "cancelling must not silently reopen as a Swing dialog")
         assertFalse(FileKitFileChooser.nativeDialogsBroken, "cancelling is not a fault; the native path stays on")
+    }
+
+    // ── SwingFileChooser: a dialog that throws is a cancel ───────────────────────
+    //
+    // This chooser is where everything else falls back to, and it has nowhere to fall back to
+    // itself. JFileChooser throws out of its own focus handling (JDK-6561072: FilePane repaints
+    // the selection with a null rectangle), and that exception used to leave the dialog and the
+    // thread waiting on it.
+
+    @Test
+    fun `a dialog that returns normally is left alone`() {
+        assertEquals("picked", SwingFileChooser.dialogOrCancelled("test") { "picked" })
+    }
+
+    @Test
+    fun `a dialog that throws comes back as a cancel`() {
+        assertNull(
+            SwingFileChooser.dialogOrCancelled<String>("test") {
+                throw NullPointerException("Cannot read field \"x\" because \"<parameter1>\" is null")
+            },
+            "an operator who cannot open a file is a problem; one whose app dies for it is worse",
+        )
+    }
+
+    @Test
+    fun `the fault reported is the one Swing threw, not the reflection wrapper`() {
+        // Everything here runs through SwingUtilities.invokeAndWait, which reports whatever the
+        // dialog threw wrapped in an InvocationTargetException — useless as a crash-report title.
+        val real = NullPointerException("Cannot read field \"x\" because \"<parameter1>\" is null")
+
+        assertSame(real, SwingFileChooser.unwrapDialogFault(InvocationTargetException(real)))
+    }
+
+    @Test
+    fun `a fault that is not wrapped is reported as itself`() {
+        val direct = IllegalStateException("no display")
+
+        assertSame(direct, SwingFileChooser.unwrapDialogFault(direct))
     }
 }


### PR DESCRIPTION
The app half of the fatal Sentry issue `NullPointerException: Cannot read field "x" because "<parameter1>" is null` (release 26.8.37, Windows), thrown from `sun.swing.FilePane$3.repaintListSelection` while a `JFileChooser` was open.

## Cause

Not ours. `JFileChooser` repaints the file list's selection when the list loses focus, and `FilePane.repaintListSelection` hands `JComponent.repaint` a rectangle `getCellBounds` returned null for — [JDK-6561072](https://bugs.openjdk.org/browse/JDK-6561072), open since 2007, worked around by catching it in every application that has hit it ([OpenRocket #668](https://github.com/openrocket/openrocket/issues/668) is the same stack).

The reported crash came through the bundled converter's own `JFileChooser` and is fixed there in [ChurchPresenter-Converter#6](https://github.com/ChurchPresenter/ChurchPresenter-Converter/pull/6); this PR closes the same exposure in the app. `SwingFileChooser` is where `FileKitFileChooser` (and, with #278, `XdgFileChooser`) falls back to, and it has nowhere to fall back to itself — so a fault inside its dialog left the coroutine that asked for a file dying with it.

## Fix

`chooseImpl`/`saveImpl` run through `dialogOrCancelled`: report the fault, answer as though the operator dismissed the dialog. An operator who cannot open a file is a problem; one whose app dies because they clicked Open is a worse one. `unwrapDialogFault` reports what Swing actually threw rather than the `InvocationTargetException` that `SwingUtilities.invokeAndWait` wraps it in — otherwise every such crash arrives in Sentry under the same useless title.

## Tests

`PlatformFileChooserTest` — a normal return passes through; the exact `FilePane` NPE comes back as a cancel; the wrapped cause is unwrapped and an unwrapped one is left alone. `./gradlew :composeApp:check` — 9818 tests, 0 failed.

Independent of #278 (no shared files); merge order does not matter. The submodule pointer bump for the converter fix is not in this PR — it follows once ChurchPresenter-Converter#6 merges.