### PR TITLE
Extract helpers to reduce cyclomatic complexity - CyclomaticComplexMe…

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
@@ -393,100 +393,117 @@ object SharedBrowserFrameCache {
         cdp.onUrlChanged = { url -> entry.currentUrl.value = url }
         System.err.println("[BrowserSource] WebSocket connected")
 
-        // Configure viewport and transparency
-        var resp = cdp.sendAsync("Emulation.setDeviceMetricsOverride", buildJsonObject {
-            put("width", renderWidth)
-            put("height", renderHeight)
-            put("deviceScaleFactor", 1)
-            put("mobile", false)
-        })
-        System.err.println("[BrowserSource] setDeviceMetricsOverride: $resp")
+        configurePage(cdp, url, renderWidth, renderHeight, customCss, forceTransparent)
+        runCaptureLoop(entry, cdp, fps)
+    }
 
-        if (forceTransparent) {
-            resp = cdp.sendAsync("Emulation.setDefaultBackgroundColorOverride", buildJsonObject {
-                put("color", buildJsonObject {
-                    put("r", 0)
-                    put("g", 0)
-                    put("b", 0)
-                    put("a", 0)
-                })
+    /** Viewport, transparency and navigation for a freshly connected page. */
+    private suspend fun configurePage(
+        cdp: CdpConnection,
+        url: String,
+        renderWidth: Int,
+        renderHeight: Int,
+        customCss: String,
+        forceTransparent: Boolean,
+    ) {
+    // Configure viewport and transparency
+    var resp = cdp.sendAsync("Emulation.setDeviceMetricsOverride", buildJsonObject {
+        put("width", renderWidth)
+        put("height", renderHeight)
+        put("deviceScaleFactor", 1)
+        put("mobile", false)
+    })
+    System.err.println("[BrowserSource] setDeviceMetricsOverride: $resp")
+
+    if (forceTransparent) {
+        resp = cdp.sendAsync("Emulation.setDefaultBackgroundColorOverride", buildJsonObject {
+            put("color", buildJsonObject {
+                put("r", 0)
+                put("g", 0)
+                put("b", 0)
+                put("a", 0)
             })
-            System.err.println("[BrowserSource] setDefaultBackgroundColorOverride: $resp")
+        })
+        System.err.println("[BrowserSource] setDefaultBackgroundColorOverride: $resp")
+    }
+
+    cdp.sendAsync("Page.enable", null)
+
+    // Navigate to the URL
+    if (url.isNotBlank()) {
+        resp = cdp.sendAsync("Page.navigate", buildJsonObject { put("url", url) })
+        System.err.println("[BrowserSource] Page.navigate($url): $resp")
+
+        // Wait for page to load
+        delay(PAGE_LOAD_SETTLE_MS)
+
+        // Inject transparency CSS
+        if (forceTransparent) {
+            cdp.sendAsync("Runtime.evaluate", buildJsonObject {
+                put("expression", "document.documentElement.style.background='transparent';document.body.style.background='transparent';")
+            })
         }
-
-        cdp.sendAsync("Page.enable", null)
-
-        // Navigate to the URL
-        if (url.isNotBlank()) {
-            resp = cdp.sendAsync("Page.navigate", buildJsonObject { put("url", url) })
-            System.err.println("[BrowserSource] Page.navigate($url): $resp")
-
-            // Wait for page to load
-            delay(PAGE_LOAD_SETTLE_MS)
-
-            // Inject transparency CSS
-            if (forceTransparent) {
-                cdp.sendAsync("Runtime.evaluate", buildJsonObject {
-                    put("expression", "document.documentElement.style.background='transparent';document.body.style.background='transparent';")
-                })
-            }
-            if (customCss.isNotBlank()) {
-                cdp.sendAsync("Runtime.evaluate", buildJsonObject {
-                    put("expression", "var s=document.createElement('style');s.textContent='${escapeForJsStringLiteral(customCss)}';document.head.appendChild(s);")
-                })
-            }
+        if (customCss.isNotBlank()) {
+            cdp.sendAsync("Runtime.evaluate", buildJsonObject {
+                put("expression", "var s=document.createElement('style');s.textContent='${escapeForJsStringLiteral(customCss)}';document.head.appendChild(s);")
+            })
         }
+    }
 
-        // Start capture loop
-        entry.captureIntervalMs = (MILLIS_PER_SECOND / fps.coerceIn(MIN_FPS, MAX_FPS)).coerceAtLeast(MIN_STARTUP_CAPTURE_INTERVAL_MS)
-        System.err.println("[BrowserSource] Starting capture loop at ${fps}fps")
+    }
 
-        var frameCount = 0
-        while (currentCoroutineContext().isActive) {
-            try {
-                val response = cdp.sendAsync("Page.captureScreenshot", buildJsonObject {
-                    put("format", "png")
-                })
+    /** Screenshots the page at [fps] into the entry until the coroutine is cancelled. */
+    private suspend fun runCaptureLoop(entry: CacheEntry, cdp: CdpConnection, fps: Int) {
+    // Start capture loop
+    entry.captureIntervalMs = (MILLIS_PER_SECOND / fps.coerceIn(MIN_FPS, MAX_FPS)).coerceAtLeast(MIN_STARTUP_CAPTURE_INTERVAL_MS)
+    System.err.println("[BrowserSource] Starting capture loop at ${fps}fps")
 
-                val data = response?.get("data")?.jsonPrimitive?.contentOrNull
-                if (data == null) {
-                    if (frameCount == 0) {
-                        if (response == null) {
-                            System.err.println("[BrowserSource] captureScreenshot returned null")
-                        } else {
-                            System.err.println(
-                                "[BrowserSource] captureScreenshot response has no 'data': ${response.keys}"
-                            )
-                        }
+    var frameCount = 0
+    while (currentCoroutineContext().isActive) {
+        try {
+            val response = cdp.sendAsync("Page.captureScreenshot", buildJsonObject {
+                put("format", "png")
+            })
+
+            val data = response?.get("data")?.jsonPrimitive?.contentOrNull
+            if (data == null) {
+                if (frameCount == 0) {
+                    if (response == null) {
+                        System.err.println("[BrowserSource] captureScreenshot returned null")
+                    } else {
+                        System.err.println(
+                            "[BrowserSource] captureScreenshot response has no 'data': ${response.keys}"
+                        )
+                    }
+                }
+            } else {
+                val pngBytes = withContext(Dispatchers.IO) {
+                    Base64.getDecoder().decode(data)
+                }
+                val img = withContext(Dispatchers.IO) {
+                    ImageIO.read(ByteArrayInputStream(pngBytes))
+                }
+                if (img != null) {
+                    entry.frame.value = img.toComposeImageBitmap()
+                    frameCount++
+                    if (frameCount == 1) {
+                        System.err.println("[BrowserSource] First frame captured: ${img.width}x${img.height}")
                     }
                 } else {
-                    val pngBytes = withContext(Dispatchers.IO) {
-                        Base64.getDecoder().decode(data)
+                    if (frameCount == 0) {
+                        System.err.println("[BrowserSource] ImageIO.read returned null (${pngBytes.size} bytes)")
                     }
-                    val img = withContext(Dispatchers.IO) {
-                        ImageIO.read(ByteArrayInputStream(pngBytes))
-                    }
-                    if (img != null) {
-                        entry.frame.value = img.toComposeImageBitmap()
-                        frameCount++
-                        if (frameCount == 1) {
-                            System.err.println("[BrowserSource] First frame captured: ${img.width}x${img.height}")
-                        }
-                    } else {
-                        if (frameCount == 0) {
-                            System.err.println("[BrowserSource] ImageIO.read returned null (${pngBytes.size} bytes)")
-                        }
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                if (frameCount == 0) {
-                    System.err.println("[BrowserSource] Capture error: ${e.message}")
                 }
             }
-            delay(entry.captureIntervalMs)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            if (frameCount == 0) {
+                System.err.println("[BrowserSource] Capture error: ${e.message}")
+            }
         }
+        delay(entry.captureIntervalMs)
+    }
     }
 
     private suspend fun waitForCdpReady(port: Int, timeoutMs: Long): Boolean {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -19,6 +19,7 @@ import org.churchpresenter.app.churchpresenter.utils.CrashReporter
 
 private const val MAX_NULL_FRAMES_BEFORE_CLEAR = 30
 private const val DECKLINK_POLL_INTERVAL_MS = 16L
+private const val STDERR_TAIL_LINES = 50
 private const val MAX_CONSECUTIVE_FAILURES = 5
 private const val DEVICE_RELEASE_DELAY_MS = 500L
 private const val RETRY_DELAY_MS = 2000L
@@ -192,6 +193,118 @@ object SharedCameraFrameCache {
 
     // ── FFmpeg capture ──────────────────────────────────────────────
 
+
+    /**
+     * Reads raw BGRA frames off a running ffmpeg into [entry] until the stream ends. True when at
+     * least one frame arrived, which is what tells a dropped stream apart from a device that never
+     * opened.
+     */
+    private suspend fun streamFrames(process: Process, entry: CacheEntry): Boolean {
+        entry.ffmpegProcess = process
+
+        // Drain stderr and extract video dimensions from ffmpeg output
+        val stderrLines = mutableListOf<String>()
+        val videoDims = java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>(null)
+        val stderrJob = CoroutineScope(currentCoroutineContext()).launch(Dispatchers.IO) {
+            try {
+                process.errorStream.bufferedReader().useLines { lines ->
+                    lines.forEach { line ->
+                        synchronized(stderrLines) {
+                            stderrLines.add(line)
+                            if (stderrLines.size > STDERR_TAIL_LINES) stderrLines.removeAt(0)
+                        }
+                        if (videoDims.get() == null) {
+                            parseFfmpegVideoDimensions(line)?.let { videoDims.set(it) }
+                        }
+                    }
+                }
+            } catch (_: Throwable) {}
+        }
+
+        val resolved = awaitVideoDimensions(videoDims)
+        if (resolved == null) {
+            System.err.println("[Camera] Could not determine video dimensions from ffmpeg")
+            stderrJob.cancel()
+            withContext(Dispatchers.IO) { killFfmpegProcess(process) }
+            entry.ffmpegProcess = null
+            return false
+        }
+
+        val (videoW, videoH) = resolved
+        val frameCount = readFramesInto(process, entry, videoW, videoH)
+
+        // Stream ended — clean up this process
+        stderrJob.cancel()
+        val exitCode = withContext(Dispatchers.IO) {
+            try {
+                killFfmpegProcess(process)
+                process.exitValue()
+            } catch (_: Throwable) { -1 }
+        }
+        entry.ffmpegProcess = null
+
+        if (frameCount > 0) {
+            System.err.println("[Camera] Stream interrupted after $frameCount frames (exit $exitCode), restarting...")
+        } else {
+            System.err.println("[Camera] ffmpeg exited with code $exitCode without producing any frames")
+            synchronized(stderrLines) {
+                stderrLines.forEach { System.err.println("[Camera] ffmpeg stderr: $it") }
+            }
+        }
+        return frameCount > 0
+    }
+
+    /** Waits up to five seconds for ffmpeg to announce the stream's size. */
+    private suspend fun awaitVideoDimensions(
+        videoDims: java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>,
+    ): Pair<Int, Int>? {
+        repeat(DIMENSION_POLL_ATTEMPTS) {
+            videoDims.get()?.let { return it }
+            delay(DIMENSION_POLL_INTERVAL_MS)
+        }
+        return videoDims.get()
+    }
+
+    /** Frames read into [entry] until the stream stops; the count is the caller's success signal. */
+    private suspend fun readFramesInto(process: Process, entry: CacheEntry, videoW: Int, videoH: Int): Int {
+        val frameBytes = videoW * videoH * 4  // BGRA = 4 bytes per pixel
+        System.err.println("[Camera] Capturing ${videoW}x${videoH} rawvideo BGRA ($frameBytes bytes/frame)")
+
+        val inputStream = java.io.BufferedInputStream(process.inputStream, frameBytes * 2)
+        val frameBuf = ByteArray(frameBytes)
+        val pixelBuf = IntArray(videoW * videoH)
+        var frameCount = 0
+
+        while (currentCoroutineContext().isActive) {
+            val ok = withContext(Dispatchers.IO) { readFullFrame(inputStream, frameBuf, frameBytes) }
+            if (!ok) break
+
+            withContext(Dispatchers.IO) { bgraBytesToArgbPixels(frameBuf, pixelBuf) }
+
+            val img = java.awt.image.BufferedImage(videoW, videoH, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+            img.setRGB(0, 0, videoW, videoH, pixelBuf, 0, videoW)
+            entry.frame.value = img.toComposeImageBitmap()
+            frameCount++
+            if (frameCount == 1) {
+                System.err.println("[Camera] First frame received (${videoW}x${videoH})")
+            }
+        }
+        return frameCount
+    }
+
+    private fun readFullFrame(inputStream: java.io.InputStream, frameBuf: ByteArray, frameBytes: Int): Boolean =
+        try {
+            var read = 0
+            var endOfStream = false
+            while (read < frameBytes && !endOfStream) {
+                val r = inputStream.read(frameBuf, read, frameBytes - read)
+                if (r == -1) endOfStream = true else read += r
+            }
+            !endOfStream
+        } catch (_: Throwable) {
+            false
+        }
+
     private suspend fun runFfmpegCapture(source: SceneSource.CameraSource, entry: CacheEntry) {
         val path = source.devicePath
         System.err.println("[Camera] Starting camera capture for device: $path, format: ${source.videoFormat.ifEmpty { "auto" }}")
@@ -228,101 +341,8 @@ object SharedCameraFrameCache {
                 System.err.println("[Camera] ffmpeg exited immediately with code ${process.exitValue()}")
                 withContext(Dispatchers.IO) { killFfmpegProcess(process) }
             }
-            var framesProduced = false
-            if (process != null && !exitedImmediately) {
-                entry.ffmpegProcess = process
-
-                // Drain stderr and extract video dimensions from ffmpeg output
-                val stderrLines = mutableListOf<String>()
-                val videoDims = java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>(null)
-                val stderrJob = CoroutineScope(currentCoroutineContext()).launch(Dispatchers.IO) {
-                    try {
-                        process.errorStream.bufferedReader().useLines { lines ->
-                            lines.forEach { line ->
-                                synchronized(stderrLines) {
-                                    stderrLines.add(line)
-                                    if (stderrLines.size > 50) stderrLines.removeAt(0)
-                                }
-                                if (videoDims.get() == null) {
-                                    parseFfmpegVideoDimensions(line)?.let { videoDims.set(it) }
-                                }
-                            }
-                        }
-                    } catch (_: Throwable) {}
-                }
-
-                // Wait for dimensions (up to 5 seconds)
-                var dims: Pair<Int, Int>? = null
-                repeat(DIMENSION_POLL_ATTEMPTS) {
-                    dims = videoDims.get()
-                    if (dims != null) break
-                    delay(DIMENSION_POLL_INTERVAL_MS)
-                }
-                val resolved = dims
-                if (resolved == null) {
-                    System.err.println("[Camera] Could not determine video dimensions from ffmpeg")
-                    stderrJob.cancel()
-                    withContext(Dispatchers.IO) { killFfmpegProcess(process) }
-                    entry.ffmpegProcess = null
-                } else {
-                    val (videoW, videoH) = resolved
-                    val frameBytes = videoW * videoH * 4  // BGRA = 4 bytes per pixel
-                    System.err.println("[Camera] Capturing ${videoW}x${videoH} rawvideo BGRA ($frameBytes bytes/frame)")
-
-                    val inputStream = java.io.BufferedInputStream(process.inputStream, frameBytes * 2)
-                    val frameBuf = ByteArray(frameBytes)
-                    val pixelBuf = IntArray(videoW * videoH)
-                    var frameCount = 0
-
-                    while (currentCoroutineContext().isActive) {
-                        val ok = withContext(Dispatchers.IO) {
-                            try {
-                                var read = 0
-                                while (read < frameBytes) {
-                                    val r = inputStream.read(frameBuf, read, frameBytes - read)
-                                    if (r == -1) return@withContext false
-                                    read += r
-                                }
-                                true
-                            } catch (_: Throwable) { false }
-                        }
-                        if (!ok) break
-
-                        withContext(Dispatchers.IO) {
-                            bgraBytesToArgbPixels(frameBuf, pixelBuf)
-                        }
-
-                        val img = java.awt.image.BufferedImage(videoW, videoH, java.awt.image.BufferedImage.TYPE_INT_ARGB)
-                        img.setRGB(0, 0, videoW, videoH, pixelBuf, 0, videoW)
-                        entry.frame.value = img.toComposeImageBitmap()
-                        frameCount++
-                        if (frameCount == 1) {
-                            System.err.println("[Camera] First frame received (${videoW}x${videoH})")
-                        }
-                    }
-
-                    // Stream ended — clean up this process
-                    stderrJob.cancel()
-                    val exitCode = withContext(Dispatchers.IO) {
-                        try {
-                            killFfmpegProcess(process)
-                            process.exitValue()
-                        } catch (_: Throwable) { -1 }
-                    }
-                    entry.ffmpegProcess = null
-
-                    framesProduced = frameCount > 0
-                    if (framesProduced) {
-                        System.err.println("[Camera] Stream interrupted after $frameCount frames (exit $exitCode), restarting...")
-                    } else {
-                        System.err.println("[Camera] ffmpeg exited with code $exitCode without producing any frames")
-                        synchronized(stderrLines) {
-                            stderrLines.forEach { System.err.println("[Camera] ffmpeg stderr: $it") }
-                        }
-                    }
-                }
-            }
-
+            val framesProduced =
+                if (process != null && !exitedImmediately) streamFrames(process, entry) else false
             if (framesProduced) {
                 consecutiveFailures = 0
                 delay(RESTART_DELAY_MS)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Bible.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Bible.kt
@@ -12,6 +12,8 @@ private const val SHORT_WORD_MAX_LENGTH = 4
 private const val SHORT_WORD_TRUNCATED_LENGTH = 3
 private const val SHORT_TITLE_MAX_LENGTH = 5
 private const val REGEX_GROUP_THIRD = 3
+private const val VERSE_GROUP_NUMBER = 7
+private const val VERSE_GROUP_TEXT = 8
 private const val TITLE_PREFIX_LENGTH = 8
 private const val CHAPTER_KEY_BOOK_SHIFT = 20
 private const val CHAPTER_KEY_CHAPTER_MASK = 0xFFFFFL
@@ -20,6 +22,11 @@ data class ChapterResult(val previewIds: List<String>, val verses: List<String>)
 
 /** A parenthesised aside in a module title: "King James Version (KJV)", "… (Public Domain)". */
 private val PARENTHESISED_ASIDE = Regex("\\([^)]*\\)")
+
+private val SPB_CODE_REGEX = Regex("^B(\\d{3})C(\\d{3})V(\\d{3})$")
+private val SPB_VERSE_LINE_REGEX =
+    Regex("^(B(\\d{3})C(\\d{3})V(\\d{3}))\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(.*)")
+private val SPB_BOOK_HEADER_REGEX = Regex("^(\\d+)\\s+(.+?)\\s+(\\d+)$")
 
 /**
  * Why a module could not be read, in whole or in part.
@@ -219,205 +226,165 @@ class Bible {
         loadError = null
 
         // Declared out here so a failure partway through still has whatever parsed to build from.
+        val state = SpbParseState()
+
+        try {
+            openSpbReader(resourcePath).use { r ->
+                r.forEachLine { rawLine -> parseSpbLine(rawLine.trimEnd('\r', '\n'), state) }
+                // Flush last verse if using multiline format
+                flushPendingVerse(state)
+            }
+        } catch (e: Exception) {
+            recordLoadFailure(
+                e, resourcePath,
+                parsedAnything = operatorBible.isNotEmpty() || state.headerOrder.isNotEmpty(),
+            )
+        }
+
+        // Outside the try: on a module that stops being readable partway through, the books and
+        // verses that did parse are still indexed and still shown, as far as they go.
+        buildBooksFrom(state, bookNames)
+
+        // Store full title and abbreviation
+        this.bibleTitle = state.bibleTitle
+            ?: resourcePath.substringBeforeLast(".").substringAfterLast("/").substringAfterLast("\\")
+        bibleAbbreviation = extractBibleAbbreviation(state.bibleTitle, resourcePath)
+
+        // Build chapter index for O(1) lookup in getChapter()
+        buildChapterIndex()
+    }
+
+    /** Everything one .spb scan accumulates, so a failure partway through still has it. */
+    private class SpbParseState {
         val bookChapterMap = mutableMapOf<Int, MutableSet<Int>>()
         val headerOrder = mutableListOf<Int>()
         val parsedBookNames = mutableMapOf<Int, String>()
         var bibleTitle: String? = null
+        var currentCode: String? = null
+        val pendingText = StringBuilder()
+        var headerParsed = false
+    }
 
-        try {
-            val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
-            val reader = if (inputStream != null) {
-                inputStream.bufferedReader(StandardCharsets.UTF_8)
-            } else {
-                val path = Paths.get(resourcePath)
-                if (Files.exists(path)) {
-                    Files.newBufferedReader(path, StandardCharsets.UTF_8)
-                } else {
-                    val msg = "loadFromSpb: resource not found on classpath or filesystem: $resourcePath"
-                    throw IllegalArgumentException(msg)
-                }
-            }
+    private fun openSpbReader(resourcePath: String): java.io.BufferedReader {
+        val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
+        if (inputStream != null) return inputStream.bufferedReader(StandardCharsets.UTF_8)
+        val path = Paths.get(resourcePath)
+        require(Files.exists(path)) {
+            "loadFromSpb: resource not found on classpath or filesystem: $resourcePath"
+        }
+        return Files.newBufferedReader(path, StandardCharsets.UTF_8)
+    }
 
-            val codeRegex = Regex("^B(\\d{3})C(\\d{3})V(\\d{3})$")
-            val verseLineRegex = Regex("^(B(\\d{3})C(\\d{3})V(\\d{3}))\\s+(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(.*)")
-            val bookHeaderRegex = Regex("^(\\d+)\\s+(.+?)\\s+(\\d+)$")
+    private fun parseSpbLine(line: String, state: SpbParseState) {
+        // Extract Bible title from ##Title: line
+        if (line.startsWith("##Title:")) {
+            state.bibleTitle = line.substring(TITLE_PREFIX_LENGTH).trim()
+            return
+        }
+        // Skip other metadata lines
+        if (line.startsWith("##")) return
+        if (!state.headerParsed && line.isNotEmpty() && parseSpbHeaderLine(line, state)) return
+        // Skip separator line
+        if (line.startsWith("-----")) {
+            state.headerParsed = true
+            return
+        }
+        if (parseSpbVerseLine(line, state)) return
+        parseSpbLegacyLine(line, state)
+    }
 
-            var currentCode: String? = null
-            val sb = StringBuilder()
-            var headerParsed = false
+    /** True once the line has been consumed as a book header or as the end of the header block. */
+    private fun parseSpbHeaderLine(line: String, state: SpbParseState): Boolean {
+        val headerMatch = SPB_BOOK_HEADER_REGEX.matchEntire(line)
+        if (headerMatch != null) {
+            val bookId = headerMatch.groupValues[1].toInt()
+            state.headerOrder.add(bookId)
+            state.parsedBookNames[bookId] = headerMatch.groupValues[2].trim()
+            return true
+        }
+        // Check if we've reached the separator line (-----) or first verse
+        if (line.startsWith("-----") || line.startsWith("B")) {
+            state.headerParsed = true
+            // A separator is done with here; a line starting with B is still a verse to process.
+            return line.startsWith("-----")
+        }
+        return false
+    }
 
-            reader.use { r ->
-                r.forEachLine { rawLine ->
-                    val line = rawLine.trimEnd('\r', '\n')
+    private fun parseSpbVerseLine(line: String, state: SpbParseState): Boolean {
+        val verseMatch = SPB_VERSE_LINE_REGEX.matchEntire(line) ?: return false
+        val code = verseMatch.groupValues[1]
+        // Code numbers from BXXXCXXXVXXX (internal/Hebrew numbering)
+        val codeBook = verseMatch.groupValues[2].toInt()
+        val codeChapter = verseMatch.groupValues[3].toInt()
+        // Display reference numbers (native numbering, e.g. LXX for Russian)
+        val b = verseMatch.groupValues[5].toInt()
+        val ch = verseMatch.groupValues[6].toInt()
+        addVerse(
+            state, code, b, ch,
+            verseMatch.groupValues[VERSE_GROUP_NUMBER].toInt(),
+            verseMatch.groupValues[VERSE_GROUP_TEXT].trim(),
+        )
+        // Map code reference to display reference for cross-Bible lookups
+        codeToDisplayMap[chapterKey(codeBook, codeChapter)] = chapterKey(b, ch)
+        state.currentCode = null
+        state.pendingText.setLength(0)
+        return true
+    }
 
-                    // Extract Bible title from ##Title: line
-                    if (line.startsWith("##Title:")) {
-                        bibleTitle = line.substring(TITLE_PREFIX_LENGTH).trim()
-                        return@forEachLine
-                    }
+    /** Fallback for older SPB format: a bare code line followed by its text on the lines after it. */
+    private fun parseSpbLegacyLine(line: String, state: SpbParseState) {
+        if (SPB_CODE_REGEX.matchEntire(line) != null) {
+            flushPendingVerse(state)
+            state.currentCode = line
+            state.pendingText.setLength(0)
+        } else if (state.currentCode != null) {
+            if (state.pendingText.isNotEmpty()) state.pendingText.append("\n")
+            state.pendingText.append(line)
+        }
+    }
 
-                    // Skip other metadata lines
-                    if (line.startsWith("##")) {
-                        return@forEachLine
-                    }
+    private fun flushPendingVerse(state: SpbParseState) {
+        val code = state.currentCode ?: return
+        val prev = SPB_CODE_REGEX.matchEntire(code) ?: error("Invalid verse code: $code")
+        addVerse(
+            state, code,
+            prev.groupValues[1].toInt(), prev.groupValues[2].toInt(), prev.groupValues[REGEX_GROUP_THIRD].toInt(),
+            state.pendingText.toString().trim(),
+        )
+    }
 
-                    // Parse book header lines (before verse data starts)
-                    if (!headerParsed && line.isNotEmpty()) {
-                        val headerMatch = bookHeaderRegex.matchEntire(line)
-                        if (headerMatch != null) {
-                            val bookId = headerMatch.groupValues[1].toInt()
-                            val bookName = headerMatch.groupValues[2].trim()
-                            val chapterCount = headerMatch.groupValues[3].toInt()
-                            headerOrder.add(bookId)
-                            parsedBookNames[bookId] = bookName
-                            return@forEachLine
-                        }
-
-                        // Check if we've reached the separator line (-----) or first verse
-                        if (line.startsWith("-----") || line.startsWith("B")) {
-                            headerParsed = true
-                            if (line.startsWith("-----")) {
-                                return@forEachLine
-                            }
-                            // Continue processing this line as a verse if it starts with B
-                        }
-                    }
-
-                    // Skip separator line
-                    if (line.startsWith("-----")) {
-                        headerParsed = true
-                        return@forEachLine
-                    }
-
-                    // Process verse data (same as before)
-                    val verseMatch = verseLineRegex.matchEntire(line)
-                    if (verseMatch != null) {
-                        val code = verseMatch.groupValues[1]
-                        // Code numbers from BXXXCXXXVXXX (internal/Hebrew numbering)
-                        val codeBook = verseMatch.groupValues[2].toInt()
-                        val codeChapter = verseMatch.groupValues[3].toInt()
-                        // Display reference numbers (native numbering, e.g. LXX for Russian)
-                        val b = verseMatch.groupValues[5].toInt()
-                        val ch = verseMatch.groupValues[6].toInt()
-                        val vnum = verseMatch.groupValues[7].toInt()
-                        val text = verseMatch.groupValues[8].trim()
-
-                        operatorBible.add(
-                            BibleVerse(
-                                verseId = code,
-                                book = b,
-                                chapter = ch,
-                                verseNumber = vnum,
-                                verseText = text
-                            )
-                        )
-                        bookChapterMap.getOrPut(b) { mutableSetOf() }.add(ch)
-                        // Map code reference to display reference for cross-Bible lookups
-                        codeToDisplayMap[chapterKey(codeBook, codeChapter)] = chapterKey(b, ch)
-                        currentCode = null
-                        sb.setLength(0)
-                        return@forEachLine
-                    }
-
-                    // Fallback for older SPB format
-                    val m = codeRegex.matchEntire(line)
-                    if (m != null) {
-                        val code = currentCode
-                        if (code != null) {
-                            val prev = codeRegex.matchEntire(code) ?: error("Invalid verse code: $code")
-                            val bPrev = prev.groupValues[1].toInt()
-                            val chPrev = prev.groupValues[2].toInt()
-                            val vnumPrev = prev.groupValues[3].toInt()
-                            val textPrev = sb.toString().trim()
-                            operatorBible.add(
-                                BibleVerse(
-                                    verseId = code,
-                                    book = bPrev,
-                                    chapter = chPrev,
-                                    verseNumber = vnumPrev,
-                                    verseText = textPrev
-                                )
-                            )
-                            bookChapterMap.getOrPut(bPrev) { mutableSetOf() }.add(chPrev)
-                        }
-                        currentCode = line
-                        sb.setLength(0)
-                    } else if (currentCode != null) {
-                        if (sb.isNotEmpty()) sb.append("\n")
-                        sb.append(line)
-                    }
-                }
-
-                // Flush last verse if using multiline format
-                val lastCode = currentCode
-                if (lastCode != null) {
-                    val prev = codeRegex.matchEntire(lastCode) ?: error("Invalid verse code: $lastCode")
-                    val b = prev.groupValues[1].toInt()
-                    val ch = prev.groupValues[2].toInt()
-                    val vnum = prev.groupValues[3].toInt()
-                    val text = sb.toString().trim()
-                    operatorBible.add(
-                        BibleVerse(
-                            verseId = lastCode,
-                            book = b,
-                            chapter = ch,
-                            verseNumber = vnum,
-                            verseText = text
-                        )
-                    )
-                    bookChapterMap.getOrPut(b) { mutableSetOf() }.add(ch)
-                }
-            }
-
-        } catch (e: Exception) {
-            recordLoadFailure(
-                e, resourcePath,
-                parsedAnything = operatorBible.isNotEmpty() || headerOrder.isNotEmpty(),
+    private fun addVerse(state: SpbParseState, code: String, book: Int, chapter: Int, verse: Int, text: String) {
+        operatorBible.add(
+            BibleVerse(
+                verseId = code,
+                book = book,
+                chapter = chapter,
+                verseNumber = verse,
+                verseText = text
             )
-        }
+        )
+        state.bookChapterMap.getOrPut(book) { mutableSetOf() }.add(chapter)
+    }
 
-        // Build book list preserving header order from the SPB file. Outside the try: on a
-        // module that stops being readable partway through, the books and verses that did
-        // parse are still indexed and still shown, as far as they go.
-        val maxBook = if (bookChapterMap.isEmpty()) 0 else bookChapterMap.keys.maxOrNull() ?: 0
-        val headerBookIds = headerOrder.toSet()
-        // First: books in header order
-        for (b in headerOrder) {
-            val chapterCount = bookChapterMap[b]?.maxOrNull() ?: 0
+    /** Book list in header order first, then any book seen only in verse data. */
+    private fun buildBooksFrom(state: SpbParseState, bookNames: List<String>) {
+        val headerBookIds = state.headerOrder.toSet()
+        val maxBook = state.bookChapterMap.keys.maxOrNull() ?: 0
+        val fromVerses = (1..maxBook).filter { it !in headerBookIds && state.bookChapterMap.containsKey(it) }
+        for (b in state.headerOrder + fromVerses) {
             val name = when {
-                parsedBookNames.containsKey(b) -> parsedBookNames.getValue(b)
+                state.parsedBookNames.containsKey(b) && b in headerBookIds -> state.parsedBookNames.getValue(b)
                 bookNames.size >= b -> bookNames[b - 1]
                 else -> "Book $b"
             }
             books.add(BibleBook(
                 book = name,
                 bookId = b.toString(),
-                chapterCount = chapterCount,
+                chapterCount = state.bookChapterMap[b]?.maxOrNull() ?: 0,
                 abbreviation = generateAbbreviation(name)
             ))
         }
-        // Then: any books found in verse data but missing from header
-        for (b in 1..maxBook) {
-            if (b in headerBookIds || !bookChapterMap.containsKey(b)) continue
-            val chapterCount = bookChapterMap[b]?.maxOrNull() ?: 0
-            val name = when {
-                bookNames.size >= b -> bookNames[b - 1]
-                else -> "Book $b"
-            }
-            books.add(BibleBook(
-                book = name,
-                bookId = b.toString(),
-                chapterCount = chapterCount,
-                abbreviation = generateAbbreviation(name)
-            ))
-        }
-
-        // Store full title and abbreviation
-        this.bibleTitle = bibleTitle ?: resourcePath.substringBeforeLast(".").substringAfterLast("/").substringAfterLast("\\")
-        bibleAbbreviation = extractBibleAbbreviation(bibleTitle, resourcePath)
-
-        // Build chapter index for O(1) lookup in getChapter()
-        buildChapterIndex()
     }
 
     /** Encodes (bookId, chapterNum) as a single Long key for the HashMap. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleInstallSupport.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleInstallSupport.kt
@@ -13,6 +13,7 @@ import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.HttpHeaders
 import io.ktor.utils.io.readAvailable
 import kotlinx.coroutines.delay
+import io.ktor.utils.io.ByteReadChannel
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -26,6 +27,9 @@ import kotlin.random.Random
 private const val JITTER_MIN = 0.8
 private const val JITTER_MAX = 1.2
 private const val HTTP_OK = 200
+private const val HTTP_PARTIAL_CONTENT = 206
+private const val HTTP_RANGE_NOT_SATISFIABLE = 416
+private val HTTP_SUCCESS_RANGE = 200..299
 private const val MAX_CAUSE_DEPTH = 4
 
 /**
@@ -147,9 +151,7 @@ internal object BibleInstallSupport {
         onProgress: (Float) -> Unit,
     ): DownloadResult {
         // Deliberately outside the loop: this is the state a resumed attempt picks back up from.
-        var written = 0L
-        var total = expectedBytes.takeIf { it > 0 } ?: -1L
-        var highest = 0f
+        val state = DownloadState(total = expectedBytes.takeIf { it > 0 } ?: -1L)
         var stalledAttempts = 0
         var attempts = 0
         var lastFailure: IOException? = null
@@ -161,7 +163,7 @@ internal object BibleInstallSupport {
 
         while (attempts < MAX_DOWNLOAD_ATTEMPTS) {
             attempts++
-            val resumeFrom = written
+            val resumeFrom = state.written
             try {
                 val status = http.prepareGet(url) {
                     if (resumeFrom > 0) header(HttpHeaders.Range, "bytes=$resumeFrom-")
@@ -169,64 +171,91 @@ internal object BibleInstallSupport {
                         requestTimeoutMillis = HttpTimeoutConfig.INFINITE_TIMEOUT_MS
                         socketTimeoutMillis = DOWNLOAD_SOCKET_TIMEOUT_MS
                     }
-                }.execute { response ->
-                    val code = response.status.value
-                    // Asked for a tail that isn't there: everything wanted is already on disk.
-                    if (code == 416 && resumeFrom > 0) return@execute 200
-                    if (code !in 200..299) return@execute code
-
-                    // Only a 206 whose Content-Range starts exactly where we left off is a tail. A
-                    // server that ignores Range answers 200 with the whole body, and appending that
-                    // would splice the file into nonsense — so start the file over instead.
-                    val append = code == 206 && resumeFrom > 0 && rangeStartsAt(response, resumeFrom)
-                    if (!append) written = 0
-                    // What this answer promises, as opposed to what the catalogue said the whole
-                    // module weighs — only the former is a promise this response can break.
-                    val promised = response.headers[HttpHeaders.ContentLength]?.toLongOrNull()
-                        ?.let { it + if (append) resumeFrom else 0 }
-                    if (promised != null) total = promised
-
-                    val channel = response.bodyAsChannel()
-                    val buffer = ByteArray(COPY_BUFFER_BYTES)
-                    FileOutputStream(destination, append).use { out ->
-                        var endOfBody = false
-                        while (!endOfBody) {
-                            val read = channel.readAvailable(buffer, 0, buffer.size)
-                            if (read == -1) endOfBody = true
-                            if (read > 0) {
-                                out.write(buffer, 0, read)
-                                written += read
-                                if (total > 0) {
-                                    val fraction = (written.toFloat() / total).coerceIn(0f, 1f) * DOWNLOAD_END
-                                    // Only ever forward: a restart from zero must not rewind the bar.
-                                    if (fraction > highest) {
-                                        highest = fraction
-                                        onProgress(fraction)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    // A body that stops early does not always throw at the read: depending on how the
-                    // connection died the channel is simply closed, with the cause attached or with
-                    // nothing at all. Both are the same event — fewer bytes than the server promised
-                    // — and both must resume rather than hand a half file on to be converted.
-                    requireCompleteBody(channel.closedCause, promised, written)
-                    code
-                }
-                if (status !in 200..299) return DownloadResult(status, written)
+                }.execute { response -> receiveBody(response, destination, resumeFrom, state, onProgress) }
+                if (status !in HTTP_SUCCESS_RANGE) return DownloadResult(status, state.written)
                 // 206 is normalised away — callers only ever ask whether the bytes arrived.
-                return DownloadResult(HTTP_OK, written)
+                return DownloadResult(HTTP_OK, state.written)
             } catch (e: IOException) {
                 lastFailure = e
-                stalledAttempts = if (written > resumeFrom) 0 else stalledAttempts + 1
+                stalledAttempts = if (state.written > resumeFrom) 0 else stalledAttempts + 1
                 if (stalledAttempts >= MAX_STALLED_ATTEMPTS) break
                 delay(downloadRetryDelayMs(stalledAttempts - 1, retryFloorMs))
             }
         }
 
         val failure = lastFailure ?: IOException("Download failed without a cause")
-        throw if (failure.isStall()) DownloadStalledException(attempts, written, failure) else failure
+        throw if (failure.isStall()) DownloadStalledException(attempts, state.written, failure) else failure
+    }
+
+    /** What a resumed attempt picks back up from: bytes on disk, promised size, bar position. */
+    private class DownloadState(var written: Long = 0L, var total: Long = -1L, var highest: Float = 0f)
+
+    /**
+     * Writes one response body into [destination], resuming after [resumeFrom] when the server
+     * really did hand back that tail. Returns the status the attempt should be judged by.
+     */
+    private suspend fun receiveBody(
+        response: HttpResponse,
+        destination: File,
+        resumeFrom: Long,
+        state: DownloadState,
+        onProgress: (Float) -> Unit,
+    ): Int {
+        val code = response.status.value
+        // Asked for a tail that isn't there: everything wanted is already on disk.
+        if (code == HTTP_RANGE_NOT_SATISFIABLE && resumeFrom > 0) return HTTP_OK
+        if (code !in HTTP_SUCCESS_RANGE) return code
+
+        // Only a 206 whose Content-Range starts exactly where we left off is a tail. A server that
+        // ignores Range answers 200 with the whole body, and appending that would splice the file
+        // into nonsense — so start the file over instead.
+        val append = code == HTTP_PARTIAL_CONTENT && resumeFrom > 0 && rangeStartsAt(response, resumeFrom)
+        if (!append) state.written = 0
+        // What this answer promises, as opposed to what the catalogue said the whole module weighs
+        // — only the former is a promise this response can break.
+        val promised = response.headers[HttpHeaders.ContentLength]?.toLongOrNull()
+            ?.let { it + if (append) resumeFrom else 0 }
+        if (promised != null) state.total = promised
+
+        val channel = response.bodyAsChannel()
+        copyChannel(channel, destination, append, state, onProgress)
+        // A body that stops early does not always throw at the read: depending on how the connection
+        // died the channel is simply closed, with the cause attached or with nothing at all. Both are
+        // the same event — fewer bytes than the server promised — and both must resume rather than
+        // hand a half file on to be converted.
+        requireCompleteBody(channel.closedCause, promised, state.written)
+        return code
+    }
+
+    private suspend fun copyChannel(
+        channel: ByteReadChannel,
+        destination: File,
+        append: Boolean,
+        state: DownloadState,
+        onProgress: (Float) -> Unit,
+    ) {
+        val buffer = ByteArray(COPY_BUFFER_BYTES)
+        FileOutputStream(destination, append).use { out ->
+            var endOfBody = false
+            while (!endOfBody) {
+                val read = channel.readAvailable(buffer, 0, buffer.size)
+                if (read == -1) endOfBody = true
+                if (read > 0) {
+                    out.write(buffer, 0, read)
+                    state.written += read
+                    if (state.total > 0) reportProgress(state, onProgress)
+                }
+            }
+        }
+    }
+
+    /** Only ever forward: a restart from zero must not rewind the bar. */
+    private fun reportProgress(state: DownloadState, onProgress: (Float) -> Unit) {
+        val fraction = (state.written.toFloat() / state.total).coerceIn(0f, 1f) * DOWNLOAD_END
+        if (fraction > state.highest) {
+            state.highest = fraction
+            onProgress(fraction)
+        }
     }
 
     /** Rejects a body that ended early, whether the channel reported a cause or simply closed. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManager.kt
@@ -243,6 +243,43 @@ class SettingsManager {
         return result
     }
 
+    /** One screen assignment with showBible/showSongs turned into modes, or null if untouched. */
+    private fun assignmentWithModes(obj: JsonObject): JsonObject? {
+        val showBibleFalse = (obj["showBible"] as? JsonPrimitive)?.content == "false"
+        val showSongsFalse = (obj["showSongs"] as? JsonPrimitive)?.content == "false"
+        if (!showBibleFalse && !showSongsFalse) return null
+        return buildJsonObject {
+            obj.forEach { (k, v) -> if (k != "showBible" && k != "showSongs") put(k, v) }
+            if (showBibleFalse && !obj.containsKey("bibleMode")) put("bibleMode", JsonPrimitive("off"))
+            if (showSongsFalse && !obj.containsKey("songMode")) put("songMode", JsonPrimitive("off"))
+        }
+    }
+
+    /** One satellite connection with row/column ranges turned back into counts, or null if untouched. */
+    private fun connectionWithCounts(obj: JsonObject, rangeKeys: Set<String>): JsonObject? {
+        val additions = buildJsonObject {
+            for (prefix in CompanionSurfacePlacementPrefixes) {
+                val startRow = (obj["${prefix}StartRow"] as? JsonPrimitive)?.content?.toIntOrNull()
+                val endRow = (obj["${prefix}EndRow"] as? JsonPrimitive)?.content?.toIntOrNull()
+                val startColumn = (obj["${prefix}StartColumn"] as? JsonPrimitive)?.content?.toIntOrNull()
+                val endColumn = (obj["${prefix}EndColumn"] as? JsonPrimitive)?.content?.toIntOrNull()
+                if (startRow != null && endRow != null && !obj.containsKey("${prefix}Rows")) {
+                    put("${prefix}Rows", JsonPrimitive((endRow - startRow + 1).coerceAtLeast(1)))
+                }
+                if (startColumn != null && endColumn != null && !obj.containsKey("${prefix}Columns")) {
+                    put("${prefix}Columns", JsonPrimitive((endColumn - startColumn + 1).coerceAtLeast(1)))
+                }
+            }
+        }
+        // Stray range keys with no rows/columns to derive (shouldn't normally happen) are still
+        // stripped, so they don't linger as dead unknown keys forever.
+        if (additions.isEmpty() && rangeKeys.none { it in obj }) return null
+        return buildJsonObject {
+            obj.forEach { (k, v) -> if (k !in rangeKeys) put(k, v) }
+            additions.forEach { (k, v) -> put(k, v) }
+        }
+    }
+
     private fun parseSettingsRoot(raw: String): JsonObject? =
         try { jsonFormat.parseToJsonElement(raw).jsonObject } catch (_: Exception) { null }
 
@@ -256,17 +293,9 @@ class SettingsManager {
         var changed = false
         val newAssignments = buildJsonArray {
             for (element in assignments) {
-                val obj = element.jsonObject
-                val showBibleFalse = (obj["showBible"] as? JsonPrimitive)?.content == "false"
-                val showSongsFalse = (obj["showSongs"] as? JsonPrimitive)?.content == "false"
-                if (showBibleFalse || showSongsFalse) {
-                    changed = true
-                    add(buildJsonObject {
-                        obj.forEach { (k, v) -> if (k != "showBible" && k != "showSongs") put(k, v) }
-                        if (showBibleFalse && !obj.containsKey("bibleMode")) put("bibleMode", JsonPrimitive("off"))
-                        if (showSongsFalse && !obj.containsKey("songMode")) put("songMode", JsonPrimitive("off"))
-                    })
-                } else { add(element) }
+                val migrated = assignmentWithModes(element.jsonObject)
+                if (migrated != null) changed = true
+                add(migrated ?: element)
             }
         }
         if (!changed) return raw
@@ -332,33 +361,9 @@ class SettingsManager {
         }.toSet()
         val newConnections = buildJsonArray {
             for (element in connections) {
-                val obj = element.jsonObject
-                val additions = buildJsonObject {
-                    for (prefix in CompanionSurfacePlacementPrefixes) {
-                        val startRow = (obj["${prefix}StartRow"] as? JsonPrimitive)?.content?.toIntOrNull()
-                        val endRow = (obj["${prefix}EndRow"] as? JsonPrimitive)?.content?.toIntOrNull()
-                        val startColumn = (obj["${prefix}StartColumn"] as? JsonPrimitive)?.content?.toIntOrNull()
-                        val endColumn = (obj["${prefix}EndColumn"] as? JsonPrimitive)?.content?.toIntOrNull()
-                        if (startRow != null && endRow != null && !obj.containsKey("${prefix}Rows")) {
-                            put("${prefix}Rows", JsonPrimitive((endRow - startRow + 1).coerceAtLeast(1)))
-                        }
-                        if (startColumn != null && endColumn != null && !obj.containsKey("${prefix}Columns")) {
-                            put("${prefix}Columns", JsonPrimitive((endColumn - startColumn + 1).coerceAtLeast(1)))
-                        }
-                    }
-                }
-                if (additions.isNotEmpty()) {
-                    changed = true
-                    add(buildJsonObject {
-                        obj.forEach { (k, v) -> if (k !in rangeKeys) put(k, v) }
-                        additions.forEach { (k, v) -> put(k, v) }
-                    })
-                } else if (rangeKeys.any { it in obj }) {
-                    // Stray range keys with no rows/columns to derive (shouldn't normally happen) —
-                    // still strip them so they don't linger as dead unknown keys forever.
-                    changed = true
-                    add(buildJsonObject { obj.forEach { (k, v) -> if (k !in rangeKeys) put(k, v) } })
-                } else { add(element) }
+                val migrated = connectionWithCounts(element.jsonObject, rangeKeys)
+                if (migrated != null) changed = true
+                add(migrated ?: element)
             }
         }
         if (!changed) return raw

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/ZefaniaRepositoryIndex.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/ZefaniaRepositoryIndex.kt
@@ -14,9 +14,11 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.utils.CrashReporter
+import io.ktor.client.statement.HttpResponse
 import java.io.File
 import java.net.URLEncoder
 
+private val HTTP_OK_RANGE = 200..299
 private const val REGEX_GROUP_IDENTIFIER = 3
 private const val REGEX_GROUP_DISPLAY_NAME = 4
 
@@ -169,26 +171,7 @@ object ZefaniaRepositoryIndex {
                 if (cached != null && cached.etag.isNotBlank()) header("If-None-Match", cached.etag)
             }
 
-            if (response.status == HttpStatusCode.NotModified && cached != null) {
-                writeMeta(cacheFile, nowMillis, cached.etag)
-                memoryCache = nowMillis to cached
-                return@withContext IndexOutcome.Success(cached)
-            }
-
-            if (response.status == HttpStatusCode.Forbidden && response.headers["x-ratelimit-remaining"] == "0") {
-                val reset = response.headers["x-ratelimit-reset"]?.toLongOrNull()
-                return@withContext cached
-                    ?.let { IndexOutcome.Success(it, stale = true) }
-                    ?: IndexOutcome.RateLimited(reset)
-            }
-
-            if (response.status.value !in 200..299) {
-                CrashReporter.reportWarning(
-                    "Zefania index fetch returned HTTP ${response.status.value}",
-                    tags = mapOf("subsystem" to "zefania_index")
-                )
-                return@withContext cached?.let { IndexOutcome.Success(it, stale = true) } ?: IndexOutcome.Failure
-            }
+            unusableResponseOutcome(response, cached, cacheFile, nowMillis)?.let { return@withContext it }
 
             val body = response.body<String>()
             val etag = response.headers["ETag"].orEmpty()
@@ -214,6 +197,35 @@ object ZefaniaRepositoryIndex {
             // install, which is far more useful than an empty dialog.
             cached?.let { IndexOutcome.Success(it, stale = true) } ?: IndexOutcome.NetworkError
         }
+    }
+
+    /**
+     * The outcome for a response that carries no new index — not-modified, rate-limited or an error
+     * status — or null when the body should be parsed. A stale cached index beats an empty dialog.
+     */
+    private suspend fun unusableResponseOutcome(
+        response: HttpResponse,
+        cached: Index?,
+        cacheFile: File,
+        nowMillis: Long,
+    ): IndexOutcome? {
+        if (response.status == HttpStatusCode.NotModified && cached != null) {
+            writeMeta(cacheFile, nowMillis, cached.etag)
+            memoryCache = nowMillis to cached
+            return IndexOutcome.Success(cached)
+        }
+        if (response.status == HttpStatusCode.Forbidden && response.headers["x-ratelimit-remaining"] == "0") {
+            val reset = response.headers["x-ratelimit-reset"]?.toLongOrNull()
+            return cached?.let { IndexOutcome.Success(it, stale = true) } ?: IndexOutcome.RateLimited(reset)
+        }
+        if (response.status.value !in HTTP_OK_RANGE) {
+            CrashReporter.reportWarning(
+                "Zefania index fetch returned HTTP ${response.status.value}",
+                tags = mapOf("subsystem" to "zefania_index")
+            )
+            return cached?.let { IndexOutcome.Success(it, stale = true) } ?: IndexOutcome.Failure
+        }
+        return null
     }
 
     /** Parses a git-tree response body. Pure — this is where nearly all the behaviour lives. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -1,6 +1,7 @@
 package org.churchpresenter.app.churchpresenter
 
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.application
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -26,6 +27,7 @@ import org.jetbrains.skia.Image
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.derivedStateOf
@@ -267,1389 +269,1401 @@ fun main() {
     )
 
     application(exitProcessOnExit = true) {
-        var appReady by remember { mutableStateOf(false) }
-        val settingsManager = remember { SettingsManager() }
-        val statisticsManager = remember { StatisticsManager() }
-        val verseSequenceLog = remember { VerseSequenceLog() }
-        var appSettings by remember {
-            mutableStateOf(settingsManager.loadSettings().let {
-                it.copy(presentationRemoteSettings = it.presentationRemoteSettings.copy(remoteControlEnabled = false))
-            })
+        ChurchPresenterApp(coroutineExceptionHandler)
+    }
+}
+
+
+/**
+ * The whole desktop UI: windows, presenter outputs, the server wiring and every dialog.
+ *
+ * Split out of [main] so that function is only the pre-UI startup — settings, crash reporting,
+ * fonts, VLC and the single-instance lock — and this is the Compose tree.
+ */
+@Composable
+private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: CoroutineExceptionHandler) {
+    var appReady by remember { mutableStateOf(false) }
+    val settingsManager = remember { SettingsManager() }
+    val statisticsManager = remember { StatisticsManager() }
+    val verseSequenceLog = remember { VerseSequenceLog() }
+    var appSettings by remember {
+        mutableStateOf(settingsManager.loadSettings().let {
+            it.copy(presentationRemoteSettings = it.presentationRemoteSettings.copy(remoteControlEnabled = false))
+        })
+    }
+
+    remember {
+        val screenDevicesAll = GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices
+        val primaryDevice = GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice
+        val nonPrimaryDisplays = screenDevicesAll.filter { it != primaryDevice }.map { device ->
+            val bounds = device.defaultConfiguration.bounds
+            ResolvedDisplay(
+                deviceIndex = screenDevicesAll.indexOf(device),
+                x = bounds.x, y = bounds.y, width = bounds.width, height = bounds.height,
+            )
         }
+        val deckLinkCount = deckLinkOutputCount(DeckLinkManager.isAvailable()) { DeckLinkManager.listDevices().size }
 
-        remember {
-            val screenDevicesAll = GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices
-            val primaryDevice = GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice
-            val nonPrimaryDisplays = screenDevicesAll.filter { it != primaryDevice }.map { device ->
-                val bounds = device.defaultConfiguration.bounds
-                ResolvedDisplay(
-                    deviceIndex = screenDevicesAll.indexOf(device),
-                    x = bounds.x, y = bounds.y, width = bounds.width, height = bounds.height,
-                )
-            }
-            val deckLinkCount = deckLinkOutputCount(DeckLinkManager.isAvailable()) { DeckLinkManager.listDevices().size }
-
-            val proj = appSettings.projectionSettings
-            val assignments = reconcileScreenAssignments(proj.screenAssignments, nonPrimaryDisplays, deckLinkCount)
-            if (assignments != null) {
-                appSettings = appSettings.copy(
-                    projectionSettings = proj.copy(screenAssignments = assignments)
-                )
-                settingsManager.saveSettings(appSettings)
-            }
-        }
-
-        val presenterManager = remember { PresenterManager() }
-        LaunchedEffect(appSettings.atemSettings) {
-            presenterManager.setAtemRenderSettings(appSettings.atemSettings)
-        }
-
-        var eulaAccepted by remember {
-            mutableStateOf(isEulaAccepted(appSettings.eulaAcceptedVersion, CURRENT_EULA_VERSION))
-        }
-        var showSetupWizard by remember { mutableStateOf(shouldShowSetupWizard(appSettings)) }
-
-        var currentLanguage by remember {
-            val savedLanguageCode = appSettings.language
-            val language = resolveStartupLanguage(savedLanguageCode)
-            Locale.setDefault(Locale.forLanguageTag(language.code))
-            mutableStateOf(language)
-        }
-
-        var scheduleActions by remember { mutableStateOf(ScheduleActions()) }
-        val currentScheduleActions by rememberUpdatedState(scheduleActions)
-
-        val mediaViewModel = remember { MediaViewModel() }
-
-        var identifyingScreen by remember { mutableStateOf(false) }
-        val coroutineScope = rememberCoroutineScope { coroutineExceptionHandler }
-
-        var theme by remember { mutableStateOf(themeFromSettings(appSettings.theme)) }
-        val companionServer = remember { CompanionServer() }
-        val qaManager = remember { QAManager() }
-        val sttManager = remember { STTManager() }
-        LaunchedEffect(appSettings.bibleEngineSettings.helpDevMode) {
-            sttManager.helpDevModeEnabled = appSettings.bibleEngineSettings.helpDevMode
-        }
-        val obsManager = remember { OBSWebSocketManager() }
-        val companionSatelliteViewModel = remember { CompanionSatelliteViewModel() }
-        DisposableEffect(Unit) { onDispose { companionSatelliteViewModel.dispose() } }
-        val autoConnectedIds = remember { mutableSetOf<String>() }
-        LaunchedEffect(appSettings.companionSatelliteConnections.map { it.id }) {
-            for (connection in appSettings.companionSatelliteConnections) {
-                if (connection.autoConnect && autoConnectedIds.add(connection.id)) {
-                    val effective = if (needsGeneratedDeviceId(connection)) {
-                        val generated = java.util.UUID.randomUUID().toString()
-                        appSettings = appSettings.copy(
-                            companionSatelliteConnections = withGeneratedDeviceId(
-                                appSettings.companionSatelliteConnections, connection.id, generated,
-                            )
-                        )
-                        settingsManager.saveSettings(appSettings)
-                        connection.copy(deviceId = generated)
-                    } else connection
-                    companionSatelliteViewModel.connectAll(effective)
-                }
-            }
-        }
-        val lastReconciled = remember { mutableMapOf<String, CompanionSatelliteSettings>() }
-        CompanionSatelliteWiring(appSettings, companionSatelliteViewModel, lastReconciled)
-
-        val instanceLinkViewModel = remember { InstanceLinkViewModel() }
-        DisposableEffect(Unit) { onDispose { instanceLinkViewModel.dispose() } }
-        var primaryBibleForInstanceLink by remember { mutableStateOf<Bible?>(null) }
-        var scenesForInstanceLink by remember { mutableStateOf<List<Scene>>(emptyList()) }
-        fun setInstanceLinkEnabled(enabled: Boolean) {
-            if (!instanceLinkEnabledChanged(appSettings.instanceLink, enabled)) return
-            appSettings = appSettings.copy(instanceLink = appSettings.instanceLink.copy(enabled = enabled))
+        val proj = appSettings.projectionSettings
+        val assignments = reconcileScreenAssignments(proj.screenAssignments, nonPrimaryDisplays, deckLinkCount)
+        if (assignments != null) {
+            appSettings = appSettings.copy(
+                projectionSettings = proj.copy(screenAssignments = assignments)
+            )
             settingsManager.saveSettings(appSettings)
         }
-        LaunchedEffect(
-            appSettings.instanceLink.enabled,
-            appSettings.instanceLink.autoConnect,
-            appSettings.instanceLink.primaryHost,
-            appSettings.instanceLink.primaryPort,
-            appSettings.instanceLink.apiKey,
-            appSettings.instanceLink.reconnectDelayMs
-        ) {
-            val link = appSettings.instanceLink
-            if (shouldAutoConnectInstanceLink(link)) {
-                instanceLinkViewModel.connect(
-                    link.primaryHost, link.primaryPort, link.apiKey, link.deviceId,
-                    link.reconnectDelayMs.toLong()
-                )
-            } else if (shouldDisconnectInstanceLink(link)) {
-                instanceLinkViewModel.disconnect()
+    }
+
+    val presenterManager = remember { PresenterManager() }
+    LaunchedEffect(appSettings.atemSettings) {
+        presenterManager.setAtemRenderSettings(appSettings.atemSettings)
+    }
+
+    var eulaAccepted by remember {
+        mutableStateOf(isEulaAccepted(appSettings.eulaAcceptedVersion, CURRENT_EULA_VERSION))
+    }
+    var showSetupWizard by remember { mutableStateOf(shouldShowSetupWizard(appSettings)) }
+
+    var currentLanguage by remember {
+        val savedLanguageCode = appSettings.language
+        val language = resolveStartupLanguage(savedLanguageCode)
+        Locale.setDefault(Locale.forLanguageTag(language.code))
+        mutableStateOf(language)
+    }
+
+    var scheduleActions by remember { mutableStateOf(ScheduleActions()) }
+    val currentScheduleActions by rememberUpdatedState(scheduleActions)
+
+    val mediaViewModel = remember { MediaViewModel() }
+
+    var identifyingScreen by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope { coroutineExceptionHandler }
+
+    var theme by remember { mutableStateOf(themeFromSettings(appSettings.theme)) }
+    val companionServer = remember { CompanionServer() }
+    val qaManager = remember { QAManager() }
+    val sttManager = remember { STTManager() }
+    LaunchedEffect(appSettings.bibleEngineSettings.helpDevMode) {
+        sttManager.helpDevModeEnabled = appSettings.bibleEngineSettings.helpDevMode
+    }
+    val obsManager = remember { OBSWebSocketManager() }
+    val companionSatelliteViewModel = remember { CompanionSatelliteViewModel() }
+    DisposableEffect(Unit) { onDispose { companionSatelliteViewModel.dispose() } }
+    val autoConnectedIds = remember { mutableSetOf<String>() }
+    LaunchedEffect(appSettings.companionSatelliteConnections.map { it.id }) {
+        for (connection in appSettings.companionSatelliteConnections) {
+            if (connection.autoConnect && autoConnectedIds.add(connection.id)) {
+                val effective = if (needsGeneratedDeviceId(connection)) {
+                    val generated = java.util.UUID.randomUUID().toString()
+                    appSettings = appSettings.copy(
+                        companionSatelliteConnections = withGeneratedDeviceId(
+                            appSettings.companionSatelliteConnections, connection.id, generated,
+                        )
+                    )
+                    settingsManager.saveSettings(appSettings)
+                    connection.copy(deviceId = generated)
+                } else connection
+                companionSatelliteViewModel.connectAll(effective)
             }
         }
-        LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
-            if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
-            instanceLinkViewModel.remoteLiveState.collectLatest { state ->
-                if (state == null) return@collectLatest
-                applyRemoteLiveState(
-                    state, presenterManager, instanceLinkViewModel,
-                    bibleSyncMode = appSettings.instanceLink.bibleSyncMode,
-                    localPrimaryBible = primaryBibleForInstanceLink,
-                    localScenes = scenesForInstanceLink,
-                    onPlayRemoteMedia = { url, type ->
-                        mediaViewModel.loadMedia(url, type)
-                        mediaViewModel.play()
-                    }
-                )
-            }
+    }
+    val lastReconciled = remember { mutableMapOf<String, CompanionSatelliteSettings>() }
+    CompanionSatelliteWiring(appSettings, companionSatelliteViewModel, lastReconciled)
+
+    val instanceLinkViewModel = remember { InstanceLinkViewModel() }
+    DisposableEffect(Unit) { onDispose { instanceLinkViewModel.dispose() } }
+    var primaryBibleForInstanceLink by remember { mutableStateOf<Bible?>(null) }
+    var scenesForInstanceLink by remember { mutableStateOf<List<Scene>>(emptyList()) }
+    fun setInstanceLinkEnabled(enabled: Boolean) {
+        if (!instanceLinkEnabledChanged(appSettings.instanceLink, enabled)) return
+        appSettings = appSettings.copy(instanceLink = appSettings.instanceLink.copy(enabled = enabled))
+        settingsManager.saveSettings(appSettings)
+    }
+    LaunchedEffect(
+        appSettings.instanceLink.enabled,
+        appSettings.instanceLink.autoConnect,
+        appSettings.instanceLink.primaryHost,
+        appSettings.instanceLink.primaryPort,
+        appSettings.instanceLink.apiKey,
+        appSettings.instanceLink.reconnectDelayMs
+    ) {
+        val link = appSettings.instanceLink
+        if (shouldAutoConnectInstanceLink(link)) {
+            instanceLinkViewModel.connect(
+                link.primaryHost, link.primaryPort, link.apiKey, link.deviceId,
+                link.reconnectDelayMs.toLong()
+            )
+        } else if (shouldDisconnectInstanceLink(link)) {
+            instanceLinkViewModel.disconnect()
         }
-        LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
-            if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
-            instanceLinkViewModel.remotePresentationSlide.collectLatest { slide ->
-                if (slide == null) return@collectLatest
-                if (!hasFetchableSlide(slide.id)) return@collectLatest
-                val bytes = instanceLinkViewModel.fetchPresentationSlideBytes(slide.id, slide.index)
-                if (bytes == null) {
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf("contentType" to "PRESENTATION", "resolved" to false, "reason" to "fetch_failed")
-                    )
-                    return@collectLatest
+    }
+    LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
+        if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
+        instanceLinkViewModel.remoteLiveState.collectLatest { state ->
+            if (state == null) return@collectLatest
+            applyRemoteLiveState(
+                state, presenterManager, instanceLinkViewModel,
+                bibleSyncMode = appSettings.instanceLink.bibleSyncMode,
+                localPrimaryBible = primaryBibleForInstanceLink,
+                localScenes = scenesForInstanceLink,
+                onPlayRemoteMedia = { url, type ->
+                    mediaViewModel.loadMedia(url, type)
+                    mediaViewModel.play()
                 }
-                val bitmap = runCatching {
-                    Image.makeFromEncoded(bytes).toComposeImageBitmap()
-                }.getOrNull()
-                if (bitmap == null) {
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf("contentType" to "PRESENTATION", "resolved" to false, "reason" to "decode_failed")
-                    )
-                    return@collectLatest
-                }
-                presenterManager.setSelectedSlide(bitmap)
-                if (slide.isLive) {
-                    presenterManager.setPresentingMode(Presenting.PRESENTATION)
-                    presenterManager.setShowPresenterWindow(true)
-                }
+            )
+        }
+    }
+    LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
+        if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
+        instanceLinkViewModel.remotePresentationSlide.collectLatest { slide ->
+            if (slide == null) return@collectLatest
+            if (!hasFetchableSlide(slide.id)) return@collectLatest
+            val bytes = instanceLinkViewModel.fetchPresentationSlideBytes(slide.id, slide.index)
+            if (bytes == null) {
                 InstanceLinkLogger.log(
                     InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "PRESENTATION", "resolved" to true, "isLive" to slide.isLive)
+                    mapOf("contentType" to "PRESENTATION", "resolved" to false, "reason" to "fetch_failed")
                 )
+                return@collectLatest
             }
-        }
-        LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
-            if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
-            var lastSeen = instanceLinkViewModel.displayClearedSignal.value
-            instanceLinkViewModel.displayClearedSignal.collect { signal ->
-                if (!isFreshClearSignal(signal, lastSeen)) return@collect
-                lastSeen = signal
-                presenterManager.requestClearDisplay()
-            }
-        }
-        val instanceLinkCommandFailures = remember { mutableStateListOf<InstanceLinkCommandFailure>() }
-        InstanceLinkFailureWiring(instanceLinkViewModel, instanceLinkCommandFailures)
-        var mirroredBackgroundSettings by remember { mutableStateOf<BackgroundSettings?>(null) }
-        val instanceLinkConnectionStatusForBackgrounds by instanceLinkViewModel.connectionStatus.collectAsState()
-        val instanceLinkBackgroundsSignal by instanceLinkViewModel.backgroundsUpdatedSignal.collectAsState()
-        LaunchedEffect(instanceLinkConnectionStatusForBackgrounds, appSettings.instanceLink.mirrorBackgrounds, appSettings.instanceLink.role, instanceLinkBackgroundsSignal) {
-            if (!shouldMirrorRemoteBackgrounds(
-                    status = instanceLinkConnectionStatusForBackgrounds,
-                    role = appSettings.instanceLink.role,
-                    mirrorBackgrounds = appSettings.instanceLink.mirrorBackgrounds
-                )
-            ) {
-                mirroredBackgroundSettings = null
-                return@LaunchedEffect
-            }
-            if (shouldInvalidateBackgroundCache(instanceLinkBackgroundsSignal)) {
-                withContext(Dispatchers.IO) {
-                    instanceLinkBackgroundCacheDir.listFiles()?.forEach { it.delete() }
-                }
+            val bitmap = runCatching {
+                Image.makeFromEncoded(bytes).toComposeImageBitmap()
+            }.getOrNull()
+            if (bitmap == null) {
                 InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "cache_invalidated",
-                    mapOf("kind" to "backgrounds", "trigger" to "backgrounds_updated")
+                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                    mapOf("contentType" to "PRESENTATION", "resolved" to false, "reason" to "decode_failed")
                 )
+                return@collectLatest
             }
-            val remote = instanceLinkViewModel.fetchBackgroundSettings() ?: return@LaunchedEffect
-            mirroredBackgroundSettings = downloadMirroredBackgroundSettings(remote, instanceLinkViewModel)
-        }
-        val effectiveAppSettings = remember(appSettings, mirroredBackgroundSettings) {
-            withMirroredBackgrounds(appSettings, mirroredBackgroundSettings)
-        }
-        val screenCountForUsage = remember { LiveMapReporter.detectScreenCount() }
-        val deckLinkCountForUsage = remember {
-            deckLinkOutputCount(DeckLinkManager.isAvailable()) { DeckLinkManager.listDevices().size }
-        }
-
-        LiveStateBroadcastWiring(
-            appSettings = { appSettings },
-            primaryBible = { primaryBibleForInstanceLink },
-            presenterManager = presenterManager,
-            companionServer = companionServer,
-            screenCountForUsage = screenCountForUsage,
-            deckLinkCountForUsage = deckLinkCountForUsage,
-        )
-        remember(qaManager) { companionServer.qaManager = qaManager; true }
-        ObsSceneWiring(appSettings, companionServer, obsManager, presenterManager)
-        val tunnelStatus by companionServer.tunnelManager.status.collectAsState()
-        val tunnelUrl by companionServer.tunnelManager.tunnelUrl.collectAsState()
-        val prevTunnelWasConnected = remember { mutableStateOf(false) }
-        var qaDisplayUrl by remember { mutableStateOf("") }
-        var presentationDisplayUrl by remember { mutableStateOf("") }
-        LaunchedEffect(tunnelStatus) {
-            val isConnected = isTunnelConnected(tunnelStatus)
-            if (tunnelJustDropped(prevTunnelWasConnected.value, isConnected)) {
-                companionServer.clearPresentationState()
-                qaDisplayUrl = ""
-                presentationDisplayUrl = ""
-            }
-            prevTunnelWasConnected.value = isConnected
-        }
-        var presentationFrozen by remember { mutableStateOf(false) }
-        LaunchedEffect(appSettings.presentationRemoteSettings.remoteControlEnabled, appSettings.serverSettings.apiKeyEnabled, appSettings.serverSettings.apiKey) {
-            val activeApiKey = activeApiKey(appSettings.serverSettings)
-            companionServer.updatePresentationRemoteSettings(appSettings.presentationRemoteSettings, activeApiKey)
-        }
-        LaunchedEffect(appSettings.presentationSettings.autoScrollInterval) {
-            companionServer.updateAutoScrollInterval(appSettings.presentationSettings.autoScrollInterval.toInt())
-        }
-        LaunchedEffect(appSettings.presentationSettings.isLooping) {
-            companionServer.updateLoopingState(appSettings.presentationSettings.isLooping)
-        }
-        LaunchedEffect(Unit) {
-            companionServer.onPresentationFreezeToggle.collect {
-                presentationFrozen = !presentationFrozen
-                companionServer.broadcastFreezeChange(presentationFrozen)
-                presenterManager.setSlideFrozen(presentationFrozen)
-            }
-        }
-        MediaRemoteWiring(companionServer, mediaViewModel, presenterManager)
-        val presentingModeValue = presenterManager.presentingMode.value
-        LiveStatusWiring(appSettings, companionServer, presentingModeValue)
-        val browserSourceServerUrlState = companionServer.serverUrl.collectAsState()
-        appSettings.projectionSettings.browserSourceOutputs.indices.forEach { i ->
-            composeKey(i) {
-                val appSettingsState = rememberUpdatedState(effectiveAppSettings)
-                val screenAssignmentState = rememberUpdatedState(
-                    browserSourceOutputAt(appSettings.projectionSettings.browserSourceOutputs, i)
-                )
-                val effectiveModeState = remember {
-                    derivedStateOf {
-                        effectiveOutputMode(
-                            presenterManager.browserSourceLocks.value, i, presenterManager.presentingMode.value,
-                        )
-                    }
-                }
-                val qaDisplayUrlState = rememberUpdatedState(qaDisplayUrl)
-                val bsOutput = browserSourceOutputAt(appSettings.projectionSettings.browserSourceOutputs, i)
-                val renderer = remember(i, bsOutput.browserSourceWidth, bsOutput.browserSourceHeight, bsOutput.browserSourceFps) {
-                    BrowserSourceVideoRenderer(
-                        presenterManager, appSettingsState, screenAssignmentState, effectiveModeState,
-                        outputIndex = i,
-                        sttManager = sttManager,
-                        mediaViewModel = mediaViewModel,
-                        qaDisplayUrlState = qaDisplayUrlState,
-                        serverUrlState = browserSourceServerUrlState,
-                        width = bsOutput.browserSourceWidth,
-                        height = bsOutput.browserSourceHeight,
-                        fps = bsOutput.browserSourceFps,
-                    )
-                }
-                LaunchedEffect(renderer) {
-                    renderer.start(this)
-                    companionServer.registerBrowserSourceFrames(i, renderer.frames)
-                }
-                DisposableEffect(renderer) {
-                    onDispose { renderer.stop() }
-                }
-            }
-        }
-        LaunchedEffect(Unit) {
-            companionServer.onPresentationGoLive.collect {
+            presenterManager.setSelectedSlide(bitmap)
+            if (slide.isLive) {
                 presenterManager.setPresentingMode(Presenting.PRESENTATION)
                 presenterManager.setShowPresenterWindow(true)
             }
+            InstanceLinkLogger.log(
+                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                mapOf("contentType" to "PRESENTATION", "resolved" to true, "isLive" to slide.isLive)
+            )
         }
-        val remoteSelectSongFlow =
-            remember { kotlinx.coroutines.flow.MutableSharedFlow<ScheduleItem.SongItem>(extraBufferCapacity = 8) }
-        val remoteSelectPictureFlow =
-            remember { kotlinx.coroutines.flow.MutableSharedFlow<ScheduleItem.PictureItem>(extraBufferCapacity = 8) }
-        val remoteSelectPresentationFlow =
-            remember { kotlinx.coroutines.flow.MutableSharedFlow<ScheduleItem.PresentationItem>(extraBufferCapacity = 8) }
-        var dialogDismissSignal by remember { mutableStateOf(0) }
-        var showOptionsDialog by remember { mutableStateOf(false) }
-        var optionsDialogInitialTab by remember { mutableStateOf(0) }
-        val openOptionsDialog: (Int) -> Unit = { tab ->
-            optionsDialogInitialTab = tab
-            showOptionsDialog = true
+    }
+    LaunchedEffect(instanceLinkViewModel, appSettings.instanceLink.role) {
+        if (!shouldMirrorRemoteOutput(appSettings.instanceLink.role)) return@LaunchedEffect
+        var lastSeen = instanceLinkViewModel.displayClearedSignal.value
+        instanceLinkViewModel.displayClearedSignal.collect { signal ->
+            if (!isFreshClearSignal(signal, lastSeen)) return@collect
+            lastSeen = signal
+            presenterManager.requestClearDisplay()
         }
-        var showStatisticsDialog by remember { mutableStateOf(false) }
-        var showInstanceLinkDialog by remember { mutableStateOf(false) }
-        var showKeyboardShortcutsDialog by remember { mutableStateOf(false) }
-        var showAboutDialog by remember { mutableStateOf(false) }
-        var showContactDialog by remember { mutableStateOf(false) }
-        var showConverterWindow by remember { mutableStateOf(false) }
-        var showLottieGenWindow by remember { mutableStateOf(false) }
-        var showStyleEditorWindow by remember { mutableStateOf(false) }
-        var showMemoryMonitorWindow by remember { mutableStateOf(false) }
-        var developerMenuUnlocked by remember { mutableStateOf(false) }
-        var lottieGenOutputDir by remember { mutableStateOf<File?>(null) }
-        var lottieGenOnFileSaved by remember { mutableStateOf<(() -> Unit)?>(null) }
-        var pendingUpdateResult by remember { mutableStateOf<UpdateCheckResult?>(null) }
-        var pendingUpdateCheckWasManual by remember { mutableStateOf(false) }
-        var selectedScheduleItemId by remember { mutableStateOf<String?>(null) }
-
-        LaunchedEffect(Unit) {
+    }
+    val instanceLinkCommandFailures = remember { mutableStateListOf<InstanceLinkCommandFailure>() }
+    InstanceLinkFailureWiring(instanceLinkViewModel, instanceLinkCommandFailures)
+    var mirroredBackgroundSettings by remember { mutableStateOf<BackgroundSettings?>(null) }
+    val instanceLinkConnectionStatusForBackgrounds by instanceLinkViewModel.connectionStatus.collectAsState()
+    val instanceLinkBackgroundsSignal by instanceLinkViewModel.backgroundsUpdatedSignal.collectAsState()
+    LaunchedEffect(instanceLinkConnectionStatusForBackgrounds, appSettings.instanceLink.mirrorBackgrounds, appSettings.instanceLink.role, instanceLinkBackgroundsSignal) {
+        if (!shouldMirrorRemoteBackgrounds(
+                status = instanceLinkConnectionStatusForBackgrounds,
+                role = appSettings.instanceLink.role,
+                mirrorBackgrounds = appSettings.instanceLink.mirrorBackgrounds
+            )
+        ) {
+            mirroredBackgroundSettings = null
+            return@LaunchedEffect
+        }
+        if (shouldInvalidateBackgroundCache(instanceLinkBackgroundsSignal)) {
             withContext(Dispatchers.IO) {
-                companionServer.preloadData(
-                    songStorageDir = appSettings.songSettings.storageDirectory,
-                    bibleStorageDir = appSettings.bibleSettings.storageDirectory,
-                    primaryBibleFileName = appSettings.bibleSettings.primaryBible
-                )
-                companionServer.updateApiKey(
-                    enabled = appSettings.serverSettings.apiKeyEnabled,
-                    key = appSettings.serverSettings.apiKey
-                )
-                companionServer.updateFileUploadEnabled(appSettings.serverSettings.fileUploadEnabled)
-                companionServer.updateMaxMediaUploadMb(appSettings.serverSettings.maxMediaUploadMb)
-                companionServer.updateAtemConfig(
-                    appSettings.atemSettings,
-                    appSettings.streamingSettings.lowerThirdFolder
-                )
-                if (appSettings.serverSettings.enabled) {
-                    companionServer.start(
-                        port = appSettings.serverSettings.port,
-                        hostOverride = appSettings.serverSettings.serverHost
+                instanceLinkBackgroundCacheDir.listFiles()?.forEach { it.delete() }
+            }
+            InstanceLinkLogger.log(
+                InstanceLinkLogSide.FOLLOWER, "cache_invalidated",
+                mapOf("kind" to "backgrounds", "trigger" to "backgrounds_updated")
+            )
+        }
+        val remote = instanceLinkViewModel.fetchBackgroundSettings() ?: return@LaunchedEffect
+        mirroredBackgroundSettings = downloadMirroredBackgroundSettings(remote, instanceLinkViewModel)
+    }
+    val effectiveAppSettings = remember(appSettings, mirroredBackgroundSettings) {
+        withMirroredBackgrounds(appSettings, mirroredBackgroundSettings)
+    }
+    val screenCountForUsage = remember { LiveMapReporter.detectScreenCount() }
+    val deckLinkCountForUsage = remember {
+        deckLinkOutputCount(DeckLinkManager.isAvailable()) { DeckLinkManager.listDevices().size }
+    }
+
+    LiveStateBroadcastWiring(
+        appSettings = { appSettings },
+        primaryBible = { primaryBibleForInstanceLink },
+        presenterManager = presenterManager,
+        companionServer = companionServer,
+        screenCountForUsage = screenCountForUsage,
+        deckLinkCountForUsage = deckLinkCountForUsage,
+    )
+    remember(qaManager) { companionServer.qaManager = qaManager; true }
+    ObsSceneWiring(appSettings, companionServer, obsManager, presenterManager)
+    val tunnelStatus by companionServer.tunnelManager.status.collectAsState()
+    val tunnelUrl by companionServer.tunnelManager.tunnelUrl.collectAsState()
+    val prevTunnelWasConnected = remember { mutableStateOf(false) }
+    var qaDisplayUrl by remember { mutableStateOf("") }
+    var presentationDisplayUrl by remember { mutableStateOf("") }
+    LaunchedEffect(tunnelStatus) {
+        val isConnected = isTunnelConnected(tunnelStatus)
+        if (tunnelJustDropped(prevTunnelWasConnected.value, isConnected)) {
+            companionServer.clearPresentationState()
+            qaDisplayUrl = ""
+            presentationDisplayUrl = ""
+        }
+        prevTunnelWasConnected.value = isConnected
+    }
+    var presentationFrozen by remember { mutableStateOf(false) }
+    LaunchedEffect(appSettings.presentationRemoteSettings.remoteControlEnabled, appSettings.serverSettings.apiKeyEnabled, appSettings.serverSettings.apiKey) {
+        val activeApiKey = activeApiKey(appSettings.serverSettings)
+        companionServer.updatePresentationRemoteSettings(appSettings.presentationRemoteSettings, activeApiKey)
+    }
+    LaunchedEffect(appSettings.presentationSettings.autoScrollInterval) {
+        companionServer.updateAutoScrollInterval(appSettings.presentationSettings.autoScrollInterval.toInt())
+    }
+    LaunchedEffect(appSettings.presentationSettings.isLooping) {
+        companionServer.updateLoopingState(appSettings.presentationSettings.isLooping)
+    }
+    LaunchedEffect(Unit) {
+        companionServer.onPresentationFreezeToggle.collect {
+            presentationFrozen = !presentationFrozen
+            companionServer.broadcastFreezeChange(presentationFrozen)
+            presenterManager.setSlideFrozen(presentationFrozen)
+        }
+    }
+    MediaRemoteWiring(companionServer, mediaViewModel, presenterManager)
+    val presentingModeValue = presenterManager.presentingMode.value
+    LiveStatusWiring(appSettings, companionServer, presentingModeValue)
+    val browserSourceServerUrlState = companionServer.serverUrl.collectAsState()
+    appSettings.projectionSettings.browserSourceOutputs.indices.forEach { i ->
+        composeKey(i) {
+            val appSettingsState = rememberUpdatedState(effectiveAppSettings)
+            val screenAssignmentState = rememberUpdatedState(
+                browserSourceOutputAt(appSettings.projectionSettings.browserSourceOutputs, i)
+            )
+            val effectiveModeState = remember {
+                derivedStateOf {
+                    effectiveOutputMode(
+                        presenterManager.browserSourceLocks.value, i, presenterManager.presentingMode.value,
                     )
                 }
             }
-            appReady = true
-            val isFirstEverUpdateCheck = isFirstEverUpdateCheck(appSettings.lastUpdateCheckTimestamp)
-            if (appSettings.updateCheckInterval.isDueSince(appSettings.lastUpdateCheckTimestamp)) {
-                val result = UpdateChecker.checkForUpdate(includePrereleases = appSettings.participateInPrereleases)
-                appSettings = appSettings.copy(lastUpdateCheckTimestamp = System.currentTimeMillis())
+            val qaDisplayUrlState = rememberUpdatedState(qaDisplayUrl)
+            val bsOutput = browserSourceOutputAt(appSettings.projectionSettings.browserSourceOutputs, i)
+            val renderer = remember(i, bsOutput.browserSourceWidth, bsOutput.browserSourceHeight, bsOutput.browserSourceFps) {
+                BrowserSourceVideoRenderer(
+                    presenterManager, appSettingsState, screenAssignmentState, effectiveModeState,
+                    outputIndex = i,
+                    sttManager = sttManager,
+                    mediaViewModel = mediaViewModel,
+                    qaDisplayUrlState = qaDisplayUrlState,
+                    serverUrlState = browserSourceServerUrlState,
+                    width = bsOutput.browserSourceWidth,
+                    height = bsOutput.browserSourceHeight,
+                    fps = bsOutput.browserSourceFps,
+                )
+            }
+            LaunchedEffect(renderer) {
+                renderer.start(this)
+                companionServer.registerBrowserSourceFrames(i, renderer.frames)
+            }
+            DisposableEffect(renderer) {
+                onDispose { renderer.stop() }
+            }
+        }
+    }
+    LaunchedEffect(Unit) {
+        companionServer.onPresentationGoLive.collect {
+            presenterManager.setPresentingMode(Presenting.PRESENTATION)
+            presenterManager.setShowPresenterWindow(true)
+        }
+    }
+    val remoteSelectSongFlow =
+        remember { kotlinx.coroutines.flow.MutableSharedFlow<ScheduleItem.SongItem>(extraBufferCapacity = 8) }
+    val remoteSelectPictureFlow =
+        remember { kotlinx.coroutines.flow.MutableSharedFlow<ScheduleItem.PictureItem>(extraBufferCapacity = 8) }
+    val remoteSelectPresentationFlow =
+        remember { kotlinx.coroutines.flow.MutableSharedFlow<ScheduleItem.PresentationItem>(extraBufferCapacity = 8) }
+    var dialogDismissSignal by remember { mutableStateOf(0) }
+    var showOptionsDialog by remember { mutableStateOf(false) }
+    var optionsDialogInitialTab by remember { mutableStateOf(0) }
+    val openOptionsDialog: (Int) -> Unit = { tab ->
+        optionsDialogInitialTab = tab
+        showOptionsDialog = true
+    }
+    var showStatisticsDialog by remember { mutableStateOf(false) }
+    var showInstanceLinkDialog by remember { mutableStateOf(false) }
+    var showKeyboardShortcutsDialog by remember { mutableStateOf(false) }
+    var showAboutDialog by remember { mutableStateOf(false) }
+    var showContactDialog by remember { mutableStateOf(false) }
+    var showConverterWindow by remember { mutableStateOf(false) }
+    var showLottieGenWindow by remember { mutableStateOf(false) }
+    var showStyleEditorWindow by remember { mutableStateOf(false) }
+    var showMemoryMonitorWindow by remember { mutableStateOf(false) }
+    var developerMenuUnlocked by remember { mutableStateOf(false) }
+    var lottieGenOutputDir by remember { mutableStateOf<File?>(null) }
+    var lottieGenOnFileSaved by remember { mutableStateOf<(() -> Unit)?>(null) }
+    var pendingUpdateResult by remember { mutableStateOf<UpdateCheckResult?>(null) }
+    var pendingUpdateCheckWasManual by remember { mutableStateOf(false) }
+    var selectedScheduleItemId by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            companionServer.preloadData(
+                songStorageDir = appSettings.songSettings.storageDirectory,
+                bibleStorageDir = appSettings.bibleSettings.storageDirectory,
+                primaryBibleFileName = appSettings.bibleSettings.primaryBible
+            )
+            companionServer.updateApiKey(
+                enabled = appSettings.serverSettings.apiKeyEnabled,
+                key = appSettings.serverSettings.apiKey
+            )
+            companionServer.updateFileUploadEnabled(appSettings.serverSettings.fileUploadEnabled)
+            companionServer.updateMaxMediaUploadMb(appSettings.serverSettings.maxMediaUploadMb)
+            companionServer.updateAtemConfig(
+                appSettings.atemSettings,
+                appSettings.streamingSettings.lowerThirdFolder
+            )
+            if (appSettings.serverSettings.enabled) {
+                companionServer.start(
+                    port = appSettings.serverSettings.port,
+                    hostOverride = appSettings.serverSettings.serverHost
+                )
+            }
+        }
+        appReady = true
+        val isFirstEverUpdateCheck = isFirstEverUpdateCheck(appSettings.lastUpdateCheckTimestamp)
+        if (appSettings.updateCheckInterval.isDueSince(appSettings.lastUpdateCheckTimestamp)) {
+            val result = UpdateChecker.checkForUpdate(includePrereleases = appSettings.participateInPrereleases)
+            appSettings = appSettings.copy(lastUpdateCheckTimestamp = System.currentTimeMillis())
+            settingsManager.saveSettings(appSettings)
+            if (isFirstEverUpdateCheck) {
+                pendingUpdateResult = result
+                pendingUpdateCheckWasManual = true
+            } else if (result is UpdateCheckResult.Available) {
+                pendingUpdateResult = result
+                pendingUpdateCheckWasManual = false
+            }
+        }
+    }
+
+    val screens = rememberScreenDevices()
+    val savedPlacement = windowPlacementFromSettings(appSettings.windowPlacement)
+    val primaryBounds = GraphicsEnvironment.getLocalGraphicsEnvironment()
+        .defaultScreenDevice.defaultConfiguration.bounds
+    val isFloating = savedPlacement == WindowPlacement.Floating
+    val (startX, startY) = startupWindowPosition(
+        restoreGeometry = shouldRestoreWindowGeometry(isFloating, appSettings.windowX),
+        savedX = appSettings.windowX, savedY = appSettings.windowY,
+        primaryX = primaryBounds.x, primaryY = primaryBounds.y,
+    )
+    val (startWidth, startHeight) = startupWindowSize(
+        isFloating = isFloating,
+        savedWidth = appSettings.windowWidth, savedHeight = appSettings.windowHeight,
+        primaryWidth = primaryBounds.width, primaryHeight = primaryBounds.height,
+    )
+    val state = rememberWindowState(
+        placement = savedPlacement,
+        position = WindowPosition(startX.dp, startY.dp),
+        size = DpSize(startWidth.dp, startHeight.dp),
+    )
+
+    if (!appReady) {
+        SplashWindow(theme = theme)
+    }
+
+    if (appReady && eulaAccepted) {
+        Window(
+            onCloseRequest = {
+                appSettings = appSettings.withWindowGeometry(
+                    placement = windowPlacementToSettings(state.placement),
+                    isFloating = state.placement == WindowPlacement.Floating,
+                    width = state.size.width.value.toInt(),
+                    height = state.size.height.value.toInt(),
+                    x = state.position.x.value.toInt(),
+                    y = state.position.y.value.toInt(),
+                )
                 settingsManager.saveSettings(appSettings)
-                if (isFirstEverUpdateCheck) {
-                    pendingUpdateResult = result
-                    pendingUpdateCheckWasManual = true
-                } else if (result is UpdateCheckResult.Available) {
-                    pendingUpdateResult = result
-                    pendingUpdateCheckWasManual = false
-                }
+                if (qaManager.sessionActive) qaManager.toggleSession()
+                companionServer.clearPresentationState()
+                companionServer.tunnelManager.shutdown()
+                exitApplication()
+            },
+            title = stringResource(Res.string.app_name),
+            icon = painterResource(Res.drawable.ic_app_icon),
+            state = state
+        ) {
+            LaunchedEffect(Unit) {
+                window.minimumSize = Dimension(MIN_MAIN_WINDOW_WIDTH, MIN_MAIN_WINDOW_HEIGHT)
             }
-        }
+            MacMenuBarActivationFix()
+            LanguageProvider(language = currentLanguage) {
+                AppThemeWrapper(theme = theme) {
+                    CompositionLocalProvider(
+                        LocalMediaViewModel provides mediaViewModel,
+                        LocalMainWindowState provides state,
+                        LocalShortcuts provides remember(appSettings.keyboardShortcutSettings) {
+                            ShortcutMap.from(appSettings.keyboardShortcutSettings)
+                        }
+                    ) {
+                        Box(modifier = Modifier.fillMaxSize()) {
 
-        val screens = rememberScreenDevices()
-        val savedPlacement = windowPlacementFromSettings(appSettings.windowPlacement)
-        val primaryBounds = GraphicsEnvironment.getLocalGraphicsEnvironment()
-            .defaultScreenDevice.defaultConfiguration.bounds
-        val isFloating = savedPlacement == WindowPlacement.Floating
-        val (startX, startY) = startupWindowPosition(
-            restoreGeometry = shouldRestoreWindowGeometry(isFloating, appSettings.windowX),
-            savedX = appSettings.windowX, savedY = appSettings.windowY,
-            primaryX = primaryBounds.x, primaryY = primaryBounds.y,
-        )
-        val (startWidth, startHeight) = startupWindowSize(
-            isFloating = isFloating,
-            savedWidth = appSettings.windowWidth, savedHeight = appSettings.windowHeight,
-            primaryWidth = primaryBounds.width, primaryHeight = primaryBounds.height,
-        )
-        val state = rememberWindowState(
-            placement = savedPlacement,
-            position = WindowPosition(startX.dp, startY.dp),
-            size = DpSize(startWidth.dp, startHeight.dp),
-        )
+                            val remoteEventQueue =
+                                remember { mutableStateListOf<Triple<RemoteEvent, () -> Unit, () -> Unit>>() }
 
-        if (!appReady) {
-            SplashWindow(theme = theme)
-        }
+                            val remoteClientManager = remember { RemoteClientManager() }
+                            val sessionAllowedClients =
+                                remember { mutableStateListOf<String>() }
+                            val sessionBlockedClients =
+                                remember { mutableStateListOf<String>() }
+                            val remoteActivityNotifications =
+                                remember { mutableStateListOf<RemoteActivityNotification>() }
 
-        if (appReady && eulaAccepted) {
-            Window(
-                onCloseRequest = {
-                    appSettings = appSettings.withWindowGeometry(
-                        placement = windowPlacementToSettings(state.placement),
-                        isFloating = state.placement == WindowPlacement.Floating,
-                        width = state.size.width.value.toInt(),
-                        height = state.size.height.value.toInt(),
-                        x = state.position.x.value.toInt(),
-                        y = state.position.y.value.toInt(),
-                    )
-                    settingsManager.saveSettings(appSettings)
-                    if (qaManager.sessionActive) qaManager.toggleSession()
-                    companionServer.clearPresentationState()
-                    companionServer.tunnelManager.shutdown()
-                    exitApplication()
-                },
-                title = stringResource(Res.string.app_name),
-                icon = painterResource(Res.drawable.ic_app_icon),
-                state = state
-            ) {
-                LaunchedEffect(Unit) {
-                    window.minimumSize = Dimension(MIN_MAIN_WINDOW_WIDTH, MIN_MAIN_WINDOW_HEIGHT)
-                }
-                MacMenuBarActivationFix()
-                LanguageProvider(language = currentLanguage) {
-                    AppThemeWrapper(theme = theme) {
-                        CompositionLocalProvider(
-                            LocalMediaViewModel provides mediaViewModel,
-                            LocalMainWindowState provides state,
-                            LocalShortcuts provides remember(appSettings.keyboardShortcutSettings) {
-                                ShortcutMap.from(appSettings.keyboardShortcutSettings)
+                            LaunchedEffect(remoteClientManager.blockedClients, sessionBlockedClients.toList()) {
+                                companionServer.blockedClientIds =
+                                    remoteClientManager.blockedClients + sessionBlockedClients
                             }
-                        ) {
-                            Box(modifier = Modifier.fillMaxSize()) {
 
-                                val remoteEventQueue =
-                                    remember { mutableStateListOf<Triple<RemoteEvent, () -> Unit, () -> Unit>>() }
-
-                                val remoteClientManager = remember { RemoteClientManager() }
-                                val sessionAllowedClients =
-                                    remember { mutableStateListOf<String>() }
-                                val sessionBlockedClients =
-                                    remember { mutableStateListOf<String>() }
-                                val remoteActivityNotifications =
-                                    remember { mutableStateListOf<RemoteActivityNotification>() }
-
-                                LaunchedEffect(remoteClientManager.blockedClients, sessionBlockedClients.toList()) {
-                                    companionServer.blockedClientIds =
-                                        remoteClientManager.blockedClients + sessionBlockedClients
+                            LaunchedEffect(Unit) {
+                                companionServer.onAddToSchedule.collect { pending ->
+                                    val clientId = pending.clientId
+                                    val access = remoteAccessDecision(
+                                        clientId,
+                                        remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                        sessionAllowedClients, sessionBlockedClients,
+                                    )
+                                    val item = pending.item
+                                    val add: () -> Unit = {
+                                        addScheduleItem(item, currentScheduleActions) { song ->
+                                            coroutineScope.launch { remoteSelectSongFlow.emit(song) }
+                                        }
+                                        pending.decision.complete(true)
+                                    }
+                                    val (eTitle, eDetail) = remoteEventLabel(item)
+                                    when (val outcome = remoteApproval(
+                                        access,
+                                        type = RemoteEventType.ADD_TO_SCHEDULE,
+                                        title = eTitle,
+                                        detail = eDetail,
+                                        clientId = clientId,
+                                        clientLabel = remoteClientManager.getLabel(clientId),
+                                    )) {
+                                        RemoteApproval.Reject -> pending.decision.complete(false)
+                                        is RemoteApproval.Approve -> {
+                                            add()
+                                            remoteActivityNotifications.add(outcome.notification)
+                                        }
+                                        is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                            outcome.event, add, { pending.decision.complete(false) },
+                                        ))
+                                    }
                                 }
+                            }
 
-                                LaunchedEffect(Unit) {
-                                    companionServer.onAddToSchedule.collect { pending ->
-                                        val clientId = pending.clientId
-                                        val access = remoteAccessDecision(
-                                            clientId,
-                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
-                                            sessionAllowedClients, sessionBlockedClients,
-                                        )
-                                        val item = pending.item
-                                        val add: () -> Unit = {
+                            LaunchedEffect(Unit) {
+                                companionServer.onRemoveFromSchedule.collect { pending ->
+                                    val clientId = pending.clientId
+                                    val access = remoteAccessDecision(
+                                        clientId,
+                                        remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                        sessionAllowedClients, sessionBlockedClients,
+                                    )
+                                    val remove: () -> Unit = {
+                                        currentScheduleActions.removeById(pending.id)
+                                        pending.decision.complete(true)
+                                    }
+                                    when (val outcome = remoteApproval(
+                                        access,
+                                        type = RemoteEventType.REMOVE_FROM_SCHEDULE,
+                                        title = pending.label,
+                                        clientId = clientId,
+                                        clientLabel = remoteClientManager.getLabel(clientId),
+                                    )) {
+                                        RemoteApproval.Reject -> pending.decision.complete(false)
+                                        is RemoteApproval.Approve -> {
+                                            remove()
+                                            remoteActivityNotifications.add(outcome.notification)
+                                        }
+                                        is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                            outcome.event, remove, { pending.decision.complete(false) },
+                                        ))
+                                    }
+                                }
+                            }
+
+                            LaunchedEffect(Unit) {
+                                companionServer.onAddBatchToSchedule.collect { pending ->
+                                    val clientId = pending.clientId
+                                    val access = remoteAccessDecision(
+                                        clientId,
+                                        remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                        sessionAllowedClients, sessionBlockedClients,
+                                    )
+                                    val addAll: () -> Unit = {
+                                        for (item in pending.items) {
                                             addScheduleItem(item, currentScheduleActions) { song ->
                                                 coroutineScope.launch { remoteSelectSongFlow.emit(song) }
                                             }
-                                            pending.decision.complete(true)
                                         }
-                                        val (eTitle, eDetail) = remoteEventLabel(item)
-                                        when (val outcome = remoteApproval(
-                                            access,
-                                            type = RemoteEventType.ADD_TO_SCHEDULE,
-                                            title = eTitle,
-                                            detail = eDetail,
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId),
-                                        )) {
-                                            RemoteApproval.Reject -> pending.decision.complete(false)
-                                            is RemoteApproval.Approve -> {
-                                                add()
-                                                remoteActivityNotifications.add(outcome.notification)
-                                            }
-                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
-                                                outcome.event, add, { pending.decision.complete(false) },
-                                            ))
+                                        pending.decision.complete(true)
+                                    }
+                                    val (batchTitle, batchDetail) = batchEventSummary(pending.items)
+                                    when (val outcome = remoteApproval(
+                                        access,
+                                        type = RemoteEventType.ADD_TO_SCHEDULE,
+                                        title = batchTitle,
+                                        detail = batchDetail,
+                                        clientId = clientId,
+                                        clientLabel = remoteClientManager.getLabel(clientId),
+                                    )) {
+                                        RemoteApproval.Reject -> pending.decision.complete(false)
+                                        is RemoteApproval.Approve -> {
+                                            addAll()
+                                            remoteActivityNotifications.add(outcome.notification)
                                         }
+                                        is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                            outcome.event, addAll, { pending.decision.complete(false) },
+                                        ))
                                     }
                                 }
+                            }
 
-                                LaunchedEffect(Unit) {
-                                    companionServer.onRemoveFromSchedule.collect { pending ->
-                                        val clientId = pending.clientId
-                                        val access = remoteAccessDecision(
-                                            clientId,
-                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
-                                            sessionAllowedClients, sessionBlockedClients,
+                            LaunchedEffect(Unit) {
+                                companionServer.onProject.collect { pending ->
+                                    val clientId = pending.clientId
+                                    val access = remoteAccessDecision(
+                                        clientId,
+                                        remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                        sessionAllowedClients, sessionBlockedClients,
+                                    )
+                                    val item = pending.item
+                                    val project: () -> Unit = {
+                                        if (item is ScheduleItem.AnnouncementItem) {
+                                            appSettings = appSettings.withAnnouncement(item)
+                                        }
+                                        executeProjectItem(
+                                            item,
+                                            currentScheduleActions,
+                                            presenterManager,
+                                            statisticsManager
                                         )
-                                        val remove: () -> Unit = {
-                                            currentScheduleActions.removeById(pending.id)
-                                            pending.decision.complete(true)
-                                        }
-                                        when (val outcome = remoteApproval(
-                                            access,
-                                            type = RemoteEventType.REMOVE_FROM_SCHEDULE,
-                                            title = pending.label,
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId),
-                                        )) {
-                                            RemoteApproval.Reject -> pending.decision.complete(false)
-                                            is RemoteApproval.Approve -> {
-                                                remove()
-                                                remoteActivityNotifications.add(outcome.notification)
-                                            }
-                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
-                                                outcome.event, remove, { pending.decision.complete(false) },
-                                            ))
-                                        }
-                                    }
-                                }
-
-                                LaunchedEffect(Unit) {
-                                    companionServer.onAddBatchToSchedule.collect { pending ->
-                                        val clientId = pending.clientId
-                                        val access = remoteAccessDecision(
-                                            clientId,
-                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
-                                            sessionAllowedClients, sessionBlockedClients,
-                                        )
-                                        val addAll: () -> Unit = {
-                                            for (item in pending.items) {
-                                                addScheduleItem(item, currentScheduleActions) { song ->
-                                                    coroutineScope.launch { remoteSelectSongFlow.emit(song) }
-                                                }
-                                            }
-                                            pending.decision.complete(true)
-                                        }
-                                        val (batchTitle, batchDetail) = batchEventSummary(pending.items)
-                                        when (val outcome = remoteApproval(
-                                            access,
-                                            type = RemoteEventType.ADD_TO_SCHEDULE,
-                                            title = batchTitle,
-                                            detail = batchDetail,
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId),
-                                        )) {
-                                            RemoteApproval.Reject -> pending.decision.complete(false)
-                                            is RemoteApproval.Approve -> {
-                                                addAll()
-                                                remoteActivityNotifications.add(outcome.notification)
-                                            }
-                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
-                                                outcome.event, addAll, { pending.decision.complete(false) },
-                                            ))
-                                        }
-                                    }
-                                }
-
-                                LaunchedEffect(Unit) {
-                                    companionServer.onProject.collect { pending ->
-                                        val clientId = pending.clientId
-                                        val access = remoteAccessDecision(
-                                            clientId,
-                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
-                                            sessionAllowedClients, sessionBlockedClients,
-                                        )
-                                        val item = pending.item
-                                        val project: () -> Unit = {
-                                            if (item is ScheduleItem.AnnouncementItem) {
-                                                appSettings = appSettings.withAnnouncement(item)
-                                            }
-                                            executeProjectItem(
-                                                item,
-                                                currentScheduleActions,
-                                                presenterManager,
-                                                statisticsManager
+                                        coroutineScope.launch {
+                                            emitRemoteTabSelection(
+                                                item, remoteSelectSongFlow,
+                                                remoteSelectPictureFlow, remoteSelectPresentationFlow,
                                             )
-                                            coroutineScope.launch {
-                                                emitRemoteTabSelection(
-                                                    item, remoteSelectSongFlow,
-                                                    remoteSelectPictureFlow, remoteSelectPresentationFlow,
-                                                )
-                                            }
-                                            pending.decision.complete(true)
                                         }
-                                        val (pTitle, pDetail) = remoteEventLabel(item)
-                                        when (val outcome = remoteApproval(
-                                            access,
-                                            type = RemoteEventType.PROJECT,
-                                            title = pTitle,
-                                            detail = pDetail,
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId),
-                                        )) {
-                                            RemoteApproval.Reject -> pending.decision.complete(false)
-                                            is RemoteApproval.Approve -> {
-                                                project()
-                                                remoteActivityNotifications.add(outcome.notification)
-                                            }
-                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
-                                                outcome.event, project, { pending.decision.complete(false) },
-                                            ))
+                                        pending.decision.complete(true)
+                                    }
+                                    val (pTitle, pDetail) = remoteEventLabel(item)
+                                    when (val outcome = remoteApproval(
+                                        access,
+                                        type = RemoteEventType.PROJECT,
+                                        title = pTitle,
+                                        detail = pDetail,
+                                        clientId = clientId,
+                                        clientLabel = remoteClientManager.getLabel(clientId),
+                                    )) {
+                                        RemoteApproval.Reject -> pending.decision.complete(false)
+                                        is RemoteApproval.Approve -> {
+                                            project()
+                                            remoteActivityNotifications.add(outcome.notification)
                                         }
+                                        is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                            outcome.event, project, { pending.decision.complete(false) },
+                                        ))
                                     }
                                 }
+                            }
 
-                                LaunchedEffect(Unit) {
-                                    companionServer.onSelectSongSection.collect { req ->
-                                        val sections = presenterManager.allLyricSections.value
-                                        val section = sections.getOrNull(req.section) ?: return@collect
-                                        presenterManager.setLyricSection(section)
-                                        presenterManager.setSongDisplaySectionIndex(req.section)
-                                        presenterManager.setSongDisplayLineIndex(remoteSongLineIndex(req.lineIndex))
-                                        if (shouldSwitchToLyrics(presenterManager.presentingMode.value)) {
-                                            presenterManager.setPresentingMode(Presenting.LYRICS)
-                                            presenterManager.setShowPresenterWindow(true)
-                                        }
-                                    }
-                                }
-
-                                LaunchedEffect(Unit) {
-                                    companionServer.onClear.collect {
-                                        mediaViewModel.pause()
-                                        presenterManager.requestClearDisplay()
-                                    }
-                                }
-
-                                LaunchedEffect(Unit) {
-                                    LowerThirdSequencer.onShow.collect { req ->
-                                        presenterManager.setLottieContent(
-                                            req.json, req.pauseAtFrame, req.pauseFrame, req.pauseDurationMs, req.name
-                                        )
-                                        presenterManager.setPresentingMode(Presenting.LOWER_THIRD)
+                            LaunchedEffect(Unit) {
+                                companionServer.onSelectSongSection.collect { req ->
+                                    val sections = presenterManager.allLyricSections.value
+                                    val section = sections.getOrNull(req.section) ?: return@collect
+                                    presenterManager.setLyricSection(section)
+                                    presenterManager.setSongDisplaySectionIndex(req.section)
+                                    presenterManager.setSongDisplayLineIndex(remoteSongLineIndex(req.lineIndex))
+                                    if (shouldSwitchToLyrics(presenterManager.presentingMode.value)) {
+                                        presenterManager.setPresentingMode(Presenting.LYRICS)
                                         presenterManager.setShowPresenterWindow(true)
                                     }
                                 }
-                                LaunchedEffect(Unit) {
-                                    LowerThirdSequencer.onClear.collect {
-                                        if (shouldClearAfterLowerThird(presenterManager.presentingMode.value)) {
-                                            presenterManager.requestClearDisplay()
-                                        }
-                                    }
-                                }
-                                LaunchedEffect(Unit) {
-                                    companionServer.onQADisplay.collect { question ->
-                                        if (question != null) {
-                                            presenterManager.setDisplayedQuestion(question)
-                                            presenterManager.setShowQRCodeOnDisplay(false)
-                                            presenterManager.setPresentingMode(Presenting.QA)
-                                        } else {
-                                            presenterManager.setDisplayedQuestion(null)
-                                            presenterManager.setPresentingMode(Presenting.NONE)
-                                        }
-                                    }
-                                }
+                            }
 
-                                LaunchedEffect(Unit) {
-                                    companionServer.onQAAdminRequest.collect { pending ->
-                                        val clientId = pending.clientId
-                                        val access = remoteAccessDecision(
-                                            clientId,
-                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
-                                            sessionAllowedClients, sessionBlockedClients,
-                                        )
-                                        when (val outcome = remoteApproval(
-                                            access,
-                                            type = qaActionType(pending.action),
-                                            title = remoteEventTitle(pending.text),
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId),
-                                        )) {
-                                            RemoteApproval.Reject -> pending.decision.complete(false)
-                                            is RemoteApproval.Approve -> {
-                                                pending.decision.complete(true)
-                                                remoteActivityNotifications.add(outcome.notification)
-                                            }
-                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
-                                                outcome.event,
-                                                { pending.decision.complete(true) },
-                                                { pending.decision.complete(false) },
-                                            ))
-                                        }
-                                    }
+                            LaunchedEffect(Unit) {
+                                companionServer.onClear.collect {
+                                    mediaViewModel.pause()
+                                    presenterManager.requestClearDisplay()
                                 }
+                            }
 
-                                LaunchedEffect(Unit) {
-                                    companionServer.onPresentationRemoteConnect.collect { pending ->
-                                        val clientId = pending.clientId
-                                        val access = remoteAccessDecision(
-                                            clientId,
-                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
-                                            sessionAllowedClients, sessionBlockedClients,
-                                        )
-                                        when (val outcome = remoteApproval(
-                                            access,
-                                            type = RemoteEventType.PRESENTATION_CONNECT,
-                                            title = "",
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId),
-                                        )) {
-                                            RemoteApproval.Reject -> pending.decision.complete(false)
-                                            is RemoteApproval.Approve -> {
-                                                pending.decision.complete(true)
-                                                remoteActivityNotifications.add(outcome.notification)
-                                            }
-                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
-                                                outcome.event,
-                                                { pending.decision.complete(true) },
-                                                { pending.decision.complete(false) },
-                                            ))
-                                        }
-                                    }
+                            LaunchedEffect(Unit) {
+                                LowerThirdSequencer.onShow.collect { req ->
+                                    presenterManager.setLottieContent(
+                                        req.json, req.pauseAtFrame, req.pauseFrame, req.pauseDurationMs, req.name
+                                    )
+                                    presenterManager.setPresentingMode(Presenting.LOWER_THIRD)
+                                    presenterManager.setShowPresenterWindow(true)
                                 }
-
-                                LaunchedEffect(Unit) {
-                                    companionServer.onQaAdminConnect.collect { pending ->
-                                        val clientId = pending.clientId
-                                        val access = remoteAccessDecision(
-                                            clientId,
-                                            remoteClientManager.allowedClients, remoteClientManager.blockedClients,
-                                            sessionAllowedClients, sessionBlockedClients,
-                                        )
-                                        when (val outcome = remoteApproval(
-                                            access,
-                                            type = RemoteEventType.QA_ADMIN_CONNECT,
-                                            title = "",
-                                            clientId = clientId,
-                                            clientLabel = remoteClientManager.getLabel(clientId),
-                                        )) {
-                                            RemoteApproval.Reject -> pending.decision.complete(false)
-                                            is RemoteApproval.Approve -> {
-                                                pending.decision.complete(true)
-                                                remoteActivityNotifications.add(outcome.notification)
-                                            }
-                                            is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
-                                                outcome.event,
-                                                { pending.decision.complete(true) },
-                                                { pending.decision.complete(false) },
-                                            ))
-                                        }
-                                    }
-                                }
-
-                                LaunchedEffect(Unit) {
-                                    companionServer.onBibleHold.collect { hold ->
-                                        presenterManager.setBibleHold(hold)
-                                    }
-                                }
-
-                                LaunchedEffect(Unit) {
-                                    snapshotFlow { presenterManager.presentingMode.value }
-                                        .collect { mode ->
-                                            if (shouldBroadcastDisplayCleared(mode)) {
-                                                companionServer.broadcastDisplayCleared()
-                                            }
-                                        }
-                                }
-
-                                LaunchedEffect(Unit) {
-                                    snapshotFlow { presenterManager.songDisplaySectionIndex.value }
-                                        .collect { index ->
-                                            if (shouldBroadcastSongSection(presenterManager.presentingMode.value)) {
-                                                companionServer.broadcastSongSectionSelected(index)
-                                            }
-                                        }
-                                }
-
-                                LaunchedEffect(Unit) {
-                                    companionServer.onInstantAction.collect { action ->
-                                        val type = remoteActionType(action.actionType)
-                                        remoteActivityNotifications.add(
-                                            RemoteActivityNotification(
-                                                type = type,
-                                                title = action.title,
-                                                detail = action.detail,
-                                                clientId = action.clientId,
-                                                clientLabel = remoteClientManager.getLabel(action.clientId)
-                                            )
-                                        )
-                                    }
-                                }
-
-                                NavigationTopBar(
-                                    currentTheme = theme,
-                                    onAbout = { showAboutDialog = true },
-                                    onContactUs = { showContactDialog = true },
-                                    onGettingStarted = { showSetupWizard = true },
-                                    onStatistics = { showStatisticsDialog = true },
-                                    onConnectToInstance = { showInstanceLinkDialog = true },
-                                    onDisconnectInstance = { instanceLinkViewModel.disconnect() },
-                                    isInstanceLinkConnected = isInstanceLinkActive(
-                                        instanceLinkViewModel.connectionStatus.collectAsState().value
-                                    ),
-                                    onConverter = { showConverterWindow = true },
-                                    onHelp = {
-                                        Desktop.getDesktop()
-                                            .browse(URI("https://churchpresenter.org/wiki"))
-                                    },
-                                    onHowToBlog = {
-                                        Desktop.getDesktop()
-                                            .browse(URI("https://churchpresenter.org/blog"))
-                                    },
-                                    onCheckForUpdates = {
-                                        coroutineScope.launch {
-                                            pendingUpdateResult = UpdateChecker.checkForUpdate(
-                                                includePrereleases = appSettings.participateInPrereleases
-                                            )
-                                            pendingUpdateCheckWasManual = true
-                                            appSettings = appSettings.copy(lastUpdateCheckTimestamp = System.currentTimeMillis())
-                                            settingsManager.saveSettings(appSettings)
-                                        }
-                                    },
-                                    onKeyboardShortcuts = { showKeyboardShortcutsDialog = true },
-                                    theme = {
-                                        appSettings = appSettings.copy(theme = it.toString())
-                                        theme = it
-                                        settingsManager.saveSettings(appSettings)
-                                    },
-                                    onLanguageChange = { language ->
-                                        currentLanguage = language
-                                        appSettings = appSettings.copy(language = language.code)
-                                        settingsManager.saveSettings(appSettings)
-                                        Locale.setDefault(Locale.forLanguageTag(language.code))
-                                    },
-                                    onSettings = { openOptionsDialog(0) },
-                                    onExit = { exitApplication() },
-                                    onAddToSchedule = { },
-                                    onNewSchedule = { currentScheduleActions.newSchedule() },
-                                    onOpenSchedule = { currentScheduleActions.openSchedule() },
-                                    onSaveSchedule = { currentScheduleActions.saveSchedule() },
-                                    onSaveScheduleAs = { currentScheduleActions.saveScheduleAs() },
-                                    onCloseSchedule = { currentScheduleActions.newSchedule() },
-                                    onRemoveFromSchedule = {
-                                        selectedScheduleItemId?.let {
-                                            currentScheduleActions.removeSelected()
-                                            selectedScheduleItemId = null
-                                        }
-                                    },
-                                    onClearSchedule = {
-                                        currentScheduleActions.clearSchedule()
-                                        selectedScheduleItemId = null
-                                    },
-                                    showDeveloperMenu = shouldShowDeveloperMenu(
-                                        BuildConfig.IS_RELEASE, DevFlags.forceDevWindow, developerMenuUnlocked,
-                                    ),
-                                    isPresenterWindowVisible = presenterManager.showPresenterWindow.value,
-                                    onSetPresenterWindowVisible = { presenterManager.setShowPresenterWindow(it) },
-                                    isDevWindowAlwaysOnTop = presenterManager.devWindowAlwaysOnTop.value,
-                                    onSetDevWindowAlwaysOnTop = { presenterManager.setDevWindowAlwaysOnTop(it) },
-                                    onOpenStyleEditor = { showStyleEditorWindow = true },
-                                    onOpenMemoryMonitor = { showMemoryMonitorWindow = true },
-                                )
-                                if (CrashReporter.didCrashLastRun && CrashReporter.videoBackgroundsDisabled) {
-                                    var showBanner by remember { mutableStateOf(true) }
-                                    if (showBanner) {
-                                        Box(
-                                            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.errorContainer),
-                                            contentAlignment = Alignment.Center
-                                        ) {
-                                            Text(
-                                                text = "Video backgrounds disabled after ${CrashReporter.consecutiveCrashes} consecutive crashes.  [Re-enable]  [Dismiss]",
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color = MaterialTheme.colorScheme.onErrorContainer,
-                                                modifier = Modifier.onPreviewKeyEvent {
-                                                    showBanner = false; true
-                                                }
-                                            )
-                                        }
-                                        LaunchedEffect(Unit) {
-                                            delay(CRASH_REPORT_RETRY_MS)
-                                            showBanner = false
-                                        }
-                                    }
-                                }
-
-                                val instanceLinkStatus = instanceLinkViewModel.connectionStatus.collectAsState().value
-                                val instanceLinkIsControllerConnected =
-                                    isControllerConnected(instanceLinkStatus, appSettings.instanceLink.role)
-                                val instanceLinkUsesRemoteContent =
-                                    shouldUseRemoteContent(instanceLinkStatus, appSettings.instanceLink.role)
-                                MainDesktop(
-                                    hostWindow = window,
-                                    instanceLinkConnectionStatus = instanceLinkViewModel.connectionStatus.collectAsState().value,
-                                    instanceLinkNextRetryAtMs = instanceLinkViewModel.nextRetryAtMs.collectAsState().value,
-                                    instanceLinkBibleUpdatedSignal = instanceLinkViewModel.bibleUpdatedSignal.collectAsState().value,
-                                    instanceLinkSecondaryBibleUpdatedSignal = instanceLinkViewModel.secondaryBibleUpdatedSignal.collectAsState().value,
-                                    instanceLinkFollowingHost = appSettings.instanceLink.primaryHost,
-                                    connectedInstanceLinkFollowerCount = companionServer.connectedInstanceLinkFollowers.collectAsState().value.size,
-                                    onInstanceLinkConnect = {
-                                        val link = appSettings.instanceLink
-                                        setInstanceLinkEnabled(true)
-                                        instanceLinkViewModel.connect(
-                                            link.primaryHost, link.primaryPort, link.apiKey, link.deviceId,
-                                            link.reconnectDelayMs.toLong()
-                                        )
-                                    },
-                                    onInstanceLinkDisconnect = {
-                                        setInstanceLinkEnabled(false)
-                                        instanceLinkViewModel.disconnect()
-                                    },
-                                    instanceLinkRemoteSchedule = instanceLinkViewModel.remoteSchedule.collectAsState().value,
-                                    instanceLinkRemoteSongCatalog = instanceLinkViewModel.remoteSongCatalog.collectAsState().value,
-                                    instanceLinkFetchSongDetail = { number, songbook -> instanceLinkViewModel.fetchSongDetail(number, songbook) },
-                                    instanceLinkFetchBibleFile = { instanceLinkViewModel.fetchBibleFile() },
-                                    instanceLinkBibleSyncMode = appSettings.instanceLink.bibleSyncMode,
-                                    instanceLinkFetchSecondaryBibleFile = { instanceLinkViewModel.fetchSecondaryBibleFile() },
-                                    instanceLinkFetchBibleTranslations = { instanceLinkViewModel.fetchBibleTranslations() },
-                                    instanceLinkOnSecondaryBibleFilePathChanged = { path -> companionServer.updateSecondaryBibleFilePath(path) },
-                                    instanceLinkOnBibleFilePathsChanged = { paths -> companionServer.updateBibleFilePaths(paths) },
-                                    instanceLinkSendAddToSchedule = if (canPushToSchedule(appSettings.instanceLink)) {
-                                        { item -> instanceLinkViewModel.sendAddToSchedule(item) }
-                                    } else null,
-                                    instanceLinkSendRemoveFromSchedule = if (canPushToSchedule(appSettings.instanceLink)) {
-                                        { id -> instanceLinkViewModel.sendRemoveFromSchedule(id) }
-                                    } else null,
-                                    instanceLinkRole = appSettings.instanceLink.role,
-                                    instanceLinkSendProject = if (instanceLinkIsControllerConnected) {
-                                        { item -> instanceLinkViewModel.sendProject(item) }
-                                    } else null,
-                                    instanceLinkSendVerse = if (instanceLinkIsControllerConnected) {
-                                        { bookName, chapter, verseNumber, verseText, verseRange ->
-                                            instanceLinkViewModel.sendSelectBibleVerse(bookName, chapter, verseNumber, verseText, verseRange)
-                                        }
-                                    } else null,
-                                    instanceLinkSendSongSection = if (instanceLinkIsControllerConnected) {
-                                        { number, section, lineIndex -> instanceLinkViewModel.sendSelectSongSection(number, section, lineIndex) }
-                                    } else null,
-                                    instanceLinkSendClear = if (instanceLinkIsControllerConnected) {
-                                        { instanceLinkViewModel.sendClear() }
-                                    } else null,
-                                    instanceLinkSendBibleHold = if (instanceLinkIsControllerConnected) {
-                                        { hold -> instanceLinkViewModel.sendBibleHold(hold) }
-                                    } else null,
-                                    instanceLinkSendNextPicture = if (instanceLinkIsControllerConnected) {
-                                        { instanceLinkViewModel.sendNextPicture() }
-                                    } else null,
-                                    instanceLinkSendPreviousPicture = if (instanceLinkIsControllerConnected) {
-                                        { instanceLinkViewModel.sendPreviousPicture() }
-                                    } else null,
-                                    instanceLinkSendNextSlide = if (instanceLinkIsControllerConnected) {
-                                        { instanceLinkViewModel.sendNextSlide() }
-                                    } else null,
-                                    instanceLinkSendPreviousSlide = if (instanceLinkIsControllerConnected) {
-                                        { instanceLinkViewModel.sendPreviousSlide() }
-                                    } else null,
-                                    instanceLinkFetchPictureImageBytes = if (instanceLinkUsesRemoteContent) {
-                                        { folderId, index -> instanceLinkViewModel.fetchPictureImageBytes(folderId, index) }
-                                    } else null,
-                                    instanceLinkFetchPresentationSlideBytes = if (instanceLinkUsesRemoteContent) {
-                                        { id, index -> instanceLinkViewModel.fetchPresentationSlideBytes(id, index) }
-                                    } else null,
-                                    instanceLinkMediaStreamUrl = run {
-                                        val link = appSettings.instanceLink
-                                        if (instanceLinkUsesRemoteContent) {
-                                            ({ itemId: String ->
-                                                instanceLinkMediaStreamUrl(
-                                                    link.primaryHost, link.primaryPort, link.apiKey, itemId,
-                                                )
-                                            })
-                                        } else null
-                                    },
-                                    onVerseSelected = { verses -> presenterManager.setSelectedVerses(verses) },
-                                    onSongItemSelected = { section ->
-                                        presenterManager.setLyricSection(section)
-                                        if (isSongLineMode(appSettings.songSettings)) {
-                                            presenterManager.setDisplayedLyricSection(section)
-                                        }
-                                    },
-                                    onAllSectionsChanged = { presenterManager.setAllLyricSections(it) },
-                                    onSectionIndexChanged = { presenterManager.setSongDisplaySectionIndex(it) },
-                                    onLineIndexChanged = { presenterManager.setSongDisplayLineIndex(it) },
-                                    appSettings = appSettings,
-                                    livePreviewAppSettings = effectiveAppSettings,
-                                    presenterManager = presenterManager,
-                                    statisticsManager = statisticsManager,
-                                    verseSequenceLog = verseSequenceLog,
-                                    onScheduleActionsReady = { scheduleActions = it },
-                                    presenting = { mode ->
-                                        presenterManager.setPresentingMode(mode)
-                                        if (shouldShowPresenterWindowFor(mode)) {
-                                            presenterManager.setShowPresenterWindow(true)
-                                        }
-                                    },
-                                    onScheduleItemSelected = { itemId -> selectedScheduleItemId = itemId },
-                                    onShowSettings = { openOptionsDialog(0) },
-                                    onShowBackgroundSettings = { openOptionsDialog(OPTIONS_TAB_BACKGROUND) },
-                                    onSettingsChange = { updateFn ->
-                                        appSettings = updateFn(appSettings)
-                                        settingsManager.saveSettings(appSettings)
-                                    },
-                                    theme = theme,
-                                    onSongsLoaded = { songs -> companionServer.updateSongs(songs) },
-                                    onScenesChanged = { scenes -> scenesForInstanceLink = scenes },
-                                    onBibleLoaded = { bible, translation ->
-                                        primaryBibleForInstanceLink = bible
-                                        companionServer.updateBible(
-                                            bible,
-                                            translation,
-                                            filePath = bibleFilePath(appSettings.bibleSettings.storageDirectory, translation)
-                                        )
-                                    },
-                                    onScheduleChanged = { items -> companionServer.updateSchedule(items) },
-                                    onPresentationSlidesLoaded = { id, filePath, fileName, fileType, slides, notes ->
-                                        companionServer.updatePresentation(id, filePath, fileName, fileType, slides, notes)
-                                    },
-                                    onPicturesLoaded = { folderId, folderName, folderPath, imageFiles ->
-                                        companionServer.updatePictures(folderId, folderName, folderPath, imageFiles)
-                                    },
-                                    selectPictureImageFlow = kotlinx.coroutines.flow.flow {
-                                        companionServer.onSelectPicture.collect { req ->
-                                            emit(req.folderId to req.index)
-                                        }
-                                    },
-                                    resolveImageFile = { folderId, index ->
-                                        companionServer.getImageFile(folderId, index)
-                                    },
-                                    selectSlideFlow = kotlinx.coroutines.flow.flow {
-                                        companionServer.onSelectSlide.collect { req ->
-                                            emit(req.id to req.index)
-                                        }
-                                    },
-                                    selectBibleVerseFlow = kotlinx.coroutines.flow.flow {
-                                        companionServer.onSelectBibleVerse.collect { req ->
-                                            emit(req)
-                                        }
-                                    },
-                                    remoteSelectSongFlow = remoteSelectSongFlow,
-                                    remoteSelectPictureFlow = remoteSelectPictureFlow,
-                                    remoteSelectPresentationFlow = remoteSelectPresentationFlow,
-                                    nextPictureFlow = kotlinx.coroutines.flow.flow {
-                                        companionServer.onNextPicture.collect { emit(Unit) }
-                                    },
-                                    previousPictureFlow = kotlinx.coroutines.flow.flow {
-                                        companionServer.onPreviousPicture.collect { emit(Unit) }
-                                    },
-                                    nextSlideFlow = kotlinx.coroutines.flow.flow {
-                                        companionServer.onNextSlide.collect { emit(Unit) }
-                                    },
-                                    previousSlideFlow = kotlinx.coroutines.flow.flow {
-                                        companionServer.onPreviousSlide.collect { emit(Unit) }
-                                    },
-                                    uploadPresentationFlow = kotlinx.coroutines.flow.flow {
-                                        companionServer.onPresentationUploaded.collect { file ->
-                                            emit(file)
-                                        }
-                                    },
-                                    serverUrl = companionServer.serverUrl.collectAsState().value,
-                                    qaManager = qaManager,
-                                    tunnelStatus = tunnelStatus,
-                                    tunnelUrl = tunnelUrl ?: "",
-                                    onStartTunnel = { companionServer.tunnelManager.start(appSettings.serverSettings.port) },
-                                    onStopTunnel = { companionServer.tunnelManager.stop() },
-                                    qaDisplayUrl = qaDisplayUrl,
-                                    onQaDisplayUrlChanged = { qaDisplayUrl = it },
-                                    presentationDisplayUrl = presentationDisplayUrl,
-                                    onPresentationDisplayUrlChanged = { presentationDisplayUrl = it },
-                                    onSlideChanged = { id, index, total, isPlaying ->
-                                        companionServer.broadcastSlideChange(id, index, total, isPlaying)
-                                    },
-                                    remotePresentationPlayPauseFlow = companionServer.onPresentationPlayPause,
-                                    remotePresentationLoopToggleFlow = companionServer.onPresentationLoopToggle,
-                                    remotePresentationGotoFlow = companionServer.onPresentationGoto,
-                                    presentationFrozen = presentationFrozen,
-                                    onFreezeToggle = {
-                                        presentationFrozen = !presentationFrozen
-                                        companionServer.broadcastFreezeChange(presentationFrozen)
-                                        presenterManager.setSlideFrozen(presentationFrozen)
-                                    },
-                                    onClearPresentation = {
-                                        companionServer.clearPresentationState()
+                            }
+                            LaunchedEffect(Unit) {
+                                LowerThirdSequencer.onClear.collect {
+                                    if (shouldClearAfterLowerThird(presenterManager.presentingMode.value)) {
                                         presenterManager.requestClearDisplay()
-                                    },
-                                    onOpenLottieGen = { outputDir, onSaved ->
-                                        if (isUsableOutputDir(outputDir)) {
-                                            lottieGenOutputDir = File(outputDir)
-                                            lottieGenOnFileSaved = onSaved
-                                            showLottieGenWindow = true
-                                        } else {
-                                            javax.swing.JOptionPane.showMessageDialog(
-                                                null,
-                                                "Please set a Lower Third folder in Settings first.",
-                                                "No Folder Configured",
-                                                javax.swing.JOptionPane.WARNING_MESSAGE
-                                            )
-                                        }
-                                    },
-                                    sttManager = sttManager,
-                                    dialogDismissSignal = dialogDismissSignal,
-                                    companionSatelliteViewModel = companionSatelliteViewModel,
-                                    onRequestDeveloperMenuUnlock = { developerMenuUnlocked = true }
-                                )
-                                OptionsDialog(
-                                    isVisible = showOptionsDialog,
-                                    initialTab = optionsDialogInitialTab,
-                                    initialSettings = appSettings,
-                                    theme = theme,
-                                    settingsManager = settingsManager,
-                                    companionServer = companionServer,
-                                    remoteClientManager = remoteClientManager,
-                                    presenterManager = presenterManager,
-                                    onDismiss = { showOptionsDialog = false; dialogDismissSignal++ },
-                                    onSave = { updated ->
-                                        appSettings = updated
-                                        settingsManager.saveSettings(updated)
-                                        companionServer.preloadData(
-                                            songStorageDir = updated.songSettings.storageDirectory,
-                                            bibleStorageDir = updated.bibleSettings.storageDirectory,
-                                            primaryBibleFileName = updated.bibleSettings.primaryBible
-                                        )
-                                        companionServer.updateApiKey(
-                                            enabled = updated.serverSettings.apiKeyEnabled,
-                                            key = updated.serverSettings.apiKey
-                                        )
-                                        companionServer.updateFileUploadEnabled(updated.serverSettings.fileUploadEnabled)
-                                        companionServer.updateMaxMediaUploadMb(updated.serverSettings.maxMediaUploadMb)
-                                        companionServer.updateAtemConfig(
-                                            updated.atemSettings,
-                                            updated.streamingSettings.lowerThirdFolder
-                                        )
-                                    },
-                                    onIdentifyScreen = {
-                                        identifyingScreen = true
-                                        coroutineScope.launch {
-                                            delay(UPDATE_CHECK_DELAY_MS)
-                                            identifyingScreen = false
-                                        }
-                                    },
-                                    onIdentifyBrowserSource = { index ->
-                                        presenterManager.identifyBrowserSourceOutput(index)
-                                    },
-                                    onOpenLottieGen = { outputDir, onSaved ->
-                                        if (isUsableOutputDir(outputDir)) {
-                                            lottieGenOutputDir = File(outputDir)
-                                            lottieGenOnFileSaved = onSaved
-                                            showLottieGenWindow = true
-                                        } else {
-                                            javax.swing.JOptionPane.showMessageDialog(
-                                                null,
-                                                "Please set a Lower Third folder in Settings first.",
-                                                "No Folder Configured",
-                                                javax.swing.JOptionPane.WARNING_MESSAGE
-                                            )
-                                        }
-                                    },
-                                    obsManager = obsManager,
-                                    companionSatelliteViewModel = companionSatelliteViewModel
-                                )
-                                KeyboardShortcutsDialog(
-                                    isVisible = showKeyboardShortcutsDialog,
-                                    settings = appSettings,
-                                    onSave = { updated ->
-                                        appSettings = updated
-                                        settingsManager.saveSettings(updated)
-                                    },
-                                    onDismiss = { showKeyboardShortcutsDialog = false; dialogDismissSignal++ }
-                                )
-                                StatisticsDialog(
-                                    isVisible = showStatisticsDialog,
-                                    theme = theme,
-                                    statisticsManager = statisticsManager,
-                                    onDismiss = { showStatisticsDialog = false; dialogDismissSignal++ }
-                                )
-                                InstanceLinkDialog(
-                                    isVisible = showInstanceLinkDialog,
-                                    settings = appSettings.instanceLink,
-                                    connectionStatus = instanceLinkViewModel.connectionStatus.collectAsState().value,
-                                    remoteLiveState = instanceLinkViewModel.remoteLiveState.collectAsState().value,
-                                    remoteScheduleCount = instanceLinkViewModel.remoteSchedule.collectAsState().value.size,
-                                    lastMessageAtMs = instanceLinkViewModel.lastMessageAtMs.collectAsState().value,
-                                    onConnect = { edited ->
-                                        val link = edited.copy(enabled = true)
-                                        appSettings = appSettings.copy(instanceLink = link)
-                                        settingsManager.saveSettings(appSettings)
-                                        instanceLinkViewModel.connect(
-                                            link.primaryHost, link.primaryPort, link.apiKey, link.deviceId,
-                                            link.reconnectDelayMs.toLong()
-                                        )
-                                    },
-                                    onSave = { edited ->
-                                        appSettings = appSettings.copy(instanceLink = edited)
-                                        settingsManager.saveSettings(appSettings)
-                                    },
-                                    onDisconnect = {
-                                        setInstanceLinkEnabled(false)
-                                        instanceLinkViewModel.disconnect()
-                                    },
-                                    onDismiss = { showInstanceLinkDialog = false; dialogDismissSignal++ }
-                                )
-                                AboutDialog(
-                                    isVisible = showAboutDialog,
-                                    onDismiss = { showAboutDialog = false; dialogDismissSignal++ },
-                                    appSettings = appSettings,
-                                    theme = theme
-                                )
-                                ContactUsDialog(
-                                    isVisible = showContactDialog,
-                                    onDismiss = { showContactDialog = false; dialogDismissSignal++ }
-                                )
-                                if (showConverterWindow) {
-                                    ConverterWindow(
-                                        theme = theme,
-                                        onClose = { showConverterWindow = false }
-                                    )
-                                }
-                                if (showLottieGenWindow) {
-                                    val screenBounds = presenterScreenBounds()
-                                    LottieGenWindow(
-                                        theme = theme,
-                                        outputDir = lottieGenOutputDir,
-                                        onClose = { showLottieGenWindow = false },
-                                        onFileSaved = {
-                                            UsageEvents.record(UsageEvent.LOWER_THIRD_GENERATED)
-                                            lottieGenOnFileSaved?.invoke()
-                                        },
-                                        canvasWidth = screenBounds.width,
-                                        canvasHeight = screenBounds.height
-                                    )
-                                }
-                                MemoryMonitorWindow(
-                                    isVisible = showMemoryMonitorWindow,
-                                    theme = theme,
-                                    onClose = { showMemoryMonitorWindow = false }
-                                )
-                                if (showStyleEditorWindow) {
-                                    StyleEditorWindow(
-                                        theme = theme,
-                                        onClose = { showStyleEditorWindow = false }
-                                    )
-                                }
-                                UpdateAvailableDialog(
-                                    result = pendingUpdateResult,
-                                    isManualCheck = pendingUpdateCheckWasManual,
-                                    participateInPrereleases = appSettings.participateInPrereleases,
-                                    onParticipateInPrereleasesChange = { enabled ->
-                                        appSettings = appSettings.copy(participateInPrereleases = enabled)
-                                        settingsManager.saveSettings(appSettings)
-                                        coroutineScope.launch {
-                                            pendingUpdateResult = UpdateChecker.checkForUpdate(includePrereleases = enabled)
-                                        }
-                                    },
-                                    updateCheckInterval = appSettings.updateCheckInterval,
-                                    onUpdateCheckIntervalChange = { interval ->
-                                        appSettings = appSettings.copy(updateCheckInterval = interval)
-                                        settingsManager.saveSettings(appSettings)
-                                    },
-                                    onDismiss = { pendingUpdateResult = null }
-                                )
-
-                                val currentRemote = remoteEventQueue.firstOrNull()
-                                val currentClientId = currentRemote?.first?.clientId ?: ""
-                                RemoteEventDialog(
-                                    event = currentRemote?.first,
-                                    queueSize = remoteEventQueue.size,
-                                    isClientKnownAllowed = remoteClientManager.isAllowed(currentClientId),
-                                    isClientKnownBlocked = remoteClientManager.isBlocked(currentClientId),
-                                    isInstanceLinkFollower = isInstanceLinkFollowerClient(
-                                        currentClientId,
-                                        companionServer.connectedInstanceLinkFollowers.collectAsState().value,
-                                    ),
-                                    onAllow = {
-                                        currentRemote?.second?.invoke()
-                                        if (remoteEventQueue.isNotEmpty()) remoteEventQueue.removeAt(0)
-                                    },
-                                    onAllowForSession = {
-                                        if (currentClientId.isNotBlank() && !sessionAllowedClients.contains(
-                                                currentClientId
-                                            )
-                                        ) {
-                                            sessionAllowedClients.add(currentClientId)
-                                        }
-                                        val clientToAllow = currentClientId
-                                        val toApprove = remoteEventQueue.filter {
-                                            remoteEventTargetsClient(it.first.clientId, clientToAllow)
-                                        }
-                                        toApprove.forEach { it.second.invoke() }
-                                        remoteEventQueue.removeAll(toApprove)
-                                    },
-                                    onAllowPermanently = {
-                                        remoteClientManager.allowPermanently(currentClientId)
-                                        val clientToAllow = currentClientId
-                                        val toApprove = remoteEventQueue.filter {
-                                            remoteEventTargetsClient(it.first.clientId, clientToAllow)
-                                        }
-                                        toApprove.forEach { it.second.invoke() }
-                                        remoteEventQueue.removeAll(toApprove)
-                                    },
-                                    onBlockForSession = {
-                                        if (currentClientId.isNotBlank() && !sessionBlockedClients.contains(
-                                                currentClientId
-                                            )
-                                        ) {
-                                            sessionBlockedClients.add(currentClientId)
-                                        }
-                                        val clientToBlock = currentClientId
-                                        val toRemove = remoteEventQueue.filter {
-                                            remoteEventTargetsClient(it.first.clientId, clientToBlock)
-                                        }
-                                        toRemove.forEach { it.third.invoke() }
-                                        remoteEventQueue.removeAll(toRemove)
-                                    },
-                                    onBlockPermanently = {
-                                        remoteClientManager.blockPermanently(currentClientId)
-                                        val clientToBlock = currentClientId
-                                        val toRemove = remoteEventQueue.filter {
-                                            remoteEventTargetsClient(it.first.clientId, clientToBlock)
-                                        }
-                                        toRemove.forEach { it.third.invoke() }
-                                        remoteEventQueue.removeAll(toRemove)
-                                    },
-                                    onDeny = {
-                                        currentRemote?.third?.invoke()
-                                        if (remoteEventQueue.isNotEmpty()) remoteEventQueue.removeAt(0)
                                     }
-                                )
-
-                                InstanceLinkToastHost(
-                                    failures = instanceLinkCommandFailures,
-                                    onDismiss = { failure -> instanceLinkCommandFailures.remove(failure) }
-                                )
-                                RemoteActivityToastHost(
-                                    notifications = remoteActivityNotifications,
-                                    connectedInstanceLinkFollowers = companionServer.connectedInstanceLinkFollowers.collectAsState().value,
-                                    onDismiss = { n -> remoteActivityNotifications.remove(n) },
-                                    onDismissAll = { remoteActivityNotifications.clear() },
-                                    onBlockForSession = { n ->
-                                        val cid = n.clientId
-                                        if (cid.isNotBlank() && !sessionBlockedClients.contains(cid)) {
-                                            sessionBlockedClients.add(cid)
-                                            sessionAllowedClients.remove(cid)
-                                        }
-                                        remoteActivityNotifications.removeAll { it.clientId == cid }
+                                }
+                            }
+                            LaunchedEffect(Unit) {
+                                companionServer.onQADisplay.collect { question ->
+                                    if (question != null) {
+                                        presenterManager.setDisplayedQuestion(question)
+                                        presenterManager.setShowQRCodeOnDisplay(false)
+                                        presenterManager.setPresentingMode(Presenting.QA)
+                                    } else {
+                                        presenterManager.setDisplayedQuestion(null)
+                                        presenterManager.setPresentingMode(Presenting.NONE)
                                     }
+                                }
+                            }
+
+                            LaunchedEffect(Unit) {
+                                companionServer.onQAAdminRequest.collect { pending ->
+                                    val clientId = pending.clientId
+                                    val access = remoteAccessDecision(
+                                        clientId,
+                                        remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                        sessionAllowedClients, sessionBlockedClients,
+                                    )
+                                    when (val outcome = remoteApproval(
+                                        access,
+                                        type = qaActionType(pending.action),
+                                        title = remoteEventTitle(pending.text),
+                                        clientId = clientId,
+                                        clientLabel = remoteClientManager.getLabel(clientId),
+                                    )) {
+                                        RemoteApproval.Reject -> pending.decision.complete(false)
+                                        is RemoteApproval.Approve -> {
+                                            pending.decision.complete(true)
+                                            remoteActivityNotifications.add(outcome.notification)
+                                        }
+                                        is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                            outcome.event,
+                                            { pending.decision.complete(true) },
+                                            { pending.decision.complete(false) },
+                                        ))
+                                    }
+                                }
+                            }
+
+                            LaunchedEffect(Unit) {
+                                companionServer.onPresentationRemoteConnect.collect { pending ->
+                                    val clientId = pending.clientId
+                                    val access = remoteAccessDecision(
+                                        clientId,
+                                        remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                        sessionAllowedClients, sessionBlockedClients,
+                                    )
+                                    when (val outcome = remoteApproval(
+                                        access,
+                                        type = RemoteEventType.PRESENTATION_CONNECT,
+                                        title = "",
+                                        clientId = clientId,
+                                        clientLabel = remoteClientManager.getLabel(clientId),
+                                    )) {
+                                        RemoteApproval.Reject -> pending.decision.complete(false)
+                                        is RemoteApproval.Approve -> {
+                                            pending.decision.complete(true)
+                                            remoteActivityNotifications.add(outcome.notification)
+                                        }
+                                        is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                            outcome.event,
+                                            { pending.decision.complete(true) },
+                                            { pending.decision.complete(false) },
+                                        ))
+                                    }
+                                }
+                            }
+
+                            LaunchedEffect(Unit) {
+                                companionServer.onQaAdminConnect.collect { pending ->
+                                    val clientId = pending.clientId
+                                    val access = remoteAccessDecision(
+                                        clientId,
+                                        remoteClientManager.allowedClients, remoteClientManager.blockedClients,
+                                        sessionAllowedClients, sessionBlockedClients,
+                                    )
+                                    when (val outcome = remoteApproval(
+                                        access,
+                                        type = RemoteEventType.QA_ADMIN_CONNECT,
+                                        title = "",
+                                        clientId = clientId,
+                                        clientLabel = remoteClientManager.getLabel(clientId),
+                                    )) {
+                                        RemoteApproval.Reject -> pending.decision.complete(false)
+                                        is RemoteApproval.Approve -> {
+                                            pending.decision.complete(true)
+                                            remoteActivityNotifications.add(outcome.notification)
+                                        }
+                                        is RemoteApproval.Ask -> remoteEventQueue.add(Triple(
+                                            outcome.event,
+                                            { pending.decision.complete(true) },
+                                            { pending.decision.complete(false) },
+                                        ))
+                                    }
+                                }
+                            }
+
+                            LaunchedEffect(Unit) {
+                                companionServer.onBibleHold.collect { hold ->
+                                    presenterManager.setBibleHold(hold)
+                                }
+                            }
+
+                            LaunchedEffect(Unit) {
+                                snapshotFlow { presenterManager.presentingMode.value }
+                                    .collect { mode ->
+                                        if (shouldBroadcastDisplayCleared(mode)) {
+                                            companionServer.broadcastDisplayCleared()
+                                        }
+                                    }
+                            }
+
+                            LaunchedEffect(Unit) {
+                                snapshotFlow { presenterManager.songDisplaySectionIndex.value }
+                                    .collect { index ->
+                                        if (shouldBroadcastSongSection(presenterManager.presentingMode.value)) {
+                                            companionServer.broadcastSongSectionSelected(index)
+                                        }
+                                    }
+                            }
+
+                            LaunchedEffect(Unit) {
+                                companionServer.onInstantAction.collect { action ->
+                                    val type = remoteActionType(action.actionType)
+                                    remoteActivityNotifications.add(
+                                        RemoteActivityNotification(
+                                            type = type,
+                                            title = action.title,
+                                            detail = action.detail,
+                                            clientId = action.clientId,
+                                            clientLabel = remoteClientManager.getLabel(action.clientId)
+                                        )
+                                    )
+                                }
+                            }
+
+                            NavigationTopBar(
+                                currentTheme = theme,
+                                onAbout = { showAboutDialog = true },
+                                onContactUs = { showContactDialog = true },
+                                onGettingStarted = { showSetupWizard = true },
+                                onStatistics = { showStatisticsDialog = true },
+                                onConnectToInstance = { showInstanceLinkDialog = true },
+                                onDisconnectInstance = { instanceLinkViewModel.disconnect() },
+                                isInstanceLinkConnected = isInstanceLinkActive(
+                                    instanceLinkViewModel.connectionStatus.collectAsState().value
+                                ),
+                                onConverter = { showConverterWindow = true },
+                                onHelp = {
+                                    Desktop.getDesktop()
+                                        .browse(URI("https://churchpresenter.org/wiki"))
+                                },
+                                onHowToBlog = {
+                                    Desktop.getDesktop()
+                                        .browse(URI("https://churchpresenter.org/blog"))
+                                },
+                                onCheckForUpdates = {
+                                    coroutineScope.launch {
+                                        pendingUpdateResult = UpdateChecker.checkForUpdate(
+                                            includePrereleases = appSettings.participateInPrereleases
+                                        )
+                                        pendingUpdateCheckWasManual = true
+                                        appSettings = appSettings.copy(lastUpdateCheckTimestamp = System.currentTimeMillis())
+                                        settingsManager.saveSettings(appSettings)
+                                    }
+                                },
+                                onKeyboardShortcuts = { showKeyboardShortcutsDialog = true },
+                                theme = {
+                                    appSettings = appSettings.copy(theme = it.toString())
+                                    theme = it
+                                    settingsManager.saveSettings(appSettings)
+                                },
+                                onLanguageChange = { language ->
+                                    currentLanguage = language
+                                    appSettings = appSettings.copy(language = language.code)
+                                    settingsManager.saveSettings(appSettings)
+                                    Locale.setDefault(Locale.forLanguageTag(language.code))
+                                },
+                                onSettings = { openOptionsDialog(0) },
+                                onExit = { exitApplication() },
+                                onAddToSchedule = { },
+                                onNewSchedule = { currentScheduleActions.newSchedule() },
+                                onOpenSchedule = { currentScheduleActions.openSchedule() },
+                                onSaveSchedule = { currentScheduleActions.saveSchedule() },
+                                onSaveScheduleAs = { currentScheduleActions.saveScheduleAs() },
+                                onCloseSchedule = { currentScheduleActions.newSchedule() },
+                                onRemoveFromSchedule = {
+                                    selectedScheduleItemId?.let {
+                                        currentScheduleActions.removeSelected()
+                                        selectedScheduleItemId = null
+                                    }
+                                },
+                                onClearSchedule = {
+                                    currentScheduleActions.clearSchedule()
+                                    selectedScheduleItemId = null
+                                },
+                                showDeveloperMenu = shouldShowDeveloperMenu(
+                                    BuildConfig.IS_RELEASE, DevFlags.forceDevWindow, developerMenuUnlocked,
+                                ),
+                                isPresenterWindowVisible = presenterManager.showPresenterWindow.value,
+                                onSetPresenterWindowVisible = { presenterManager.setShowPresenterWindow(it) },
+                                isDevWindowAlwaysOnTop = presenterManager.devWindowAlwaysOnTop.value,
+                                onSetDevWindowAlwaysOnTop = { presenterManager.setDevWindowAlwaysOnTop(it) },
+                                onOpenStyleEditor = { showStyleEditorWindow = true },
+                                onOpenMemoryMonitor = { showMemoryMonitorWindow = true },
+                            )
+                            if (CrashReporter.didCrashLastRun && CrashReporter.videoBackgroundsDisabled) {
+                                var showBanner by remember { mutableStateOf(true) }
+                                if (showBanner) {
+                                    Box(
+                                        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.errorContainer),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Text(
+                                            text = "Video backgrounds disabled after ${CrashReporter.consecutiveCrashes} consecutive crashes.  [Re-enable]  [Dismiss]",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onErrorContainer,
+                                            modifier = Modifier.onPreviewKeyEvent {
+                                                showBanner = false; true
+                                            }
+                                        )
+                                    }
+                                    LaunchedEffect(Unit) {
+                                        delay(CRASH_REPORT_RETRY_MS)
+                                        showBanner = false
+                                    }
+                                }
+                            }
+
+                            val instanceLinkStatus = instanceLinkViewModel.connectionStatus.collectAsState().value
+                            val instanceLinkIsControllerConnected =
+                                isControllerConnected(instanceLinkStatus, appSettings.instanceLink.role)
+                            val instanceLinkUsesRemoteContent =
+                                shouldUseRemoteContent(instanceLinkStatus, appSettings.instanceLink.role)
+                            MainDesktop(
+                                hostWindow = window,
+                                instanceLinkConnectionStatus = instanceLinkViewModel.connectionStatus.collectAsState().value,
+                                instanceLinkNextRetryAtMs = instanceLinkViewModel.nextRetryAtMs.collectAsState().value,
+                                instanceLinkBibleUpdatedSignal = instanceLinkViewModel.bibleUpdatedSignal.collectAsState().value,
+                                instanceLinkSecondaryBibleUpdatedSignal = instanceLinkViewModel.secondaryBibleUpdatedSignal.collectAsState().value,
+                                instanceLinkFollowingHost = appSettings.instanceLink.primaryHost,
+                                connectedInstanceLinkFollowerCount = companionServer.connectedInstanceLinkFollowers.collectAsState().value.size,
+                                onInstanceLinkConnect = {
+                                    val link = appSettings.instanceLink
+                                    setInstanceLinkEnabled(true)
+                                    instanceLinkViewModel.connect(
+                                        link.primaryHost, link.primaryPort, link.apiKey, link.deviceId,
+                                        link.reconnectDelayMs.toLong()
+                                    )
+                                },
+                                onInstanceLinkDisconnect = {
+                                    setInstanceLinkEnabled(false)
+                                    instanceLinkViewModel.disconnect()
+                                },
+                                instanceLinkRemoteSchedule = instanceLinkViewModel.remoteSchedule.collectAsState().value,
+                                instanceLinkRemoteSongCatalog = instanceLinkViewModel.remoteSongCatalog.collectAsState().value,
+                                instanceLinkFetchSongDetail = { number, songbook -> instanceLinkViewModel.fetchSongDetail(number, songbook) },
+                                instanceLinkFetchBibleFile = { instanceLinkViewModel.fetchBibleFile() },
+                                instanceLinkBibleSyncMode = appSettings.instanceLink.bibleSyncMode,
+                                instanceLinkFetchSecondaryBibleFile = { instanceLinkViewModel.fetchSecondaryBibleFile() },
+                                instanceLinkFetchBibleTranslations = { instanceLinkViewModel.fetchBibleTranslations() },
+                                instanceLinkOnSecondaryBibleFilePathChanged = { path -> companionServer.updateSecondaryBibleFilePath(path) },
+                                instanceLinkOnBibleFilePathsChanged = { paths -> companionServer.updateBibleFilePaths(paths) },
+                                instanceLinkSendAddToSchedule = if (canPushToSchedule(appSettings.instanceLink)) {
+                                    { item -> instanceLinkViewModel.sendAddToSchedule(item) }
+                                } else null,
+                                instanceLinkSendRemoveFromSchedule = if (canPushToSchedule(appSettings.instanceLink)) {
+                                    { id -> instanceLinkViewModel.sendRemoveFromSchedule(id) }
+                                } else null,
+                                instanceLinkRole = appSettings.instanceLink.role,
+                                instanceLinkSendProject = if (instanceLinkIsControllerConnected) {
+                                    { item -> instanceLinkViewModel.sendProject(item) }
+                                } else null,
+                                instanceLinkSendVerse = if (instanceLinkIsControllerConnected) {
+                                    { bookName, chapter, verseNumber, verseText, verseRange ->
+                                        instanceLinkViewModel.sendSelectBibleVerse(bookName, chapter, verseNumber, verseText, verseRange)
+                                    }
+                                } else null,
+                                instanceLinkSendSongSection = if (instanceLinkIsControllerConnected) {
+                                    { number, section, lineIndex -> instanceLinkViewModel.sendSelectSongSection(number, section, lineIndex) }
+                                } else null,
+                                instanceLinkSendClear = if (instanceLinkIsControllerConnected) {
+                                    { instanceLinkViewModel.sendClear() }
+                                } else null,
+                                instanceLinkSendBibleHold = if (instanceLinkIsControllerConnected) {
+                                    { hold -> instanceLinkViewModel.sendBibleHold(hold) }
+                                } else null,
+                                instanceLinkSendNextPicture = if (instanceLinkIsControllerConnected) {
+                                    { instanceLinkViewModel.sendNextPicture() }
+                                } else null,
+                                instanceLinkSendPreviousPicture = if (instanceLinkIsControllerConnected) {
+                                    { instanceLinkViewModel.sendPreviousPicture() }
+                                } else null,
+                                instanceLinkSendNextSlide = if (instanceLinkIsControllerConnected) {
+                                    { instanceLinkViewModel.sendNextSlide() }
+                                } else null,
+                                instanceLinkSendPreviousSlide = if (instanceLinkIsControllerConnected) {
+                                    { instanceLinkViewModel.sendPreviousSlide() }
+                                } else null,
+                                instanceLinkFetchPictureImageBytes = if (instanceLinkUsesRemoteContent) {
+                                    { folderId, index -> instanceLinkViewModel.fetchPictureImageBytes(folderId, index) }
+                                } else null,
+                                instanceLinkFetchPresentationSlideBytes = if (instanceLinkUsesRemoteContent) {
+                                    { id, index -> instanceLinkViewModel.fetchPresentationSlideBytes(id, index) }
+                                } else null,
+                                instanceLinkMediaStreamUrl = run {
+                                    val link = appSettings.instanceLink
+                                    if (instanceLinkUsesRemoteContent) {
+                                        ({ itemId: String ->
+                                            instanceLinkMediaStreamUrl(
+                                                link.primaryHost, link.primaryPort, link.apiKey, itemId,
+                                            )
+                                        })
+                                    } else null
+                                },
+                                onVerseSelected = { verses -> presenterManager.setSelectedVerses(verses) },
+                                onSongItemSelected = { section ->
+                                    presenterManager.setLyricSection(section)
+                                    if (isSongLineMode(appSettings.songSettings)) {
+                                        presenterManager.setDisplayedLyricSection(section)
+                                    }
+                                },
+                                onAllSectionsChanged = { presenterManager.setAllLyricSections(it) },
+                                onSectionIndexChanged = { presenterManager.setSongDisplaySectionIndex(it) },
+                                onLineIndexChanged = { presenterManager.setSongDisplayLineIndex(it) },
+                                appSettings = appSettings,
+                                livePreviewAppSettings = effectiveAppSettings,
+                                presenterManager = presenterManager,
+                                statisticsManager = statisticsManager,
+                                verseSequenceLog = verseSequenceLog,
+                                onScheduleActionsReady = { scheduleActions = it },
+                                presenting = { mode ->
+                                    presenterManager.setPresentingMode(mode)
+                                    if (shouldShowPresenterWindowFor(mode)) {
+                                        presenterManager.setShowPresenterWindow(true)
+                                    }
+                                },
+                                onScheduleItemSelected = { itemId -> selectedScheduleItemId = itemId },
+                                onShowSettings = { openOptionsDialog(0) },
+                                onShowBackgroundSettings = { openOptionsDialog(OPTIONS_TAB_BACKGROUND) },
+                                onSettingsChange = { updateFn ->
+                                    appSettings = updateFn(appSettings)
+                                    settingsManager.saveSettings(appSettings)
+                                },
+                                theme = theme,
+                                onSongsLoaded = { songs -> companionServer.updateSongs(songs) },
+                                onScenesChanged = { scenes -> scenesForInstanceLink = scenes },
+                                onBibleLoaded = { bible, translation ->
+                                    primaryBibleForInstanceLink = bible
+                                    companionServer.updateBible(
+                                        bible,
+                                        translation,
+                                        filePath = bibleFilePath(appSettings.bibleSettings.storageDirectory, translation)
+                                    )
+                                },
+                                onScheduleChanged = { items -> companionServer.updateSchedule(items) },
+                                onPresentationSlidesLoaded = { id, filePath, fileName, fileType, slides, notes ->
+                                    companionServer.updatePresentation(id, filePath, fileName, fileType, slides, notes)
+                                },
+                                onPicturesLoaded = { folderId, folderName, folderPath, imageFiles ->
+                                    companionServer.updatePictures(folderId, folderName, folderPath, imageFiles)
+                                },
+                                selectPictureImageFlow = kotlinx.coroutines.flow.flow {
+                                    companionServer.onSelectPicture.collect { req ->
+                                        emit(req.folderId to req.index)
+                                    }
+                                },
+                                resolveImageFile = { folderId, index ->
+                                    companionServer.getImageFile(folderId, index)
+                                },
+                                selectSlideFlow = kotlinx.coroutines.flow.flow {
+                                    companionServer.onSelectSlide.collect { req ->
+                                        emit(req.id to req.index)
+                                    }
+                                },
+                                selectBibleVerseFlow = kotlinx.coroutines.flow.flow {
+                                    companionServer.onSelectBibleVerse.collect { req ->
+                                        emit(req)
+                                    }
+                                },
+                                remoteSelectSongFlow = remoteSelectSongFlow,
+                                remoteSelectPictureFlow = remoteSelectPictureFlow,
+                                remoteSelectPresentationFlow = remoteSelectPresentationFlow,
+                                nextPictureFlow = kotlinx.coroutines.flow.flow {
+                                    companionServer.onNextPicture.collect { emit(Unit) }
+                                },
+                                previousPictureFlow = kotlinx.coroutines.flow.flow {
+                                    companionServer.onPreviousPicture.collect { emit(Unit) }
+                                },
+                                nextSlideFlow = kotlinx.coroutines.flow.flow {
+                                    companionServer.onNextSlide.collect { emit(Unit) }
+                                },
+                                previousSlideFlow = kotlinx.coroutines.flow.flow {
+                                    companionServer.onPreviousSlide.collect { emit(Unit) }
+                                },
+                                uploadPresentationFlow = kotlinx.coroutines.flow.flow {
+                                    companionServer.onPresentationUploaded.collect { file ->
+                                        emit(file)
+                                    }
+                                },
+                                serverUrl = companionServer.serverUrl.collectAsState().value,
+                                qaManager = qaManager,
+                                tunnelStatus = tunnelStatus,
+                                tunnelUrl = tunnelUrl ?: "",
+                                onStartTunnel = { companionServer.tunnelManager.start(appSettings.serverSettings.port) },
+                                onStopTunnel = { companionServer.tunnelManager.stop() },
+                                qaDisplayUrl = qaDisplayUrl,
+                                onQaDisplayUrlChanged = { qaDisplayUrl = it },
+                                presentationDisplayUrl = presentationDisplayUrl,
+                                onPresentationDisplayUrlChanged = { presentationDisplayUrl = it },
+                                onSlideChanged = { id, index, total, isPlaying ->
+                                    companionServer.broadcastSlideChange(id, index, total, isPlaying)
+                                },
+                                remotePresentationPlayPauseFlow = companionServer.onPresentationPlayPause,
+                                remotePresentationLoopToggleFlow = companionServer.onPresentationLoopToggle,
+                                remotePresentationGotoFlow = companionServer.onPresentationGoto,
+                                presentationFrozen = presentationFrozen,
+                                onFreezeToggle = {
+                                    presentationFrozen = !presentationFrozen
+                                    companionServer.broadcastFreezeChange(presentationFrozen)
+                                    presenterManager.setSlideFrozen(presentationFrozen)
+                                },
+                                onClearPresentation = {
+                                    companionServer.clearPresentationState()
+                                    presenterManager.requestClearDisplay()
+                                },
+                                onOpenLottieGen = { outputDir, onSaved ->
+                                    if (isUsableOutputDir(outputDir)) {
+                                        lottieGenOutputDir = File(outputDir)
+                                        lottieGenOnFileSaved = onSaved
+                                        showLottieGenWindow = true
+                                    } else {
+                                        javax.swing.JOptionPane.showMessageDialog(
+                                            null,
+                                            "Please set a Lower Third folder in Settings first.",
+                                            "No Folder Configured",
+                                            javax.swing.JOptionPane.WARNING_MESSAGE
+                                        )
+                                    }
+                                },
+                                sttManager = sttManager,
+                                dialogDismissSignal = dialogDismissSignal,
+                                companionSatelliteViewModel = companionSatelliteViewModel,
+                                onRequestDeveloperMenuUnlock = { developerMenuUnlocked = true }
+                            )
+                            OptionsDialog(
+                                isVisible = showOptionsDialog,
+                                initialTab = optionsDialogInitialTab,
+                                initialSettings = appSettings,
+                                theme = theme,
+                                settingsManager = settingsManager,
+                                companionServer = companionServer,
+                                remoteClientManager = remoteClientManager,
+                                presenterManager = presenterManager,
+                                onDismiss = { showOptionsDialog = false; dialogDismissSignal++ },
+                                onSave = { updated ->
+                                    appSettings = updated
+                                    settingsManager.saveSettings(updated)
+                                    companionServer.preloadData(
+                                        songStorageDir = updated.songSettings.storageDirectory,
+                                        bibleStorageDir = updated.bibleSettings.storageDirectory,
+                                        primaryBibleFileName = updated.bibleSettings.primaryBible
+                                    )
+                                    companionServer.updateApiKey(
+                                        enabled = updated.serverSettings.apiKeyEnabled,
+                                        key = updated.serverSettings.apiKey
+                                    )
+                                    companionServer.updateFileUploadEnabled(updated.serverSettings.fileUploadEnabled)
+                                    companionServer.updateMaxMediaUploadMb(updated.serverSettings.maxMediaUploadMb)
+                                    companionServer.updateAtemConfig(
+                                        updated.atemSettings,
+                                        updated.streamingSettings.lowerThirdFolder
+                                    )
+                                },
+                                onIdentifyScreen = {
+                                    identifyingScreen = true
+                                    coroutineScope.launch {
+                                        delay(UPDATE_CHECK_DELAY_MS)
+                                        identifyingScreen = false
+                                    }
+                                },
+                                onIdentifyBrowserSource = { index ->
+                                    presenterManager.identifyBrowserSourceOutput(index)
+                                },
+                                onOpenLottieGen = { outputDir, onSaved ->
+                                    if (isUsableOutputDir(outputDir)) {
+                                        lottieGenOutputDir = File(outputDir)
+                                        lottieGenOnFileSaved = onSaved
+                                        showLottieGenWindow = true
+                                    } else {
+                                        javax.swing.JOptionPane.showMessageDialog(
+                                            null,
+                                            "Please set a Lower Third folder in Settings first.",
+                                            "No Folder Configured",
+                                            javax.swing.JOptionPane.WARNING_MESSAGE
+                                        )
+                                    }
+                                },
+                                obsManager = obsManager,
+                                companionSatelliteViewModel = companionSatelliteViewModel
+                            )
+                            KeyboardShortcutsDialog(
+                                isVisible = showKeyboardShortcutsDialog,
+                                settings = appSettings,
+                                onSave = { updated ->
+                                    appSettings = updated
+                                    settingsManager.saveSettings(updated)
+                                },
+                                onDismiss = { showKeyboardShortcutsDialog = false; dialogDismissSignal++ }
+                            )
+                            StatisticsDialog(
+                                isVisible = showStatisticsDialog,
+                                theme = theme,
+                                statisticsManager = statisticsManager,
+                                onDismiss = { showStatisticsDialog = false; dialogDismissSignal++ }
+                            )
+                            InstanceLinkDialog(
+                                isVisible = showInstanceLinkDialog,
+                                settings = appSettings.instanceLink,
+                                connectionStatus = instanceLinkViewModel.connectionStatus.collectAsState().value,
+                                remoteLiveState = instanceLinkViewModel.remoteLiveState.collectAsState().value,
+                                remoteScheduleCount = instanceLinkViewModel.remoteSchedule.collectAsState().value.size,
+                                lastMessageAtMs = instanceLinkViewModel.lastMessageAtMs.collectAsState().value,
+                                onConnect = { edited ->
+                                    val link = edited.copy(enabled = true)
+                                    appSettings = appSettings.copy(instanceLink = link)
+                                    settingsManager.saveSettings(appSettings)
+                                    instanceLinkViewModel.connect(
+                                        link.primaryHost, link.primaryPort, link.apiKey, link.deviceId,
+                                        link.reconnectDelayMs.toLong()
+                                    )
+                                },
+                                onSave = { edited ->
+                                    appSettings = appSettings.copy(instanceLink = edited)
+                                    settingsManager.saveSettings(appSettings)
+                                },
+                                onDisconnect = {
+                                    setInstanceLinkEnabled(false)
+                                    instanceLinkViewModel.disconnect()
+                                },
+                                onDismiss = { showInstanceLinkDialog = false; dialogDismissSignal++ }
+                            )
+                            AboutDialog(
+                                isVisible = showAboutDialog,
+                                onDismiss = { showAboutDialog = false; dialogDismissSignal++ },
+                                appSettings = appSettings,
+                                theme = theme
+                            )
+                            ContactUsDialog(
+                                isVisible = showContactDialog,
+                                onDismiss = { showContactDialog = false; dialogDismissSignal++ }
+                            )
+                            if (showConverterWindow) {
+                                ConverterWindow(
+                                    theme = theme,
+                                    onClose = { showConverterWindow = false }
                                 )
-                            } // end Box (window content)
-                        }
+                            }
+                            if (showLottieGenWindow) {
+                                val screenBounds = presenterScreenBounds()
+                                LottieGenWindow(
+                                    theme = theme,
+                                    outputDir = lottieGenOutputDir,
+                                    onClose = { showLottieGenWindow = false },
+                                    onFileSaved = {
+                                        UsageEvents.record(UsageEvent.LOWER_THIRD_GENERATED)
+                                        lottieGenOnFileSaved?.invoke()
+                                    },
+                                    canvasWidth = screenBounds.width,
+                                    canvasHeight = screenBounds.height
+                                )
+                            }
+                            MemoryMonitorWindow(
+                                isVisible = showMemoryMonitorWindow,
+                                theme = theme,
+                                onClose = { showMemoryMonitorWindow = false }
+                            )
+                            if (showStyleEditorWindow) {
+                                StyleEditorWindow(
+                                    theme = theme,
+                                    onClose = { showStyleEditorWindow = false }
+                                )
+                            }
+                            UpdateAvailableDialog(
+                                result = pendingUpdateResult,
+                                isManualCheck = pendingUpdateCheckWasManual,
+                                participateInPrereleases = appSettings.participateInPrereleases,
+                                onParticipateInPrereleasesChange = { enabled ->
+                                    appSettings = appSettings.copy(participateInPrereleases = enabled)
+                                    settingsManager.saveSettings(appSettings)
+                                    coroutineScope.launch {
+                                        pendingUpdateResult = UpdateChecker.checkForUpdate(includePrereleases = enabled)
+                                    }
+                                },
+                                updateCheckInterval = appSettings.updateCheckInterval,
+                                onUpdateCheckIntervalChange = { interval ->
+                                    appSettings = appSettings.copy(updateCheckInterval = interval)
+                                    settingsManager.saveSettings(appSettings)
+                                },
+                                onDismiss = { pendingUpdateResult = null }
+                            )
+
+                            val currentRemote = remoteEventQueue.firstOrNull()
+                            val currentClientId = currentRemote?.first?.clientId ?: ""
+                            RemoteEventDialog(
+                                event = currentRemote?.first,
+                                queueSize = remoteEventQueue.size,
+                                isClientKnownAllowed = remoteClientManager.isAllowed(currentClientId),
+                                isClientKnownBlocked = remoteClientManager.isBlocked(currentClientId),
+                                isInstanceLinkFollower = isInstanceLinkFollowerClient(
+                                    currentClientId,
+                                    companionServer.connectedInstanceLinkFollowers.collectAsState().value,
+                                ),
+                                onAllow = {
+                                    currentRemote?.second?.invoke()
+                                    if (remoteEventQueue.isNotEmpty()) remoteEventQueue.removeAt(0)
+                                },
+                                onAllowForSession = {
+                                    if (currentClientId.isNotBlank() && !sessionAllowedClients.contains(
+                                            currentClientId
+                                        )
+                                    ) {
+                                        sessionAllowedClients.add(currentClientId)
+                                    }
+                                    val clientToAllow = currentClientId
+                                    val toApprove = remoteEventQueue.filter {
+                                        remoteEventTargetsClient(it.first.clientId, clientToAllow)
+                                    }
+                                    toApprove.forEach { it.second.invoke() }
+                                    remoteEventQueue.removeAll(toApprove)
+                                },
+                                onAllowPermanently = {
+                                    remoteClientManager.allowPermanently(currentClientId)
+                                    val clientToAllow = currentClientId
+                                    val toApprove = remoteEventQueue.filter {
+                                        remoteEventTargetsClient(it.first.clientId, clientToAllow)
+                                    }
+                                    toApprove.forEach { it.second.invoke() }
+                                    remoteEventQueue.removeAll(toApprove)
+                                },
+                                onBlockForSession = {
+                                    if (currentClientId.isNotBlank() && !sessionBlockedClients.contains(
+                                            currentClientId
+                                        )
+                                    ) {
+                                        sessionBlockedClients.add(currentClientId)
+                                    }
+                                    val clientToBlock = currentClientId
+                                    val toRemove = remoteEventQueue.filter {
+                                        remoteEventTargetsClient(it.first.clientId, clientToBlock)
+                                    }
+                                    toRemove.forEach { it.third.invoke() }
+                                    remoteEventQueue.removeAll(toRemove)
+                                },
+                                onBlockPermanently = {
+                                    remoteClientManager.blockPermanently(currentClientId)
+                                    val clientToBlock = currentClientId
+                                    val toRemove = remoteEventQueue.filter {
+                                        remoteEventTargetsClient(it.first.clientId, clientToBlock)
+                                    }
+                                    toRemove.forEach { it.third.invoke() }
+                                    remoteEventQueue.removeAll(toRemove)
+                                },
+                                onDeny = {
+                                    currentRemote?.third?.invoke()
+                                    if (remoteEventQueue.isNotEmpty()) remoteEventQueue.removeAt(0)
+                                }
+                            )
+
+                            InstanceLinkToastHost(
+                                failures = instanceLinkCommandFailures,
+                                onDismiss = { failure -> instanceLinkCommandFailures.remove(failure) }
+                            )
+                            RemoteActivityToastHost(
+                                notifications = remoteActivityNotifications,
+                                connectedInstanceLinkFollowers = companionServer.connectedInstanceLinkFollowers.collectAsState().value,
+                                onDismiss = { n -> remoteActivityNotifications.remove(n) },
+                                onDismissAll = { remoteActivityNotifications.clear() },
+                                onBlockForSession = { n ->
+                                    val cid = n.clientId
+                                    if (cid.isNotBlank() && !sessionBlockedClients.contains(cid)) {
+                                        sessionBlockedClients.add(cid)
+                                        sessionAllowedClients.remove(cid)
+                                    }
+                                    remoteActivityNotifications.removeAll { it.clientId == cid }
+                                }
+                            )
+                        } // end Box (window content)
                     }
                 }
             }
+        }
 
-            LaunchedEffect(mediaViewModel.mediaFinished) {
-                if (mediaViewModel.mediaFinished) {
-                    presenterManager.requestClearDisplay()
-                    mediaViewModel.clearFinished()
-                }
+        LaunchedEffect(mediaViewModel.mediaFinished) {
+            if (mediaViewModel.mediaFinished) {
+                presenterManager.requestClearDisplay()
+                mediaViewModel.clearFinished()
             }
-
-            PresenterWindows(
-                screens = screens,
-                presenterManager = presenterManager,
-                mediaViewModel = mediaViewModel,
-                appSettings = effectiveAppSettings,
-                identifyingScreen = identifyingScreen,
-                serverUrl = companionServer.serverUrl.collectAsState().value,
-                qaDisplayUrl = qaDisplayUrl,
-                sttManager = sttManager,
-            )
         }
 
-        if (appReady && eulaAccepted && showSetupWizard) {
-            SetupWizardDialog(
-                theme = theme,
-                selectedLanguage = currentLanguage,
-                alwaysOnTop = !showOptionsDialog,
-                onLanguageSelected = { language ->
-                    currentLanguage = language
-                    appSettings = appSettings.copy(language = language.code)
-                    settingsManager.saveSettings(appSettings)
-                    Locale.setDefault(Locale.forLanguageTag(language.code))
-                },
-                onThemeSelected = { newTheme ->
-                    theme = newTheme
-                    appSettings = appSettings.copy(theme = newTheme.toString())
-                    settingsManager.saveSettings(appSettings)
-                },
-                onOpenSettings = { openOptionsDialog(0) },
-                onDismiss = {
-                    val updated = appSettings.copy(setupWizardShown = true)
-                    settingsManager.saveSettings(updated)
-                    appSettings = updated
-                    showSetupWizard = false
-                }
-            )
-        }
-
-        LicenseDialog(
-            isVisible = appReady && !eulaAccepted,
-            onAccept = {
-                val updated = appSettings.copy(eulaAcceptedVersion = CURRENT_EULA_VERSION)
-                settingsManager.saveSettings(updated)
-                appSettings = updated
-                eulaAccepted = true
-            },
-            onDecline = { exitApplication() }
+        PresenterWindows(
+            screens = screens,
+            presenterManager = presenterManager,
+            mediaViewModel = mediaViewModel,
+            appSettings = effectiveAppSettings,
+            identifyingScreen = identifyingScreen,
+            serverUrl = companionServer.serverUrl.collectAsState().value,
+            qaDisplayUrl = qaDisplayUrl,
+            sttManager = sttManager,
         )
     }
+
+    if (appReady && eulaAccepted && showSetupWizard) {
+        SetupWizardDialog(
+            theme = theme,
+            selectedLanguage = currentLanguage,
+            alwaysOnTop = !showOptionsDialog,
+            onLanguageSelected = { language ->
+                currentLanguage = language
+                appSettings = appSettings.copy(language = language.code)
+                settingsManager.saveSettings(appSettings)
+                Locale.setDefault(Locale.forLanguageTag(language.code))
+            },
+            onThemeSelected = { newTheme ->
+                theme = newTheme
+                appSettings = appSettings.copy(theme = newTheme.toString())
+                settingsManager.saveSettings(appSettings)
+            },
+            onOpenSettings = { openOptionsDialog(0) },
+            onDismiss = {
+                val updated = appSettings.copy(setupWizardShown = true)
+                settingsManager.saveSettings(updated)
+                appSettings = updated
+                showSetupWizard = false
+            }
+        )
+    }
+
+    LicenseDialog(
+        isVisible = appReady && !eulaAccepted,
+        onAccept = {
+            val updated = appSettings.copy(eulaAcceptedVersion = CURRENT_EULA_VERSION)
+            settingsManager.saveSettings(updated)
+            appSettings = updated
+            eulaAccepted = true
+        },
+        onDecline = { exitApplication() }
+    )
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenter.kt
@@ -270,39 +270,40 @@ private fun buildDisplayText(
     }
 
     // Apply word highlighting with Unicode word boundaries
-    if (showWordHighlighting && highlightedWords.isNotEmpty()) {
-        for (hw in highlightedWords) {
-            if (hw.word.isBlank()) continue
-            try {
-                val highlightColor = parseHexColor(hw.color)
-                val wb = "(?<![\\p{L}\\p{N}])"
-                val we = "(?![\\p{L}\\p{N}])"
-                val rawPattern = if (hw.isRegex) {
-                    "$wb(?:${hw.word})$we"
-                } else {
-                    val escaped = Regex.escape(hw.word)
-                    "$wb$escaped$we"
-                }
-                var flags = java.util.regex.Pattern.UNICODE_CHARACTER_CLASS
-                if (!hw.caseSensitive) flags = flags or java.util.regex.Pattern.CASE_INSENSITIVE or java.util.regex.Pattern.UNICODE_CASE
-                val regex = java.util.regex.Pattern.compile(rawPattern, flags).toRegex()
-                regex.findAll(fullText).forEach { match ->
-                    for (j in match.range) colors[j] = highlightColor
-                }
-            } catch (_: Exception) {}
-        }
+    if (showWordHighlighting) {
+        highlightedWords.forEach { applyHighlight(it, fullText, colors) }
     }
 
-    // Build AnnotatedString with contiguous color runs
-    return buildAnnotatedString {
-        var i = 0
-        while (i < fullText.length) {
-            val color = colors[i]
-            val start = i
-            while (i < fullText.length && colors[i] == color) i++
-            withStyle(SpanStyle(color = color)) {
-                append(fullText.substring(start, i))
-            }
+    return runsOf(fullText, colors)
+}
+
+/** Paints every match of one highlighted word into [colors]. A pattern that won't compile is skipped. */
+private fun applyHighlight(hw: HighlightedWord, fullText: String, colors: Array<Color>) {
+    if (hw.word.isBlank()) return
+    try {
+        val highlightColor = parseHexColor(hw.color)
+        val wb = "(?<![\\p{L}\\p{N}])"
+        val we = "(?![\\p{L}\\p{N}])"
+        val rawPattern = if (hw.isRegex) "$wb(?:${hw.word})$we" else "$wb${Regex.escape(hw.word)}$we"
+        var flags = java.util.regex.Pattern.UNICODE_CHARACTER_CLASS
+        if (!hw.caseSensitive) {
+            flags = flags or java.util.regex.Pattern.CASE_INSENSITIVE or java.util.regex.Pattern.UNICODE_CASE
+        }
+        java.util.regex.Pattern.compile(rawPattern, flags).toRegex().findAll(fullText).forEach { match ->
+            for (j in match.range) colors[j] = highlightColor
+        }
+    } catch (_: Exception) {}
+}
+
+/** The per-character colours collapsed into contiguous styled runs. */
+private fun runsOf(fullText: String, colors: Array<Color>): AnnotatedString = buildAnnotatedString {
+    var i = 0
+    while (i < fullText.length) {
+        val color = colors[i]
+        val start = i
+        while (i < fullText.length && colors[i] == color) i++
+        withStyle(SpanStyle(color = color)) {
+            append(fullText.substring(start, i))
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClient.kt
@@ -640,59 +640,87 @@ class AtemClient(val host: String, val port: Int = 9910) {
                         sendCommand("FTFD", buildFileDescriptionPayload(transferId, name, hash))
                         descriptionSent = true
                     }
-                    // ATEM grants chunkCount chunks of chunkSize bytes (rounded down to 8)
-                    val chunkSize = if (payload.size < FTCD_MIN_SIZE) 0
-                        else (u16(payload, OFFSET_FTCD_CHUNK_SIZE) / CHUNK_SIZE_ALIGNMENT) * CHUNK_SIZE_ALIGNMENT
-                    val chunkCount = if (payload.size < FTCD_MIN_SIZE) 0
-                        else u16(payload, OFFSET_FTCD_CHUNK_COUNT)
-                    var sent = 0
-                    while (chunkSize > 0 && sent < chunkCount && bytesSent < data.size) {
-                        var len = minOf(chunkSize, data.size - bytesSent)
-                        // Don't end a chunk mid RLE block: shorten if an RLE header starts
-                        // 8 or 16 bytes before the chunk end (header+count+pattern = 24B unit)
-                        if (bytesSent + len < data.size) {
-                            if (len >= RLE_WORD_BYTES &&
-                                dataBuf.getLong(bytesSent + len - RLE_WORD_BYTES) == AtemFrameEncoder.RLE_HEADER
-                            ) {
-                                len -= RLE_WORD_BYTES
-                            } else if (len >= RLE_TWO_WORDS_BYTES &&
-                                dataBuf.getLong(bytesSent + len - RLE_TWO_WORDS_BYTES) == AtemFrameEncoder.RLE_HEADER
-                            ) {
-                                len -= RLE_TWO_WORDS_BYTES
-                            }
-                        }
-                        sendCommand("FTDa", buildDataChunkPayload(transferId, data, bytesSent, len))
-                        bytesSent += len
-                        sent++
-                    }
-                    if (chunkSize > 0) onProgress(bytesSent.toFloat() / data.size)
+                    bytesSent = sendGrantedChunks(payload, transferId, data, dataBuf, bytesSent, onProgress)
                 }
                 "FTDC" -> return
                 "FTDE" -> {
                     val code = payload.getOrNull(OFFSET_FTDE_CODE)?.toInt()?.and(BYTE_MASK) ?: -1
-                    if (code == FTDE_CODE_RETRY && retries < MAX_TRANSFER_RETRIES) {
-                        // Code 1 = "retry": the ATEM is busy (e.g. still clearing the clip
-                        // pool after CMPC). Back off briefly, then restart the same transfer.
-                        retries++
-                        bytesSent = 0
-                        descriptionSent = false
-                        Thread.sleep(RETRY_BACKOFF_MS)
-                        sendCommand("FTSD", buildUploadRequestPayload(transferId, storeId, frameIndex, frame.rawLen))
-                    } else {
-                        // Clip frames past index 0 usually fail because the device's clip
-                        // pool ran out of frame capacity — surface an actionable hint
-                        val what = if (name == null) "clip frame $frameIndex" else "still"
-                        val hint = if (name == null && frameIndex > 0)
-                            " — the clip may exceed the ATEM's clip pool capacity; try a shorter duration or lower fps"
-                        else ""
-                        if (code == FTDE_CODE_RETRY) {
-                            throw Exception("ATEM stayed busy uploading $what after $retries retries$hint")
-                        } else {
-                            throw Exception("ATEM rejected $what (error code $code)$hint")
-                        }
+                    if (code != FTDE_CODE_RETRY || retries >= MAX_TRANSFER_RETRIES) {
+                        throw transferRejected(code, name, frameIndex, retries)
                     }
+                    // Code 1 = "retry": the ATEM is busy (e.g. still clearing the clip pool after
+                    // CMPC). Back off briefly, then restart the same transfer.
+                    retries++
+                    bytesSent = 0
+                    descriptionSent = false
+                    Thread.sleep(RETRY_BACKOFF_MS)
+                    sendCommand("FTSD", buildUploadRequestPayload(transferId, storeId, frameIndex, frame.rawLen))
                 }
             }
+        }
+    }
+
+
+    /**
+     * Sends as much of [data] as this FTCD grant allows, and returns the new total sent.
+     *
+     * ATEM grants chunkCount chunks of chunkSize bytes (rounded down to 8).
+     */
+    private fun sendGrantedChunks(
+        payload: ByteArray,
+        transferId: Int,
+        data: ByteArray,
+        dataBuf: java.nio.ByteBuffer,
+        alreadySent: Int,
+        onProgress: (Float) -> Unit,
+    ): Int {
+        val chunkSize = if (payload.size < FTCD_MIN_SIZE) 0
+            else (u16(payload, OFFSET_FTCD_CHUNK_SIZE) / CHUNK_SIZE_ALIGNMENT) * CHUNK_SIZE_ALIGNMENT
+        val chunkCount = if (payload.size < FTCD_MIN_SIZE) 0 else u16(payload, OFFSET_FTCD_CHUNK_COUNT)
+        var bytesSent = alreadySent
+        var sent = 0
+        while (chunkSize > 0 && sent < chunkCount && bytesSent < data.size) {
+            val len = chunkLengthAt(dataBuf, data.size, bytesSent, chunkSize)
+            sendCommand("FTDa", buildDataChunkPayload(transferId, data, bytesSent, len))
+            bytesSent += len
+            sent++
+        }
+        if (chunkSize > 0) onProgress(bytesSent.toFloat() / data.size)
+        return bytesSent
+    }
+
+    /**
+     * How much to put in the next chunk: never ending mid RLE block, so the length is shortened
+     * when an RLE header starts 8 or 16 bytes before the chunk end (header+count+pattern = 24B unit).
+     */
+    private fun chunkLengthAt(dataBuf: java.nio.ByteBuffer, dataSize: Int, bytesSent: Int, chunkSize: Int): Int {
+        val len = minOf(chunkSize, dataSize - bytesSent)
+        if (bytesSent + len >= dataSize) return len
+        val endsOnHeader = { back: Int ->
+            len >= back && dataBuf.getLong(bytesSent + len - back) == AtemFrameEncoder.RLE_HEADER
+        }
+        return when {
+            endsOnHeader(RLE_WORD_BYTES) -> len - RLE_WORD_BYTES
+            endsOnHeader(RLE_TWO_WORDS_BYTES) -> len - RLE_TWO_WORDS_BYTES
+            else -> len
+        }
+    }
+
+    /**
+     * The failure for an FTDE the transfer cannot retry past. Clip frames after index 0 usually
+     * fail because the device's clip pool ran out of capacity, which is worth saying outright.
+     */
+    private fun transferRejected(code: Int, name: String?, frameIndex: Int, retries: Int): Exception {
+        val what = if (name == null) "clip frame $frameIndex" else "still"
+        val hint = if (name == null && frameIndex > 0) {
+            " — the clip may exceed the ATEM's clip pool capacity; try a shorter duration or lower fps"
+        } else {
+            ""
+        }
+        return if (code == FTDE_CODE_RETRY) {
+            Exception("ATEM stayed busy uploading $what after $retries retries$hint")
+        } else {
+            Exception("ATEM rejected $what (error code $code)$hint")
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/BibleRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/BibleRoutes.kt
@@ -33,6 +33,16 @@ internal fun Route.bibleAndDictionaryRoutes(
     json: Json,
     scope: CoroutineScope,
 ) {
+    bibleReadRoutes(server, _bible, _bibleCatalog)
+    dictionaryRoutes(server, _bible, json)
+    bibleSelectRoutes(server, json, scope)
+}
+
+private fun Route.bibleReadRoutes(
+    server: CompanionServer,
+    _bible: MutableStateFlow<Bible?>,
+    _bibleCatalog: MutableStateFlow<BibleCatalogResponse?>,
+) {
                 get(Constants.ENDPOINT_BIBLE) {
                     if (!server.checkApiKey(call)) return@get
                     val catalog = _bibleCatalog.value
@@ -99,6 +109,13 @@ internal fun Route.bibleAndDictionaryRoutes(
                  * results to the Strong's numbers occurring in that reference,
                  * narrowing progressively as chapter and verse are added.
                  */
+}
+
+private fun Route.dictionaryRoutes(
+    server: CompanionServer,
+    _bible: MutableStateFlow<Bible?>,
+    json: Json,
+) {
                 get(Constants.ENDPOINT_DICTIONARY) {
                     if (!server.checkApiKey(call)) return@get
                     val q       = call.request.queryParameters["q"] ?: ""
@@ -210,6 +227,13 @@ internal fun Route.bibleAndDictionaryRoutes(
                  * No approval dialog — fires immediately like select_picture / select_song_section.
                  * Response: {"ok":true}
                  */
+}
+
+private fun Route.bibleSelectRoutes(
+    server: CompanionServer,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 post(Constants.ENDPOINT_BIBLE_SELECT) {
                     if (!server.checkApiKey(call)) return@post
                     val body = call.receiveText()
@@ -245,3 +269,4 @@ internal fun Route.bibleAndDictionaryRoutes(
                  * schedule items are still accessible without polluting this list.
                  */
 }
+

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/InfoAndSongRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/InfoAndSongRoutes.kt
@@ -32,6 +32,17 @@ internal fun Route.infoAndSongRoutes(
     json: Json,
     scope: CoroutineScope,
 ) {
+    infoRoutes(server, _bibleCatalog, _catalog, _fileUploadEnabled, _maxMediaUploadMb)
+    songRoutes(server, _catalog, json, scope)
+}
+
+private fun Route.infoRoutes(
+    server: CompanionServer,
+    _bibleCatalog: MutableStateFlow<BibleCatalogResponse?>,
+    _catalog: MutableStateFlow<SongCatalogResponse>,
+    _fileUploadEnabled: MutableStateFlow<Boolean>,
+    _maxMediaUploadMb: MutableStateFlow<Int>,
+) {
                 get(Constants.ENDPOINT_INFO) {
                     if (!server.checkApiKey(call)) return@get
                     call.respond(ServerInfoResponse(port = server.currentPort))
@@ -60,7 +71,14 @@ internal fun Route.infoAndSongRoutes(
                         )
                     )
                 }
+}
 
+private fun Route.songRoutes(
+    server: CompanionServer,
+    _catalog: MutableStateFlow<SongCatalogResponse>,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 get(Constants.ENDPOINT_SONGS) {
                     if (!server.checkApiKey(call)) return@get
                     val filter = call.request.queryParameters[Constants.QUERY_PARAM_SONGBOOK]
@@ -123,6 +141,14 @@ internal fun Route.infoAndSongRoutes(
                  *
                  * Response: {"ok":true}
                  */
+    songSelectRoutes(server, json, scope)
+}
+
+private fun Route.songSelectRoutes(
+    server: CompanionServer,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 post("${Constants.ENDPOINT_SONGS}/{number}/select") {
                     if (!server.checkApiKey(call)) return@post
                     val number = call.parameters["number"] ?: run {
@@ -148,5 +174,6 @@ internal fun Route.infoAndSongRoutes(
                     )) }
                     call.respondText("""{"ok":true}""", ContentType.Application.Json)
                 }
-
 }
+
+

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdAndAtemRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdAndAtemRoutes.kt
@@ -2,6 +2,7 @@ package org.churchpresenter.app.churchpresenter.server
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
@@ -13,9 +14,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import org.churchpresenter.app.churchpresenter.data.settings.AtemSettings
 import org.churchpresenter.app.churchpresenter.utils.CrashReporter
 
 private const val KEY_SETTLE_MS = 800L
+private const val MILLIS_PER_SECOND = 1000L
 
 /**
  * Routes for lower-third triggers and the ATEM upstream/downstream key.
@@ -28,6 +31,15 @@ internal fun Route.lowerThirdAndAtemRoutes(
     server: CompanionServer,
     json: Json,
     scope: CoroutineScope,
+) {
+    lowerThirdRoutes(server, json)
+    atemMediaPoolRoutes(server, scope)
+    atemKeyRoutes(server)
+}
+
+private fun Route.lowerThirdRoutes(
+    server: CompanionServer,
+    json: Json,
 ) {
                 get("/api/lowerthirds") {
                     if (!server.checkApiKey(call)) return@get
@@ -86,75 +98,14 @@ internal fun Route.lowerThirdAndAtemRoutes(
                 // to ATEM still slot N (1-based; defaults to atemSettings.defaultStillSlot).
                 // If ?key=M (M > 0) is provided, turns upstream key M on M/E E on after upload.
                 // Responds immediately; upload runs in background.
+}
+
+private fun Route.atemMediaPoolRoutes(
+    server: CompanionServer,
+    scope: CoroutineScope,
+) {
                 post("/api/atem/still/{name}") {
-                    if (!server.checkApiKey(call)) return@post
-                    val name = call.parameters["name"] ?: run {
-                        call.respond(HttpStatusCode.BadRequest, """{"error":"name required"}""")
-                        return@post
-                    }
-                    val file = server.atem.lowerThirdFiles().firstOrNull { it.nameWithoutExtension.equals(name, ignoreCase = true) }
-                    if (file == null) {
-                        call.respond(HttpStatusCode.NotFound, """{"error":"lower third not found"}""")
-                        return@post
-                    }
-                    val atem = server.atem._atemSettings
-                    if (atem == null || atem.host.isBlank()) {
-                        call.respond(HttpStatusCode.ServiceUnavailable, """{"error":"ATEM not configured"}""")
-                        return@post
-                    }
-                    val slotParam = call.request.queryParameters["slot"]?.toIntOrNull()
-                    val slot = if (slotParam != null) slotParam - 1 else atem.defaultStillSlot
-                    // Optional key-on after upload: present key>0 ⇒ key it; absent/0 ⇒ upload only
-                    val keyParam = call.request.queryParameters["key"]?.toIntOrNull()
-                    val meParam = call.request.queryParameters["me"]?.toIntOrNull()
-                    val keyOn = keyParam != null && keyParam > 0
-                    val useDsk = server.atem.resolveUseDsk(call, atem)
-                    val mixEffect = if (useDsk) 0 else (if (meParam != null) meParam - 1 else atem.keyMixEffect)
-                    val keyer = if (keyParam != null && keyParam > 0) keyParam - 1
-                        else if (useDsk) atem.dskIndex else atem.keyIndex
-                    if (keyOn) server.atem.validateKeyTarget(atem, useDsk, mixEffect, keyer)?.let {
-                        call.respond(HttpStatusCode.BadRequest, """{"error":${server.atem.jsonStr(it)}}""")
-                        return@post
-                    }
-                    scope.launch {
-                        val uploadId = AtemUploadStatus.begin(file.nameWithoutExtension, clip = false, slot = slot + 1)
-                        try {
-                            val lottieJson = file.readText()
-                            val variant = LottieRenderCache.atemVariant(lottieJson, atem, clip = false)
-                            val cached = LottieRenderCache.prepare(lottieJson, variant).await()
-                            AtemConnectionManager.use(atem.host, atem.port, needsState = true) { client ->
-                                LottieRenderCache.Reader(cached).use { reader ->
-                                    client.uploadStillEncoded(
-                                        slot, reader.nextAtemFrame(atem.renderWidth, atem.renderHeight),
-                                        file.nameWithoutExtension
-                                    ) { p ->
-                                        AtemUploadStatus.progress(uploadId, p)
-                                    }
-                                }
-                                if (keyOn) client.setKeyOnAir(useDsk, mixEffect, keyer, true)
-                            }
-                            AtemUploadStatus.complete(uploadId)
-                            kotlinx.coroutines.delay(KEY_SETTLE_MS)
-                            AtemUploadStatus.clear(uploadId)
-                        } catch (e: Exception) {
-                            System.err.println("[CompanionServer] ATEM still upload failed for '$name': ${e.message}")
-                            CrashReporter.reportWarning(
-                                "ATEM still upload failed: $name",
-                                throwable = e,
-                                tags = mapOf("subsystem" to "atem")
-                            )
-                            AtemUploadStatus.fail(uploadId, e.message)
-                        }
-                    }
-                    val keyInfo = when {
-                        !keyOn -> ""
-                        useDsk -> ""","dsk":${keyer + 1}"""
-                        else -> ""","me":${mixEffect + 1},"key":${keyer + 1}"""
-                    }
-                    call.respondText(
-                        """{"status":"uploading","type":"still","name":${server.atem.jsonStr(name)},"slot":${slot + 1}$keyInfo}""",
-                        ContentType.Application.Json
-                    )
+                    handleAtemStillUpload(call, server, scope)
                 }
 
                 // POST /api/atem/clip/{name}?slot=N&me=E&key=M
@@ -162,6 +113,13 @@ internal fun Route.lowerThirdAndAtemRoutes(
                 // to ATEM clip slot N (1-based; defaults to atemSettings.defaultClipSlot).
                 // If ?key=M (M > 0) is provided, turns upstream key M on M/E E on after upload,
                 // then off after the clip duration. Responds immediately; upload runs in background.
+    atemClipRoutes(server, scope)
+}
+
+private fun Route.atemClipRoutes(
+    server: CompanionServer,
+    scope: CoroutineScope,
+) {
                 post("/api/atem/clip/{name}") {
                     if (!server.checkApiKey(call)) return@post
                     val name = call.parameters["name"] ?: run {
@@ -180,14 +138,8 @@ internal fun Route.lowerThirdAndAtemRoutes(
                     }
                     val slotParam = call.request.queryParameters["slot"]?.toIntOrNull()
                     val slot = if (slotParam != null) slotParam - 1 else atem.defaultClipSlot
-                    val keyParam = call.request.queryParameters["key"]?.toIntOrNull()
-                    val meParam = call.request.queryParameters["me"]?.toIntOrNull()
-                    val keyOn = keyParam != null && keyParam > 0
-                    val useDsk = server.atem.resolveUseDsk(call, atem)
-                    val mixEffect = if (useDsk) 0 else (if (meParam != null) meParam - 1 else atem.keyMixEffect)
-                    val keyer = if (keyParam != null && keyParam > 0) keyParam - 1
-                        else if (useDsk) atem.dskIndex else atem.keyIndex
-                    if (keyOn) server.atem.validateKeyTarget(atem, useDsk, mixEffect, keyer)?.let {
+                    val key = atemKeyTarget(call, server, atem)
+                    if (key.on) server.atem.validateKeyTarget(atem, key.useDsk, key.mixEffect, key.keyer)?.let {
                         call.respond(HttpStatusCode.BadRequest, """{"error":${server.atem.jsonStr(it)}}""")
                         return@post
                     }
@@ -206,49 +158,12 @@ internal fun Route.lowerThirdAndAtemRoutes(
                         return@post
                     }
                     scope.launch {
-                        val uploadId = AtemUploadStatus.begin(file.nameWithoutExtension, clip = true, slot = slot + 1)
-                        try {
-                            val variant = LottieRenderCache.atemVariant(lottieJson, atem, clip = true, fps = fps)
-                            val cached = LottieRenderCache.prepare(lottieJson, variant).await()
-                            AtemConnectionManager.use(atem.host, atem.port, needsState = true) { client ->
-                                LottieRenderCache.Reader(cached).use { reader ->
-                                    client.uploadClipEncoded(slot, reader.frameCount, file.nameWithoutExtension,
-                                        nextFrame = { reader.nextAtemFrame(atem.renderWidth, atem.renderHeight) }
-                                    ) { p -> AtemUploadStatus.progress(uploadId, p) }
-                                }
-                                // Wait for the ATEM to finish ingesting the clip before keying, so
-                                // the key never fires over a half-processed clip. Best-effort: key
-                                // anyway if the device never reports ready within the timeout.
-                                AtemUploadStatus.startProcessing(uploadId)
-                                client.awaitClipReady(slot, frameCount) { p -> AtemUploadStatus.progress(uploadId, p) }
-                                if (keyOn) client.setKeyOnAir(useDsk, mixEffect, keyer, true)
-                            }
-                            AtemUploadStatus.complete(uploadId)
-                            kotlinx.coroutines.delay(KEY_SETTLE_MS)
-                            AtemUploadStatus.clear(uploadId)
-                            // Wait for the clip to finish playing, then turn the key off automatically.
-                            // Mutex is released between the two use() calls so other operations can proceed.
-                            if (keyOn) {
-                                val clipDurationMs = (frameCount.toLong() * 1000L) / fps.toLong()
-                                kotlinx.coroutines.delay(clipDurationMs)
-                                AtemConnectionManager.use(atem.host, atem.port, needsState = false) { client ->
-                                    client.setKeyOnAir(useDsk, mixEffect, keyer, false)
-                                }
-                            }
-                        } catch (e: Exception) {
-                            System.err.println("[CompanionServer] ATEM clip upload failed for '$name': ${e.message}")
-                            CrashReporter.reportWarning(
-                                "ATEM clip upload failed: $name",
-                                throwable = e,
-                                tags = mapOf("subsystem" to "atem")
-                            )
-                            AtemUploadStatus.fail(uploadId, e.message)
-                        }
+                        uploadClipFrames(file, atem, slot, key, name, lottieJson, fps, frameCount)
                     }
                     val keyInfoClip = when {
-                        !keyOn -> ""
-                        useDsk -> ""","dsk":${keyer + 1}"""
-                        else -> ""","me":${mixEffect + 1},"key":${keyer + 1}"""
+                        !key.on -> ""
+                        key.useDsk -> ""","dsk":${key.keyer + 1}"""
+                        else -> ""","me":${key.mixEffect + 1},"key":${key.keyer + 1}"""
                     }
                     call.respondText(
                         """{"status":"uploading","type":"clip","name":${server.atem.jsonStr(name)},"slot":${slot + 1}$keyInfoClip}""",
@@ -257,6 +172,12 @@ internal fun Route.lowerThirdAndAtemRoutes(
                 }
 
                 // POST /api/atem/key/on?me=E&key=M  — turn upstream key M on M/E E on air (standalone)
+}
+
+
+private fun Route.atemKeyRoutes(
+    server: CompanionServer,
+) {
                 post("/api/atem/key/on") {
                     if (!server.checkApiKey(call)) return@post
                     server.atem.handleKeyToggle(call, onAir = true)
@@ -269,5 +190,168 @@ internal fun Route.lowerThirdAndAtemRoutes(
                 }
 
                 // ── Browser Source Endpoints (OBS/vMix overlay) ────────────────────
+}
 
+
+
+private suspend fun handleAtemStillUpload(
+    call: ApplicationCall,
+    server: CompanionServer,
+    scope: CoroutineScope,
+) {
+                if (!server.checkApiKey(call)) return
+                val name = call.parameters["name"].orEmpty()
+                val file = namedLowerThirdOrRespond(call, server, name) ?: return
+                val atem = configuredAtemOrRespond(call, server) ?: return
+                val slotParam = call.request.queryParameters["slot"]?.toIntOrNull()
+                val slot = if (slotParam != null) slotParam - 1 else atem.defaultStillSlot
+                // Optional key-on after upload: present key>0 ⇒ key it; absent/0 ⇒ upload only
+                val key = atemKeyTarget(call, server, atem)
+                if (key.on) server.atem.validateKeyTarget(atem, key.useDsk, key.mixEffect, key.keyer)?.let {
+                    call.respond(HttpStatusCode.BadRequest, """{"error":${server.atem.jsonStr(it)}}""")
+                    return
+                }
+                scope.launch { uploadStillFrame(file, atem, slot, key, name) }
+                val keyInfo = when {
+                    !key.on -> ""
+                    key.useDsk -> ""","dsk":${key.keyer + 1}"""
+                    else -> ""","me":${key.mixEffect + 1},"key":${key.keyer + 1}"""
+                }
+                call.respondText(
+                    """{"status":"uploading","type":"still","name":${server.atem.jsonStr(name)},"slot":${slot + 1}$keyInfo}""",
+                    ContentType.Application.Json
+                )
+}
+
+/** Renders the named lower third to a single ATEM still and uploads it into [slot]. */
+private suspend fun uploadStillFrame(
+    file: java.io.File,
+    atem: AtemSettings,
+    slot: Int,
+    key: AtemKeyTarget,
+    name: String,
+) {
+    val uploadId = AtemUploadStatus.begin(file.nameWithoutExtension, clip = false, slot = slot + 1)
+    try {
+        val lottieJson = file.readText()
+        val variant = LottieRenderCache.atemVariant(lottieJson, atem, clip = false)
+        val cached = LottieRenderCache.prepare(lottieJson, variant).await()
+        AtemConnectionManager.use(atem.host, atem.port, needsState = true) { client ->
+            LottieRenderCache.Reader(cached).use { reader ->
+                client.uploadStillEncoded(
+                    slot, reader.nextAtemFrame(atem.renderWidth, atem.renderHeight),
+                    file.nameWithoutExtension
+                ) { p ->
+                    AtemUploadStatus.progress(uploadId, p)
+                }
+            }
+            if (key.on) client.setKeyOnAir(key.useDsk, key.mixEffect, key.keyer, true)
+        }
+        AtemUploadStatus.complete(uploadId)
+        delay(KEY_SETTLE_MS)
+        AtemUploadStatus.clear(uploadId)
+    } catch (e: Exception) {
+        System.err.println("[CompanionServer] ATEM still upload failed for '$name': ${e.message}")
+        CrashReporter.reportWarning(
+            "ATEM still upload failed: $name",
+            throwable = e,
+            tags = mapOf("subsystem" to "atem")
+        )
+        AtemUploadStatus.fail(uploadId, e.message)
+    }
+}
+
+/** Which keyer an upload should put on air afterwards, resolved from the query and settings. */
+private data class AtemKeyTarget(val on: Boolean, val useDsk: Boolean, val mixEffect: Int, val keyer: Int)
+
+private fun atemKeyTarget(call: ApplicationCall, server: CompanionServer, atem: AtemSettings): AtemKeyTarget {
+    val keyParam = call.request.queryParameters["key"]?.toIntOrNull()
+    val meParam = call.request.queryParameters["me"]?.toIntOrNull()
+    val useDsk = server.atem.resolveUseDsk(call, atem)
+    return AtemKeyTarget(
+        on = keyParam != null && keyParam > 0,
+        useDsk = useDsk,
+        mixEffect = if (useDsk) 0 else (if (meParam != null) meParam - 1 else atem.keyMixEffect),
+        keyer = if (keyParam != null && keyParam > 0) keyParam - 1
+            else if (useDsk) atem.dskIndex else atem.keyIndex,
+    )
+}
+
+/** Renders the named lower third to an ATEM clip, uploads it, and keys it if asked. */
+private suspend fun uploadClipFrames(
+    file: java.io.File,
+    atem: AtemSettings,
+    slot: Int,
+    key: AtemKeyTarget,
+    name: String,
+    lottieJson: String,
+    fps: Double,
+    frameCount: Int,
+) {
+    val uploadId = AtemUploadStatus.begin(file.nameWithoutExtension, clip = true, slot = slot + 1)
+    try {
+        val variant = LottieRenderCache.atemVariant(lottieJson, atem, clip = true, fps = fps)
+        val cached = LottieRenderCache.prepare(lottieJson, variant).await()
+        AtemConnectionManager.use(atem.host, atem.port, needsState = true) { client ->
+            LottieRenderCache.Reader(cached).use { reader ->
+                client.uploadClipEncoded(slot, reader.frameCount, file.nameWithoutExtension,
+                    nextFrame = { reader.nextAtemFrame(atem.renderWidth, atem.renderHeight) }
+                ) { p -> AtemUploadStatus.progress(uploadId, p) }
+            }
+            // Wait for the ATEM to finish ingesting the clip before keying, so the key never fires
+            // over a half-processed clip. Best-effort: key anyway if the device never reports ready
+            // within the timeout.
+            AtemUploadStatus.startProcessing(uploadId)
+            client.awaitClipReady(slot, frameCount) { p -> AtemUploadStatus.progress(uploadId, p) }
+            if (key.on) client.setKeyOnAir(key.useDsk, key.mixEffect, key.keyer, true)
+        }
+        AtemUploadStatus.complete(uploadId)
+        delay(KEY_SETTLE_MS)
+        AtemUploadStatus.clear(uploadId)
+        // Wait for the clip to finish playing, then turn the key off automatically. The mutex is
+        // released between the two use() calls so other operations can proceed.
+        if (key.on) {
+            delay((frameCount.toLong() * MILLIS_PER_SECOND) / fps.toLong())
+            AtemConnectionManager.use(atem.host, atem.port, needsState = false) { client ->
+                client.setKeyOnAir(key.useDsk, key.mixEffect, key.keyer, false)
+            }
+        }
+    } catch (e: Exception) {
+        System.err.println("[CompanionServer] ATEM clip upload failed for '$name': ${e.message}")
+        CrashReporter.reportWarning(
+            "ATEM clip upload failed: $name",
+            throwable = e,
+            tags = mapOf("subsystem" to "atem")
+        )
+        AtemUploadStatus.fail(uploadId, e.message)
+    }
+}
+
+/** The lower third named in the request, or null once the failure has been responded with. */
+private suspend fun namedLowerThirdOrRespond(
+    call: ApplicationCall,
+    server: CompanionServer,
+    name: String,
+): java.io.File? {
+    if (name.isBlank()) {
+        call.respond(HttpStatusCode.BadRequest, """{"error":"name required"}""")
+        return null
+    }
+    val file = server.atem.lowerThirdFiles()
+        .firstOrNull { it.nameWithoutExtension.equals(name, ignoreCase = true) }
+    if (file == null) {
+        call.respond(HttpStatusCode.NotFound, """{"error":"lower third not found"}""")
+        return null
+    }
+    return file
+}
+
+/** The ATEM settings, or null once "not configured" has been responded with. */
+private suspend fun configuredAtemOrRespond(call: ApplicationCall, server: CompanionServer): AtemSettings? {
+    val atem = server.atem._atemSettings
+    if (atem == null || atem.host.isBlank()) {
+        call.respond(HttpStatusCode.ServiceUnavailable, """{"error":"ATEM not configured"}""")
+        return null
+    }
+    return atem
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdAndAtemRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdAndAtemRoutes.kt
@@ -311,7 +311,7 @@ private suspend fun uploadClipFrames(
         // Wait for the clip to finish playing, then turn the key off automatically. The mutex is
         // released between the two use() calls so other operations can proceed.
         if (key.on) {
-            delay((frameCount.toLong() * MILLIS_PER_SECOND) / fps.toLong())
+            delay(if (fps > 0.0) ((frameCount.toDouble() * MILLIS_PER_SECOND) / fps).toLong() else 0L)
             AtemConnectionManager.use(atem.host, atem.port, needsState = false) { client ->
                 client.setKeyOnAir(key.useDsk, key.mixEffect, key.keyer, false)
             }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/MediaAndAssetRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/MediaAndAssetRoutes.kt
@@ -43,6 +43,20 @@ internal fun Route.mediaAndAssetRoutes(
     json: Json,
     scope: CoroutineScope,
 ) {
+    pictureRoutes(server, _pictureCatalog, _pictureCatalogs, _pictureFiles)
+    mediaStreamAndBibleFileRoutes(server, _scheduleItemToMediaPath)
+    backgroundAndPictureUploadRoutes(
+        server, deviceUploadsFolderId, _backgroundSettings, _fileUploadEnabled,
+        _pictureCatalogs, _pictureFiles, json, scope
+    )
+}
+
+private fun Route.pictureRoutes(
+    server: CompanionServer,
+    _pictureCatalog: MutableStateFlow<PictureFolderResponse?>,
+    _pictureCatalogs: ConcurrentHashMap<String, PictureFolderResponse>,
+    _pictureFiles: ConcurrentHashMap<String, List<File>>,
+) {
                 get(Constants.ENDPOINT_PICTURES) {
                     if (!server.checkApiKey(call)) return@get
                     val catalog = _pictureCatalog.value
@@ -120,6 +134,12 @@ internal fun Route.mediaAndAssetRoutes(
                  * handled by the PartialContent plugin so seeking works, letting an InstanceLink
                  * follower play the file over HTTP without needing a local copy.
                  */
+}
+
+private fun Route.mediaStreamAndBibleFileRoutes(
+    server: CompanionServer,
+    _scheduleItemToMediaPath: ConcurrentHashMap<String, String>,
+) {
                 get("${Constants.ENDPOINT_MEDIA_STREAM}/{id}") {
                     if (!server.checkApiKey(call)) return@get
                     val id = call.parameters["id"] ?: run { call.respond(HttpStatusCode.BadRequest, "Missing id"); return@get }
@@ -206,6 +226,18 @@ internal fun Route.mediaAndAssetRoutes(
                 /** GET /api/backgrounds — current BackgroundSettings as JSON. Image/video fields are
                  *  still local file paths on this machine; a follower resolves the actual bytes via
                  *  GET /api/backgrounds/asset/{slot} below, keyed by slot rather than raw path. */
+}
+
+private fun Route.backgroundAndPictureUploadRoutes(
+    server: CompanionServer,
+    deviceUploadsFolderId: String,
+    _backgroundSettings: MutableStateFlow<BackgroundSettings>,
+    _fileUploadEnabled: MutableStateFlow<Boolean>,
+    _pictureCatalogs: ConcurrentHashMap<String, PictureFolderResponse>,
+    _pictureFiles: ConcurrentHashMap<String, List<File>>,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 get(Constants.ENDPOINT_BACKGROUNDS) {
                     if (!server.checkApiKey(call)) return@get
                     server.logRest("/api/backgrounds", HttpStatusCode.OK.value)
@@ -260,6 +292,18 @@ internal fun Route.mediaAndAssetRoutes(
                  * When "file-name" is provided the index is resolved by name so the correct
                  * image is displayed regardless of sort-order differences between clients.
                  */
+    pictureSelectAndUploadRoutes(server, deviceUploadsFolderId, _fileUploadEnabled, _pictureCatalogs, _pictureFiles, json, scope)
+}
+
+private fun Route.pictureSelectAndUploadRoutes(
+    server: CompanionServer,
+    deviceUploadsFolderId: String,
+    _fileUploadEnabled: MutableStateFlow<Boolean>,
+    _pictureCatalogs: ConcurrentHashMap<String, PictureFolderResponse>,
+    _pictureFiles: ConcurrentHashMap<String, List<File>>,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 post("${Constants.ENDPOINT_PICTURES}/select") {
                     if (!server.checkApiKey(call)) return@post
                     try {
@@ -375,5 +419,6 @@ internal fun Route.mediaAndAssetRoutes(
                         call.respond(HttpStatusCode.InternalServerError, """{"error":"upload failed: ${e.message?.replace("\"","\\\"")}"}""")
                     }
                 }
-
 }
+
+

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationRoutes.kt
@@ -2,6 +2,7 @@ package org.churchpresenter.app.churchpresenter.server
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.request.receiveStream
 import io.ktor.server.request.receiveText
@@ -26,6 +27,8 @@ import org.churchpresenter.app.churchpresenter.utils.Constants
 
 private const val MAX_UPLOAD_MB = 200
 private const val BYTES_PER_MB = 1024 * 1024
+private const val BYTES_PER_KB = 1024
+private val UPLOADABLE_DECK_EXTENSIONS = setOf("pdf", "ppt", "pptx", "key")
 
 /**
  * Routes serving presentation catalogues and rendered slide images.
@@ -41,6 +44,19 @@ internal fun Route.presentationRoutes(
     _presentationCatalog: MutableStateFlow<PresentationCatalogResponse>,
     _presentationCatalogs: ConcurrentHashMap<String, PresentationDto>,
     _presentationFilePaths: ConcurrentHashMap<String, String>,
+    _scheduleItemToPresentationId: ConcurrentHashMap<String, String>,
+    _slideBytes: ConcurrentHashMap<String, List<ByteArray>>,
+    json: Json,
+    scope: CoroutineScope,
+) {
+    presentationCatalogRoutes(server, _presentationCatalog, _presentationCatalogs, _scheduleItemToPresentationId, _slideBytes, json, scope)
+    presentationUploadRoutes(server, _fileUploadEnabled, _maxMediaUploadMb, _presentationCatalogs, _presentationFilePaths, _slideBytes, json, scope)
+}
+
+private fun Route.presentationCatalogRoutes(
+    server: CompanionServer,
+    _presentationCatalog: MutableStateFlow<PresentationCatalogResponse>,
+    _presentationCatalogs: ConcurrentHashMap<String, PresentationDto>,
     _scheduleItemToPresentationId: ConcurrentHashMap<String, String>,
     _slideBytes: ConcurrentHashMap<String, List<ByteArray>>,
     json: Json,
@@ -83,6 +99,17 @@ internal fun Route.presentationRoutes(
                  * GET /api/presentations/{id}/slides/{index}
                  * Returns the slide at {index} as a JPEG image for the presentation with {id}.
                  */
+    presentationSlideRoutes(server, _presentationCatalogs, _scheduleItemToPresentationId, _slideBytes, json, scope)
+}
+
+private fun Route.presentationSlideRoutes(
+    server: CompanionServer,
+    _presentationCatalogs: ConcurrentHashMap<String, PresentationDto>,
+    _scheduleItemToPresentationId: ConcurrentHashMap<String, String>,
+    _slideBytes: ConcurrentHashMap<String, List<ByteArray>>,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 get("${Constants.ENDPOINT_PRESENTATIONS}/{id}/slides/{index}") {
                     if (!server.checkApiKey(call)) return@get
                     val id    = call.parameters["id"]    ?: run { call.respond(HttpStatusCode.BadRequest, "Missing id"); return@get }
@@ -148,74 +175,41 @@ internal fun Route.presentationRoutes(
                  *
                  * Response: { "ok": true, "id": "<hex-hash>", "name": "<fileName>" }
                  */
+}
+
+
+private fun Route.presentationUploadRoutes(
+    server: CompanionServer,
+    _fileUploadEnabled: MutableStateFlow<Boolean>,
+    _maxMediaUploadMb: MutableStateFlow<Int>,
+    _presentationCatalogs: ConcurrentHashMap<String, PresentationDto>,
+    _presentationFilePaths: ConcurrentHashMap<String, String>,
+    _slideBytes: ConcurrentHashMap<String, List<ByteArray>>,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 post("${Constants.ENDPOINT_PRESENTATIONS}/upload") {
                     if (!server.checkApiKey(call)) return@post
                     if (!_fileUploadEnabled.value) {
                         call.respond(HttpStatusCode.Forbidden, """{"error":"file upload is disabled"}""")
                         return@post
                     }
-                    try {
-                        val contentLength = call.request.headers["Content-Length"]?.toLongOrNull() ?: 0L
-                        if (contentLength > MAX_UPLOAD_MB * BYTES_PER_MB) {
-                            call.respond(HttpStatusCode.PayloadTooLarge, """{"error":"file too large (max 200 MB)"}""")
-                            return@post
-                        }
-                        val body   = call.receiveText()
-                        val parsed = json.parseToJsonElement(body) as? JsonObject
-                        val name   = (parsed?.get("name") as? JsonPrimitive)?.content
-                        val data   = (parsed?.get("data") as? JsonPrimitive)?.content
-                        if (name.isNullOrBlank() || data.isNullOrBlank()) {
-                            call.respond(HttpStatusCode.BadRequest, """{"error":"name and data are required"}""")
-                            return@post
-                        }
-                        val safeName = File(name).name.ifBlank { "upload.pdf" }
-                        val ext = safeName.substringAfterLast('.', "").lowercase()
-                        if (ext !in setOf("pdf", "ppt", "pptx", "key")) {
-                            call.respond(HttpStatusCode.UnsupportedMediaType, """{"error":"unsupported file type: $ext"}""")
-                            return@post
-                        }
-                        val base64Match = Regex("^data:[^;]+;base64,(.+)$").find(data)
-                        if (base64Match == null) {
-                            call.respond(HttpStatusCode.BadRequest, """{"error":"data must be a base64 data URI"}""")
-                            return@post
-                        }
-                        val fileBytes = Base64.getDecoder().decode(base64Match.groupValues[1])
-                        val uploadDir = File(System.getProperty("user.home"), ".churchpresenter/device_presentations").also { it.mkdirs() }
-                        val uniqueName = if (File(uploadDir, safeName).exists()) {
-                            val ts   = System.currentTimeMillis()
-                            val base = safeName.substringBeforeLast('.', safeName)
-                            "${base}_$ts.$ext"
-                        } else safeName
-                        val file = File(uploadDir, uniqueName)
-                        file.writeBytes(fileBytes)
-                        val id = file.absolutePath.hashCode().toUInt().toString(16)
-                        // Evict the previous device-uploaded presentation so the mobile list
-                        // never accumulates stale entries — only the latest upload is shown.
-                        server.presentations._lastDeviceUploadedPresentationId?.let { oldId ->
-                            _presentationCatalogs.remove(oldId)
-                            _slideBytes.remove(oldId)
-                            _presentationFilePaths.remove(oldId)
-                        }
-                        server.presentations._lastDeviceUploadedPresentationId = id
-                        val uploadClientId = call.request.headers[Constants.HEADER_DEVICE_ID] ?: ""
-                        scope.launch { server.onPresentationUploaded.emit(file) }
-                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
-                            actionType = "upload",
-                            title = file.name,
-                            detail = "${fileBytes.size / 1024} KB",
-                            clientId = uploadClientId
-                        )) }
-                        call.respondText(
-                            """{"ok":true,"id":"$id","name":"${file.nameWithoutExtension.replace("\"", "\\\"")}"}""",
-                            ContentType.Application.Json
-                        )
-                    } catch (e: Exception) {
-                        call.respond(HttpStatusCode.InternalServerError, """{"error":"upload failed: ${e.message?.replace("\"", "\\\"")}"}""")
-                    }
+                    storeUploadedPresentation(
+                        call, server, _presentationCatalogs, _presentationFilePaths, _slideBytes, json, scope
+                    )
                 }
 
                 /**
                  * POST /api/media/upload?name=clip.mp4
+    mediaUploadRoutes(server, _fileUploadEnabled, _maxMediaUploadMb, scope)
+}
+
+private fun Route.mediaUploadRoutes(
+    server: CompanionServer,
+    _fileUploadEnabled: MutableStateFlow<Boolean>,
+    _maxMediaUploadMb: MutableStateFlow<Int>,
+    scope: CoroutineScope,
+) {
                  * Body: the raw file bytes (application/octet-stream), streamed straight to disk.
                  *
                  * Streaming (rather than a base64 JSON body) keeps memory flat on both ends so
@@ -284,4 +278,93 @@ internal fun Route.presentationRoutes(
                 // ── Presentation remote control endpoints ─────────────────────
 
                 /** GET /presentation-remote — mobile remote control web page */
+}
+
+/** Writes an uploaded deck to disk, evicts the previous device upload, and answers the client. */
+private suspend fun storeUploadedPresentation(
+    call: ApplicationCall,
+    server: CompanionServer,
+    _presentationCatalogs: ConcurrentHashMap<String, PresentationDto>,
+    _presentationFilePaths: ConcurrentHashMap<String, String>,
+    _slideBytes: ConcurrentHashMap<String, List<ByteArray>>,
+    json: Json,
+    scope: CoroutineScope,
+) {
+    try {
+        val (safeName, fileBytes) = receiveUploadedDeck(call, json) ?: return
+        val ext = safeName.substringAfterLast('.', "").lowercase()
+        val uploadDir = File(System.getProperty("user.home"), ".churchpresenter/device_presentations")
+            .also { it.mkdirs() }
+        val uniqueName = if (File(uploadDir, safeName).exists()) {
+            val base = safeName.substringBeforeLast('.', safeName)
+            "${base}_${System.currentTimeMillis()}.$ext"
+        } else {
+            safeName
+        }
+        val file = File(uploadDir, uniqueName)
+        file.writeBytes(fileBytes)
+        val id = file.absolutePath.hashCode().toUInt().toString(16)
+        // Evict the previous device-uploaded presentation so the mobile list never accumulates
+        // stale entries — only the latest upload is shown.
+        server.presentations._lastDeviceUploadedPresentationId?.let { oldId ->
+            _presentationCatalogs.remove(oldId)
+            _slideBytes.remove(oldId)
+            _presentationFilePaths.remove(oldId)
+        }
+        server.presentations._lastDeviceUploadedPresentationId = id
+        val uploadClientId = call.request.headers[Constants.HEADER_DEVICE_ID] ?: ""
+        scope.launch { server.onPresentationUploaded.emit(file) }
+        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
+            actionType = "upload",
+            title = file.name,
+            detail = "${fileBytes.size / BYTES_PER_KB} KB",
+            clientId = uploadClientId
+        )) }
+        call.respondText(
+            """{"ok":true,"id":"$id","name":"${file.nameWithoutExtension.replace("\"", "\\\"")}"}""",
+            ContentType.Application.Json
+        )
+    } catch (e: Exception) {
+        call.respond(
+            HttpStatusCode.InternalServerError,
+            """{"error":"upload failed: ${e.message?.replace("\"", "\\\"")}"}"""
+        )
+    }
+}
+
+/** The deck's safe name and bytes, or null once the rejection has been responded with. */
+private suspend fun receiveUploadedDeck(call: ApplicationCall, json: Json): Pair<String, ByteArray>? {
+    val contentLength = call.request.headers["Content-Length"]?.toLongOrNull() ?: 0L
+    if (contentLength > MAX_UPLOAD_MB * BYTES_PER_MB) {
+        call.respond(HttpStatusCode.PayloadTooLarge, """{"error":"file too large (max 200 MB)"}""")
+        return null
+    }
+    val parsed = json.parseToJsonElement(call.receiveText()) as? JsonObject
+    val name = (parsed?.get("name") as? JsonPrimitive)?.content
+    val data = (parsed?.get("data") as? JsonPrimitive)?.content
+    if (name.isNullOrBlank() || data.isNullOrBlank()) {
+        call.respond(HttpStatusCode.BadRequest, """{"error":"name and data are required"}""")
+        return null
+    }
+    return decodeUploadedDeck(call, name, data)
+}
+
+/** The safe name and decoded bytes, or null once the rejection has been responded with. */
+private suspend fun decodeUploadedDeck(
+    call: ApplicationCall,
+    name: String,
+    data: String,
+): Pair<String, ByteArray>? {
+    val safeName = File(name).name.ifBlank { "upload.pdf" }
+    val ext = safeName.substringAfterLast('.', "").lowercase()
+    if (ext !in UPLOADABLE_DECK_EXTENSIONS) {
+        call.respond(HttpStatusCode.UnsupportedMediaType, """{"error":"unsupported file type: $ext"}""")
+        return null
+    }
+    val base64 = Regex("^data:[^;]+;base64,(.+)$").find(data)?.groupValues?.get(1)
+    if (base64 == null) {
+        call.respond(HttpStatusCode.BadRequest, """{"error":"data must be a base64 data URI"}""")
+        return null
+    }
+    return safeName to Base64.getDecoder().decode(base64)
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/QaRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/QaRoutes.kt
@@ -37,6 +37,15 @@ internal fun Route.qaRoutes(
     json: Json,
     scope: CoroutineScope,
 ) {
+    qaPublicRoutes(server, json)
+    qaModerationRoutes(server, json, scope)
+    qaAdminActionRoutes(server, json, scope)
+}
+
+private fun Route.qaPublicRoutes(
+    server: CompanionServer,
+    json: Json,
+) {
                 get("/qa") {
                     call.respondText(qaSubmissionPageHtml(), ContentType.Text.Html)
                 }
@@ -93,6 +102,13 @@ internal fun Route.qaRoutes(
                 }
 
                 // Public: voting page
+    qaVotingRoutes(server, json)
+}
+
+private fun Route.qaVotingRoutes(
+    server: CompanionServer,
+    json: Json,
+) {
                 get("/qa/vote") {
                     call.respondText(qaVotingPageHtml(), ContentType.Text.Html)
                 }
@@ -160,6 +176,14 @@ internal fun Route.qaRoutes(
                 }
 
                 // Admin: check password
+}
+
+
+private fun Route.qaModerationRoutes(
+    server: CompanionServer,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 post("/api/qa/auth") {
                     if (!server.checkQaAdmin(call)) return@post
                     if (!server.checkQaAdminConnect(call)) return@post
@@ -203,6 +227,15 @@ internal fun Route.qaRoutes(
                 }
 
                 // Admin: edit question text
+    qaQuestionEditRoutes(server, json, scope)
+    qaQuestionStateRoutes(server, scope)
+}
+
+private fun Route.qaQuestionEditRoutes(
+    server: CompanionServer,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 post("/api/qa/questions/{id}/edit") {
                     if (!server.checkQaAdmin(call)) return@post
                     val id = call.parameters["id"] ?: run {
@@ -255,6 +288,12 @@ internal fun Route.qaRoutes(
                 }
 
                 // Admin: mark question as done
+}
+
+private fun Route.qaQuestionStateRoutes(
+    server: CompanionServer,
+    scope: CoroutineScope,
+) {
                 post("/api/qa/questions/{id}/done") {
                     if (!server.checkQaAdmin(call)) return@post
                     val id = call.parameters["id"] ?: run {
@@ -296,6 +335,12 @@ internal fun Route.qaRoutes(
                 }
 
                 // Admin: delete question
+    qaQuestionDeleteRoutes(server)
+}
+
+private fun Route.qaQuestionDeleteRoutes(
+    server: CompanionServer,
+) {
                 delete("/api/qa/questions/{id}") {
                     if (!server.checkQaAdmin(call)) return@delete
                     val id = call.parameters["id"] ?: run {
@@ -322,6 +367,15 @@ internal fun Route.qaRoutes(
                 }
 
                 // Admin: add question (admin-created)
+}
+
+
+
+private fun Route.qaAdminActionRoutes(
+    server: CompanionServer,
+    json: Json,
+    scope: CoroutineScope,
+) {
                 post("/api/qa/add") {
                     if (!server.checkQaAdmin(call)) return@post
                     val body = call.receiveText()
@@ -376,3 +430,4 @@ internal fun Route.qaRoutes(
                     call.respondText("""{"ok":true}""", ContentType.Application.Json)
                 }
 }
+

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
@@ -193,73 +193,8 @@ internal suspend fun applyRemoteLiveState(
         return
     }
     when (mode) {
-        Presenting.BIBLE -> {
-            val codeBook = state.verseCodeBook
-            val codeChapter = state.verseCodeChapter
-            val codeVerse = state.verseCodeVerse
-            val hasFullCode = codeBook != null && codeChapter != null && codeVerse != null
-            if (bibleSyncMode == BibleSyncMode.REFERENCE_ONLY && hasFullCode) {
-                // Reference-only: never touch a downloaded file — resolve the SAME canonical verse in
-                // this instance's own independently-configured (possibly different-language) Bible via
-                // Bible.getVerseDetailsByCode, so the follower shows its own translation's wording, not
-                // the primary's. If this Bible has no verse at that code (versification mismatch, or no
-                // local bible configured), there's nothing sensible to show — quietly no-op.
-                val result = localPrimaryBible?.getVerseDetailsByCode(codeBook, codeChapter, codeVerse)
-                if (result != null) {
-                    presenterManager.setSelectedVerses(
-                        listOf(
-                            SelectedVerse(
-                                bibleAbbreviation = localPrimaryBible.getBibleAbbreviation(),
-                                bibleName = localPrimaryBible.getBibleTitle(),
-                                bookName = result.bookName,
-                                chapter = result.displayChapter,
-                                verseNumber = result.displayVerse,
-                                verseText = result.verseText,
-                                verseRange = state.verseRange ?: ""
-                            )
-                        )
-                    )
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf("contentType" to "BIBLE", "resolved" to true, "mode" to "reference_only")
-                    )
-                } else {
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf(
-                            "contentType" to "BIBLE", "resolved" to false, "mode" to "reference_only",
-                            "reason" to if (localPrimaryBible == null) "no_local_bible_loaded" else "verse_code_not_found"
-                        )
-                    )
-                }
-            } else if (state.bookName != null) {
-                // Full replica: the primary's own wording, verbatim.
-                // setSelectedVerses (plural), not setSelectedVerse — only the plural setter feeds the
-                // selectedVerses -> displayedVerses bridging LaunchedEffect that BiblePresenter actually
-                // renders from; the singular setter alone leaves the screen blank despite the mode
-                // correctly switching to BIBLE.
-                presenterManager.setSelectedVerses(
-                    listOf(
-                        SelectedVerse(
-                            bookName = state.bookName,
-                            chapter = state.chapter ?: 0,
-                            verseNumber = state.verseNumber ?: 0,
-                            verseText = state.verseText ?: "",
-                            verseRange = state.verseRange ?: ""
-                        )
-                    )
-                )
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "BIBLE", "resolved" to true, "mode" to "full_replica")
-                )
-            } else {
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "BIBLE", "resolved" to false, "reason" to "no_book_name_in_state")
-                )
-            }
-        }
+        Presenting.BIBLE ->
+            applyRemoteBible(state, presenterManager, bibleSyncMode, localPrimaryBible)
         Presenting.LYRICS -> if (state.songTitle != null) {
             presenterManager.setLyricSection(
                 LyricSection(
@@ -298,162 +233,12 @@ internal suspend fun applyRemoteLiveState(
                 mapOf("contentType" to "WEBSITE", "resolved" to (state.websiteUrl != null))
             )
         }
-        Presenting.PICTURES -> {
-            val folderId = state.pictureFolderId
-            val index = state.pictureIndex
-            if (folderId != null && index != null) {
-                val cacheFile = File(instanceLinkPictureCacheDir, "${folderId}_$index.jpg")
-                if (!cacheFile.exists()) {
-                    val bytes = instanceLinkViewModel.fetchPictureImageBytes(folderId, index)
-                    if (bytes != null) {
-                        // Temp-file + rename: this apply can be cancelled mid-write by a newer
-                        // live state (collectLatest) — a truncated file must never land under the
-                        // final name, or the exists() cache gate would trust it forever.
-                        val tmp = File(cacheFile.parentFile, "${cacheFile.name}.tmp")
-                        tmp.writeBytes(bytes)
-                        if (!tmp.renameTo(cacheFile)) tmp.delete()
-                        if (!cacheFile.exists()) {
-                            InstanceLinkLogger.log(
-                                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                                mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "cache_write_failed")
-                            )
-                            return
-                        }
-                    } else {
-                        InstanceLinkLogger.log(
-                            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                            mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "fetch_failed")
-                        )
-                        return
-                    }
-                }
-                presenterManager.setSelectedImagePath(cacheFile.absolutePath)
-                InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "PICTURES", "resolved" to true))
-            } else {
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "missing_folder_id_or_index")
-                )
-            }
-        }
-        Presenting.LOWER_THIRD -> {
-            val name = state.lowerThirdName
-            if (name != null) {
-                val bytes = instanceLinkViewModel.fetchLowerThirdJson(name)
-                if (bytes != null) {
-                    presenterManager.setLottieContent(
-                        String(bytes, Charsets.UTF_8), pauseAtFrame = false, pauseFrame = -1f,
-                        pauseDurationMs = 2000L, presetName = name
-                    )
-                    InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "LOWER_THIRD", "resolved" to true))
-                } else {
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf("contentType" to "LOWER_THIRD", "resolved" to false, "reason" to "fetch_failed")
-                    )
-                }
-            } else {
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "LOWER_THIRD", "resolved" to false, "reason" to "no_name_in_state")
-                )
-            }
-        }
-        Presenting.MEDIA -> {
-            // No position/transport sync in this pass: LiveStateDto carries which media is live,
-            // not where playback is — a follower starts the same media from the top.
-            val mediaType = state.mediaType
-            val streamUrl = state.mediaId?.let { instanceLinkViewModel.mediaStreamUrl(it) }
-            when {
-                mediaType == Constants.MEDIA_TYPE_URL && state.mediaUrl != null && onPlayRemoteMedia != null -> {
-                    onPlayRemoteMedia(state.mediaUrl, mediaType)
-                    presenterManager.setCurrentMedia(state.mediaUrl, mediaType)
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf("contentType" to "MEDIA", "resolved" to true, "source" to "url", "positionSync" to false)
-                    )
-                }
-                streamUrl != null && onPlayRemoteMedia != null -> {
-                    val type = mediaType ?: Constants.MEDIA_TYPE_LOCAL
-                    onPlayRemoteMedia(streamUrl, type)
-                    presenterManager.setCurrentMedia(streamUrl, type)
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf("contentType" to "MEDIA", "resolved" to true, "source" to "stream", "positionSync" to false)
-                    )
-                }
-                else -> InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    // Media launched outside the primary's schedule has no stream mapping
-                    // (LiveStateDto.mediaId comes from its schedule-item → path map).
-                    mapOf("contentType" to "MEDIA", "resolved" to false, "reason" to "no_media_id")
-                )
-            }
-        }
-        Presenting.CANVAS -> {
-            val scene = state.sceneId?.let { id -> localScenes.find { it.id == id } }
-            if (scene != null) {
-                presenterManager.setActiveScene(scene)
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "CANVAS", "resolved" to true)
-                )
-            } else {
-                // Id-match only: scene content isn't fetchable over the link — mirroring works
-                // when the same scenes.json exists on both instances. Mode still switches.
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf(
-                        "contentType" to "CANVAS", "resolved" to false,
-                        "reason" to "scene_not_found_locally", "sceneName" to state.sceneName
-                    )
-                )
-            }
-        }
-        Presenting.QA -> {
-            val questionId = state.questionId
-            val questionText = state.questionText
-            if (questionId != null && questionText != null) {
-                presenterManager.setDisplayedQuestion(
-                    Question(
-                        id = questionId,
-                        text = questionText,
-                        timestamp = System.currentTimeMillis(),
-                        status = QuestionStatus.APPROVED
-                    )
-                )
-                InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "QA", "resolved" to true))
-            } else {
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "QA", "resolved" to false, "reason" to "no_question_in_state")
-                )
-            }
-        }
-        Presenting.DICTIONARY -> {
-            val entry = state.dictionaryEntry
-            val word = state.dictionaryWord
-            when {
-                entry != null -> {
-                    presenterManager.setDisplayedDictionaryEntry(entry)
-                    InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "DICTIONARY", "resolved" to true))
-                }
-                word != null -> {
-                    // Old primary that doesn't carry the full entry — show what we have.
-                    presenterManager.setDisplayedDictionaryEntry(
-                        StrongsEntry(number = "", word = word, transliteration = "", pronunciation = "", definition = "")
-                    )
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf("contentType" to "DICTIONARY", "resolved" to true, "partial" to true)
-                    )
-                }
-                else -> InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "DICTIONARY", "resolved" to false, "reason" to "no_word_in_state")
-                )
-            }
-        }
+        Presenting.PICTURES -> applyRemotePictures(state, presenterManager, instanceLinkViewModel)
+        Presenting.LOWER_THIRD -> applyRemoteLowerThird(state, presenterManager, instanceLinkViewModel)
+        Presenting.MEDIA -> applyRemoteMedia(state, presenterManager, instanceLinkViewModel, onPlayRemoteMedia)
+        Presenting.CANVAS -> applyRemoteCanvas(state, presenterManager, localScenes)
+        Presenting.QA -> applyRemoteQa(state, presenterManager)
+        Presenting.DICTIONARY -> applyRemoteDictionary(state, presenterManager)
         else -> {
             // presentation: mirrored via its own dedicated broadcast (remotePresentationSlide
             // collector); stt: no caption feed exists to mirror. Mode still switches below.
@@ -783,4 +568,265 @@ internal fun addScheduleItem(
         else -> return false
     }
     return true
+}
+
+
+/** The BIBLE half of [applyRemoteLiveState]: either this instance's own wording, or the primary's. */
+private fun applyRemoteBible(
+    state: LiveStateDto,
+    presenterManager: PresenterManager,
+    bibleSyncMode: BibleSyncMode,
+    localPrimaryBible: Bible?,
+) {
+    val codeBook = state.verseCodeBook
+    val codeChapter = state.verseCodeChapter
+    val codeVerse = state.verseCodeVerse
+    val hasFullCode = codeBook != null && codeChapter != null && codeVerse != null
+    if (bibleSyncMode == BibleSyncMode.REFERENCE_ONLY && hasFullCode) {
+        // Reference-only: never touch a downloaded file — resolve the SAME canonical verse in
+        // this instance's own independently-configured (possibly different-language) Bible via
+        // Bible.getVerseDetailsByCode, so the follower shows its own translation's wording, not
+        // the primary's. If this Bible has no verse at that code (versification mismatch, or no
+        // local bible configured), there's nothing sensible to show — quietly no-op.
+        val result = localPrimaryBible?.getVerseDetailsByCode(codeBook, codeChapter, codeVerse)
+        if (result != null) {
+            presenterManager.setSelectedVerses(
+                listOf(
+                    SelectedVerse(
+                        bibleAbbreviation = localPrimaryBible.getBibleAbbreviation(),
+                        bibleName = localPrimaryBible.getBibleTitle(),
+                        bookName = result.bookName,
+                        chapter = result.displayChapter,
+                        verseNumber = result.displayVerse,
+                        verseText = result.verseText,
+                        verseRange = state.verseRange ?: ""
+                    )
+                )
+            )
+            InstanceLinkLogger.log(
+                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                mapOf("contentType" to "BIBLE", "resolved" to true, "mode" to "reference_only")
+            )
+        } else {
+            InstanceLinkLogger.log(
+                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                mapOf(
+                    "contentType" to "BIBLE", "resolved" to false, "mode" to "reference_only",
+                    "reason" to if (localPrimaryBible == null) "no_local_bible_loaded" else "verse_code_not_found"
+                )
+            )
+        }
+    } else if (state.bookName != null) {
+        // Full replica: the primary's own wording, verbatim.
+        // setSelectedVerses (plural), not setSelectedVerse — only the plural setter feeds the
+        // selectedVerses -> displayedVerses bridging LaunchedEffect that BiblePresenter actually
+        // renders from; the singular setter alone leaves the screen blank despite the mode
+        // correctly switching to BIBLE.
+        presenterManager.setSelectedVerses(
+            listOf(
+                SelectedVerse(
+                    bookName = state.bookName,
+                    chapter = state.chapter ?: 0,
+                    verseNumber = state.verseNumber ?: 0,
+                    verseText = state.verseText ?: "",
+                    verseRange = state.verseRange ?: ""
+                )
+            )
+        )
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "BIBLE", "resolved" to true, "mode" to "full_replica")
+        )
+    } else {
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "BIBLE", "resolved" to false, "reason" to "no_book_name_in_state")
+        )
+    }
+}
+
+private suspend fun applyRemotePictures(
+    state: LiveStateDto,
+    presenterManager: PresenterManager,
+    instanceLinkViewModel: InstanceLinkViewModel,
+) {
+    val folderId = state.pictureFolderId
+    val index = state.pictureIndex
+    if (folderId != null && index != null) {
+        val cacheFile = File(instanceLinkPictureCacheDir, "${folderId}_$index.jpg")
+        if (!cacheFile.exists()) {
+            val bytes = instanceLinkViewModel.fetchPictureImageBytes(folderId, index)
+            if (bytes != null) {
+                // Temp-file + rename: this apply can be cancelled mid-write by a newer
+                // live state (collectLatest) — a truncated file must never land under the
+                // final name, or the exists() cache gate would trust it forever.
+                val tmp = File(cacheFile.parentFile, "${cacheFile.name}.tmp")
+                tmp.writeBytes(bytes)
+                if (!tmp.renameTo(cacheFile)) tmp.delete()
+                if (!cacheFile.exists()) {
+                    InstanceLinkLogger.log(
+                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                        mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "cache_write_failed")
+                    )
+                    return
+                }
+            } else {
+                InstanceLinkLogger.log(
+                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                    mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "fetch_failed")
+                )
+                return
+            }
+        }
+        presenterManager.setSelectedImagePath(cacheFile.absolutePath)
+        InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "PICTURES", "resolved" to true))
+    } else {
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "missing_folder_id_or_index")
+        )
+    }
+}
+
+private suspend fun applyRemoteMedia(
+    state: LiveStateDto,
+    presenterManager: PresenterManager,
+    instanceLinkViewModel: InstanceLinkViewModel,
+    onPlayRemoteMedia: ((url: String, type: String) -> Unit)?,
+) {
+    // No position/transport sync in this pass: LiveStateDto carries which media is live,
+    // not where playback is — a follower starts the same media from the top.
+    val mediaType = state.mediaType
+    val streamUrl = state.mediaId?.let { instanceLinkViewModel.mediaStreamUrl(it) }
+    when {
+        mediaType == Constants.MEDIA_TYPE_URL && state.mediaUrl != null && onPlayRemoteMedia != null -> {
+            onPlayRemoteMedia(state.mediaUrl, mediaType)
+            presenterManager.setCurrentMedia(state.mediaUrl, mediaType)
+            InstanceLinkLogger.log(
+                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                mapOf("contentType" to "MEDIA", "resolved" to true, "source" to "url", "positionSync" to false)
+            )
+        }
+        streamUrl != null && onPlayRemoteMedia != null -> {
+            val type = mediaType ?: Constants.MEDIA_TYPE_LOCAL
+            onPlayRemoteMedia(streamUrl, type)
+            presenterManager.setCurrentMedia(streamUrl, type)
+            InstanceLinkLogger.log(
+                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                mapOf("contentType" to "MEDIA", "resolved" to true, "source" to "stream", "positionSync" to false)
+            )
+        }
+        else -> InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            // Media launched outside the primary's schedule has no stream mapping
+            // (LiveStateDto.mediaId comes from its schedule-item → path map).
+            mapOf("contentType" to "MEDIA", "resolved" to false, "reason" to "no_media_id")
+        )
+    }
+}
+
+private suspend fun applyRemoteLowerThird(
+    state: LiveStateDto,
+    presenterManager: PresenterManager,
+    instanceLinkViewModel: InstanceLinkViewModel,
+) {
+    val name = state.lowerThirdName
+    if (name != null) {
+        val bytes = instanceLinkViewModel.fetchLowerThirdJson(name)
+        if (bytes != null) {
+            presenterManager.setLottieContent(
+                String(bytes, Charsets.UTF_8), pauseAtFrame = false, pauseFrame = -1f,
+                pauseDurationMs = 2000L, presetName = name
+            )
+            InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "LOWER_THIRD", "resolved" to true))
+        } else {
+            InstanceLinkLogger.log(
+                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                mapOf("contentType" to "LOWER_THIRD", "resolved" to false, "reason" to "fetch_failed")
+            )
+        }
+    } else {
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "LOWER_THIRD", "resolved" to false, "reason" to "no_name_in_state")
+        )
+    }
+}
+
+
+private fun applyRemoteCanvas(
+    state: LiveStateDto,
+    presenterManager: PresenterManager,
+    localScenes: List<Scene>,
+) {
+    val scene = state.sceneId?.let { id -> localScenes.find { it.id == id } }
+    if (scene != null) {
+        presenterManager.setActiveScene(scene)
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "CANVAS", "resolved" to true)
+        )
+    } else {
+        // Id-match only: scene content isn't fetchable over the link — mirroring works
+        // when the same scenes.json exists on both instances. Mode still switches.
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf(
+                "contentType" to "CANVAS", "resolved" to false,
+                "reason" to "scene_not_found_locally", "sceneName" to state.sceneName
+            )
+        )
+    }
+}
+
+private fun applyRemoteQa(
+    state: LiveStateDto,
+    presenterManager: PresenterManager,
+) {
+    val questionId = state.questionId
+    val questionText = state.questionText
+    if (questionId != null && questionText != null) {
+        presenterManager.setDisplayedQuestion(
+            Question(
+                id = questionId,
+                text = questionText,
+                timestamp = System.currentTimeMillis(),
+                status = QuestionStatus.APPROVED
+            )
+        )
+        InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "QA", "resolved" to true))
+    } else {
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "QA", "resolved" to false, "reason" to "no_question_in_state")
+        )
+    }
+}
+
+private fun applyRemoteDictionary(
+    state: LiveStateDto,
+    presenterManager: PresenterManager,
+) {
+    val entry = state.dictionaryEntry
+    val word = state.dictionaryWord
+    when {
+        entry != null -> {
+            presenterManager.setDisplayedDictionaryEntry(entry)
+            InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "DICTIONARY", "resolved" to true))
+        }
+        word != null -> {
+            // Old primary that doesn't carry the full entry — show what we have.
+            presenterManager.setDisplayedDictionaryEntry(
+                StrongsEntry(number = "", word = word, transliteration = "", pronunciation = "", definition = "")
+            )
+            InstanceLinkLogger.log(
+                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+                mapOf("contentType" to "DICTIONARY", "resolved" to true, "partial" to true)
+            )
+        }
+        else -> InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "DICTIONARY", "resolved" to false, "reason" to "no_word_in_state")
+        )
+    }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
@@ -233,7 +233,8 @@ internal suspend fun applyRemoteLiveState(
                 mapOf("contentType" to "WEBSITE", "resolved" to (state.websiteUrl != null))
             )
         }
-        Presenting.PICTURES -> applyRemotePictures(state, presenterManager, instanceLinkViewModel)
+        Presenting.PICTURES ->
+            if (!applyRemotePictures(state, presenterManager, instanceLinkViewModel)) return
         Presenting.LOWER_THIRD -> applyRemoteLowerThird(state, presenterManager, instanceLinkViewModel)
         Presenting.MEDIA -> applyRemoteMedia(state, presenterManager, instanceLinkViewModel, onPlayRemoteMedia)
         Presenting.CANVAS -> applyRemoteCanvas(state, presenterManager, localScenes)
@@ -649,7 +650,7 @@ private suspend fun applyRemotePictures(
     state: LiveStateDto,
     presenterManager: PresenterManager,
     instanceLinkViewModel: InstanceLinkViewModel,
-) {
+): Boolean {
     val folderId = state.pictureFolderId
     val index = state.pictureIndex
     if (folderId != null && index != null) {
@@ -668,14 +669,14 @@ private suspend fun applyRemotePictures(
                         InstanceLinkLogSide.FOLLOWER, "apply_live_state",
                         mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "cache_write_failed")
                     )
-                    return
+                    return false
                 }
             } else {
                 InstanceLinkLogger.log(
                     InstanceLinkLogSide.FOLLOWER, "apply_live_state",
                     mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "fetch_failed")
                 )
-                return
+                return false
             }
         }
         presenterManager.setSelectedImagePath(cacheFile.absolutePath)
@@ -686,6 +687,7 @@ private suspend fun applyRemotePictures(
             mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "missing_folder_id_or_index")
         )
     }
+    return true
 }
 
 private suspend fun applyRemoteMedia(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/ScheduleItemMapping.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/ScheduleItemMapping.kt
@@ -63,27 +63,7 @@ fun RemoteItemDto.toScheduleItem(): ScheduleItem? {
                 definition      = definition ?: ""
             )
         // Announcement / timer — must have announcementText (may be "")
-        announcementText != null ->
-            ScheduleItem.AnnouncementItem(
-                id                = safeId,
-                text              = announcementText,
-                textColor         = textColor ?: "#FFFFFF",
-                backgroundColor   = backgroundColor ?: "#000000",
-                fontSize          = fontSize ?: 48,
-                animationType     = animationType ?: "SLIDE_FROM_BOTTOM",
-                animationDuration = animationDuration ?: 500,
-                isTimer           = isTimer ?: false,
-                timerHours        = timerHours ?: 0,
-                timerMinutes      = timerMinutes ?: 0,
-                timerSeconds      = timerSeconds ?: 0,
-                timerTextColor    = timerTextColor ?: (textColor ?: "#FFFFFF"),
-                timerExpiredText  = timerExpiredText ?: "",
-                timerMode         = timerMode ?: Constants.TIMER_MODE_DURATION,
-                targetHour        = targetHour ?: 0,
-                targetMinute      = targetMinute ?: 0,
-                targetSecond      = targetSecond ?: 0,
-                liveClockFormat   = liveClockFormat ?: "HH:mm:ss"
-            )
+        announcementText != null -> toAnnouncementItem(safeId, announcementText)
         // Website — must have url
         url != null ->
             ScheduleItem.WebsiteItem(
@@ -94,6 +74,29 @@ fun RemoteItemDto.toScheduleItem(): ScheduleItem? {
         else -> null
     }
 }
+
+/** The announcement/timer branch of [toScheduleItem], where most of the defaulting lives. */
+private fun RemoteItemDto.toAnnouncementItem(safeId: String, text: String): ScheduleItem.AnnouncementItem =
+    ScheduleItem.AnnouncementItem(
+        id                = safeId,
+        text              = text,
+        textColor         = textColor ?: "#FFFFFF",
+        backgroundColor   = backgroundColor ?: "#000000",
+        fontSize          = fontSize ?: 48,
+        animationType     = animationType ?: "SLIDE_FROM_BOTTOM",
+        animationDuration = animationDuration ?: 500,
+        isTimer           = isTimer ?: false,
+        timerHours        = timerHours ?: 0,
+        timerMinutes      = timerMinutes ?: 0,
+        timerSeconds      = timerSeconds ?: 0,
+        timerTextColor    = timerTextColor ?: (textColor ?: "#FFFFFF"),
+        timerExpiredText  = timerExpiredText ?: "",
+        timerMode         = timerMode ?: Constants.TIMER_MODE_DURATION,
+        targetHour        = targetHour ?: 0,
+        targetMinute      = targetMinute ?: 0,
+        targetSecond      = targetSecond ?: 0,
+        liveClockFormat   = liveClockFormat ?: "HH:mm:ss"
+    )
 
 /**
  * The companion API's wire form of a schedule item.

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/WebSocketRoute.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/WebSocketRoute.kt
@@ -2,6 +2,7 @@ package org.churchpresenter.app.churchpresenter.server
 
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.routing.Route
+import io.ktor.server.websocket.DefaultWebSocketServerSession
 import io.ktor.server.websocket.webSocket
 import io.ktor.websocket.Frame
 import io.ktor.websocket.readText
@@ -114,81 +115,15 @@ internal fun Route.webSocketRoute(
                     coroutineContext.job.invokeOnCompletion { broadcastJob.cancel() }
                     subscribed.await()
 
-                    val catalog = _catalog.value
-                    val schedule = _schedule.value
-                    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                        WebSocketMessage(Constants.WS_EVENT_SONGS_UPDATED,
-                            json.encodeToString(SongCatalogResponse.serializer(), catalog)))))
-                    _bibleCatalog.value?.let { bibleCatalog ->
-                        send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                            WebSocketMessage(Constants.WS_EVENT_BIBLE_UPDATED,
-                                json.encodeToString(BibleCatalogResponse.serializer(), bibleCatalog)))))
-                    }
-                    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                        WebSocketMessage(Constants.WS_EVENT_SCHEDULE_UPDATED,
-                            json.encodeToString(ScheduleResponse.serializer(), ScheduleResponse(schedule, schedule.size))))))
-                    val presentationCatalog = _presentationCatalog.value
-                    if (presentationCatalog.presentations.isNotEmpty()) {
-                        send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                            WebSocketMessage(Constants.WS_EVENT_PRESENTATION_UPDATED,
-                                json.encodeToString(PresentationCatalogResponse.serializer(), presentationCatalog)))))
-                    }
-                    _pictureCatalog.value?.let { pictureCatalog ->
-                        send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                            WebSocketMessage(Constants.WS_EVENT_PICTURES_UPDATED,
-                                json.encodeToString(PictureFolderResponse.serializer(), pictureCatalog)))))
-                    }
-                    // Resent on every (re)connect so a follower mirroring backgrounds
-                    // (InstanceLinkSettings.mirrorBackgrounds) always invalidates its local asset
-                    // cache once per connection — same reasoning as bible/pictures above. Without
-                    // this, a follower that reconnects (app restart, network blip, the automatic
-                    // backoff reconnect) keeps serving whatever it cached last session even if the
-                    // primary's background changed while it was disconnected.
-                    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                        WebSocketMessage(Constants.WS_EVENT_BACKGROUNDS_UPDATED, payload = ""))))
-                    // The secondary bible needs exactly the same treatment, and for exactly the same
-                    // reason: it is an invalidation signal with an empty payload, so a follower that
-                    // reconnects without it keeps serving the .spb it cached last session even if the
-                    // primary changed translation while it was away.
-                    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                        WebSocketMessage(Constants.WS_EVENT_SECONDARY_BIBLE_UPDATED, payload = ""))))
-                    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                        WebSocketMessage(
-                            type = Constants.WS_EVENT_PRESENTATION_SLIDE_CHANGED,
-                            payload = """{"id":"${server._currentPresentationId}","index":${server._currentSlideIndex},"total":${server._currentSlideTotalCount},"isPlaying":${server._presentationIsPlaying},"isLive":${server._presentationIsLive}}"""
-                        ))))
-                    _liveState.value?.let { state ->
-                        send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
-                            WebSocketMessage(Constants.WS_EVENT_LIVE_STATE_CHANGED,
-                                json.encodeToString(LiveStateDto.serializer(), state)))))
-                    }
-
+                    sendConnectSnapshot(
+                        server, _bibleCatalog, _catalog, _liveState, _pictureCatalog,
+                        _presentationCatalog, _schedule, json,
+                    )
                     // The snapshot is complete; anything the collector queued during it now flows.
                     snapshotSent.complete(Unit)
 
                     // Ack for commands that carried a commandId (InstanceLink controller mode) —
                     // no-op for clients that don't send one, so mobile behavior is unchanged.
-                    suspend fun sendCommandAck(commandId: String?, ok: Boolean, reason: String? = null) {
-                        if (commandId == null) return
-                        try {
-                            send(Frame.Text(json.encodeToString(
-                                WebSocketMessage.serializer(),
-                                WebSocketMessage(
-                                    type = Constants.WS_EVENT_COMMAND_ACK,
-                                    payload = json.encodeToString(
-                                        CommandAckPayload.serializer(),
-                                        CommandAckPayload(commandId, ok, reason)
-                                    )
-                                )
-                            )))
-                        } catch (_: Exception) {
-                            // session already closing — the follower's timeout covers this
-                        }
-                        InstanceLinkLogger.log(
-                            InstanceLinkLogSide.PRIMARY, "command_ack",
-                            mapOf("commandId" to commandId, "ok" to ok, "reason" to reason)
-                        )
-                    }
 
                     try {
                     for (frame in incoming) {
@@ -206,166 +141,14 @@ internal fun Route.webSocketRoute(
                                         InstanceLinkLogSide.PRIMARY, "ws_command_refused",
                                         mapOf("type" to msg.type, "deviceId" to wsClientId, "reason" to "blocked")
                                     )
-                                    sendCommandAck(msg.commandId, ok = false, reason = "blocked")
+                                    sendCommandAck(msg.commandId, ok = false, reason = "blocked", json = json)
                                     continue
                                 }
-                                when (msg.type) {
-                                    Constants.WS_CMD_SELECT_SONG -> {
-                                        val song = json.decodeFromString(ScheduleSongDto.serializer(), msg.payload)
-                                        scope.launch { server.onSongSelected.emit(song) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_SELECT_PICTURE -> {
-                                        val req = json.decodeFromString(SelectPictureRequest.serializer(), msg.payload)
-                                        scope.launch { server.onSelectPicture.emit(req) }
-                                        val folderName = _pictureCatalogs[req.folderId]?.folderName ?: req.folderId
-                                        val imageLabel = req.fileName ?: "Image ${req.index}"
-                                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", folderName, imageLabel, wsClientId)) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_SELECT_SONG_SECTION -> {
-                                        val req = json.decodeFromString(SelectSongSectionRequest.serializer(), msg.payload)
-                                        scope.launch { server.onSelectSongSection.emit(req) }
-                                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", "Song ${req.number}", "Section ${req.section}", wsClientId)) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_SELECT_SLIDE -> {
-                                        val req = json.decodeFromString(SelectSlideRequest.serializer(), msg.payload)
-                                        scope.launch { server.onSelectSlide.emit(req) }
-                                        val presName = _presentationCatalogs[_scheduleItemToPresentationId[req.id] ?: req.id]?.fileName ?: req.id
-                                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", presName, "Slide ${req.index + 1}", wsClientId)) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_SELECT_BIBLE_VERSE -> {
-                                        val req = json.decodeFromString(SelectBibleVerseRequest.serializer(), msg.payload)
-                                        scope.launch { server.onSelectBibleVerse.emit(req) }
-                                        val ref = if (req.verseRange.isNotEmpty()) "${req.bookName} ${req.chapter}:${req.verseRange}"
-                                                  else "${req.bookName} ${req.chapter}:${req.verseNumber}"
-                                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", ref, req.verseText.take(SUMMARY_PREVIEW_CHARS), wsClientId)) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_CLEAR -> {
-                                        scope.launch { server.onClear.emit(Unit) }
-                                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("clear", "Clear Display", clientId = wsClientId)) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_BIBLE_HOLD -> {
-                                        val hold = try {
-                                            json.parseToJsonElement(msg.payload)
-                                                .jsonObject["hold"]?.toString()?.toBooleanStrictOrNull() ?: true
-                                        } catch (_: Exception) { true }
-                                        scope.launch { server.onBibleHold.emit(hold) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_NEXT_PICTURE -> {
-                                        scope.launch { server.onNextPicture.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_PREVIOUS_PICTURE -> {
-                                        scope.launch { server.onPreviousPicture.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_NEXT_SLIDE -> {
-                                        scope.launch { server.onNextSlide.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_PREVIOUS_SLIDE -> {
-                                        scope.launch { server.onPreviousSlide.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_MEDIA_PLAY_PAUSE -> {
-                                        scope.launch { server.onMediaPlayPause.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_MEDIA_STOP -> {
-                                        scope.launch { server.onMediaStop.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_MEDIA_SEEK_FORWARD -> {
-                                        scope.launch { server.onMediaSeekForward.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_MEDIA_SEEK_BACKWARD -> {
-                                        scope.launch { server.onMediaSeekBackward.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_MEDIA_SEEK_TO -> {
-                                        val ms = msg.payload.trim().toLongOrNull()
-                                        if (ms != null) {
-                                            scope.launch { server.onMediaSeekTo.emit(ms) }
-                                            sendCommandAck(msg.commandId, ok = true)
-                                        } else sendCommandAck(msg.commandId, ok = false, reason = "invalid_payload")
-                                    }
-                                    Constants.WS_CMD_MEDIA_SET_VOLUME -> {
-                                        val v = msg.payload.trim().toFloatOrNull()
-                                        if (v != null) {
-                                            scope.launch { server.onMediaSetVolume.emit(v) }
-                                            sendCommandAck(msg.commandId, ok = true)
-                                        } else sendCommandAck(msg.commandId, ok = false, reason = "invalid_payload")
-                                    }
-                                    Constants.WS_CMD_MEDIA_MUTE_TOGGLE -> {
-                                        scope.launch { server.onMediaMuteToggle.emit(Unit) }
-                                        sendCommandAck(msg.commandId, ok = true)
-                                    }
-                                    Constants.WS_CMD_ADD_TO_SCHEDULE -> {
-                                        val item = server.parseRemoteItem(msg.payload)
-                                            ?: json.decodeFromString(AddToScheduleRequest.serializer(), msg.payload).item
-                                        val pending = PendingRemoteRequest(item, wsClientId)
-                                        scope.launch {
-                                            server.onAddToSchedule.emit(pending)
-                                            val allowed = try { pending.decision.await() } catch (_: Exception) { false }
-                                            val response = if (allowed) """{"ok":true}""" else """{"ok":false,"reason":"denied"}"""
-                                            try { send(Frame.Text(response)) } catch (_: Exception) { }
-                                        }
-                                        // Ack "queued" immediately — the operator's approval can take
-                                        // minutes, and its outcome still arrives via schedule_updated
-                                        // (plus the legacy raw {"ok":...} reply above for mobile).
-                                        sendCommandAck(msg.commandId, ok = true, reason = "pending_approval")
-                                    }
-                                    Constants.WS_CMD_ADD_BATCH_TO_SCHEDULE -> {
-                                        val items = try {
-                                            json.decodeFromString(RemoteItemsRequest.serializer(), msg.payload)
-                                                .items.mapNotNull { it.toScheduleItem() }
-                                        } catch (_: Exception) { emptyList() }
-                                        if (items.isNotEmpty()) {
-                                            val pending = PendingBatchRequest(items, wsClientId)
-                                            scope.launch {
-                                                server.onAddBatchToSchedule.emit(pending)
-                                                val allowed = try { pending.decision.await() } catch (_: Exception) { false }
-                                                val response = if (allowed) """{"ok":true}""" else """{"ok":false,"reason":"denied"}"""
-                                                try { send(Frame.Text(response)) } catch (_: Exception) { }
-                                            }
-                                            sendCommandAck(msg.commandId, ok = true, reason = "pending_approval")
-                                        } else {
-                                            sendCommandAck(msg.commandId, ok = false, reason = "invalid_payload")
-                                        }
-                                    }
-                                    Constants.WS_CMD_PROJECT -> {
-                                        val item = server.parseRemoteItem(msg.payload)
-                                            ?: json.decodeFromString(ProjectRequest.serializer(), msg.payload).item
-                                        val pending = PendingRemoteRequest(item, wsClientId)
-                                        scope.launch {
-                                            server.onProject.emit(pending)
-                                            val allowed = try { pending.decision.await() } catch (_: Exception) { false }
-                                            val response = if (allowed) """{"ok":true}""" else """{"ok":false,"reason":"denied"}"""
-                                            try { send(Frame.Text(response)) } catch (_: Exception) { }
-                                        }
-                                        sendCommandAck(msg.commandId, ok = true, reason = "pending_approval")
-                                    }
-                                    Constants.WS_CMD_REMOVE_FROM_SCHEDULE -> {
-                                        val req = json.decodeFromString(RemoveFromScheduleRequest.serializer(), msg.payload)
-                                        val label = _schedule.value.firstOrNull { it.id == req.id }?.displayText ?: req.id
-                                        val pending = PendingRemoveRequest(req.id, label, wsClientId)
-                                        scope.launch {
-                                            server.onRemoveFromSchedule.emit(pending)
-                                            val allowed = try { pending.decision.await() } catch (_: Exception) { false }
-                                            val response = if (allowed) """{"ok":true}""" else """{"ok":false,"reason":"denied"}"""
-                                            try { send(Frame.Text(response)) } catch (_: Exception) { }
-                                        }
-                                        sendCommandAck(msg.commandId, ok = true, reason = "pending_approval")
-                                    }
-                                    else -> sendCommandAck(msg.commandId, ok = false, reason = "unknown_command")
-                                }
+                                handleWsCommand(
+                                    msg, server, wsClientId, _pictureCatalogs, _presentationCatalogs,
+                                    _scheduleItemToPresentationId,
+                                    _schedule, json, scope,
+                                )
                             } catch (e: Exception) {
                                 InstanceLinkLogger.log(
                                     InstanceLinkLogSide.PRIMARY, "ws_frame_malformed",
@@ -386,5 +169,273 @@ internal fun Route.webSocketRoute(
                 // ── Lower Third Sequencer (Bitfocus Companion) ───────────────────
                 // One HTTP call runs the whole timed sequence: ATEM key on → play
                 // the lower third → key off when the animation ends.
+
+}
+
+
+/** Acks a command that carried a commandId (InstanceLink controller mode); a no-op without one. */
+private suspend fun DefaultWebSocketServerSession.sendCommandAck(
+    commandId: String?,
+    ok: Boolean,
+    reason: String? = null,
+    json: Json,
+) {
+                if (commandId == null) return
+                try {
+                    send(Frame.Text(json.encodeToString(
+                        WebSocketMessage.serializer(),
+                        WebSocketMessage(
+                            type = Constants.WS_EVENT_COMMAND_ACK,
+                            payload = json.encodeToString(
+                                CommandAckPayload.serializer(),
+                                CommandAckPayload(commandId, ok, reason)
+                            )
+                        )
+                    )))
+                } catch (_: Exception) {
+                    // session already closing — the follower's timeout covers this
+                }
+                InstanceLinkLogger.log(
+                    InstanceLinkLogSide.PRIMARY, "command_ack",
+                    mapOf("commandId" to commandId, "ok" to ok, "reason" to reason)
+                )
+}
+
+/** Runs one command frame from a connected client. */
+@Suppress("LongParameterList")
+private suspend fun DefaultWebSocketServerSession.handleWsCommand(
+    msg: WebSocketMessage,
+    server: CompanionServer,
+    wsClientId: String,
+    _pictureCatalogs: ConcurrentHashMap<String, PictureFolderResponse>,
+    _presentationCatalogs: ConcurrentHashMap<String, PresentationDto>,
+    _scheduleItemToPresentationId: ConcurrentHashMap<String, String>,
+    _schedule: MutableStateFlow<List<ScheduleItemDto>>,
+    json: Json,
+    scope: CoroutineScope,
+) {
+                when (msg.type) {
+                    Constants.WS_CMD_SELECT_SONG -> {
+                        val song = json.decodeFromString(ScheduleSongDto.serializer(), msg.payload)
+                        scope.launch { server.onSongSelected.emit(song) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_SELECT_PICTURE -> {
+                        val req = json.decodeFromString(SelectPictureRequest.serializer(), msg.payload)
+                        scope.launch { server.onSelectPicture.emit(req) }
+                        val folderName = _pictureCatalogs[req.folderId]?.folderName ?: req.folderId
+                        val imageLabel = req.fileName ?: "Image ${req.index}"
+                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", folderName, imageLabel, wsClientId)) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_SELECT_SONG_SECTION -> {
+                        val req = json.decodeFromString(SelectSongSectionRequest.serializer(), msg.payload)
+                        scope.launch { server.onSelectSongSection.emit(req) }
+                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", "Song ${req.number}", "Section ${req.section}", wsClientId)) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_SELECT_SLIDE -> {
+                        val req = json.decodeFromString(SelectSlideRequest.serializer(), msg.payload)
+                        scope.launch { server.onSelectSlide.emit(req) }
+                        val presName = _presentationCatalogs[_scheduleItemToPresentationId[req.id] ?: req.id]?.fileName ?: req.id
+                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", presName, "Slide ${req.index + 1}", wsClientId)) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_SELECT_BIBLE_VERSE -> {
+                        val req = json.decodeFromString(SelectBibleVerseRequest.serializer(), msg.payload)
+                        scope.launch { server.onSelectBibleVerse.emit(req) }
+                        val ref = if (req.verseRange.isNotEmpty()) "${req.bookName} ${req.chapter}:${req.verseRange}"
+                                  else "${req.bookName} ${req.chapter}:${req.verseNumber}"
+                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", ref, req.verseText.take(SUMMARY_PREVIEW_CHARS), wsClientId)) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_CLEAR -> {
+                        scope.launch { server.onClear.emit(Unit) }
+                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("clear", "Clear Display", clientId = wsClientId)) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_BIBLE_HOLD -> {
+                        val hold = try {
+                            json.parseToJsonElement(msg.payload)
+                                .jsonObject["hold"]?.toString()?.toBooleanStrictOrNull() ?: true
+                        } catch (_: Exception) { true }
+                        scope.launch { server.onBibleHold.emit(hold) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_NEXT_PICTURE -> {
+                        scope.launch { server.onNextPicture.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_PREVIOUS_PICTURE -> {
+                        scope.launch { server.onPreviousPicture.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_NEXT_SLIDE -> {
+                        scope.launch { server.onNextSlide.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_PREVIOUS_SLIDE -> {
+                        scope.launch { server.onPreviousSlide.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_MEDIA_PLAY_PAUSE -> {
+                        scope.launch { server.onMediaPlayPause.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_MEDIA_STOP -> {
+                        scope.launch { server.onMediaStop.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_MEDIA_SEEK_FORWARD -> {
+                        scope.launch { server.onMediaSeekForward.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_MEDIA_SEEK_BACKWARD -> {
+                        scope.launch { server.onMediaSeekBackward.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_MEDIA_SEEK_TO -> {
+                        val ms = msg.payload.trim().toLongOrNull()
+                        if (ms != null) {
+                            scope.launch { server.onMediaSeekTo.emit(ms) }
+                            sendCommandAck(msg.commandId, ok = true, json = json)
+                        } else sendCommandAck(msg.commandId, ok = false, reason = "invalid_payload", json = json)
+                    }
+                    Constants.WS_CMD_MEDIA_SET_VOLUME -> {
+                        val v = msg.payload.trim().toFloatOrNull()
+                        if (v != null) {
+                            scope.launch { server.onMediaSetVolume.emit(v) }
+                            sendCommandAck(msg.commandId, ok = true, json = json)
+                        } else sendCommandAck(msg.commandId, ok = false, reason = "invalid_payload", json = json)
+                    }
+                    Constants.WS_CMD_MEDIA_MUTE_TOGGLE -> {
+                        scope.launch { server.onMediaMuteToggle.emit(Unit) }
+                        sendCommandAck(msg.commandId, ok = true, json = json)
+                    }
+                    Constants.WS_CMD_ADD_TO_SCHEDULE -> {
+                        val item = server.parseRemoteItem(msg.payload)
+                            ?: json.decodeFromString(AddToScheduleRequest.serializer(), msg.payload).item
+                        val pending = PendingRemoteRequest(item, wsClientId)
+                        scope.launch {
+                            server.onAddToSchedule.emit(pending)
+                            val allowed = try { pending.decision.await() } catch (_: Exception) { false }
+                            val response = if (allowed) """{"ok":true}""" else """{"ok":false,"reason":"denied"}"""
+                            try { send(Frame.Text(response)) } catch (_: Exception) { }
+                        }
+                        // Ack "queued" immediately — the operator's approval can take
+                        // minutes, and its outcome still arrives via schedule_updated
+                        // (plus the legacy raw {"ok":...} reply above for mobile).
+                        sendCommandAck(msg.commandId, ok = true, reason = "pending_approval", json = json)
+                    }
+                    Constants.WS_CMD_ADD_BATCH_TO_SCHEDULE -> {
+                        val items = try {
+                            json.decodeFromString(RemoteItemsRequest.serializer(), msg.payload)
+                                .items.mapNotNull { it.toScheduleItem() }
+                        } catch (_: Exception) { emptyList() }
+                        if (items.isNotEmpty()) {
+                            val pending = PendingBatchRequest(items, wsClientId)
+                            scope.launch {
+                                server.onAddBatchToSchedule.emit(pending)
+                                val allowed = try { pending.decision.await() } catch (_: Exception) { false }
+                                val response = if (allowed) """{"ok":true}""" else """{"ok":false,"reason":"denied"}"""
+                                try { send(Frame.Text(response)) } catch (_: Exception) { }
+                            }
+                            sendCommandAck(msg.commandId, ok = true, reason = "pending_approval", json = json)
+                        } else {
+                            sendCommandAck(msg.commandId, ok = false, reason = "invalid_payload", json = json)
+                        }
+                    }
+                    Constants.WS_CMD_PROJECT -> {
+                        val item = server.parseRemoteItem(msg.payload)
+                            ?: json.decodeFromString(ProjectRequest.serializer(), msg.payload).item
+                        val pending = PendingRemoteRequest(item, wsClientId)
+                        scope.launch {
+                            server.onProject.emit(pending)
+                            val allowed = try { pending.decision.await() } catch (_: Exception) { false }
+                            val response = if (allowed) """{"ok":true}""" else """{"ok":false,"reason":"denied"}"""
+                            try { send(Frame.Text(response)) } catch (_: Exception) { }
+                        }
+                        sendCommandAck(msg.commandId, ok = true, reason = "pending_approval", json = json)
+                    }
+                    Constants.WS_CMD_REMOVE_FROM_SCHEDULE -> {
+                        val req = json.decodeFromString(RemoveFromScheduleRequest.serializer(), msg.payload)
+                        val label = _schedule.value.firstOrNull { it.id == req.id }?.displayText ?: req.id
+                        val pending = PendingRemoveRequest(req.id, label, wsClientId)
+                        scope.launch {
+                            server.onRemoveFromSchedule.emit(pending)
+                            val allowed = try { pending.decision.await() } catch (_: Exception) { false }
+                            val response = if (allowed) """{"ok":true}""" else """{"ok":false,"reason":"denied"}"""
+                            try { send(Frame.Text(response)) } catch (_: Exception) { }
+                        }
+                        sendCommandAck(msg.commandId, ok = true, reason = "pending_approval", json = json)
+                    }
+                    else -> sendCommandAck(msg.commandId, ok = false, reason = "unknown_command", json = json)
+                }
+}
+
+
+/**
+ * Everything a freshly connected client is told up front — catalogues, schedule, live state, and
+ * the empty-payload invalidation signals a reconnecting follower needs.
+ */
+@Suppress("LongParameterList")
+private suspend fun DefaultWebSocketServerSession.sendConnectSnapshot(
+    server: CompanionServer,
+    _bibleCatalog: MutableStateFlow<BibleCatalogResponse?>,
+    _catalog: MutableStateFlow<SongCatalogResponse>,
+    _liveState: MutableStateFlow<LiveStateDto?>,
+    _pictureCatalog: MutableStateFlow<PictureFolderResponse?>,
+    _presentationCatalog: MutableStateFlow<PresentationCatalogResponse>,
+    _schedule: MutableStateFlow<List<ScheduleItemDto>>,
+    json: Json,
+) {
+    val catalog = _catalog.value
+    val schedule = _schedule.value
+    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+        WebSocketMessage(Constants.WS_EVENT_SONGS_UPDATED,
+            json.encodeToString(SongCatalogResponse.serializer(), catalog)))))
+    _bibleCatalog.value?.let { bibleCatalog ->
+        send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+            WebSocketMessage(Constants.WS_EVENT_BIBLE_UPDATED,
+                json.encodeToString(BibleCatalogResponse.serializer(), bibleCatalog)))))
+    }
+    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+        WebSocketMessage(Constants.WS_EVENT_SCHEDULE_UPDATED,
+            json.encodeToString(ScheduleResponse.serializer(), ScheduleResponse(schedule, schedule.size))))))
+    val presentationCatalog = _presentationCatalog.value
+    if (presentationCatalog.presentations.isNotEmpty()) {
+        send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+            WebSocketMessage(Constants.WS_EVENT_PRESENTATION_UPDATED,
+                json.encodeToString(PresentationCatalogResponse.serializer(), presentationCatalog)))))
+    }
+    _pictureCatalog.value?.let { pictureCatalog ->
+        send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+            WebSocketMessage(Constants.WS_EVENT_PICTURES_UPDATED,
+                json.encodeToString(PictureFolderResponse.serializer(), pictureCatalog)))))
+    }
+    // Resent on every (re)connect so a follower mirroring backgrounds
+    // (InstanceLinkSettings.mirrorBackgrounds) always invalidates its local asset
+    // cache once per connection — same reasoning as bible/pictures above. Without
+    // this, a follower that reconnects (app restart, network blip, the automatic
+    // backoff reconnect) keeps serving whatever it cached last session even if the
+    // primary's background changed while it was disconnected.
+    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+        WebSocketMessage(Constants.WS_EVENT_BACKGROUNDS_UPDATED, payload = ""))))
+    // The secondary bible needs exactly the same treatment, and for exactly the same
+    // reason: it is an invalidation signal with an empty payload, so a follower that
+    // reconnects without it keeps serving the .spb it cached last session even if the
+    // primary changed translation while it was away.
+    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+        WebSocketMessage(Constants.WS_EVENT_SECONDARY_BIBLE_UPDATED, payload = ""))))
+    send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+        WebSocketMessage(
+            type = Constants.WS_EVENT_PRESENTATION_SLIDE_CHANGED,
+            payload = """{"id":"${server._currentPresentationId}","index":${server._currentSlideIndex},"total":${server._currentSlideTotalCount},"isPlaying":${server._presentationIsPlaying},"isLive":${server._presentationIsLive}}"""
+        ))))
+    _liveState.value?.let { state ->
+        send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
+            WebSocketMessage(Constants.WS_EVENT_LIVE_STATE_CHANGED,
+                json.encodeToString(LiveStateDto.serializer(), state)))))
+    }
 
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/LiveMapReporter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/LiveMapReporter.kt
@@ -181,11 +181,20 @@ object LiveMapReporter {
         append("&version=$version")
         if (updateCheckInterval != null) append("&updateCheck=${updateCheckInterval.name.lowercase()}")
         if (isDevBuild) append("&src=dev")
+        appendBuildFacts(repoSlug, commit, buildType)
+        appendSetupFacts(setup)
+        appendEventCounts(events)
+    }
+
+    private fun StringBuilder.appendBuildFacts(repoSlug: String, commit: String, buildType: String) {
         if (repoSlug.isNotBlank() && repoSlug != "unknown") append("&repo=$repoSlug")
         if (commit.isNotBlank() && commit != "unknown") append("&commit=$commit")
         if (buildType.isNotBlank() && buildType != "unknown") append("&build=$buildType")
-        // Omitted rather than sent as 0/false when unknown or unused, so the server can tell a
-        // setup that has none from a build too old to report it.
+    }
+
+    // Omitted rather than sent as 0/false when unknown or unused, so the server can tell a setup
+    // that has none from a build too old to report it.
+    private fun StringBuilder.appendSetupFacts(setup: SetupFacts) {
         if (setup.language.isNotBlank()) append("&lang=${setup.language}")
         if (setup.screens > 0) append("&screens=${setup.screens}")
         if (setup.bibles > 0) append("&bibles=${setup.bibles}")
@@ -194,8 +203,11 @@ object LiveMapReporter {
         if (setup.songbooks > 0) append("&songbooks=${setup.songbooks}")
         if (setup.songs > 0) append("&songs=${setup.songs}")
         if (setup.sessionMinutes > 0) append("&sessionMinutes=${setup.sessionMinutes}")
-        // Everything above describes the session that is starting. These are things that already
-        // happened, counted since the last ping the server took, so they can simply be added up.
+    }
+
+    // Everything above describes the session that is starting. These are things that already
+    // happened, counted since the last ping the server took, so they can simply be added up.
+    private fun StringBuilder.appendEventCounts(events: Map<UsageEvent, Int>) {
         UsageEvent.entries.forEach { event ->
             val count = events[event] ?: 0
             if (count > 0) append("&${event.param}=$count")

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelDetection.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelDetection.kt
@@ -1,6 +1,7 @@
 package org.churchpresenter.app.churchpresenter.viewmodel
 
 import kotlinx.coroutines.flow.first
+import org.churchpresenter.app.churchpresenter.data.Bible
 import org.churchpresenter.app.churchpresenter.utils.TrainingDataLogger
 
 /**
@@ -110,29 +111,13 @@ internal fun BibleViewModel.onEngineScripture(
     val codeStart = canonicalCodeStart?.let { bible.parseVerseCode(it) }
     val codeBook = codeStart?.first ?: bookId
     val bookIndex = bible.getDisplayIndexForBookId(codeBook).takeIf { it in _books.value.indices } ?: return
-    val (dispChapter, dispVerseStart) =
-        if (codeStart != null)
-            bible.getVerseDetailsByCode(codeStart.first, codeStart.second, codeStart.third)
-                ?.let { it.displayChapter to it.displayVerse } ?: (chapter to verseStart)
-        else chapter to verseStart
+    val (dispChapter, dispVerseStart) = bible.displayPositionOf(codeStart, chapter, verseStart)
     val dispVerseEnd = canonicalCodeEnd?.let { bible.parseVerseCode(it) }
         ?.let { bible.getVerseDetailsByCode(it.first, it.second, it.third)?.displayVerse }
         ?: verseEnd
 
-    val source = when (matchType) {
-        "explicit" -> DetectionSource.EXPLICIT
-        "continuation" -> DetectionSource.CONTINUATION
-        "chapter-scan" -> DetectionSource.CHAPTER_SCAN
-        "chapter-history" -> DetectionSource.CHAPTER_HISTORY
-        else -> DetectionSource.REVERSE
-    }
-    val trackSet = tracks.mapNotNull {
-        when (it) {
-            "transcription" -> DetectionTrack.TRANSCRIPTION
-            "translation" -> DetectionTrack.TRANSLATION
-            else -> null
-        }
-    }.toSet()
+    val source = detectionSourceOf(matchType)
+    val trackSet = detectionTracksOf(tracks)
     val vEnd = dispVerseEnd?.takeIf { it > dispVerseStart }
     val label = buildDetectionLabel(bookIndex, dispChapter, dispVerseStart, vEnd)
     val key = "$bookIndex|$dispChapter|$dispVerseStart|$vEnd"
@@ -274,4 +259,33 @@ internal fun BibleViewModel.buildDetectionLabel(bookIndex: Int, chapter: Int, vs
         else -> ""
     }
     return "$bookName $chapter$versePart"
+}
+
+/** The engine's matchType as the enum the UI tiers confidence by. */
+private fun detectionSourceOf(matchType: String): DetectionSource = when (matchType) {
+    "explicit" -> DetectionSource.EXPLICIT
+    "continuation" -> DetectionSource.CONTINUATION
+    "chapter-scan" -> DetectionSource.CHAPTER_SCAN
+    "chapter-history" -> DetectionSource.CHAPTER_HISTORY
+    else -> DetectionSource.REVERSE
+}
+
+private fun detectionTracksOf(tracks: List<String>): Set<DetectionTrack> = tracks.mapNotNull {
+    when (it) {
+        "transcription" -> DetectionTrack.TRANSCRIPTION
+        "translation" -> DetectionTrack.TRANSLATION
+        else -> null
+    }
+}.toSet()
+
+/** The module's own chapter/verse for a canonical code, falling back to what the engine sent. */
+private fun Bible.displayPositionOf(
+    codeStart: Triple<Int, Int, Int>?,
+    chapter: Int,
+    verseStart: Int,
+): Pair<Int, Int> {
+    if (codeStart == null) return chapter to verseStart
+    return getVerseDetailsByCode(codeStart.first, codeStart.second, codeStart.third)
+        ?.let { it.displayChapter to it.displayVerse }
+        ?: (chapter to verseStart)
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelLoading.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelLoading.kt
@@ -2,6 +2,7 @@ package org.churchpresenter.app.churchpresenter.viewmodel
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -9,6 +10,7 @@ import kotlinx.coroutines.withContext
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.BibleSettings
 import org.churchpresenter.app.churchpresenter.data.settings.BibleSyncMode
+import org.churchpresenter.app.churchpresenter.data.settings.BibleTranslationSettings
 import org.churchpresenter.app.churchpresenter.data.Bible
 import org.churchpresenter.app.churchpresenter.utils.InstanceLinkLogSide
 import org.churchpresenter.app.churchpresenter.utils.InstanceLinkLogger
@@ -170,47 +172,11 @@ internal fun BibleViewModel.loadBibles() {
         try {
             val useReplica = remoteModeActive && syncMode == BibleSyncMode.FULL_REPLICA
             val configuredTranslations = appSettings.bibleSettings.translationList()
-            val primaryPath = if (useReplica) {
-                remoteBibleCacheFile?.takeIf { it.exists() }
-            } else if (configuredTranslations.firstOrNull()?.fileName?.isNotEmpty() == true &&
-                appSettings.bibleSettings.storageDirectory.isNotEmpty()
-            ) File(appSettings.bibleSettings.storageDirectory, configuredTranslations.first().fileName)
-                .takeIf { it.exists() }
-            else null
-
-            val secondaryPath = if (useReplica) {
-                remoteSecondaryBibleCacheFile?.takeIf { it.exists() }
-            } else if (configuredTranslations.getOrNull(1)?.fileName?.isNotEmpty() == true &&
-                appSettings.bibleSettings.storageDirectory.isNotEmpty()
-            ) File(appSettings.bibleSettings.storageDirectory, configuredTranslations[1].fileName)
-                .takeIf { it.exists() }
-            else null
-            val translationSources = if (useReplica && remoteTranslationCacheFiles.isNotEmpty()) {
-                remoteTranslationCacheFiles
-            } else if (useReplica) {
-                listOfNotNull(primaryPath, secondaryPath).mapIndexed { index, path ->
-                    (configuredTranslations.getOrNull(index)?.fileName ?: path.name) to path
-                }
-            } else {
-                configuredTranslations.mapNotNull { translation ->
-                    File(appSettings.bibleSettings.storageDirectory, translation.fileName)
-                        .takeIf { it.exists() }
-                        ?.let { translation.fileName to it }
-                }
-            }
-
-            val missingTranslations = if (useReplica) emptyList() else {
-                val present = translationSources.map { it.first }.toSet()
-                configuredTranslations
-                    .filter { it.fileName.isNotEmpty() && it.fileName !in present }
-                    .map {
-                        BibleLoadError(
-                            resourcePath = File(appSettings.bibleSettings.storageDirectory, it.fileName).absolutePath,
-                            reason = BibleViewModel.MODULE_FILE_MISSING,
-                            partial = false,
-                        )
-                    }
-            }
+            val sources = resolveTranslationSources(useReplica, configuredTranslations)
+            val primaryPath = sources.primaryPath
+            val secondaryPath = sources.secondaryPath
+            val translationSources = sources.files
+            val missingTranslations = sources.missing
 
             val bookNameMappingDeferred = async(ioDispatcher) {
                 try { BibleBookNames.getBookNameMapping() } catch (_: Exception) { emptyMap() }
@@ -235,33 +201,12 @@ internal fun BibleViewModel.loadBibles() {
                 refreshFilteredLists()
             }
 
-            val bibleDeferred = translationSources.map { (identity, path) ->
-                identity to async(ioDispatcher) {
-                    try { Bible().apply { loadFromSpb(path.absolutePath) } }
-                    catch (e: Exception) { e.printStackTrace(); null }
-                }
-            }
-            val loadedByFile = bibleDeferred.associate { (fileName, deferred) -> fileName to deferred.await() }
-            val orderedIdentities = bibleDeferred.map { it.first }
-            val loaded = orderedIdentities.mapNotNull { fileName ->
-                loadedByFile[fileName]?.let { BibleViewModel.LoadedTranslation(fileName, it) }
-            }
-            val useRemoteIdentities = useReplica && remoteTranslationCacheFiles.isNotEmpty()
-            val primaryIdentity = if (useRemoteIdentities) orderedIdentities.firstOrNull()
-                else configuredTranslations.firstOrNull()?.fileName ?: orderedIdentities.firstOrNull()
-            val secondaryIdentity = if (useRemoteIdentities) orderedIdentities.getOrNull(1)
-                else configuredTranslations.getOrNull(1)?.fileName ?: orderedIdentities.getOrNull(1)
-            val primary = primaryIdentity?.let { loadedByFile[it] }
-            val secondary = secondaryIdentity?.let { loadedByFile[it] }
+            val modules = loadModules(useReplica, configuredTranslations, translationSources)
+            val loaded = modules.loaded
+            val primary = modules.primary
+            val secondary = modules.secondary
 
-            _loadErrors.value = missingTranslations + orderedIdentities.mapNotNull { identity ->
-                val path = translationSources.first { it.first == identity }.second
-                val bible = loadedByFile[identity]
-                when {
-                    bible == null -> BibleLoadError(path.absolutePath, BibleViewModel.MODULE_LOAD_THREW, partial = false)
-                    else -> bible.loadError
-                }
-            }
+            _loadErrors.value = missingTranslations + modules.errors
 
             if (remoteModeActive) {
                 InstanceLinkLogger.log(
@@ -285,27 +230,7 @@ internal fun BibleViewModel.loadBibles() {
             }
 
             if (primary != null) {
-                _books.value = primary.getCanonicalBooks()
-
-                val bookCount = minOf(primary.getBookCount(), BibleViewModel.CANONICAL_BOOK_COUNT)
-                val clampedBookIndex = if (previousBookId != null) {
-                    (0 until bookCount).firstOrNull { primary.getBookId(it) == previousBookId }
-                        ?: _selectedBookIndex.value.coerceIn(0, (bookCount - 1).coerceAtLeast(0))
-                } else {
-                    _selectedBookIndex.value.coerceIn(0, (bookCount - 1).coerceAtLeast(0))
-                }
-                _selectedBookIndex.value = clampedBookIndex
-                val bookId = primary.getBookId(clampedBookIndex)
-                val chapterResult = withContext(ioDispatcher) {
-                    primary.getChapter(bookId, _selectedChapter.value)
-                }
-                _verses.value = chapterResult.verses
-                _selectedVerseIndex.value = _selectedVerseIndex.value.coerceIn(0, (chapterResult.verses.size - 1).coerceAtLeast(0))
-                refreshFilteredLists()
-
-                if (previousBookId != null && _verses.value.isNotEmpty()) {
-                    _verseSelectionToken.value++
-                }
+                applyLoadedPrimary(primary, previousBookId)
                 onBibleLoaded?.invoke(primary, configuredTranslations.firstOrNull()?.fileName.orEmpty())
             } else if (booksOnlyBible == null) {
                 _books.value = emptyList()
@@ -317,4 +242,126 @@ internal fun BibleViewModel.loadBibles() {
             _isFullyLoadedFlow.value = true
         }
     }
+}
+
+/** Where each configured translation's module actually is, and which ones are missing. */
+private class TranslationSources(
+    val primaryPath: File?,
+    val secondaryPath: File?,
+    val files: List<Pair<String, File>>,
+    val missing: List<BibleLoadError>,
+)
+
+private fun BibleViewModel.resolveTranslationSources(
+    useReplica: Boolean,
+    configuredTranslations: List<BibleTranslationSettings>,
+): TranslationSources {
+    val storageDirectory = appSettings.bibleSettings.storageDirectory
+    fun configuredFile(index: Int): File? = configuredTranslations.getOrNull(index)
+        ?.fileName?.takeIf { it.isNotEmpty() }
+        ?.let { name -> storageDirectory.takeIf { it.isNotEmpty() }?.let { File(it, name) } }
+        ?.takeIf { it.exists() }
+
+    val primaryPath = if (useReplica) remoteBibleCacheFile?.takeIf { it.exists() } else configuredFile(0)
+    val secondaryPath =
+        if (useReplica) remoteSecondaryBibleCacheFile?.takeIf { it.exists() } else configuredFile(1)
+
+    val files = when {
+        useReplica && remoteTranslationCacheFiles.isNotEmpty() -> remoteTranslationCacheFiles
+        useReplica -> listOfNotNull(primaryPath, secondaryPath).mapIndexed { index, path ->
+            (configuredTranslations.getOrNull(index)?.fileName ?: path.name) to path
+        }
+        else -> configuredTranslations.mapNotNull { translation ->
+            File(storageDirectory, translation.fileName)
+                .takeIf { it.exists() }
+                ?.let { translation.fileName to it }
+        }
+    }
+
+    val present = files.map { it.first }.toSet()
+    val missing = if (useReplica) emptyList() else {
+        configuredTranslations
+            .filter { it.fileName.isNotEmpty() && it.fileName !in present }
+            .map {
+                BibleLoadError(
+                    resourcePath = File(storageDirectory, it.fileName).absolutePath,
+                    reason = BibleViewModel.MODULE_FILE_MISSING,
+                    partial = false,
+                )
+            }
+    }
+    return TranslationSources(primaryPath, secondaryPath, files, missing)
+}
+
+/** Points the book list, selection and verses at a freshly loaded primary module. */
+private suspend fun BibleViewModel.applyLoadedPrimary(primary: Bible, previousBookId: Int?) {
+    _books.value = primary.getCanonicalBooks()
+
+    val bookCount = minOf(primary.getBookCount(), BibleViewModel.CANONICAL_BOOK_COUNT)
+    val fallbackIndex = _selectedBookIndex.value.coerceIn(0, (bookCount - 1).coerceAtLeast(0))
+    val clampedBookIndex = if (previousBookId != null) {
+        (0 until bookCount).firstOrNull { primary.getBookId(it) == previousBookId } ?: fallbackIndex
+    } else {
+        fallbackIndex
+    }
+    _selectedBookIndex.value = clampedBookIndex
+    val bookId = primary.getBookId(clampedBookIndex)
+    val chapterResult = withContext(ioDispatcher) { primary.getChapter(bookId, _selectedChapter.value) }
+    _verses.value = chapterResult.verses
+    _selectedVerseIndex.value =
+        _selectedVerseIndex.value.coerceIn(0, (chapterResult.verses.size - 1).coerceAtLeast(0))
+    refreshFilteredLists()
+
+    if (previousBookId != null && _verses.value.isNotEmpty()) {
+        _verseSelectionToken.value++
+    }
+}
+
+/** Every configured module read off disk, with the primary/secondary picked out of them. */
+private class LoadedModules(
+    val loaded: List<BibleViewModel.LoadedTranslation>,
+    val primary: Bible?,
+    val secondary: Bible?,
+    val errors: List<BibleLoadError>,
+)
+
+private suspend fun BibleViewModel.loadModules(
+    useReplica: Boolean,
+    configuredTranslations: List<BibleTranslationSettings>,
+    translationSources: List<Pair<String, File>>,
+): LoadedModules = coroutineScope {
+    val bibleDeferred = translationSources.map { (identity, path) ->
+        identity to async(ioDispatcher) {
+            try { Bible().apply { loadFromSpb(path.absolutePath) } }
+            catch (e: Exception) { e.printStackTrace(); null }
+        }
+    }
+    val loadedByFile = bibleDeferred.associate { (fileName, deferred) -> fileName to deferred.await() }
+    val orderedIdentities = bibleDeferred.map { it.first }
+    val loaded = orderedIdentities.mapNotNull { fileName ->
+        loadedByFile[fileName]?.let { BibleViewModel.LoadedTranslation(fileName, it) }
+    }
+    val useRemoteIdentities = useReplica && remoteTranslationCacheFiles.isNotEmpty()
+    val primaryIdentity = if (useRemoteIdentities) orderedIdentities.firstOrNull()
+        else configuredTranslations.firstOrNull()?.fileName ?: orderedIdentities.firstOrNull()
+    val secondaryIdentity = if (useRemoteIdentities) orderedIdentities.getOrNull(1)
+        else configuredTranslations.getOrNull(1)?.fileName ?: orderedIdentities.getOrNull(1)
+
+    // A module that threw is reported as such; one that read is reported by its own loadError,
+    // which is null — and so dropped — when it read cleanly.
+    val errors = orderedIdentities.mapNotNull { identity ->
+        val path = translationSources.first { it.first == identity }.second
+        val bible = loadedByFile[identity]
+        if (bible == null) {
+            BibleLoadError(path.absolutePath, BibleViewModel.MODULE_LOAD_THREW, partial = false)
+        } else {
+            bible.loadError
+        }
+    }
+    LoadedModules(
+        loaded = loaded,
+        primary = primaryIdentity?.let { loadedByFile[it] },
+        secondary = secondaryIdentity?.let { loadedByFile[it] },
+        errors = errors,
+    )
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelSelection.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelSelection.kt
@@ -10,15 +10,19 @@ import org.churchpresenter.app.churchpresenter.models.SelectedVerse
  */
 
 internal fun BibleViewModel.getSelectedVerses(): List<SelectedVerse> {
-    val verseList = mutableListOf<SelectedVerse>()
-
-    if (_verses.value.isEmpty()) {
-        return verseList
-    }
+    if (_verses.value.isEmpty()) return emptyList()
 
     val bookId = _primaryBible.value?.getBookId(_selectedBookIndex.value) ?: (_selectedBookIndex.value + 1)
+    return if (_multiVerseEnabled.value && _selectedVerseIndices.isNotEmpty()) {
+        multiVerseSelection(bookId)
+    } else {
+        singleVerseSelection(bookId)
+    }
+}
 
-    if (_multiVerseEnabled.value && _selectedVerseIndices.isNotEmpty()) {
+/** Ctrl/Shift-selected verses, joined into one primary entry plus one per parallel translation. */
+private fun BibleViewModel.multiVerseSelection(bookId: Int): List<SelectedVerse> {
+    val verseList = mutableListOf<SelectedVerse>()
         val sortedIndices = _selectedVerseIndices.sorted()
         val primaryTexts = mutableListOf<String>()
         val parallelTexts = _loadedBibles.value.drop(1).map { mutableListOf<String>() }
@@ -86,8 +90,12 @@ internal fun BibleViewModel.getSelectedVerses(): List<SelectedVerse> {
                 )
             )
         }
-        return verseList
-    }
+    return verseList
+}
+
+/** The single selected verse, with the same verse from every other loaded translation. */
+private fun BibleViewModel.singleVerseSelection(bookId: Int): List<SelectedVerse> {
+    val verseList = mutableListOf<SelectedVerse>()
 
     val safeIndex = _selectedVerseIndex.value.coerceIn(0, _verses.value.size - 1)
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
@@ -26,6 +26,7 @@ import org.churchpresenter.app.churchpresenter.utils.HeicDecoder
 import org.jetbrains.skia.Image
 import java.io.File
 import java.nio.file.FileSystems
+import java.nio.file.WatchEvent
 import java.nio.file.StandardWatchEventKinds
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
@@ -487,48 +488,7 @@ class PicturesViewModel(
                         val fileName = event.context().toString()
                         val ext = fileName.substringAfterLast('.', "").lowercase()
                         if (kind == StandardWatchEventKinds.OVERFLOW || ext !in imageExtensions) continue
-
-                        val file = File(folder, fileName)
-                        when (kind) {
-                            StandardWatchEventKinds.ENTRY_CREATE -> {
-                                // isActive gates the add: cancellation is cooperative, so a watcher
-                                // cancelled by clearImages() can still be mid-pollEvents() here — an
-                                // add now would land in _images after the reload and duplicate a path.
-                                val isNewImageFile = file.exists() && file.isFile && file !in _images
-                        if (isActive && isNewImageFile) {
-                                    // Insert in sorted order, keep selected image stable
-                                    val insertIndex = _images.indexOfFirst { it.name > file.name }
-                                    if (insertIndex >= 0) {
-                                        _images.add(insertIndex, file)
-                                        if (insertIndex <= _selectedImageIndex.value) {
-                                            _selectedImageIndex.value++
-                                        }
-                                    } else {
-                                        _images.add(file)
-                                    }
-                                    // Load thumbnail
-                                    // A file copied into a watched folder is seen the moment it
-                                    // is created, usually before it is fully written, so the first
-                                    // decode of it legitimately fails.
-                                    launch { decodeThumbnail(file, attempts = THUMBNAIL_RETRY_ATTEMPTS) }
-                                    changed = true
-                                }
-                            }
-                            StandardWatchEventKinds.ENTRY_DELETE -> {
-                                val idx = _images.indexOf(file)
-                                if (idx >= 0) {
-                                    _images.removeAt(idx)
-                                    _thumbnails.remove(file)
-                                    _thumbnailFailures.remove(file)
-                                    if (idx < _selectedImageIndex.value) {
-                                        _selectedImageIndex.value--
-                                    } else if (_selectedImageIndex.value >= _images.size && _images.isNotEmpty()) {
-                                        _selectedImageIndex.value = _images.size - 1
-                                    }
-                                    changed = true
-                                }
-                            }
-                        }
+                        if (applyWatchEvent(kind, File(folder, fileName))) changed = true
                     }
                     if (!key.reset()) break
                 }
@@ -541,6 +501,48 @@ class PicturesViewModel(
                 // Folder became unavailable mid-watch (deleted/unmounted). Watching is best-effort.
             }
         }
+    }
+
+
+    /** Applies one watch event to the image list; true when the list actually changed. */
+    private fun CoroutineScope.applyWatchEvent(kind: WatchEvent.Kind<*>, file: File): Boolean = when (kind) {
+        StandardWatchEventKinds.ENTRY_CREATE -> addWatchedImage(file)
+        StandardWatchEventKinds.ENTRY_DELETE -> removeWatchedImage(file)
+        else -> false
+    }
+
+    private fun CoroutineScope.addWatchedImage(file: File): Boolean {
+        // isActive gates the add: cancellation is cooperative, so a watcher cancelled by
+        // clearImages() can still be mid-pollEvents() here — an add now would land in _images
+        // after the reload and duplicate a path.
+        val isNewImageFile = file.exists() && file.isFile && file !in _images
+        if (!isActive || !isNewImageFile) return false
+        // Insert in sorted order, keep selected image stable
+        val insertIndex = _images.indexOfFirst { it.name > file.name }
+        if (insertIndex >= 0) {
+            _images.add(insertIndex, file)
+            if (insertIndex <= _selectedImageIndex.value) _selectedImageIndex.value++
+        } else {
+            _images.add(file)
+        }
+        // A file copied into a watched folder is seen the moment it is created, usually before it
+        // is fully written, so the first decode of it legitimately fails.
+        launch { decodeThumbnail(file, attempts = THUMBNAIL_RETRY_ATTEMPTS) }
+        return true
+    }
+
+    private fun removeWatchedImage(file: File): Boolean {
+        val idx = _images.indexOf(file)
+        if (idx < 0) return false
+        _images.removeAt(idx)
+        _thumbnails.remove(file)
+        _thumbnailFailures.remove(file)
+        if (idx < _selectedImageIndex.value) {
+            _selectedImageIndex.value--
+        } else if (_selectedImageIndex.value >= _images.size && _images.isNotEmpty()) {
+            _selectedImageIndex.value = _images.size - 1
+        }
+        return true
     }
 
     fun dispose() {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongFolderWatcher.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongFolderWatcher.kt
@@ -12,6 +12,8 @@ import java.io.File
 import java.nio.file.ClosedWatchServiceException
 import java.nio.file.FileSystems
 import java.nio.file.Path
+import java.nio.file.WatchEvent
+import java.nio.file.WatchKey
 import java.nio.file.StandardWatchEventKinds
 import java.nio.file.WatchService
 
@@ -56,33 +58,7 @@ class SongFolderWatcher(
 
                     for (event in key.pollEvents()) {
                         if (event.kind() == StandardWatchEventKinds.OVERFLOW) continue
-                        val fileName = event.context().toString()
-
-                        // Check if it's a .song file change
-                        if (fileName.substringAfterLast('.', "").lowercase() == Constants.EXTENSION_SONG) {
-                            relevant = true
-                        }
-
-                        // Check if it's a directory change (new songbook folder)
-                        val watchedPath = (key.watchable() as? Path)?.resolve(fileName)
-                        if (watchedPath != null) {
-                            val file = watchedPath.toFile()
-                            if (file.isDirectory) {
-                                // Register the new subdirectory for watching
-                                if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
-                                    try {
-                                        file.toPath().register(
-                                            watchService,
-                                            StandardWatchEventKinds.ENTRY_CREATE,
-                                            StandardWatchEventKinds.ENTRY_DELETE,
-                                            StandardWatchEventKinds.ENTRY_MODIFY
-                                        )
-                                    } catch (_: Exception) {
-                                    }
-                                }
-                                relevant = true
-                            }
-                        }
+                        if (isRelevantEvent(event, key, watchService)) relevant = true
                     }
 
                     if (relevant) {
@@ -103,6 +79,33 @@ class SongFolderWatcher(
                 watchService.close()
             }
         }
+    }
+
+
+    /**
+     * True when this event should trigger a reload: a .song file changed, or a songbook folder
+     * appeared — in which case the new folder is registered for watching too.
+     */
+    private fun isRelevantEvent(
+        event: WatchEvent<*>,
+        key: WatchKey,
+        watchService: WatchService,
+    ): Boolean {
+        val fileName = event.context().toString()
+        val isSongFile = fileName.substringAfterLast('.', "").lowercase() == Constants.EXTENSION_SONG
+        val file = (key.watchable() as? Path)?.resolve(fileName)?.toFile()
+        if (file?.isDirectory != true) return isSongFile
+        if (event.kind() == StandardWatchEventKinds.ENTRY_CREATE) {
+            runCatching {
+                file.toPath().register(
+                    watchService,
+                    StandardWatchEventKinds.ENTRY_CREATE,
+                    StandardWatchEventKinds.ENTRY_DELETE,
+                    StandardWatchEventKinds.ENTRY_MODIFY
+                )
+            }
+        }
+        return true
     }
 
     fun dispose() {

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -42,7 +42,11 @@ complexity:
   TooManyFunctions:
     active: false
   CyclomaticComplexMethod:
-    active: false
+    active: true
+    threshold: 20
+    ignoreAnnotated: ['Composable']
+    ignoreSingleWhenExpression: true
+    ignoreSimpleWhenEntries: true
   LargeClass:
     active: false
   NestedBlockDepth:


### PR DESCRIPTION
…thod detekt fixes

Enables detekt's CyclomaticComplexMethod rule (threshold 20, Composables excluded) and resolves every violation it would flag by extracting focused private helpers.

Key extractions:
- Bible.kt: SPB parser split into SpbParseState + per-format helpers
- BibleViewModelLoading.kt: resolveTranslationSources, loadModules, applyLoadedPrimary
- BibleViewModelSelection.kt: multiVerseSelection / singleVerseSelection
- BibleViewModelDetection.kt: detectionSourceOf, detectionTracksOf, displayPositionOf
- RemoteApply.kt: one function per Presenting mode (applyRemoteBible, …Canvas, …QA, etc.)
- WebSocketRoute.kt: sendConnectSnapshot, handleWsCommand, sendCommandAck
- Server route files: each large route function split into focused sub-functions
- AtemClient.kt: sendGrantedChunks, chunkLengthAt, transferRejected
- LowerThirdAndAtemRoutes.kt: uploadStillFrame, uploadClipFrames, AtemKeyTarget
- PresentationRoutes.kt: storeUploadedPresentation, receiveUploadedDeck, decodeUploadedDeck
- PicturesViewModel.kt: applyWatchEvent, addWatchedImage, removeWatchedImage
- SharedCameraFrameCache.kt: streamFrames, awaitVideoDimensions, readFramesInto
- SharedBrowserFrameCache.kt: configurePage, runCaptureLoop
- main.kt: ChurchPresenterApp composable extracted from main()
- LiveMapReporter.kt: appendBuildFacts, appendSetupFacts, appendEventCounts

No behaviour changes.