### PR TITLE
Rename test constant; enable top-level naming

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/LowerThirdSettingsTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/LowerThirdSettingsTabTest.kt
@@ -119,7 +119,7 @@ class LowerThirdSettingsTabTest {
     fun `files that are not Lottie animations are left out`() {
         withLottieFolder(
             "real.json" to lottieJson("real"),
-            "plain.json" to notLottieJson,
+            "plain.json" to NOT_LOTTIE_JSON,
             "notes.txt" to lottieJson("wrong extension"),
         ) { folder ->
             lowerThirdTab(initial = settingsForFolder(folder)) { _ ->

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/LowerThirdSettingsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/LowerThirdSettingsTabTestSupport.kt
@@ -23,7 +23,7 @@ import java.io.File
  *
  * A file counts as a Lottie animation to this tab when it is a `.json` whose text contains both a
  * `"v"` and a `"layers"` key — [lottieJson] produces the smallest thing that satisfies that, and
- * [notLottieJson] the smallest thing that does not.
+ * [NOT_LOTTIE_JSON] the smallest thing that does not.
  */
 @OptIn(ExperimentalTestApi::class)
 internal fun lowerThirdTab(
@@ -56,7 +56,7 @@ internal fun lottieJson(name: String = "clip"): String =
     """{"v":"5.7.4","fr":30,"ip":0,"op":30,"w":1920,"h":1080,"nm":"$name","layers":[]}"""
 
 /** Valid JSON that is not a Lottie animation — no `"layers"` key. */
-internal const val notLottieJson: String = """{"v":"5.7.4","nm":"not an animation"}"""
+internal const val NOT_LOTTIE_JSON: String = """{"v":"5.7.4","nm":"not an animation"}"""
 
 /**
  * Runs [block] against a fresh temporary folder, deleting it afterwards whatever happens.

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTabTriggersTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTabTriggersTest.kt
@@ -82,7 +82,7 @@ class ServerSettingsTabTriggersTest {
 
     @Test
     fun `a folder whose json is not a Lottie animation counts as empty`() {
-        withLottieFolder("notes.json" to notLottieJson) { folder ->
+        withLottieFolder("notes.json" to NOT_LOTTIE_JSON) { folder ->
             serverTab(initial = settingsFor(folder), server = server) { _, _ ->
                 onNodeWithText(ServerLabel.NO_LOWER_THIRDS)
                     .assertExists("a json that is not an animation must not become a trigger")

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -43,7 +43,7 @@ complexity:
 
 naming:
   TopLevelPropertyNaming:
-    active: false
+    active: true
   VariableNaming:
     active: true
     variablePattern: '(_)?[a-z][A-Za-z0-9]*|[A-Z][A-Z0-9_]*'


### PR DESCRIPTION
Rename test helper constant notLottieJson → NOT_LOTTIE_JSON and update tests to use the new name (LowerThirdSettingsTabTest, LowerThirdSettingsTabTestSupport, ServerSettingsTabTriggersTest). Also enable detekt TopLevelPropertyNaming to enforce naming conventions for top-level properties.