### PR TITLE
Refactor and harden server/media helpers - ReturnCount Detekt issues

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/StageMonitorScreen.kt
@@ -231,10 +231,8 @@ fun StageMonitorScreen(
 
     fun contentFor(zone: StageMonitorZone): StageMonitorContentType? {
         val assigned = StageMonitorContentType.entries.filter { sm.zoneFor(it) == zone }
-        if (assigned.isEmpty()) return null
-        assigned.firstOrNull { it in activeTypes }?.let { return it }
-        if (StageMonitorContentType.CLOCK in assigned) return StageMonitorContentType.CLOCK
-        return null
+        return assigned.firstOrNull { it in activeTypes }
+            ?: StageMonitorContentType.CLOCK.takeIf { it in assigned }
     }
 
     val fullScreenContent = contentFor(StageMonitorZone.FULL_SCREEN)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LoopingVideoBackground.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LoopingVideoBackground.kt
@@ -34,11 +34,10 @@ fun LoopingVideoBackground(
     videoPath: String,
     modifier: Modifier = Modifier
 ) {
-    if (videoPath.isBlank()) return
     val file = remember(videoPath) { File(videoPath) }
-    if (!file.exists()) return
-    if (!isVlcAvailable) return
-    if (CrashReporter.videoBackgroundsDisabled) return
+    val playable = videoPath.isNotBlank() && file.exists() &&
+        isVlcAvailable && !CrashReporter.videoBackgroundsDisabled
+    if (!playable) return
 
     val currentFrame = remember { mutableStateOf<ImageBitmap?>(null) }
     val frameVersion = remember { mutableStateOf(0L) }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
@@ -276,6 +276,45 @@ object SharedBrowserFrameCache {
 
     // ── CDP Browser Lifecycle ──────────────────────────────────────
 
+    /** The CDP connection to the freshly launched browser, or null once the failure is reported. */
+    private suspend fun connectCdp(entry: CacheEntry, port: Int): CdpConnection? {
+        if (!waitForCdpReady(port, timeoutMs = 15000)) {
+            System.err.println("[BrowserSource] CDP did not become ready in time")
+            CrashReporter.reportWarning(
+                "BrowserSource: CDP did not become ready in time",
+                tags = mapOf("subsystem" to "browser-source")
+            )
+            entry.error.value = "Browser failed to start"
+            return null
+        }
+        System.err.println("[BrowserSource] CDP ready on port $port")
+        return openCdpWebSocket(port)
+    }
+
+    private suspend fun openCdpWebSocket(port: Int): CdpConnection? {
+        val wsUrl = withContext(Dispatchers.IO) { getPageWebSocketUrl(port) }
+        if (wsUrl == null) {
+            System.err.println("[BrowserSource] Could not get page WebSocket URL")
+            CrashReporter.reportWarning(
+                "BrowserSource: Could not get page WebSocket URL",
+                tags = mapOf("subsystem" to "browser-source")
+            )
+            return null
+        }
+        System.err.println("[BrowserSource] Connecting WebSocket: $wsUrl")
+        val cdp = CdpConnection()
+        val connected = withContext(Dispatchers.IO) { cdp.connect(wsUrl) }
+        if (!connected) {
+            System.err.println("[BrowserSource] WebSocket connection failed")
+            CrashReporter.reportWarning(
+                "BrowserSource: WebSocket connection to CDP failed",
+                tags = mapOf("subsystem" to "browser-source")
+            )
+            return null
+        }
+        return cdp
+    }
+
     private suspend fun startBrowser(
         entry: CacheEntry,
         url: String,
@@ -329,44 +368,8 @@ object SharedBrowserFrameCache {
             } catch (_: Throwable) {}
         }
 
-        // Wait for CDP to be ready
-        val ready = waitForCdpReady(port, timeoutMs = 15000)
-        if (!ready) {
-            System.err.println("[BrowserSource] CDP did not become ready in time")
-            CrashReporter.reportWarning(
-                "BrowserSource: CDP did not become ready in time",
-                tags = mapOf("subsystem" to "browser-source")
-            )
-            entry.error.value = "Browser failed to start"
-            killProcess(process)
-            entry.browserProcess = null
-            return
-        }
-        System.err.println("[BrowserSource] CDP ready on port $port")
-
-        // Get the page's WebSocket URL
-        val wsUrl = withContext(Dispatchers.IO) { getPageWebSocketUrl(port) }
-        if (wsUrl == null) {
-            System.err.println("[BrowserSource] Could not get page WebSocket URL")
-            CrashReporter.reportWarning(
-                "BrowserSource: Could not get page WebSocket URL",
-                tags = mapOf("subsystem" to "browser-source")
-            )
-            killProcess(process)
-            entry.browserProcess = null
-            return
-        }
-        System.err.println("[BrowserSource] Connecting WebSocket: $wsUrl")
-
-        // Connect WebSocket
-        val cdp = CdpConnection()
-        val connected = withContext(Dispatchers.IO) { cdp.connect(wsUrl) }
-        if (!connected) {
-            System.err.println("[BrowserSource] WebSocket connection failed")
-            CrashReporter.reportWarning(
-                "BrowserSource: WebSocket connection to CDP failed",
-                tags = mapOf("subsystem" to "browser-source")
-            )
+        val cdp = connectCdp(entry, port)
+        if (cdp == null) {
             killProcess(process)
             entry.browserProcess = null
             return

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/VideoPlayer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/VideoPlayer.kt
@@ -284,15 +284,12 @@ private fun isVlcInstalledOnSystem(): Boolean =
  * trying only where distributions reliably ship the two together.
  */
 internal fun vlcInstalledOn(osName: String, customPath: String, run: CommandRunner): Boolean {
-    if (customPath.isNotBlank()) {
-        val custom = try { Paths.get(customPath) } catch (_: Exception) { null }
-        if (custom != null && dirContainsVlcLib(custom)) return true
-    }
+    val custom = customPath.takeIf { it.isNotBlank() }
+        ?.let { try { Paths.get(it) } catch (_: Exception) { null } }
+    if (custom != null && dirContainsVlcLib(custom)) return true
     if (detectVlcInstallPathFor(osName).isNotBlank()) return true
-    if ("win" !in osName && "mac" !in osName && "darwin" !in osName) {
-        return run(listOf("which", "vlc"), 0L).exitCode == 0
-    }
-    return false
+    val unixLike = "win" !in osName && "mac" !in osName && "darwin" !in osName
+    return unixLike && run(listOf("which", "vlc"), 0L).exitCode == 0
 }
 
 data class VlcAudioDevice(val id: String, val description: String)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/CrosswordData.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/CrosswordData.kt
@@ -240,18 +240,24 @@ object CrosswordLayoutEngine {
         var hasIntersection = false
         for (i in word.indices) {
             val (r, c) = if (dir == CrosswordDirection.ACROSS) row to col + i else row + i to col
-            val existing = grid[r to c]
-            if (existing != null) {
-                if (existing != word[i]) return false  // letter conflict
-                hasIntersection = true
-            } else {
-                // No parallel adjacency — perpendicular neighbours must be empty
-                val n1 = if (dir == CrosswordDirection.ACROSS) r - 1 to c else r to c - 1
-                val n2 = if (dir == CrosswordDirection.ACROSS) r + 1 to c else r to c + 1
-                if (grid.containsKey(n1) || grid.containsKey(n2)) return false
-            }
+            if (blocksLetter(grid, r, c, word[i], dir)) return false
+            if (grid.containsKey(r to c)) hasIntersection = true
         }
         return hasIntersection  // must share at least one letter with an existing word
+    }
+
+    private fun blocksLetter(
+        grid: Map<Pair<Int, Int>, Char>,
+        r: Int, c: Int,
+        letter: Char,
+        dir: CrosswordDirection
+    ): Boolean {
+        val existing = grid[r to c]
+        if (existing != null) return existing != letter  // letter conflict
+        // No parallel adjacency — perpendicular neighbours must be empty
+        val n1 = if (dir == CrosswordDirection.ACROSS) r - 1 to c else r to c - 1
+        val n2 = if (dir == CrosswordDirection.ACROSS) r + 1 to c else r to c + 1
+        return grid.containsKey(n1) || grid.containsKey(n2)
     }
 
     internal fun renderGrid(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/CrosswordData.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/CrosswordData.kt
@@ -96,17 +96,17 @@ object CrosswordDecoder {
 
     /** `"1 ACROSS 3 5"` → the clue key and its (row, col) origin, or null if the line is malformed. */
     private fun parseLayoutLine(line: String): Pair<Pair<Int, CrosswordDirection>, Pair<Int, Int>>? {
-        val parts = line.split(" ")
-        if (parts.size != CLUE_LINE_FIELDS) return null
-        val num = parts[0].toIntOrNull() ?: return null
+        val parts = line.split(" ").takeIf { it.size == CLUE_LINE_FIELDS } ?: return null
+        val num = parts[0].toIntOrNull()
         val dir = when (parts[1].uppercase()) {
             "ACROSS" -> CrosswordDirection.ACROSS
             "DOWN" -> CrosswordDirection.DOWN
-            else -> return null
+            else -> null
         }
-        val row = parts[2].toIntOrNull() ?: return null
-        val col = parts[3].toIntOrNull() ?: return null
-        return (num to dir) to (row to col)
+        if (num == null || dir == null) return null
+        val row = parts[2].toIntOrNull()
+        val col = parts[3].toIntOrNull()
+        return if (row != null && col != null) (num to dir) to (row to col) else null
     }
 
     /** `"1. Clue text | ANSWER"` → the clue, or null if the line is malformed or has no answer. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManager.kt
@@ -12,6 +12,7 @@ import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -239,11 +240,14 @@ class SettingsManager {
         return result
     }
 
+    private fun parseSettingsRoot(raw: String): JsonObject? =
+        try { jsonFormat.parseToJsonElement(raw).jsonObject } catch (_: Exception) { null }
+
     /** Schema version 1. Converts old showBible:false/showSongs:false booleans to
      * bibleMode:"off"/songMode:"off" strings. */
     private fun migrateScreenAssignmentModes(raw: String): String {
         if (!raw.contains("\"showBible\"") && !raw.contains("\"showSongs\"")) return raw
-        val root = try { jsonFormat.parseToJsonElement(raw).jsonObject } catch (_: Exception) { return raw }
+        val root = parseSettingsRoot(raw) ?: return raw
         val proj = root["projectionSettings"]?.jsonObject ?: return raw
         val assignments = proj["screenAssignments"]?.jsonArray ?: return raw
         var changed = false
@@ -281,7 +285,7 @@ class SettingsManager {
      * [migrateCompanionSatelliteRowColumnRangeBackToCount].) */
     private fun migrateCompanionSatelliteStartPage(raw: String): String {
         if (!raw.contains("\"companionSatelliteConnections\"")) return raw
-        val root = try { jsonFormat.parseToJsonElement(raw).jsonObject } catch (_: Exception) { return raw }
+        val root = parseSettingsRoot(raw) ?: return raw
         val connections = root["companionSatelliteConnections"]?.jsonArray ?: return raw
         val renames = mapOf("rows" to "tabRows", "columns" to "tabColumns", "bitmapSize" to "tabBitmapSize")
         var changed = false
@@ -317,7 +321,7 @@ class SettingsManager {
      * rows=N — identical count to what was already configured, just without the (unreliable) offset. */
     private fun migrateCompanionSatelliteRowColumnRangeBackToCount(raw: String): String {
         if (!raw.contains("\"companionSatelliteConnections\"")) return raw
-        val root = try { jsonFormat.parseToJsonElement(raw).jsonObject } catch (_: Exception) { return raw }
+        val root = parseSettingsRoot(raw) ?: return raw
         val connections = root["companionSatelliteConnections"]?.jsonArray ?: return raw
         var changed = false
         val rangeKeys = CompanionSurfacePlacementPrefixes.flatMap { prefix ->
@@ -363,7 +367,7 @@ class SettingsManager {
 
     /** Schema version 2. Migrates old screen1-4Assignment fields to screenAssignments list. */
     private fun migrateProjectionSettings(raw: String): String {
-        val root = try { jsonFormat.parseToJsonElement(raw).jsonObject } catch (_: Exception) { return raw }
+        val root = parseSettingsRoot(raw) ?: return raw
         val proj = root["projectionSettings"]?.jsonObject ?: return raw
         if ("screenAssignments" in proj) return raw // already new format
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SongFileParser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SongFileParser.kt
@@ -271,29 +271,22 @@ class SongFileParser {
         }
         private val cacheFile = File(System.getProperty("user.home"), ".churchpresenter/song_cache.json")
 
-        fun loadSongCache(storageDirectory: String): List<SongItem>? {
-            try {
-                if (!cacheFile.exists()) return null
-                val cache = cacheJson.decodeFromString<SongCache>(cacheFile.readText(StandardCharsets.UTF_8))
-                if (cache.storageDirectory != storageDirectory) return null
-                // Prefer cachedSongs (with timestamps); fall back to legacy songs list
-                return if (cache.cachedSongs.isNotEmpty()) cache.cachedSongs.map { it.song }
-                else cache.songs.ifEmpty { null }
-            } catch (_: Exception) {
-                return null
-            }
+        private fun readCacheFor(storageDirectory: String): SongCache? = try {
+            cacheJson.decodeFromString<SongCache>(cacheFile.readText(StandardCharsets.UTF_8))
+                .takeIf { it.storageDirectory == storageDirectory }
+        } catch (_: Exception) {
+            null
         }
 
-        fun loadCachedSongMap(storageDirectory: String): Map<String, CachedSong> {
-            try {
-                if (!cacheFile.exists()) return emptyMap()
-                val cache = cacheJson.decodeFromString<SongCache>(cacheFile.readText(StandardCharsets.UTF_8))
-                if (cache.storageDirectory != storageDirectory) return emptyMap()
-                return cache.cachedSongs.associateBy { it.song.sourceFile }
-            } catch (_: Exception) {
-                return emptyMap()
-            }
+        fun loadSongCache(storageDirectory: String): List<SongItem>? {
+            val cache = readCacheFor(storageDirectory) ?: return null
+            // Prefer cachedSongs (with timestamps); fall back to legacy songs list
+            return if (cache.cachedSongs.isNotEmpty()) cache.cachedSongs.map { it.song }
+            else cache.songs.ifEmpty { null }
         }
+
+        fun loadCachedSongMap(storageDirectory: String): Map<String, CachedSong> =
+            readCacheFor(storageDirectory)?.cachedSongs?.associateBy { it.song.sourceFile } ?: emptyMap()
 
         fun saveSongCache(storageDirectory: String, cachedSongs: List<CachedSong>) {
             try {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Songs.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Songs.kt
@@ -8,6 +8,9 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Paths
 
+private const val SPS_FIELD_SEPARATOR = "#\$#"
+
+private const val SPS_MIN_FIELDS = 6
 
 class Songs {
     private val items = mutableStateListOf<SongItem>()
@@ -295,89 +298,51 @@ class Songs {
     }
 
     fun saveSongToFile(originalSong: SongItem, updatedSong: SongItem, storageDirectory: String): Boolean {
-        try {
-            if (storageDirectory.isEmpty()) {
-                return false
+        if (storageDirectory.isEmpty()) return false
+        val sourceFile = updatedSong.sourceFile.ifEmpty { originalSong.sourceFile }
+        return try {
+            if (sourceFile.isNotEmpty()) {
+                SongFileParser().writeSongFile(updatedSong.copy(sourceFile = sourceFile), sourceFile)
+                true
+            } else {
+                val dir = java.io.File(storageDirectory)
+                val spsFiles = dir.listFiles { file ->
+                    file.extension.lowercase() == Constants.EXTENSION_SPS
+                } ?: emptyArray()
+                spsFiles.any { updateSongInFile(it.absolutePath, originalSong, updatedSong) }
             }
-
-            // If the song has a sourceFile (.song format), save directly to that file
-            if (updatedSong.sourceFile.isNotEmpty()) {
-                val parser = SongFileParser()
-                parser.writeSongFile(updatedSong, updatedSong.sourceFile)
-                return true
-            }
-            if (originalSong.sourceFile.isNotEmpty()) {
-                val parser = SongFileParser()
-                parser.writeSongFile(updatedSong.copy(sourceFile = originalSong.sourceFile), originalSong.sourceFile)
-                return true
-            }
-
-            val dir = java.io.File(storageDirectory)
-            if (!dir.exists() || !dir.isDirectory) {
-                return false
-            }
-
-            val spsFiles = dir.listFiles { file ->
-                file.extension.lowercase() == Constants.EXTENSION_SPS
-            } ?: emptyArray()
-
-            for (file in spsFiles) {
-                if (updateSongInFile(file.absolutePath, originalSong, updatedSong)) {
-                    return true
-                }
-            }
-
-            return false
         } catch (e: Exception) {
-            return false
+            false
         }
     }
 
-    /**
-     * Update a song in a specific .sps file
-     */
-    private fun updateSongInFile(filePath: String, originalSong: SongItem, updatedSong: SongItem): Boolean {
-        try {
-            val path = Paths.get(filePath)
-            if (!Files.exists(path)) {
-                return false
-            }
-
-            val lines = Files.readAllLines(path, StandardCharsets.UTF_8).toMutableList()
-            var songUpdated = false
-
-            for (i in lines.indices) {
-                val line = lines[i]
-
-                if (line.startsWith("##") || line.isBlank()) continue
-
-                val parts = line.split("#\$#")
-                if (parts.size >= 6) {
-                    val number = parts[0]
-                    val title = parts[1]
-
-                    if (number == originalSong.number && title == originalSong.title) {
-                        val lyricsText = formatLyricsForSps(updatedSong.lyrics)
-                        val categoryId = if (parts.size >= 3) parts[2] else ""
-
-                        val updatedLine = "${updatedSong.number}#\$#${updatedSong.title}#\$#$categoryId#\$#${updatedSong.tune}#\$#${updatedSong.author}#\$#${updatedSong.composer}#\$#$lyricsText"
-
-                        lines[i] = updatedLine
-                        songUpdated = true
-                        break
-                    }
-                }
-            }
-
-            if (songUpdated) {
-                Files.write(path, lines, StandardCharsets.UTF_8)
-                return true
-            }
-
-            return false
-        } catch (e: Exception) {
-            return false
+    /** Update a song in a specific .sps file */
+    private fun updateSongInFile(filePath: String, originalSong: SongItem, updatedSong: SongItem): Boolean = try {
+        val path = Paths.get(filePath)
+        val lines = Files.readAllLines(path, StandardCharsets.UTF_8).toMutableList()
+        val index = lines.indexOfFirst { isSpsLineFor(it, originalSong) }
+        if (index >= 0) {
+            lines[index] = spsLineFor(lines[index], updatedSong)
+            Files.write(path, lines, StandardCharsets.UTF_8)
         }
+        index >= 0
+    } catch (e: Exception) {
+        false
+    }
+
+    private fun isSpsLineFor(line: String, song: SongItem): Boolean {
+        if (line.startsWith("##") || line.isBlank()) return false
+        val parts = line.split(SPS_FIELD_SEPARATOR)
+        return parts.size >= SPS_MIN_FIELDS && parts[0] == song.number && parts[1] == song.title
+    }
+
+    private fun spsLineFor(existingLine: String, song: SongItem): String {
+        val parts = existingLine.split(SPS_FIELD_SEPARATOR)
+        val categoryId = parts.getOrElse(2) { "" }
+        val lyricsText = formatLyricsForSps(song.lyrics)
+        return listOf(
+            song.number, song.title, categoryId, song.tune, song.author, song.composer, lyricsText
+        ).joinToString(SPS_FIELD_SEPARATOR)
     }
 
     /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PicturePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PicturePresenter.kt
@@ -154,23 +154,25 @@ private fun ImageContent(currentImagePath: String?) {
     }
 }
 
+private fun decodePictureBytes(file: File): Image? = try {
+    Image.makeFromEncoded(file.readBytes())
+} catch (_: Exception) {
+    // A HEIC/HEIF that Skia cannot read is transcoded to JPEG first
+    if (file.extension.lowercase() in listOf("heic", "heif")) {
+        HeicDecoder.toJpegBytes(file)?.let { jpegBytes ->
+            try { Image.makeFromEncoded(jpegBytes) } catch (_: Exception) { null }
+        }
+    } else {
+        null
+    }
+}
+
 internal fun loadAndDownscaleImage(imagePath: String, maxWidth: Int = 1920, maxHeight: Int = 1080): ImageBitmap? {
     return try {
         val file = File(imagePath)
         if (!file.exists()) return null
 
-        val bytes = file.readBytes()
-
-        val originalImage = try {
-            Image.makeFromEncoded(bytes)
-        } catch (e: Exception) {
-            if (file.extension.lowercase() in listOf("heic", "heif")) {
-                val jpegBytes = HeicDecoder.toJpegBytes(file) ?: return null
-                try {
-                    Image.makeFromEncoded(jpegBytes)
-                } catch (_: Exception) { return null }
-            } else return null
-        }
+        val originalImage = decodePictureBytes(file) ?: return null
 
         // Cap at actual screen resolution — no point storing more pixels than the display can show
         val widthScale = maxWidth.toFloat() / originalImage.width

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/SttDripFeed.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/SttDripFeed.kt
@@ -77,12 +77,14 @@ internal fun reanchorCursor(prevFull: String, prevRevealed: Int, newFull: String
     if (newFull.startsWith(shown)) return revealed
 
     val carriedOver = overlapLength(shown, newFull)
-    if (carriedOver > 0) return carriedOver
-    if (revealed == 0) return 0
-    // Nothing shown survived. If the new caption still picks up where the old one left off, the
-    // window merely scrolled past it and the rest has never been read — reveal it properly.
-    if (overlapLength(prevFull, newFull) > 0) return 0
-    return newFull.length
+    return when {
+        carriedOver > 0 -> carriedOver
+        revealed == 0 -> 0
+        // Nothing shown survived. If the new caption still picks up where the old one left off,
+        // the window merely scrolled past it and the rest has never been read — reveal it properly.
+        overlapLength(prevFull, newFull) > 0 -> 0
+        else -> newFull.length
+    }
 }
 
 /** The largest number of characters by which the tail of [a] and the head of [b] coincide. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemBridge.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemBridge.kt
@@ -45,26 +45,39 @@ internal class AtemBridge(private val json: Json) {
     internal fun jsonStr(s: String): String =
         json.encodeToString(kotlinx.serialization.serializer<String>(), s)
 
+    private data class TriggeredLowerThird(val file: File, val json: String, val durationMs: Long)
+
+    /** The lower third named in the request, or null once the failure has been responded with. */
+    private suspend fun loadTriggeredLowerThird(call: ApplicationCall, rawName: String): TriggeredLowerThird? {
+        val file = lowerThirdFiles().firstOrNull { it.nameWithoutExtension.equals(rawName, ignoreCase = true) }
+        if (file == null) {
+            call.respond(HttpStatusCode.NotFound, """{"error":"lower third not found"}""")
+            return null
+        }
+        val ltJson = runCatching { file.readText() }.getOrNull()
+        val durationMs = ltJson?.let { LottieRenderCache.lottieDurationMs(it) }
+        return when {
+            ltJson == null -> {
+                call.respond(HttpStatusCode.InternalServerError, """{"error":"could not read lottie file"}""")
+                null
+            }
+            durationMs == null -> {
+                call.respond(HttpStatusCode.UnprocessableEntity, """{"error":"lottie has no timing information"}""")
+                null
+            }
+            else -> TriggeredLowerThird(file, ltJson, durationMs)
+        }
+    }
+
     /** Shared body of the run/show endpoints. */
     internal suspend fun handleLowerThirdTrigger(
         call: ApplicationCall,
         autoEnd: Boolean
     ) {
-        val rawName = call.parameters["name"] ?: ""
-        val file = lowerThirdFiles().firstOrNull { it.nameWithoutExtension.equals(rawName, ignoreCase = true) }
-        if (file == null) {
-            call.respond(HttpStatusCode.NotFound, """{"error":"lower third not found"}""")
-            return
-        }
-        val ltJson = try { file.readText() } catch (_: Exception) {
-            call.respond(HttpStatusCode.InternalServerError, """{"error":"could not read lottie file"}""")
-            return
-        }
-        val durationMs = LottieRenderCache.lottieDurationMs(ltJson)
-        if (durationMs == null) {
-            call.respond(HttpStatusCode.UnprocessableEntity, """{"error":"lottie has no timing information"}""")
-            return
-        }
+        val loaded = loadTriggeredLowerThird(call, call.parameters["name"] ?: "") ?: return
+        val file = loaded.file
+        val ltJson = loaded.json
+        val durationMs = loaded.durationMs
         val atem = _atemSettings ?: AtemSettings()
 
         // Key target: USK (M/E + keyer) or DSK (?keytype / setting) from settings;
@@ -155,16 +168,19 @@ internal class AtemBridge(private val json: Json) {
      */
     internal fun validateKeyTarget(atem: AtemSettings, useDsk: Boolean, mixEffect: Int, keyer: Int): String? {
         if (useDsk) {
-            if (atem.detectedDownstreamKeyers > 0 && keyer !in 0 until atem.detectedDownstreamKeyers)
-                return "DSK ${keyer + 1} does not exist (available: 1-${atem.detectedDownstreamKeyers})"
-            return null
+            val unknownDsk = atem.detectedDownstreamKeyers > 0 &&
+                keyer !in 0 until atem.detectedDownstreamKeyers
+            return "DSK ${keyer + 1} does not exist (available: 1-${atem.detectedDownstreamKeyers})"
+                .takeIf { unknownDsk }
         }
-        if (atem.detectedMixEffects > 0 && mixEffect !in 0 until atem.detectedMixEffects)
-            return "M/E ${mixEffect + 1} does not exist (available: 1-${atem.detectedMixEffects})"
         val keyers = atem.detectedKeyersPerMe.getOrNull(mixEffect)
-        if (keyers != null && keyers > 0 && keyer !in 0 until keyers)
-            return "Key ${keyer + 1} does not exist on M/E ${mixEffect + 1} (available: 1-$keyers)"
-        return null
+        return when {
+            atem.detectedMixEffects > 0 && mixEffect !in 0 until atem.detectedMixEffects ->
+                "M/E ${mixEffect + 1} does not exist (available: 1-${atem.detectedMixEffects})"
+            keyers != null && keyers > 0 && keyer !in 0 until keyers ->
+                "Key ${keyer + 1} does not exist on M/E ${mixEffect + 1} (available: 1-$keyers)"
+            else -> null
+        }
     }
 
     /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServer.kt
@@ -77,6 +77,10 @@ import org.churchpresenter.app.churchpresenter.viewmodel.QAManager
  * Data is pushed in via [updateSongs] / [updateSchedule].
  * Song-selection events from mobile arrive via [onSongSelected].
  */
+private const val MAX_UPLOAD_BYTES = 200L * 1024 * 1024
+
+private val UPLOADABLE_EXTENSIONS = setOf("pdf", "ppt", "pptx", "key")
+
 class CompanionServer {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -1032,63 +1036,55 @@ class CompanionServer {
      * Try to parse a [ScheduleItem] from raw JSON using the flat [RemoteItemRequest] format first,
      * then fall back to the legacy sealed-class [AddToScheduleRequest] format.
      */
-    internal fun parseRemoteItem(body: String): ScheduleItem? {
-        // 1. Try flat format: {"item":{"songNumber":42,"title":"…","songbook":"…"}}
-        try {
-            val req = json.decodeFromString(RemoteItemRequest.serializer(), body)
-            val dto = req.item
-            // Handle picture identified by folder-id (companion app format).
-            // folderPath is null in this case — resolve via the cached catalog.
-            if (dto.folderId != null && dto.folderPath == null) {
-                val catalog = pictures.catalogs[dto.folderId]
-                if (catalog != null) {
-                    val safeId = dto.id.ifBlank { java.util.UUID.randomUUID().toString() }
-                    return ScheduleItem.PictureItem(
-                        id         = safeId,
-                        folderPath = catalog.folderPath,
-                        folderName = catalog.folderName,
-                        imageCount = catalog.imageTotal
-                    )
-                }
-            }
-            // Handle presentation identified by id/fileHash (companion app format).
-            // filePath is not sent — resolve via presentations._presentationFilePaths (populated by
-            // updatePresentation and updateSchedule) then fall back to _schedule scan.
-            // NOTE: mobile may omit the "type" field when it equals the default ("presentation"),
-            // so also accept type==null as long as the id resolves in presentations._presentationFilePaths.
-            val looksLikePresentation = dto.type == "presentation" || dto.type == null
-            val noExplicitTarget = dto.filePath == null && dto.folderId == null
-            if (noExplicitTarget && dto.id.isNotBlank() && looksLikePresentation) {
-                val filePath = presentations._presentationFilePaths[dto.id]
-                    ?: _schedule.value.firstOrNull { s ->
-                        s.type == "presentation" && (
-                            s.id == dto.id ||
-                            s.filePath?.hashCode()?.toUInt()?.toString(16) == dto.id
-                        )
-                    }?.filePath
-                if (filePath != null) {
-                    val catalog = presentations._presentationCatalogs[dto.id]
-                    return ScheduleItem.PresentationItem(
-                        id         = java.util.UUID.randomUUID().toString(),
-                        filePath   = filePath,
-                        fileName   = catalog?.fileName ?: dto.title ?: "",
-                        slideCount = catalog?.slideTotal ?: 0,
-                        fileType   = catalog?.fileType ?: ""
-                    )
-                }
-            }
-            val item = dto.toScheduleItem()
-            if (item != null) return item
-        } catch (_: Exception) {
-            // ignore — try legacy format below
-        }
-        // 2. Fall back to legacy sealed-class format with discriminator
-        try {
-            return json.decodeFromString(AddToScheduleRequest.serializer(), body).item
-        } catch (_: Exception) {
-            // ignore
-        }
-        return null
+    internal fun parseRemoteItem(body: String): ScheduleItem? =
+        // 1. flat format: {"item":{"songNumber":42,"title":"…","songbook":"…"}}
+        runCatching { parseFlatRemoteItem(body) }.getOrNull()
+        // 2. legacy sealed-class format with discriminator
+            ?: runCatching { json.decodeFromString(AddToScheduleRequest.serializer(), body).item }.getOrNull()
+
+    private fun parseFlatRemoteItem(body: String): ScheduleItem? {
+        val dto = json.decodeFromString(RemoteItemRequest.serializer(), body).item
+        return pictureItemFor(dto) ?: presentationItemFor(dto) ?: dto.toScheduleItem()
+    }
+
+    // Picture identified by folder-id (companion app format): folderPath is null in that case —
+    // resolve it via the cached catalog.
+    private fun pictureItemFor(dto: RemoteItemDto): ScheduleItem.PictureItem? {
+        if (dto.folderId == null || dto.folderPath != null) return null
+        val catalog = pictures.catalogs[dto.folderId] ?: return null
+        return ScheduleItem.PictureItem(
+            id         = dto.id.ifBlank { java.util.UUID.randomUUID().toString() },
+            folderPath = catalog.folderPath,
+            folderName = catalog.folderName,
+            imageCount = catalog.imageTotal
+        )
+    }
+
+    // Presentation identified by id/fileHash (companion app format): filePath is not sent — resolve
+    // via presentations._presentationFilePaths (populated by updatePresentation and updateSchedule)
+    // then fall back to a _schedule scan.
+    // NOTE: mobile may omit the "type" field when it equals the default ("presentation"), so also
+    // accept type==null as long as the id resolves in presentations._presentationFilePaths.
+    private fun presentationItemFor(dto: RemoteItemDto): ScheduleItem.PresentationItem? {
+        val looksLikePresentation = dto.type == "presentation" || dto.type == null
+        val noExplicitTarget = dto.filePath == null && dto.folderId == null
+        if (!noExplicitTarget || dto.id.isBlank() || !looksLikePresentation) return null
+        val filePath = presentations._presentationFilePaths[dto.id]
+            ?: _schedule.value.firstOrNull { s ->
+                s.type == "presentation" && (
+                    s.id == dto.id ||
+                    s.filePath?.hashCode()?.toUInt()?.toString(16) == dto.id
+                )
+            }?.filePath
+            ?: return null
+        val catalog = presentations._presentationCatalogs[dto.id]
+        return ScheduleItem.PresentationItem(
+            id         = java.util.UUID.randomUUID().toString(),
+            filePath   = filePath,
+            fileName   = catalog?.fileName ?: dto.title ?: "",
+            slideCount = catalog?.slideTotal ?: 0,
+            fileType   = catalog?.fileType ?: ""
+        )
     }
 
     internal suspend fun checkApiKey(call: ApplicationCall): Boolean {
@@ -1138,33 +1134,42 @@ class CompanionServer {
         return approved
     }
 
+    /** The uploaded file's safe name and bytes, or null once the rejection has been responded with. */
+    private suspend fun receiveUploadedFile(call: ApplicationCall): Pair<String, ByteArray>? {
+        val contentLength = call.request.headers["Content-Length"]?.toLongOrNull() ?: 0L
+        if (contentLength > MAX_UPLOAD_BYTES) {
+            call.respond(HttpStatusCode.PayloadTooLarge, """{"error":"file too large (max 200 MB)"}""")
+            return null
+        }
+        val parsed = json.parseToJsonElement(call.receiveText()) as? JsonObject
+        val name   = (parsed?.get("name") as? JsonPrimitive)?.content
+        val data   = (parsed?.get("data") as? JsonPrimitive)?.content
+        if (name.isNullOrBlank() || data.isNullOrBlank()) {
+            call.respond(HttpStatusCode.BadRequest, """{"error":"name and data are required"}""")
+            return null
+        }
+        return decodeUploadedFile(call, name, data)
+    }
+
+    private suspend fun decodeUploadedFile(call: ApplicationCall, name: String, data: String): Pair<String, ByteArray>? {
+        val safeName = File(name).name.ifBlank { "upload.pdf" }
+        val ext = safeName.substringAfterLast('.', "").lowercase()
+        if (ext !in UPLOADABLE_EXTENSIONS) {
+            call.respond(HttpStatusCode.UnsupportedMediaType, """{"error":"unsupported file type: $ext"}""")
+            return null
+        }
+        val base64Match = Regex("^data:[^;]+;base64,(.+)$").find(data)
+        if (base64Match == null) {
+            call.respond(HttpStatusCode.BadRequest, """{"error":"data must be a base64 data URI"}""")
+            return null
+        }
+        return safeName to Base64.getDecoder().decode(base64Match.groupValues[1])
+    }
+
     internal suspend fun handlePresentationFileUpload(call: ApplicationCall) {
         try {
-            val contentLength = call.request.headers["Content-Length"]?.toLongOrNull() ?: 0L
-            if (contentLength > 200 * 1024 * 1024) {
-                call.respond(HttpStatusCode.PayloadTooLarge, """{"error":"file too large (max 200 MB)"}""")
-                return
-            }
-            val body   = call.receiveText()
-            val parsed = json.parseToJsonElement(body) as? JsonObject
-            val name   = (parsed?.get("name") as? JsonPrimitive)?.content
-            val data   = (parsed?.get("data") as? JsonPrimitive)?.content
-            if (name.isNullOrBlank() || data.isNullOrBlank()) {
-                call.respond(HttpStatusCode.BadRequest, """{"error":"name and data are required"}""")
-                return
-            }
-            val safeName = File(name).name.ifBlank { "upload.pdf" }
+            val (safeName, fileBytes) = receiveUploadedFile(call) ?: return
             val ext = safeName.substringAfterLast('.', "").lowercase()
-            if (ext !in setOf("pdf", "ppt", "pptx", "key")) {
-                call.respond(HttpStatusCode.UnsupportedMediaType, """{"error":"unsupported file type: $ext"}""")
-                return
-            }
-            val base64Match = Regex("^data:[^;]+;base64,(.+)$").find(data)
-            if (base64Match == null) {
-                call.respond(HttpStatusCode.BadRequest, """{"error":"data must be a base64 data URI"}""")
-                return
-            }
-            val fileBytes = Base64.getDecoder().decode(base64Match.groupValues[1])
             val uploadDir = File(System.getProperty("user.home"), ".churchpresenter/device_presentations").also { it.mkdirs() }
             val uniqueName = if (File(uploadDir, safeName).exists()) {
                 val ts   = System.currentTimeMillis()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkClient.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
@@ -242,69 +243,54 @@ class InstanceLinkClient(
         else -> "other"
     }
 
-    internal fun handleMessage(raw: String) {
-        val msg = runCatching { json.decodeFromString(WebSocketMessage.serializer(), raw) }.getOrNull()
-        if (msg == null) {
+    /** Decodes one payload, logging the decode failure the follower log expects, or null. */
+    private fun <T> decodePayload(payload: String, context: String, serializer: KSerializer<T>): T? {
+        val decoded = runCatching { json.decodeFromString(serializer, payload) }.getOrNull()
+        if (decoded == null) {
             InstanceLinkLogger.log(
                 InstanceLinkLogSide.FOLLOWER, "ws_message_decode_failed",
-                mapOf("context" to "envelope")
+                mapOf("context" to context)
             )
-            return
         }
+        return decoded
+    }
+
+    internal fun handleMessage(raw: String) {
+        val msg = decodePayload(raw, "envelope", WebSocketMessage.serializer()) ?: return
         InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "ws_message_received", mapOf("type" to msg.type))
         onMessageReceived()
         when (msg.type) {
-            Constants.WS_EVENT_SCHEDULE_UPDATED -> {
-                val response = runCatching { json.decodeFromString(ScheduleResponse.serializer(), msg.payload) }.getOrNull()
-                if (response == null) {
-                    InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "ws_message_decode_failed", mapOf("context" to "schedule"))
-                    return
-                }
-                onScheduleUpdated(response.items)
-            }
-            Constants.WS_EVENT_LIVE_STATE_CHANGED -> {
-                val state = runCatching { json.decodeFromString(LiveStateDto.serializer(), msg.payload) }.getOrNull()
-                if (state == null) {
-                    InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "ws_message_decode_failed", mapOf("context" to "live_state"))
-                    return
-                }
-                onLiveStateUpdated(state)
-            }
-            Constants.WS_EVENT_SONGS_UPDATED -> {
-                val catalog = runCatching { json.decodeFromString(SongCatalogResponse.serializer(), msg.payload) }.getOrNull()
-                if (catalog == null) {
-                    InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "ws_message_decode_failed", mapOf("context" to "song_catalog"))
-                    return
-                }
-                onSongsUpdated(catalog)
-            }
+            Constants.WS_EVENT_SCHEDULE_UPDATED ->
+                decodePayload(msg.payload, "schedule", ScheduleResponse.serializer())
+                    ?.let { onScheduleUpdated(it.items) }
+            Constants.WS_EVENT_LIVE_STATE_CHANGED ->
+                decodePayload(msg.payload, "live_state", LiveStateDto.serializer())
+                    ?.let { onLiveStateUpdated(it) }
+            Constants.WS_EVENT_SONGS_UPDATED ->
+                decodePayload(msg.payload, "song_catalog", SongCatalogResponse.serializer())
+                    ?.let { onSongsUpdated(it) }
             Constants.WS_EVENT_DISPLAY_CLEARED -> onDisplayCleared()
             Constants.WS_EVENT_BIBLE_UPDATED -> onBibleUpdated()
             Constants.WS_EVENT_SECONDARY_BIBLE_UPDATED -> onSecondaryBibleUpdated()
             Constants.WS_EVENT_PICTURES_UPDATED -> onPicturesUpdated()
             Constants.WS_EVENT_BACKGROUNDS_UPDATED -> onBackgroundsUpdated()
-            Constants.WS_EVENT_COMMAND_ACK -> {
-                val ack = runCatching { json.decodeFromString(CommandAckPayload.serializer(), msg.payload) }.getOrNull()
-                if (ack == null) {
-                    InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "ws_message_decode_failed", mapOf("context" to "command_ack"))
-                    return
-                }
-                pendingAcks.remove(ack.commandId)?.complete(ack)
-            }
-            Constants.WS_EVENT_SONG_SECTION_SELECTED -> {
-                val index = msg.payload.toIntOrNull() ?: return
-                onSongSectionSelected(index)
-            }
-            Constants.WS_EVENT_PRESENTATION_SLIDE_CHANGED -> {
-                val obj = runCatching { json.parseToJsonElement(msg.payload).jsonObject }.getOrNull() ?: return
-                val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return
-                val index = obj["index"]?.jsonPrimitive?.intOrNull ?: return
-                val total = obj["total"]?.jsonPrimitive?.intOrNull ?: return
-                val isPlaying = obj["isPlaying"]?.jsonPrimitive?.booleanOrNull ?: false
-                val isLive = obj["isLive"]?.jsonPrimitive?.booleanOrNull ?: false
-                onPresentationSlideChanged(id, index, total, isPlaying, isLive)
-            }
+            Constants.WS_EVENT_COMMAND_ACK ->
+                decodePayload(msg.payload, "command_ack", CommandAckPayload.serializer())
+                    ?.let { ack -> pendingAcks.remove(ack.commandId)?.complete(ack) }
+            Constants.WS_EVENT_SONG_SECTION_SELECTED ->
+                msg.payload.toIntOrNull()?.let { onSongSectionSelected(it) }
+            Constants.WS_EVENT_PRESENTATION_SLIDE_CHANGED -> handlePresentationSlideChanged(msg.payload)
         }
+    }
+
+    private fun handlePresentationSlideChanged(payload: String) {
+        val obj = runCatching { json.parseToJsonElement(payload).jsonObject }.getOrNull() ?: return
+        val id = obj["id"]?.jsonPrimitive?.contentOrNull ?: return
+        val index = obj["index"]?.jsonPrimitive?.intOrNull ?: return
+        val total = obj["total"]?.jsonPrimitive?.intOrNull ?: return
+        val isPlaying = obj["isPlaying"]?.jsonPrimitive?.booleanOrNull ?: false
+        val isLive = obj["isLive"]?.jsonPrimitive?.booleanOrNull ?: false
+        onPresentationSlideChanged(id, index, total, isPlaying, isLive)
     }
 
     /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationStore.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationStore.kt
@@ -124,62 +124,63 @@ internal class PresentationStore(
      * JPEGs are reused directly (any resolution); otherwise the deck is rendered here — into the
      * same shared cache, so a later tab open at the default width hits it too.
      */
+    private fun slidesForServer(file: File): Pair<List<ByteArray>, List<String>>? =
+        slideDiskCache.lookup(file, renderWidthPx = null)
+            ?.let { cached -> cached.slideFiles.map { it.readBytes() } to cached.notes }
+            ?: renderSlidesForServer(file)
+
+    private fun renderSlidesForServer(file: File): Pair<List<ByteArray>, List<String>>? {
+        // The Presentation tab is rendering this very deck into the shared entry. Starting
+        // a second render here would take the entry away from it mid-deck, so leave it be:
+        // the client's 404-retry path comes back once the tab's render has committed.
+        if (slideDiskCache.isWriting(file)) return null
+        val deck = when (val result = PresentationLoader.load(file)) {
+            is LoadResult.Failure -> {
+                CrashReporter.reportWarning(
+                    "Presentation: No slides extracted from ${file.extension.lowercase()} file (server)",
+                    tags = mapOf(
+                        "subsystem" to "presentation",
+                        "file.type" to file.extension.lowercase(),
+                        "failure.reason" to result.error.name.lowercase()
+                    )
+                )
+                return null
+            }
+            is LoadResult.Success -> result.deck
+        }
+        val writer = slideDiskCache.beginWrite(file, deck.format, DeckRasterizer.DEFAULT_TARGET_WIDTH_PX)
+        var committed = false
+        return try {
+            val jpegSlides = CrashReporter.trace("server.render", "Server render presentation") {
+                DeckRasterizer(deck).use { rasterizer ->
+                    deck.slides.map { slide ->
+                        val slideFile = writer.putSlide(
+                            index = slide.index,
+                            image = rasterizer.renderFinalFrame(slide.index),
+                            note = slide.notes,
+                            fidelity = slide.fidelity,
+                            hasTimeline = slide.timeline != null
+                        )
+                        slideFile.readBytes()
+                    }
+                }
+            }
+            writer.commit()
+            committed = true
+            jpegSlides to deck.slides.map { it.notes }
+        } catch (superseded: SlideCacheSupersededException) {
+            // A tab render took the entry over after this one started; it finishes the job.
+            null
+        } finally {
+            if (!committed) writer.abort()
+        }
+    }
+
     internal fun renderPresentationForServer(presentationId: String, filePath: String) {
         val file = File(filePath)
         if (!file.exists()) return
         try {
-            val jpegSlides: List<ByteArray>
-            val notes: List<String>
-            val cached = slideDiskCache.lookup(file, renderWidthPx = null)
-            if (cached != null) {
-                jpegSlides = cached.slideFiles.map { it.readBytes() }
-                notes = cached.notes
-            } else {
-                // The Presentation tab is rendering this very deck into the shared entry. Starting
-                // a second render here would take the entry away from it mid-deck, so leave it be:
-                // the client's 404-retry path comes back once the tab's render has committed.
-                if (slideDiskCache.isWriting(file)) return
-                val deck = when (val result = PresentationLoader.load(file)) {
-                    is LoadResult.Failure -> {
-                        CrashReporter.reportWarning(
-                            "Presentation: No slides extracted from ${file.extension.lowercase()} file (server)",
-                            tags = mapOf(
-                                "subsystem" to "presentation",
-                                "file.type" to file.extension.lowercase(),
-                                "failure.reason" to result.error.name.lowercase()
-                            )
-                        )
-                        return
-                    }
-                    is LoadResult.Success -> result.deck
-                }
-                notes = deck.slides.map { it.notes }
-                val writer = slideDiskCache.beginWrite(file, deck.format, DeckRasterizer.DEFAULT_TARGET_WIDTH_PX)
-                var committed = false
-                try {
-                    jpegSlides = CrashReporter.trace("server.render", "Server render presentation") {
-                        DeckRasterizer(deck).use { rasterizer ->
-                            deck.slides.map { slide ->
-                                val slideFile = writer.putSlide(
-                                    index = slide.index,
-                                    image = rasterizer.renderFinalFrame(slide.index),
-                                    note = slide.notes,
-                                    fidelity = slide.fidelity,
-                                    hasTimeline = slide.timeline != null
-                                )
-                                slideFile.readBytes()
-                            }
-                        }
-                    }
-                    writer.commit()
-                    committed = true
-                } catch (superseded: SlideCacheSupersededException) {
-                    // A tab render took the entry over after this one started; it finishes the job.
-                    return
-                } finally {
-                    if (!committed) writer.abort()
-                }
-            }
+            val (jpegSlides, notes) = slidesForServer(file) ?: return
             if (jpegSlides.isEmpty()) return
             cacheSlideBytes(presentationId, jpegSlides)
             _presentationFilePaths[presentationId] = filePath

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ChordSheetImporter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ChordSheetImporter.kt
@@ -43,16 +43,17 @@ object ChordSheetImporter {
      * themselves come from [SongSectionWords], shared with the parser and the preview's colouring.
      */
     fun sectionMarkerOf(line: String, verseCounter: () -> Int): String? {
+        if (line.isBlank()) return null
         val t = line.trim()
-        if (t.isEmpty()) return null
         // Already in the app's own form — take it as it stands.
         if (ChordTransposer.isSectionHeader(t)) return t
         val group = SongSectionWords.looseGroupOf(t) ?: return null
         val name = SongSectionWords.CANONICAL.getValue(group)
-        if (group == SongSectionWordGroup.CHORUS) return "{$name}"
-        if (group != SongSectionWordGroup.VERSE) return "[$name]"
-        val number = Regex("\\d+").find(t)?.value?.toIntOrNull() ?: verseCounter()
-        return "[$name $number]"
+        return when (group) {
+            SongSectionWordGroup.CHORUS -> "{$name}"
+            SongSectionWordGroup.VERSE -> "[$name ${Regex("\\d+").find(t)?.value?.toIntOrNull() ?: verseCounter()}]"
+            else -> "[$name]"
+        }
     }
 
     /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/UpdateChecker.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/UpdateChecker.kt
@@ -139,20 +139,25 @@ object UpdateChecker {
         }
     }
 
+    /** The installer for the detected OS among the release's assets, or null when it has none. */
+    private fun installerUrl(obj: JsonObject): String? {
+        val assets = obj["assets"]?.jsonArray ?: return null
+        return selectDownloadUrl(
+            assets.mapNotNull { it.jsonObject["browser_download_url"]?.jsonPrimitive?.contentOrNull }
+        )
+    }
+
     /**
      * The release as an [UpdateInfo], or null when it is a draft, a pre-release the caller does not
      * want, or carries no installer for the detected OS.
      */
     private fun installableRelease(obj: JsonObject, includePrereleases: Boolean): UpdateInfo? {
         if (obj["draft"]?.jsonPrimitive?.booleanOrNull == true) return null
+        val downloadUrl = installerUrl(obj) ?: return null
+        val latestVersion = obj["tag_name"]?.jsonPrimitive?.contentOrNull?.removePrefix("v") ?: return null
+
         val isPrerelease = obj["prerelease"]?.jsonPrimitive?.booleanOrNull == true
         if (isPrerelease && !includePrereleases) return null
-
-        val urls = (obj["assets"]?.jsonArray ?: return null)
-            .mapNotNull { it.jsonObject["browser_download_url"]?.jsonPrimitive?.contentOrNull }
-        val downloadUrl = selectDownloadUrl(urls) ?: return null
-        val latestVersion = (obj["tag_name"]?.jsonPrimitive?.contentOrNull ?: return null)
-            .removePrefix("v")
 
         return UpdateInfo(
             latestVersion = latestVersion,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/WindowsWindowCapture.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/WindowsWindowCapture.kt
@@ -70,13 +70,13 @@ object WindowsWindowCapture {
     }
 
     internal fun getWindowBoundsWith(user32: User32, hwnd: Long): Rectangle? {
-        return try {
+        return runCatching {
             val hwndPtr = WinDef.HWND(Pointer(hwnd))
             val rect = WinDef.RECT()
             if (user32.GetWindowRect(hwndPtr, rect)) {
                 rectToBounds(rect.left, rect.top, rect.right, rect.bottom)
             } else null
-        } catch (_: Throwable) { null }
+        }.getOrNull()
     }
 
     fun captureWindow(hwnd: Long): BufferedImage? {
@@ -85,46 +85,55 @@ object WindowsWindowCapture {
     }
 
     internal fun captureWindowWith(user32: User32, gdi32: GDI32, hwnd: Long): BufferedImage? {
-        return try {
+        return runCatching {
             val hwndPtr = WinDef.HWND(Pointer(hwnd))
             val rect = WinDef.RECT()
-            if (!user32.GetWindowRect(hwndPtr, rect)) return null
+            if (!user32.GetWindowRect(hwndPtr, rect)) null
+            else printWindowToImage(
+                user32, gdi32, hwndPtr,
+                width = rect.right - rect.left,
+                height = rect.bottom - rect.top
+            )
+        }.getOrNull()
+    }
 
-            val width = rect.right - rect.left
-            val height = rect.bottom - rect.top
-            if (width <= 0 || height <= 0) return null
+    private fun printWindowToImage(
+        user32: User32,
+        gdi32: GDI32,
+        hwndPtr: WinDef.HWND,
+        width: Int,
+        height: Int
+    ): BufferedImage? {
+        if (width <= 0 || height <= 0) return null
+        val hdcWindow = user32.GetDC(hwndPtr) ?: return null
 
-            val hdcWindow = user32.GetDC(hwndPtr)
-            if (hdcWindow == null) return null
+        val hdcMem = gdi32.CreateCompatibleDC(hdcWindow)
+        val hBitmap = gdi32.CreateCompatibleBitmap(hdcWindow, width, height)
+        val hOld = gdi32.SelectObject(hdcMem, hBitmap)
 
-            val hdcMem = gdi32.CreateCompatibleDC(hdcWindow)
-            val hBitmap = gdi32.CreateCompatibleBitmap(hdcWindow, width, height)
-            val hOld = gdi32.SelectObject(hdcMem, hBitmap)
+        // PrintWindow with PW_RENDERFULLCONTENT (0x2) for occluded capture
+        user32.PrintWindow(hwndPtr, hdcMem, 2)
 
-            // PrintWindow with PW_RENDERFULLCONTENT (0x2) for occluded capture
-            user32.PrintWindow(hwndPtr, hdcMem, 2)
+        // Read pixels from bitmap
+        val bmi = WinGDI.BITMAPINFO()
+        bmi.bmiHeader.biSize = bmi.bmiHeader.size()
+        bmi.bmiHeader.biWidth = width
+        bmi.bmiHeader.biHeight = -height // top-down
+        bmi.bmiHeader.biPlanes = 1
+        bmi.bmiHeader.biBitCount = 32
+        bmi.bmiHeader.biCompression = WinGDI.BI_RGB
 
-            // Read pixels from bitmap
-            val bmi = WinGDI.BITMAPINFO()
-            bmi.bmiHeader.biSize = bmi.bmiHeader.size()
-            bmi.bmiHeader.biWidth = width
-            bmi.bmiHeader.biHeight = -height // top-down
-            bmi.bmiHeader.biPlanes = 1
-            bmi.bmiHeader.biBitCount = 32
-            bmi.bmiHeader.biCompression = WinGDI.BI_RGB
+        val bufferSize = width.toLong() * height * 4
+        val buffer = Memory(bufferSize)
+        gdi32.GetDIBits(hdcMem, hBitmap, 0, height, buffer, bmi, WinGDI.DIB_RGB_COLORS)
 
-            val bufferSize = width.toLong() * height * 4
-            val buffer = Memory(bufferSize)
-            gdi32.GetDIBits(hdcMem, hBitmap, 0, height, buffer, bmi, WinGDI.DIB_RGB_COLORS)
+        // Cleanup GDI objects
+        gdi32.SelectObject(hdcMem, hOld)
+        gdi32.DeleteObject(hBitmap)
+        gdi32.DeleteDC(hdcMem)
+        user32.ReleaseDC(hwndPtr, hdcWindow)
 
-            // Cleanup GDI objects
-            gdi32.SelectObject(hdcMem, hOld)
-            gdi32.DeleteObject(hBitmap)
-            gdi32.DeleteDC(hdcMem)
-            user32.ReleaseDC(hwndPtr, hdcWindow)
-
-            bgraBufferToImage(buffer, width, height)
-        } catch (_: Throwable) { null }
+        return bgraBufferToImage(buffer, width, height)
     }
 
     internal fun rectToBounds(left: Int, top: Int, right: Int, bottom: Int): Rectangle =

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/X11WindowCapture.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/X11WindowCapture.kt
@@ -129,7 +129,7 @@ object X11WindowCapture {
         redirected: MutableSet<Long> = redirectedWindows,
     ): BufferedImage? {
         val wid = NativeLong(windowId)
-        return try {
+        return runCatching {
             // Redirect window to off-screen pixmap if not already
             if (windowId !in redirected) {
                 lib.XCompositeRedirectWindow(dpy, wid, CompositeRedirectAutomatic)
@@ -139,27 +139,26 @@ object X11WindowCapture {
             // Get window attributes for size
             val attrs = XWindowAttributes()
             lib.XGetWindowAttributes(dpy, wid, attrs)
-            val w = attrs.width
-            val h = attrs.height
-            if (w <= 0 || h <= 0) return null
+            capturePixmap(lib, dpy, wid, attrs.width, attrs.height)
+        }.getOrNull()
+    }
 
-            // Get the composite pixmap
-            val pixmap = lib.XCompositeNameWindowPixmap(dpy, wid)
-            if (pixmap.toLong() == 0L) return null
+    private fun capturePixmap(lib: X11, dpy: Pointer, wid: NativeLong, w: Int, h: Int): BufferedImage? {
+        if (w <= 0 || h <= 0) return null
 
-            // Read pixels from the pixmap
-            val allPlanes = NativeLong(-1L)
-            val imagePtr = lib.XGetImage(dpy, pixmap, 0, 0, w, h, allPlanes, ZPixmap)
-            lib.XFreePixmap(dpy, pixmap)
+        // Get the composite pixmap
+        val pixmap = lib.XCompositeNameWindowPixmap(dpy, wid)
+        if (pixmap.toLong() == 0L) return null
 
-            if (imagePtr == null) return null
+        // Read pixels from the pixmap
+        val allPlanes = NativeLong(-1L)
+        val imagePtr = lib.XGetImage(dpy, pixmap, 0, 0, w, h, allPlanes, ZPixmap)
+        lib.XFreePixmap(dpy, pixmap)
+        if (imagePtr == null) return null
 
-            val img = ximageToImage(lib, imagePtr, w, h)
-            lib.XDestroyImage(imagePtr)
-            img
-        } catch (_: Throwable) {
-            null
-        }
+        val img = ximageToImage(lib, imagePtr, w, h)
+        lib.XDestroyImage(imagePtr)
+        return img
     }
 
     internal fun ximageToImage(lib: X11, imagePtr: Pointer, w: Int, h: Int): BufferedImage {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClient.kt
@@ -213,23 +213,23 @@ class BibleEngineClient(
 
     private fun handleMessage(raw: String) {
         val obj = runCatching { JSONObject(raw) }.getOrNull() ?: return
-        val type = obj.optString("type")
-        if (type == "engine_status") {
-            // The engine's real upstream STT health (broadcast on transitions and replayed to
-            // late joiners). sttConfigured=false means a deliberate WS-input-only engine — treat
-            // its STT link as fine so the UI doesn't flag a non-error.
-            val configured = obj.optBoolean("sttConfigured", true)
-            _engineSttConnected.value = if (!configured) true else obj.optBoolean("sttConnected", false)
-            return
-        }
-        if (type == "version_detected") {
-            onVersion(
+        when (val type = obj.optString("type")) {
+            "engine_status" -> {
+                // The engine's real upstream STT health (broadcast on transitions and replayed to
+                // late joiners). sttConfigured=false means a deliberate WS-input-only engine — treat
+                // its STT link as fine so the UI doesn't flag a non-error.
+                val configured = obj.optBoolean("sttConfigured", true)
+                _engineSttConnected.value = if (!configured) true else obj.optBoolean("sttConnected", false)
+            }
+            "version_detected" -> onVersion(
                 if (obj.isNull("version")) null
                 else obj.optString("version").takeIf { it.isNotEmpty() }
             )
-            return
+            else -> if (type.startsWith("scripture.")) handleScripture(obj)
         }
-        if (!type.startsWith("scripture.")) return
+    }
+
+    private fun handleScripture(obj: JSONObject) {
         val ref = obj.optJSONObject("reference") ?: return
         val bookId = ref.optInt("bookId", -1)
         if (bookId < 0) return

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
@@ -27,6 +27,7 @@ import java.io.File
 import org.churchpresenter.app.churchpresenter.data.settings.BibleSyncMode
 
 private const val MAX_HISTORY_ENTRIES = 50
+private const val ASCII_LIMIT = 128
 
 class BibleViewModel(
     internal var appSettings: AppSettings,
@@ -591,7 +592,7 @@ class BibleViewModel(
     }
 
     private fun booksNamedInEnglish(query: String): List<String> {
-        if (!query.all { it.isLetter() && it.code < 128 }) return emptyList()
+        if (!query.all { it.isLetter() && it.code < ASCII_LIMIT }) return emptyList()
         val bible = _primaryBible.value ?: return emptyList()
         return STANDARD_ENGLISH_BOOKS
             .mapIndexedNotNull { index, englishName ->

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModel.kt
@@ -582,43 +582,21 @@ class BibleViewModel(
 
     fun getFilteredBooks(): List<String> {
         val query = _bookSearchQuery.value
+        if (query.isEmpty()) return _books.value
 
-        if (query.isEmpty()) {
-            return _books.value
-        }
+        return _books.value.filter { it.contains(query, ignoreCase = true) }
+            .ifEmpty { booksNamedInEnglish(query) }
+    }
 
-        val directMatch = _books.value.filter {
-            it.contains(query, ignoreCase = true)
-        }
-
-        if (directMatch.isNotEmpty()) {
-            return directMatch
-        }
-
-        val isLatin = query.all { it.isLetter() && it.code < 128 }
-
-        if (!isLatin) {
-            return emptyList()
-        }
-
-        val matchingBookIds = STANDARD_ENGLISH_BOOKS.mapIndexedNotNull { index, englishName ->
-            if (englishName.contains(query, ignoreCase = true)) {
-                index + 1
-            } else {
-                null
+    private fun booksNamedInEnglish(query: String): List<String> {
+        if (!query.all { it.isLetter() && it.code < 128 }) return emptyList()
+        val bible = _primaryBible.value ?: return emptyList()
+        return STANDARD_ENGLISH_BOOKS
+            .mapIndexedNotNull { index, englishName ->
+                (index + 1).takeIf { englishName.contains(query, ignoreCase = true) }
             }
-        }
-
-        if (matchingBookIds.isEmpty()) {
-            return emptyList()
-        }
-
-        val bible = _primaryBible.value
-        val mappedResults = matchingBookIds.mapNotNull { bookId ->
-            bible?.getBookName(bookId)
-        }.filter { it in _books.value }
-
-        return mappedResults
+            .mapNotNull { bookId -> bible.getBookName(bookId) }
+            .filter { it in _books.value }
     }
 
     fun getFilteredChapters(): List<String> {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelSelection.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelSelection.kt
@@ -1,6 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
 import kotlinx.coroutines.flow.first
+import org.churchpresenter.app.churchpresenter.data.Bible
 import org.churchpresenter.app.churchpresenter.models.SelectedVerse
 
 /**
@@ -155,18 +156,23 @@ internal fun BibleViewModel.getNextVerses(): List<SelectedVerse> {
         return buildNextVerseList(bookId, _selectedChapter.value, verseNumber, verseTextOf(verse))
     }
 
+    return firstVersesOfNextChapter()
+}
+
+private fun BibleViewModel.firstVersesOfNextChapter(): List<SelectedVerse> {
     val bible = _primaryBible.value ?: return emptyList()
-    var nextBookIndex = _selectedBookIndex.value
-    var nextChapter = _selectedChapter.value + 1
-    if (nextChapter > bible.getChapterCount(nextBookIndex)) {
-        nextBookIndex += 1
-        nextChapter = 1
-        if (nextBookIndex >= _books.value.size) return emptyList()
-    }
+    val (nextBookIndex, nextChapter) = nextChapterPosition(bible) ?: return emptyList()
     val nextBookId = bible.getBookId(nextBookIndex)
     val firstVerse = bible.getChapter(nextBookId, nextChapter).verses.firstOrNull() ?: return emptyList()
     val verseNumber = verseNumberOf(firstVerse) ?: return emptyList()
     return buildNextVerseList(nextBookId, nextChapter, verseNumber, verseTextOf(firstVerse))
+}
+
+private fun BibleViewModel.nextChapterPosition(bible: Bible): Pair<Int, Int>? {
+    val bookIndex = _selectedBookIndex.value
+    val chapter = _selectedChapter.value + 1
+    if (chapter <= bible.getChapterCount(bookIndex)) return bookIndex to chapter
+    return (bookIndex + 1).takeIf { it < _books.value.size }?.let { it to 1 }
 }
 
 internal fun BibleViewModel.buildNextVerseList(bookId: Int, chapter: Int, verseNumber: Int, verseText: String): List<SelectedVerse> {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelSmartSearch.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelSmartSearch.kt
@@ -67,11 +67,12 @@ internal fun BibleViewModel.resolveBook(token: String): Int = rankedBookMatches(
 internal fun BibleViewModel.resolveBookForLiveNav(token: String): Int {
     val norm = token.trim().lowercase()
     if (norm.isEmpty()) return -1
-    _books.value.indexOfFirst { it.lowercase() == norm }.takeIf { it >= 0 }?.let { return it }
+    val exact = _books.value.indexOfFirst { it.lowercase() == norm }
+    if (exact >= 0) return exact
     val ranked = rankedBookMatches(token)
-    val top = ranked.firstOrNull() ?: return -1
-    val topCount = ranked.count { it.second == top.second }
-    return if (topCount == 1) top.first else -1
+    val top = ranked.firstOrNull()
+    val topCount = ranked.count { it.second == top?.second }
+    return if (top != null && topCount == 1) top.first else -1
 }
 
 internal fun BibleViewModel.parseReference(input: String): SmartReference? {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManager.kt
@@ -450,7 +450,7 @@ class STTManager {
             .GET()
             .build()
         val statusResponse = client.send(statusRequest, HttpResponse.BodyHandlers.ofString())
-        if (statusResponse.statusCode() != 200) return null
+        if (statusResponse.statusCode() != HTTP_OK) return null
         return JSONObject(statusResponse.body()).optJSONObject("state")?.stringOrNull("db_name")
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManager.kt
@@ -424,14 +424,7 @@ class STTManager {
         TrainingDataLogger.cleanupOldLogsOnce()
 
         val client = HttpClient.newHttpClient()
-        val statusRequest = HttpRequest.newBuilder()
-            .uri(URI.create("$baseUrl/api/transcription/status"))
-            .GET()
-            .build()
-        val statusResponse = client.send(statusRequest, HttpResponse.BodyHandlers.ofString())
-        if (statusResponse.statusCode() != 200) return
-        val state = JSONObject(statusResponse.body()).optJSONObject("state") ?: return
-        val dbName = state.stringOrNull("db_name") ?: return
+        val dbName = remoteDbName(client, baseUrl) ?: return
 
         val encodedPath = URLEncoder.encode(dbName, "UTF-8")
         val downloadRequest = HttpRequest.newBuilder()
@@ -446,6 +439,16 @@ class STTManager {
         val tmp = File(logDir, "${target.name}.tmp")
         tmp.writeBytes(downloadResponse.body())
         Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+    }
+
+    private fun remoteDbName(client: HttpClient, baseUrl: String): String? {
+        val statusRequest = HttpRequest.newBuilder()
+            .uri(URI.create("$baseUrl/api/transcription/status"))
+            .GET()
+            .build()
+        val statusResponse = client.send(statusRequest, HttpResponse.BodyHandlers.ofString())
+        if (statusResponse.statusCode() != 200) return null
+        return JSONObject(statusResponse.body()).optJSONObject("state")?.stringOrNull("db_name")
     }
 
     fun dispose() {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -21,7 +21,9 @@ style:
   MagicNumber:
     active: false
   ReturnCount:
-    active: false
+    active: true
+    max: 3
+    excludeGuardClauses: true
   LoopWithTooManyJumpStatements:
     active: false
   UnusedPrivateMember:


### PR DESCRIPTION
Large refactor across server, media, parsing and viewmodel code to improve error handling, reduce duplication and clarify control flow.

Highlights:
- Extracted helpers and simplified guards (StageMonitorScreen, LoopingVideoBackground, VideoPlayer vlc detection).
- Improved browser/CDP lifecycle with connectCdp/openCdpWebSocket and clearer failure paths (SharedBrowserFrameCache).
- Safer .sps handling: constants for field separator/min fields and streamlined update/write logic (Songs, SongFileParser).
- Robust picture loading with HEIC→JPEG fallback helper (PicturePresenter).
- Server improvements: lower-third loading/validation extraction and clearer error responses (AtemBridge); upload parsing, size/type checks and Base64 decoding (CompanionServer); parseRemoteItem split into helpers for picture/presentation handling.
- Resilient InstanceLinkClient message decoding with generic decodePayload and small handler extraction.
- PresentationStore: unified slide lookup/render paths (slidesForServer/renderSlidesForServer) and cleaner commit/abort handling.
- Various small refactors and safety fixes: Crossword adjacency logic, window-capture helpers for Windows/X11, STT/remote-db helper, Bible viewmodel/search refinements, STT drip-feed logic, ChordSheetImporter simplification.
- Enabled ReturnCount rule in detekt with max=3 (exclude guard clauses).

Overall intent: reduce nested error handling, centralize decoding/validation, and make flows easier to read and maintain.