### PR TITLE
Refactor nested logic and enable depth lint - NestedBlockDepth detekt fix

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
@@ -310,6 +310,20 @@ internal fun macCamerasFrom(run: CommandRunner): List<CameraDevice> {
     return parseMacCameras(profilerOutput, ffmpegOutput)
 }
 
+/** Adds an `[0] Camera name` line from ffmpeg's AVFoundation listing, if it names a new device. */
+private fun addIndexedAvfDevice(
+    line: String,
+    devices: MutableList<CameraDevice>,
+    seenNames: MutableSet<String>,
+) {
+    val match = Regex("\\[(\\d+)]\\s+(.+)").find(line) ?: return
+    val index = match.groupValues[1]
+    val name = match.groupValues[2].trim()
+    if (name.lowercase() in seenNames) return
+    devices.add(CameraDevice(name = name, path = "avfoundation://$index", displayName = name))
+    seenNames.add(name.lowercase())
+}
+
 internal fun parseMacCameras(systemProfilerOutput: String, ffmpegOutput: String): List<CameraDevice> {
     val devices = mutableListOf<CameraDevice>()
     val seenNames = mutableSetOf<String>()
@@ -339,17 +353,7 @@ internal fun parseMacCameras(systemProfilerOutput: String, ffmpegOutput: String)
 
         if (line.contains("AVFoundation video devices")) isVideo = true
         else if (line.contains("AVFoundation audio devices")) isVideo = false
-        else if (isVideo) {
-            val match = Regex("\\[(\\d+)]\\s+(.+)").find(line)
-            if (match != null) {
-                val index = match.groupValues[1]
-                val name = match.groupValues[2].trim()
-                if (name.lowercase() !in seenNames) {
-                    devices.add(CameraDevice(name = name, path = "avfoundation://$index", displayName = name))
-                    seenNames.add(name.lowercase())
-                }
-            }
-        }
+        else if (isVideo) addIndexedAvfDevice(line, devices, seenNames)
     }
 
     return devices

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
@@ -198,6 +198,16 @@ object SharedBrowserFrameCache {
 
     // ── Browser Discovery ──────────────────────────────────────────
 
+    /** The executable `which`/`where` reports for [name], when it exists on disk. */
+    private fun browserOnPath(whichCmd: String, name: String): String? = try {
+        val proc = ProcessBuilder(whichCmd, name).redirectErrorStream(true).start()
+        val output = proc.inputStream.bufferedReader().readText().trim()
+        val path = output.lines().firstOrNull()?.trim()
+        if (proc.waitFor() == 0 && !path.isNullOrBlank() && java.io.File(path).exists()) path else null
+    } catch (_: Exception) {
+        null
+    }
+
     internal fun findBrowserExecutable(): String? {
         val osName = System.getProperty("os.name", "").lowercase()
         val isWindows = osName.contains("win")
@@ -239,17 +249,7 @@ object SharedBrowserFrameCache {
         val names = if (isWindows) listOf("msedge.exe", "chrome.exe")
                     else listOf("google-chrome-stable", "google-chrome", "chromium-browser", "chromium", "microsoft-edge-stable")
         val whichCmd = if (isWindows) "where" else "which"
-        for (name in names) {
-            try {
-                val proc = ProcessBuilder(whichCmd, name).redirectErrorStream(true).start()
-                val output = proc.inputStream.bufferedReader().readText().trim()
-                if (proc.waitFor() == 0 && output.isNotBlank()) {
-                    val path = output.lines().first().trim()
-                    if (java.io.File(path).exists()) return path
-                }
-            } catch (_: Exception) {}
-        }
-        return null
+        return names.firstNotNullOfOrNull { name -> browserOnPath(whichCmd, name) }
     }
 
     internal fun findFreePort(): Int {
@@ -393,99 +393,108 @@ object SharedBrowserFrameCache {
         cdp.onUrlChanged = { url -> entry.currentUrl.value = url }
         System.err.println("[BrowserSource] WebSocket connected")
 
-        // Configure viewport and transparency
-        var resp = cdp.sendAsync("Emulation.setDeviceMetricsOverride", buildJsonObject {
-            put("width", renderWidth)
-            put("height", renderHeight)
-            put("deviceScaleFactor", 1)
-            put("mobile", false)
-        })
-        System.err.println("[BrowserSource] setDeviceMetricsOverride: $resp")
+        configurePage(cdp, url, renderWidth, renderHeight, customCss, forceTransparent)
+        runCaptureLoop(entry, cdp, fps)
+    }
 
-        if (forceTransparent) {
-            resp = cdp.sendAsync("Emulation.setDefaultBackgroundColorOverride", buildJsonObject {
-                put("color", buildJsonObject {
-                    put("r", 0)
-                    put("g", 0)
-                    put("b", 0)
-                    put("a", 0)
-                })
+    /** Viewport, transparency and navigation for a freshly connected page. */
+    private suspend fun configurePage(
+        cdp: CdpConnection,
+        url: String,
+        renderWidth: Int,
+        renderHeight: Int,
+        customCss: String,
+        forceTransparent: Boolean,
+    ) {
+    // Configure viewport and transparency
+    var resp = cdp.sendAsync("Emulation.setDeviceMetricsOverride", buildJsonObject {
+        put("width", renderWidth)
+        put("height", renderHeight)
+        put("deviceScaleFactor", 1)
+        put("mobile", false)
+    })
+    System.err.println("[BrowserSource] setDeviceMetricsOverride: $resp")
+
+    if (forceTransparent) {
+        resp = cdp.sendAsync("Emulation.setDefaultBackgroundColorOverride", buildJsonObject {
+            put("color", buildJsonObject {
+                put("r", 0)
+                put("g", 0)
+                put("b", 0)
+                put("a", 0)
             })
-            System.err.println("[BrowserSource] setDefaultBackgroundColorOverride: $resp")
+        })
+        System.err.println("[BrowserSource] setDefaultBackgroundColorOverride: $resp")
+    }
+
+    cdp.sendAsync("Page.enable", null)
+
+    // Navigate to the URL
+    if (url.isNotBlank()) {
+        resp = cdp.sendAsync("Page.navigate", buildJsonObject { put("url", url) })
+        System.err.println("[BrowserSource] Page.navigate($url): $resp")
+
+        // Wait for page to load
+        delay(PAGE_LOAD_SETTLE_MS)
+
+        // Inject transparency CSS
+        if (forceTransparent) {
+            cdp.sendAsync("Runtime.evaluate", buildJsonObject {
+                put("expression", "document.documentElement.style.background='transparent';document.body.style.background='transparent';")
+            })
         }
-
-        cdp.sendAsync("Page.enable", null)
-
-        // Navigate to the URL
-        if (url.isNotBlank()) {
-            resp = cdp.sendAsync("Page.navigate", buildJsonObject { put("url", url) })
-            System.err.println("[BrowserSource] Page.navigate($url): $resp")
-
-            // Wait for page to load
-            delay(PAGE_LOAD_SETTLE_MS)
-
-            // Inject transparency CSS
-            if (forceTransparent) {
-                cdp.sendAsync("Runtime.evaluate", buildJsonObject {
-                    put("expression", "document.documentElement.style.background='transparent';document.body.style.background='transparent';")
-                })
-            }
-            if (customCss.isNotBlank()) {
-                cdp.sendAsync("Runtime.evaluate", buildJsonObject {
-                    put("expression", "var s=document.createElement('style');s.textContent='${escapeForJsStringLiteral(customCss)}';document.head.appendChild(s);")
-                })
-            }
+        if (customCss.isNotBlank()) {
+            cdp.sendAsync("Runtime.evaluate", buildJsonObject {
+                put("expression", "var s=document.createElement('style');s.textContent='${escapeForJsStringLiteral(customCss)}';document.head.appendChild(s);")
+            })
         }
+    }
 
-        // Start capture loop
-        entry.captureIntervalMs = (MILLIS_PER_SECOND / fps.coerceIn(MIN_FPS, MAX_FPS)).coerceAtLeast(MIN_STARTUP_CAPTURE_INTERVAL_MS)
+    }
+
+    /** Screenshots the page at [fps] into the entry until the coroutine is cancelled. */
+    private suspend fun runCaptureLoop(entry: CacheEntry, cdp: CdpConnection, fps: Int) {
+        entry.captureIntervalMs =
+            (MILLIS_PER_SECOND / fps.coerceIn(MIN_FPS, MAX_FPS)).coerceAtLeast(MIN_STARTUP_CAPTURE_INTERVAL_MS)
         System.err.println("[BrowserSource] Starting capture loop at ${fps}fps")
 
         var frameCount = 0
         while (currentCoroutineContext().isActive) {
             try {
-                val response = cdp.sendAsync("Page.captureScreenshot", buildJsonObject {
-                    put("format", "png")
-                })
-
-                val data = response?.get("data")?.jsonPrimitive?.contentOrNull
-                if (data == null) {
-                    if (frameCount == 0) {
-                        if (response == null) {
-                            System.err.println("[BrowserSource] captureScreenshot returned null")
-                        } else {
-                            System.err.println(
-                                "[BrowserSource] captureScreenshot response has no 'data': ${response.keys}"
-                            )
-                        }
-                    }
-                } else {
-                    val pngBytes = withContext(Dispatchers.IO) {
-                        Base64.getDecoder().decode(data)
-                    }
-                    val img = withContext(Dispatchers.IO) {
-                        ImageIO.read(ByteArrayInputStream(pngBytes))
-                    }
-                    if (img != null) {
-                        entry.frame.value = img.toComposeImageBitmap()
-                        frameCount++
-                        if (frameCount == 1) {
-                            System.err.println("[BrowserSource] First frame captured: ${img.width}x${img.height}")
-                        }
-                    } else {
-                        if (frameCount == 0) {
-                            System.err.println("[BrowserSource] ImageIO.read returned null (${pngBytes.size} bytes)")
-                        }
-                    }
-                }
+                if (captureFrame(entry, cdp, first = frameCount == 0)) frameCount++
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
-                if (frameCount == 0) {
-                    System.err.println("[BrowserSource] Capture error: ${e.message}")
-                }
+                if (frameCount == 0) System.err.println("[BrowserSource] Capture error: ${e.message}")
             }
             delay(entry.captureIntervalMs)
+        }
+    }
+
+    /** Screenshots the page once into [entry]; false when nothing decodable came back. */
+    private suspend fun captureFrame(entry: CacheEntry, cdp: CdpConnection, first: Boolean): Boolean {
+        val response = cdp.sendAsync("Page.captureScreenshot", buildJsonObject { put("format", "png") })
+        val data = response?.get("data")?.jsonPrimitive?.contentOrNull
+        if (data == null) {
+            if (first) reportMissingScreenshot(response)
+            return false
+        }
+        val pngBytes = withContext(Dispatchers.IO) { Base64.getDecoder().decode(data) }
+        val img = withContext(Dispatchers.IO) { ImageIO.read(ByteArrayInputStream(pngBytes)) }
+        if (img == null) {
+            if (first) System.err.println("[BrowserSource] ImageIO.read returned null (${pngBytes.size} bytes)")
+            return false
+        }
+        entry.frame.value = img.toComposeImageBitmap()
+        if (first) System.err.println("[BrowserSource] First frame captured: ${img.width}x${img.height}")
+        return true
+    }
+
+    private fun reportMissingScreenshot(response: JsonObject?) {
+        if (response == null) {
+            System.err.println("[BrowserSource] captureScreenshot returned null")
+        } else {
+            System.err.println("[BrowserSource] captureScreenshot response has no 'data': ${response.keys}")
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
@@ -212,6 +212,16 @@ object SharedBrowserFrameCache {
 
     // ── Browser Discovery ──────────────────────────────────────────
 
+    /** The executable `which`/`where` reports for [name], when it exists on disk. */
+    private fun browserOnPath(whichCmd: String, name: String): String? = try {
+        val proc = ProcessBuilder(whichCmd, name).redirectErrorStream(true).start()
+        val output = proc.inputStream.bufferedReader().readText().trim()
+        val path = output.lines().firstOrNull()?.trim()
+        if (proc.waitFor() == 0 && !path.isNullOrBlank() && java.io.File(path).exists()) path else null
+    } catch (_: Exception) {
+        null
+    }
+
     internal fun findBrowserExecutable(): String? {
         val osName = System.getProperty("os.name", "").lowercase()
         val isWindows = osName.contains("win")
@@ -259,17 +269,7 @@ object SharedBrowserFrameCache {
                         "microsoft-edge-stable"
                     )
         val whichCmd = if (isWindows) "where" else "which"
-        for (name in names) {
-            try {
-                val proc = ProcessBuilder(whichCmd, name).redirectErrorStream(true).start()
-                val output = proc.inputStream.bufferedReader().readText().trim()
-                if (proc.waitFor() == 0 && output.isNotBlank()) {
-                    val path = output.lines().first().trim()
-                    if (java.io.File(path).exists()) return path
-                }
-            } catch (_: Exception) {}
-        }
-        return null
+        return names.firstNotNullOfOrNull { name -> browserOnPath(whichCmd, name) }
     }
 
     internal fun findFreePort(): Int {
@@ -482,58 +482,53 @@ object SharedBrowserFrameCache {
 
     /** Screenshots the page at [fps] into the entry until the coroutine is cancelled. */
     private suspend fun runCaptureLoop(entry: CacheEntry, cdp: CdpConnection, fps: Int) {
-    // Start capture loop
-    entry.captureIntervalMs = (
-        MILLIS_PER_SECOND / fps.coerceIn(MIN_FPS, MAX_FPS)
-    ).coerceAtLeast(MIN_STARTUP_CAPTURE_INTERVAL_MS)
-    System.err.println("[BrowserSource] Starting capture loop at ${fps}fps")
+        entry.captureIntervalMs = (
+            MILLIS_PER_SECOND / fps.coerceIn(MIN_FPS, MAX_FPS)
+        ).coerceAtLeast(MIN_STARTUP_CAPTURE_INTERVAL_MS)
+        System.err.println("[BrowserSource] Starting capture loop at ${fps}fps")
 
-    var frameCount = 0
-    while (currentCoroutineContext().isActive) {
-        try {
-            val response = cdp.sendAsync("Page.captureScreenshot", buildJsonObject {
-                put("format", "png")
-            })
-
-            val data = response?.get("data")?.jsonPrimitive?.contentOrNull
-            if (data == null) {
-                if (frameCount == 0) {
-                    if (response == null) {
-                        System.err.println("[BrowserSource] captureScreenshot returned null")
-                    } else {
-                        System.err.println(
-                            "[BrowserSource] captureScreenshot response has no 'data': ${response.keys}"
-                        )
-                    }
-                }
-            } else {
-                val pngBytes = withContext(Dispatchers.IO) {
-                    Base64.getDecoder().decode(data)
-                }
-                val img = withContext(Dispatchers.IO) {
-                    ImageIO.read(ByteArrayInputStream(pngBytes))
-                }
-                if (img != null) {
-                    entry.frame.value = img.toComposeImageBitmap()
-                    frameCount++
-                    if (frameCount == 1) {
-                        System.err.println("[BrowserSource] First frame captured: ${img.width}x${img.height}")
-                    }
-                } else {
-                    if (frameCount == 0) {
-                        System.err.println("[BrowserSource] ImageIO.read returned null (${pngBytes.size} bytes)")
-                    }
-                }
+        var frameCount = 0
+        while (currentCoroutineContext().isActive) {
+            try {
+                if (captureFrame(entry, cdp, first = frameCount == 0)) frameCount++
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                if (frameCount == 0) System.err.println("[BrowserSource] Capture error: ${e.message}")
             }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Throwable) {
-            if (frameCount == 0) {
-                System.err.println("[BrowserSource] Capture error: ${e.message}")
-            }
+            delay(entry.captureIntervalMs)
         }
-        delay(entry.captureIntervalMs)
     }
+
+    /** Screenshots the page once into [entry]; false when nothing decodable came back. */
+    private suspend fun captureFrame(entry: CacheEntry, cdp: CdpConnection, first: Boolean): Boolean {
+        val response = cdp.sendAsync("Page.captureScreenshot", buildJsonObject { put("format", "png") })
+        val data = response?.get("data")?.jsonPrimitive?.contentOrNull
+        if (data == null) {
+            if (first) reportMissingScreenshot(response)
+            return false
+        }
+        val pngBytes = withContext(Dispatchers.IO) { Base64.getDecoder().decode(data) }
+        val img = withContext(Dispatchers.IO) { ImageIO.read(ByteArrayInputStream(pngBytes)) }
+        if (img == null) {
+            if (first) {
+                System.err.println("[BrowserSource] ImageIO.read returned null (${pngBytes.size} bytes)")
+            }
+            return false
+        }
+        entry.frame.value = img.toComposeImageBitmap()
+        if (first) {
+            System.err.println("[BrowserSource] First frame captured: ${img.width}x${img.height}")
+        }
+        return true
+    }
+
+    private fun reportMissingScreenshot(response: JsonObject?) {
+        if (response == null) {
+            System.err.println("[BrowserSource] captureScreenshot returned null")
+        } else {
+            System.err.println("[BrowserSource] captureScreenshot response has no 'data': ${response.keys}")
+        }
     }
 
     private suspend fun waitForCdpReady(port: Int, timeoutMs: Long): Boolean {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -137,6 +137,22 @@ object SharedCameraFrameCache {
 
     // ── DeckLink capture ────────────────────────────────────────────
 
+    /** Puts one polled DeckLink frame on screen; false when the poll returned no usable frame. */
+    private suspend fun showDeckLinkFrame(frameData: IntArray?, entry: CacheEntry, first: Boolean): Boolean {
+        if (frameData == null || frameData.size <= 2) return false
+        val w = frameData[0]
+        val h = frameData[1]
+        if (w <= 0 || h <= 0) return false
+        val img = withContext(Dispatchers.IO) {
+            val bi = java.awt.image.BufferedImage(w, h, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+            bi.setRGB(0, 0, w, h, frameData, 2, w)
+            bi
+        }
+        entry.frame.value = img.toComposeImageBitmap()
+        if (first) System.err.println("[DeckLink Input] First frame: ${w}x${h}")
+        return true
+    }
+
     private suspend fun runDeckLinkCapture(source: SceneSource.CameraSource, entry: CacheEntry) {
         System.err.println("[DeckLink Input] Opening device ${source.deckLinkIndex}, " +
             "format: ${source.videoFormat.ifEmpty { "auto" }}, connection: ${source.videoConnection}")
@@ -164,22 +180,9 @@ object SharedCameraFrameCache {
                 DeckLinkManager.getInputFrame(source.deckLinkIndex)
             }
 
-            if (frameData != null && frameData.size > 2) {
-                val w = frameData[0]
-                val h = frameData[1]
-                if (w > 0 && h > 0) {
-                    val img = withContext(Dispatchers.IO) {
-                        val bi = java.awt.image.BufferedImage(w, h, java.awt.image.BufferedImage.TYPE_INT_ARGB)
-                        bi.setRGB(0, 0, w, h, frameData, 2, w)
-                        bi
-                    }
-                    entry.frame.value = img.toComposeImageBitmap()
-                    frameCount++
-                    nullCount = 0
-                    if (frameCount == 1) {
-                        System.err.println("[DeckLink Input] First frame: ${w}x${h}")
-                    }
-                }
+            if (showDeckLinkFrame(frameData, entry, first = frameCount == 0)) {
+                frameCount++
+                nullCount = 0
             } else {
                 nullCount++
                 if (nullCount > MAX_NULL_FRAMES_BEFORE_CLEAR && entry.frame.value != null) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -19,6 +19,7 @@ import org.churchpresenter.app.churchpresenter.utils.CrashReporter
 
 private const val MAX_NULL_FRAMES_BEFORE_CLEAR = 30
 private const val DECKLINK_POLL_INTERVAL_MS = 16L
+private const val STDERR_TAIL_LINES = 50
 private const val MAX_CONSECUTIVE_FAILURES = 5
 private const val DEVICE_RELEASE_DELAY_MS = 500L
 private const val RETRY_DELAY_MS = 2000L
@@ -136,6 +137,22 @@ object SharedCameraFrameCache {
 
     // ── DeckLink capture ────────────────────────────────────────────
 
+    /** Puts one polled DeckLink frame on screen; false when the poll returned no usable frame. */
+    private suspend fun showDeckLinkFrame(frameData: IntArray?, entry: CacheEntry, first: Boolean): Boolean {
+        if (frameData == null || frameData.size <= 2) return false
+        val w = frameData[0]
+        val h = frameData[1]
+        if (w <= 0 || h <= 0) return false
+        val img = withContext(Dispatchers.IO) {
+            val bi = java.awt.image.BufferedImage(w, h, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+            bi.setRGB(0, 0, w, h, frameData, 2, w)
+            bi
+        }
+        entry.frame.value = img.toComposeImageBitmap()
+        if (first) System.err.println("[DeckLink Input] First frame: ${w}x${h}")
+        return true
+    }
+
     private suspend fun runDeckLinkCapture(source: SceneSource.CameraSource, entry: CacheEntry) {
         System.err.println("[DeckLink Input] Opening device ${source.deckLinkIndex}, " +
             "format: ${source.videoFormat.ifEmpty { "auto" }}, connection: ${source.videoConnection}")
@@ -163,22 +180,9 @@ object SharedCameraFrameCache {
                 DeckLinkManager.getInputFrame(source.deckLinkIndex)
             }
 
-            if (frameData != null && frameData.size > 2) {
-                val w = frameData[0]
-                val h = frameData[1]
-                if (w > 0 && h > 0) {
-                    val img = withContext(Dispatchers.IO) {
-                        val bi = java.awt.image.BufferedImage(w, h, java.awt.image.BufferedImage.TYPE_INT_ARGB)
-                        bi.setRGB(0, 0, w, h, frameData, 2, w)
-                        bi
-                    }
-                    entry.frame.value = img.toComposeImageBitmap()
-                    frameCount++
-                    nullCount = 0
-                    if (frameCount == 1) {
-                        System.err.println("[DeckLink Input] First frame: ${w}x${h}")
-                    }
-                }
+            if (showDeckLinkFrame(frameData, entry, first = frameCount == 0)) {
+                frameCount++
+                nullCount = 0
             } else {
                 nullCount++
                 if (nullCount > MAX_NULL_FRAMES_BEFORE_CLEAR && entry.frame.value != null) {
@@ -191,6 +195,132 @@ object SharedCameraFrameCache {
     }
 
     // ── FFmpeg capture ──────────────────────────────────────────────
+
+
+    /**
+     * Reads raw BGRA frames off a running ffmpeg into [entry] until the stream ends. True when at
+     * least one frame arrived, which is what tells a dropped stream apart from a device that never
+     * opened.
+     */
+    private suspend fun streamFrames(process: Process, entry: CacheEntry): Boolean {
+        entry.ffmpegProcess = process
+
+        // Drain stderr and extract video dimensions from ffmpeg output
+        val stderrLines = mutableListOf<String>()
+        val videoDims = java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>(null)
+        val stderrJob = CoroutineScope(currentCoroutineContext()).launch(Dispatchers.IO) {
+            drainFfmpegStderr(process, stderrLines, videoDims)
+        }
+
+        val resolved = awaitVideoDimensions(videoDims)
+        if (resolved == null) {
+            System.err.println("[Camera] Could not determine video dimensions from ffmpeg")
+            stderrJob.cancel()
+            withContext(Dispatchers.IO) { killFfmpegProcess(process) }
+            entry.ffmpegProcess = null
+            return false
+        }
+
+        val (videoW, videoH) = resolved
+        val frameCount = readFramesInto(process, entry, videoW, videoH)
+
+        // Stream ended — clean up this process
+        stderrJob.cancel()
+        val exitCode = withContext(Dispatchers.IO) {
+            try {
+                killFfmpegProcess(process)
+                process.exitValue()
+            } catch (_: Throwable) { -1 }
+        }
+        entry.ffmpegProcess = null
+
+        if (frameCount > 0) {
+            System.err.println("[Camera] Stream interrupted after $frameCount frames (exit $exitCode), restarting...")
+        } else {
+            System.err.println("[Camera] ffmpeg exited with code $exitCode without producing any frames")
+            synchronized(stderrLines) {
+                stderrLines.forEach { System.err.println("[Camera] ffmpeg stderr: $it") }
+            }
+        }
+        return frameCount > 0
+    }
+
+    private fun drainFfmpegStderr(
+        process: Process,
+        stderrLines: MutableList<String>,
+        videoDims: java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>,
+    ) {
+        try {
+            process.errorStream.bufferedReader().useLines { lines ->
+                lines.forEach { line -> noteStderrLine(line, stderrLines, videoDims) }
+            }
+        } catch (_: Throwable) {}
+    }
+
+    private fun noteStderrLine(
+        line: String,
+        stderrLines: MutableList<String>,
+        videoDims: java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>,
+    ) {
+        synchronized(stderrLines) {
+            stderrLines.add(line)
+            if (stderrLines.size > STDERR_TAIL_LINES) stderrLines.removeAt(0)
+        }
+        if (videoDims.get() == null) {
+            parseFfmpegVideoDimensions(line)?.let { videoDims.set(it) }
+        }
+    }
+
+    /** Waits up to five seconds for ffmpeg to announce the stream's size. */
+    private suspend fun awaitVideoDimensions(
+        videoDims: java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>,
+    ): Pair<Int, Int>? {
+        repeat(DIMENSION_POLL_ATTEMPTS) {
+            videoDims.get()?.let { return it }
+            delay(DIMENSION_POLL_INTERVAL_MS)
+        }
+        return videoDims.get()
+    }
+
+    /** Frames read into [entry] until the stream stops; the count is the caller's success signal. */
+    private suspend fun readFramesInto(process: Process, entry: CacheEntry, videoW: Int, videoH: Int): Int {
+        val frameBytes = videoW * videoH * 4  // BGRA = 4 bytes per pixel
+        System.err.println("[Camera] Capturing ${videoW}x${videoH} rawvideo BGRA ($frameBytes bytes/frame)")
+
+        val inputStream = java.io.BufferedInputStream(process.inputStream, frameBytes * 2)
+        val frameBuf = ByteArray(frameBytes)
+        val pixelBuf = IntArray(videoW * videoH)
+        var frameCount = 0
+
+        while (currentCoroutineContext().isActive) {
+            val ok = withContext(Dispatchers.IO) { readFullFrame(inputStream, frameBuf, frameBytes) }
+            if (!ok) break
+
+            withContext(Dispatchers.IO) { bgraBytesToArgbPixels(frameBuf, pixelBuf) }
+
+            val img = java.awt.image.BufferedImage(videoW, videoH, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+            img.setRGB(0, 0, videoW, videoH, pixelBuf, 0, videoW)
+            entry.frame.value = img.toComposeImageBitmap()
+            frameCount++
+            if (frameCount == 1) {
+                System.err.println("[Camera] First frame received (${videoW}x${videoH})")
+            }
+        }
+        return frameCount
+    }
+
+    private fun readFullFrame(inputStream: java.io.InputStream, frameBuf: ByteArray, frameBytes: Int): Boolean =
+        try {
+            var read = 0
+            var endOfStream = false
+            while (read < frameBytes && !endOfStream) {
+                val r = inputStream.read(frameBuf, read, frameBytes - read)
+                if (r == -1) endOfStream = true else read += r
+            }
+            !endOfStream
+        } catch (_: Throwable) {
+            false
+        }
 
     private suspend fun runFfmpegCapture(source: SceneSource.CameraSource, entry: CacheEntry) {
         val path = source.devicePath
@@ -228,101 +358,8 @@ object SharedCameraFrameCache {
                 System.err.println("[Camera] ffmpeg exited immediately with code ${process.exitValue()}")
                 withContext(Dispatchers.IO) { killFfmpegProcess(process) }
             }
-            var framesProduced = false
-            if (process != null && !exitedImmediately) {
-                entry.ffmpegProcess = process
-
-                // Drain stderr and extract video dimensions from ffmpeg output
-                val stderrLines = mutableListOf<String>()
-                val videoDims = java.util.concurrent.atomic.AtomicReference<Pair<Int, Int>?>(null)
-                val stderrJob = CoroutineScope(currentCoroutineContext()).launch(Dispatchers.IO) {
-                    try {
-                        process.errorStream.bufferedReader().useLines { lines ->
-                            lines.forEach { line ->
-                                synchronized(stderrLines) {
-                                    stderrLines.add(line)
-                                    if (stderrLines.size > 50) stderrLines.removeAt(0)
-                                }
-                                if (videoDims.get() == null) {
-                                    parseFfmpegVideoDimensions(line)?.let { videoDims.set(it) }
-                                }
-                            }
-                        }
-                    } catch (_: Throwable) {}
-                }
-
-                // Wait for dimensions (up to 5 seconds)
-                var dims: Pair<Int, Int>? = null
-                repeat(DIMENSION_POLL_ATTEMPTS) {
-                    dims = videoDims.get()
-                    if (dims != null) break
-                    delay(DIMENSION_POLL_INTERVAL_MS)
-                }
-                val resolved = dims
-                if (resolved == null) {
-                    System.err.println("[Camera] Could not determine video dimensions from ffmpeg")
-                    stderrJob.cancel()
-                    withContext(Dispatchers.IO) { killFfmpegProcess(process) }
-                    entry.ffmpegProcess = null
-                } else {
-                    val (videoW, videoH) = resolved
-                    val frameBytes = videoW * videoH * 4  // BGRA = 4 bytes per pixel
-                    System.err.println("[Camera] Capturing ${videoW}x${videoH} rawvideo BGRA ($frameBytes bytes/frame)")
-
-                    val inputStream = java.io.BufferedInputStream(process.inputStream, frameBytes * 2)
-                    val frameBuf = ByteArray(frameBytes)
-                    val pixelBuf = IntArray(videoW * videoH)
-                    var frameCount = 0
-
-                    while (currentCoroutineContext().isActive) {
-                        val ok = withContext(Dispatchers.IO) {
-                            try {
-                                var read = 0
-                                while (read < frameBytes) {
-                                    val r = inputStream.read(frameBuf, read, frameBytes - read)
-                                    if (r == -1) return@withContext false
-                                    read += r
-                                }
-                                true
-                            } catch (_: Throwable) { false }
-                        }
-                        if (!ok) break
-
-                        withContext(Dispatchers.IO) {
-                            bgraBytesToArgbPixels(frameBuf, pixelBuf)
-                        }
-
-                        val img = java.awt.image.BufferedImage(videoW, videoH, java.awt.image.BufferedImage.TYPE_INT_ARGB)
-                        img.setRGB(0, 0, videoW, videoH, pixelBuf, 0, videoW)
-                        entry.frame.value = img.toComposeImageBitmap()
-                        frameCount++
-                        if (frameCount == 1) {
-                            System.err.println("[Camera] First frame received (${videoW}x${videoH})")
-                        }
-                    }
-
-                    // Stream ended — clean up this process
-                    stderrJob.cancel()
-                    val exitCode = withContext(Dispatchers.IO) {
-                        try {
-                            killFfmpegProcess(process)
-                            process.exitValue()
-                        } catch (_: Throwable) { -1 }
-                    }
-                    entry.ffmpegProcess = null
-
-                    framesProduced = frameCount > 0
-                    if (framesProduced) {
-                        System.err.println("[Camera] Stream interrupted after $frameCount frames (exit $exitCode), restarting...")
-                    } else {
-                        System.err.println("[Camera] ffmpeg exited with code $exitCode without producing any frames")
-                        synchronized(stderrLines) {
-                            stderrLines.forEach { System.err.println("[Camera] ffmpeg stderr: $it") }
-                        }
-                    }
-                }
-            }
-
+            val framesProduced =
+                if (process != null && !exitedImmediately) streamFrames(process, entry) else false
             if (framesProduced) {
                 consecutiveFailures = 0
                 delay(RESTART_DELAY_MS)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Bible.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Bible.kt
@@ -151,39 +151,45 @@ class Bible {
      * Stops as soon as the separator line or first verse is encountered.
      * Call this first to show the book list immediately, then call loadFromSpb() for full data.
      */
+    private fun openHeaderReader(resourcePath: String): java.io.BufferedReader {
+        val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
+        if (inputStream != null) return inputStream.bufferedReader(StandardCharsets.UTF_8)
+        val path = Paths.get(resourcePath)
+        if (!Files.exists(path)) {
+            throw FileNotFoundException(
+                "loadBooksOnly: module not found on classpath or filesystem: $resourcePath"
+            )
+        }
+        return Files.newBufferedReader(path, StandardCharsets.UTF_8)
+    }
+
+    private fun collectBookHeader(
+        line: String,
+        headerOrder: MutableList<Int>,
+        parsedBookNames: MutableMap<Int, String>,
+        parsedChapterCounts: MutableMap<Int, Int>,
+    ) {
+        val m = SPB_BOOK_HEADER_REGEX.matchEntire(line) ?: return
+        val bookId = m.groupValues[1].toInt()
+        headerOrder.add(bookId)
+        parsedBookNames[bookId] = m.groupValues[2].trim()
+        parsedChapterCounts[bookId] = m.groupValues[REGEX_GROUP_THIRD].toInt()
+    }
+
     fun loadBooksOnly(resourcePath: String) {
         books.clear()
         loadError = null
-        val bookHeaderRegex = Regex("^(\\d+)\\s+(.+?)\\s+(\\d+)$")
         val headerOrder = mutableListOf<Int>()
         val parsedBookNames = mutableMapOf<Int, String>()
         val parsedChapterCounts = mutableMapOf<Int, Int>()
         try {
-            val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
-            val reader = if (inputStream != null) {
-                inputStream.bufferedReader(StandardCharsets.UTF_8)
-            } else {
-                val path = Paths.get(resourcePath)
-                if (!Files.exists(path)) {
-                    throw FileNotFoundException(
-                        "loadBooksOnly: module not found on classpath or filesystem: $resourcePath"
-                    )
-                }
-                Files.newBufferedReader(path, StandardCharsets.UTF_8)
-            }
-            reader.use { r ->
+            openHeaderReader(resourcePath).use { r ->
                 r.lineSequence()
                     .map { it.trimEnd('\r', '\n') }
                     .takeWhile { !it.startsWith("-----") && !it.startsWith("B") }
                     .filter { it.isNotEmpty() && !it.startsWith("##") }
                     .forEach { line ->
-                        val m = bookHeaderRegex.matchEntire(line)
-                        if (m != null) {
-                            val bookId = m.groupValues[1].toInt()
-                            headerOrder.add(bookId)
-                            parsedBookNames[bookId] = m.groupValues[2].trim()
-                            parsedChapterCounts[bookId] = m.groupValues[REGEX_GROUP_THIRD].toInt()
-                        }
+                        collectBookHeader(line, headerOrder, parsedBookNames, parsedChapterCounts)
                     }
             }
         } catch (e: Exception) {
@@ -678,46 +684,47 @@ class Bible {
          * [maxLines] bounds how far in it will look. A caller that only wants the title can pass
          * [TITLE_SCAN_LINE_LIMIT] and skip the book list entirely.
          */
+        private class SummaryScan {
+            var title: String? = null
+            var hasOld = false
+            var hasNew = false
+        }
+
+        private fun openSummaryReader(resourcePath: String): java.io.BufferedReader? {
+            val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
+            if (inputStream != null) return inputStream.bufferedReader(StandardCharsets.UTF_8)
+            val path = Paths.get(resourcePath)
+            if (!Files.exists(path)) return null
+            return Files.newBufferedReader(path, StandardCharsets.UTF_8)
+        }
+
+        private fun scanSummaryLine(line: String, scan: SummaryScan) {
+            // The converter writes a TAB after the colon and hand-made modules often write a
+            // space, so the separator is trimmed, not counted.
+            if (line.startsWith("##Title:")) scan.title = line.removePrefix("##Title:").trim()
+            if (line.startsWith("##") || line.isEmpty()) return
+            when (SPB_BOOK_HEADER_REGEX.matchEntire(line)?.groupValues?.get(1)?.toIntOrNull()) {
+                in OLD_TESTAMENT_BOOK_IDS -> scan.hasOld = true
+                in NEW_TESTAMENT_BOOK_IDS -> scan.hasNew = true
+                else -> Unit
+            }
+        }
+
         fun readTranslationSummary(
             resourcePath: String,
             maxLines: Int = HEADER_SCAN_LINE_LIMIT,
         ): TranslationSummary? {
             try {
-                val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
-                val reader = if (inputStream != null) {
-                    inputStream.bufferedReader(StandardCharsets.UTF_8)
-                } else {
-                    val path = Paths.get(resourcePath)
-                    if (!Files.exists(path)) return null
-                    Files.newBufferedReader(path, StandardCharsets.UTF_8)
-                }
-                val bookHeaderRegex = Regex("^(\\d+)\\s+(.+?)\\s+(\\d+)$")
-                var title: String? = null
-                var hasOld = false
-                var hasNew = false
+                val reader = openSummaryReader(resourcePath) ?: return null
+                val scan = SummaryScan()
                 reader.use { r ->
                     r.lineSequence()
                         .take(maxLines)
                         .map { it.trimEnd('\r', '\n') }
                         .takeWhile { !it.startsWith("-----") && !it.startsWith("B") }
-                        .forEach { line ->
-                            when {
-                                // The converter writes a TAB after the colon and hand-made modules
-                                // often write a space, so the separator is trimmed, not counted.
-                                line.startsWith("##Title:") -> title = line.removePrefix("##Title:").trim()
-                                line.startsWith("##") || line.isEmpty() -> Unit
-                                else -> {
-                                    val bookId = bookHeaderRegex.matchEntire(line)
-                                        ?.groupValues?.get(1)?.toIntOrNull()
-                                    if (bookId != null) {
-                                        if (bookId in OLD_TESTAMENT_BOOK_IDS) hasOld = true
-                                        if (bookId in NEW_TESTAMENT_BOOK_IDS) hasNew = true
-                                    }
-                                }
-                            }
-                        }
+                        .forEach { line -> scanSummaryLine(line, scan) }
                 }
-                return TranslationSummary(title, hasOld, hasNew)
+                return TranslationSummary(scan.title, scan.hasOld, scan.hasNew)
             } catch (_: Exception) {
                 return null
             }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Bible.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Bible.kt
@@ -21,6 +21,8 @@ data class ChapterResult(val previewIds: List<String>, val verses: List<String>)
 /** A parenthesised aside in a module title: "King James Version (KJV)", "… (Public Domain)". */
 private val PARENTHESISED_ASIDE = Regex("\\([^)]*\\)")
 
+private val SPB_BOOK_HEADER_REGEX = Regex("^(\\d+)\\s+(.+?)\\s+(\\d+)$")
+
 /**
  * Why a module could not be read, in whole or in part.
  *
@@ -144,39 +146,45 @@ class Bible {
      * Stops as soon as the separator line or first verse is encountered.
      * Call this first to show the book list immediately, then call loadFromSpb() for full data.
      */
+    private fun collectBookHeader(
+        line: String,
+        headerOrder: MutableList<Int>,
+        parsedBookNames: MutableMap<Int, String>,
+        parsedChapterCounts: MutableMap<Int, Int>,
+    ) {
+        val m = SPB_BOOK_HEADER_REGEX.matchEntire(line) ?: return
+        val bookId = m.groupValues[1].toInt()
+        headerOrder.add(bookId)
+        parsedBookNames[bookId] = m.groupValues[2].trim()
+        parsedChapterCounts[bookId] = m.groupValues[REGEX_GROUP_THIRD].toInt()
+    }
+
+    private fun openHeaderReader(resourcePath: String): java.io.BufferedReader {
+        val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
+        if (inputStream != null) return inputStream.bufferedReader(StandardCharsets.UTF_8)
+        val path = Paths.get(resourcePath)
+        if (!Files.exists(path)) {
+            throw FileNotFoundException(
+                "loadBooksOnly: module not found on classpath or filesystem: $resourcePath"
+            )
+        }
+        return Files.newBufferedReader(path, StandardCharsets.UTF_8)
+    }
+
     fun loadBooksOnly(resourcePath: String) {
         books.clear()
         loadError = null
-        val bookHeaderRegex = Regex("^(\\d+)\\s+(.+?)\\s+(\\d+)$")
         val headerOrder = mutableListOf<Int>()
         val parsedBookNames = mutableMapOf<Int, String>()
         val parsedChapterCounts = mutableMapOf<Int, Int>()
         try {
-            val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
-            val reader = if (inputStream != null) {
-                inputStream.bufferedReader(StandardCharsets.UTF_8)
-            } else {
-                val path = Paths.get(resourcePath)
-                if (!Files.exists(path)) {
-                    throw FileNotFoundException(
-                        "loadBooksOnly: module not found on classpath or filesystem: $resourcePath"
-                    )
-                }
-                Files.newBufferedReader(path, StandardCharsets.UTF_8)
-            }
-            reader.use { r ->
+            openHeaderReader(resourcePath).use { r ->
                 r.lineSequence()
                     .map { it.trimEnd('\r', '\n') }
                     .takeWhile { !it.startsWith("-----") && !it.startsWith("B") }
                     .filter { it.isNotEmpty() && !it.startsWith("##") }
                     .forEach { line ->
-                        val m = bookHeaderRegex.matchEntire(line)
-                        if (m != null) {
-                            val bookId = m.groupValues[1].toInt()
-                            headerOrder.add(bookId)
-                            parsedBookNames[bookId] = m.groupValues[2].trim()
-                            parsedChapterCounts[bookId] = m.groupValues[REGEX_GROUP_THIRD].toInt()
-                        }
+                        collectBookHeader(line, headerOrder, parsedBookNames, parsedChapterCounts)
                     }
             }
         } catch (e: Exception) {
@@ -708,46 +716,52 @@ class Bible {
          * [maxLines] bounds how far in it will look. A caller that only wants the title can pass
          * [TITLE_SCAN_LINE_LIMIT] and skip the book list entirely.
          */
+        private class SummaryScan {
+            var title: String? = null
+            var hasOld = false
+            var hasNew = false
+        }
+
+        private fun scanSummaryLine(line: String, scan: SummaryScan) {
+            // The converter writes a TAB after the colon and hand-made modules often write a
+            // space, so the separator is trimmed, not counted.
+            if (line.startsWith("##Title:")) scan.title = line.removePrefix("##Title:").trim()
+            when (summaryBookId(line)) {
+                in OLD_TESTAMENT_BOOK_IDS -> scan.hasOld = true
+                in NEW_TESTAMENT_BOOK_IDS -> scan.hasNew = true
+                else -> Unit
+            }
+        }
+
+        private fun openSummaryReader(resourcePath: String): java.io.BufferedReader? {
+            val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
+            if (inputStream != null) return inputStream.bufferedReader(StandardCharsets.UTF_8)
+            val path = Paths.get(resourcePath)
+            if (!Files.exists(path)) return null
+            return Files.newBufferedReader(path, StandardCharsets.UTF_8)
+        }
+
+        /** The book id a header line names, or null for metadata, blanks and anything else. */
+        private fun summaryBookId(line: String): Int? {
+            if (line.startsWith("##") || line.isEmpty()) return null
+            return SPB_BOOK_HEADER_REGEX.matchEntire(line)?.groupValues?.get(1)?.toIntOrNull()
+        }
+
         fun readTranslationSummary(
             resourcePath: String,
             maxLines: Int = HEADER_SCAN_LINE_LIMIT,
         ): TranslationSummary? {
             try {
-                val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(resourcePath)
-                val reader = if (inputStream != null) {
-                    inputStream.bufferedReader(StandardCharsets.UTF_8)
-                } else {
-                    val path = Paths.get(resourcePath)
-                    if (!Files.exists(path)) return null
-                    Files.newBufferedReader(path, StandardCharsets.UTF_8)
-                }
-                val bookHeaderRegex = Regex("^(\\d+)\\s+(.+?)\\s+(\\d+)$")
-                var title: String? = null
-                var hasOld = false
-                var hasNew = false
+                val reader = openSummaryReader(resourcePath) ?: return null
+                val scan = SummaryScan()
                 reader.use { r ->
                     r.lineSequence()
                         .take(maxLines)
                         .map { it.trimEnd('\r', '\n') }
                         .takeWhile { !it.startsWith("-----") && !it.startsWith("B") }
-                        .forEach { line ->
-                            when {
-                                // The converter writes a TAB after the colon and hand-made modules
-                                // often write a space, so the separator is trimmed, not counted.
-                                line.startsWith("##Title:") -> title = line.removePrefix("##Title:").trim()
-                                line.startsWith("##") || line.isEmpty() -> Unit
-                                else -> {
-                                    val bookId = bookHeaderRegex.matchEntire(line)
-                                        ?.groupValues?.get(1)?.toIntOrNull()
-                                    if (bookId != null) {
-                                        if (bookId in OLD_TESTAMENT_BOOK_IDS) hasOld = true
-                                        if (bookId in NEW_TESTAMENT_BOOK_IDS) hasNew = true
-                                    }
-                                }
-                            }
-                        }
+                        .forEach { line -> scanSummaryLine(line, scan) }
                 }
-                return TranslationSummary(title, hasOld, hasNew)
+                return TranslationSummary(scan.title, scan.hasOld, scan.hasNew)
             } catch (_: Exception) {
                 return null
             }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleInstallSupport.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/BibleInstallSupport.kt
@@ -238,15 +238,27 @@ internal object BibleInstallSupport {
         FileOutputStream(destination, append).use { out ->
             var endOfBody = false
             while (!endOfBody) {
-                val read = channel.readAvailable(buffer, 0, buffer.size)
-                if (read == -1) endOfBody = true
-                if (read > 0) {
-                    out.write(buffer, 0, read)
-                    state.written += read
-                    if (state.total > 0) reportProgress(state, onProgress)
-                }
+                endOfBody = !writeChunk(channel, buffer, out, state, onProgress)
             }
         }
+    }
+
+    /** Writes one read's worth of bytes; false once the channel is exhausted. */
+    private suspend fun writeChunk(
+        channel: ByteReadChannel,
+        buffer: ByteArray,
+        out: FileOutputStream,
+        state: DownloadState,
+        onProgress: (Float) -> Unit,
+    ): Boolean {
+        val read = channel.readAvailable(buffer, 0, buffer.size)
+        if (read == -1) return false
+        if (read > 0) {
+            out.write(buffer, 0, read)
+            state.written += read
+            if (state.total > 0) reportProgress(state, onProgress)
+        }
+        return true
     }
 
     /** Only ever forward: a restart from zero must not rewind the bar. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/CrossReferenceRepository.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/CrossReferenceRepository.kt
@@ -177,15 +177,27 @@ internal fun mergeCrossRefs(perVerse: List<List<CrossRef>>, limit: Int): List<Cr
     val seen = HashSet<CrossRef>()
     val deepest = perVerse.maxOfOrNull { it.size } ?: 0
     for (position in 0 until deepest) {
-        for (refs in perVerse) {
-            val ref = refs.getOrNull(position) ?: continue
-            if (seen.add(ref)) {
-                merged.add(ref)
-                if (merged.size == limit) return merged
-            }
-        }
+        if (takeRefsAt(perVerse, position, merged, seen, limit)) break
     }
     return merged
+}
+
+/** Takes each verse's ref at [position]; true once [limit] is reached. */
+private fun takeRefsAt(
+    perVerse: List<List<CrossRef>>,
+    position: Int,
+    merged: MutableList<CrossRef>,
+    seen: MutableSet<CrossRef>,
+    limit: Int,
+): Boolean {
+    for (refs in perVerse) {
+        val ref = refs.getOrNull(position) ?: continue
+        if (seen.add(ref)) {
+            merged.add(ref)
+            if (merged.size == limit) return true
+        }
+    }
+    return false
 }
 
 /** A passage that several verses of a reading point at, and how many of them do. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/CrosswordData.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/CrosswordData.kt
@@ -69,6 +69,19 @@ object CrosswordDecoder {
      *   DOWN:
      *   2. Clue text | ANSWER
      */
+    private fun putLayoutEntry(
+        line: String,
+        layout: MutableMap<Pair<Int, CrosswordDirection>, Pair<Int, Int>>,
+    ) {
+        val (key, position) = parseLayoutLine(line) ?: return
+        layout[key] = position
+    }
+
+    private fun addClue(line: String, direction: CrosswordDirection?, clues: MutableList<CrosswordClue>) {
+        val dir = direction ?: return
+        parseClueLine(line, dir)?.let { clues.add(it) }
+    }
+
     private fun parseText(text: String): Triple<String, List<CrosswordClue>, Map<Pair<Int, CrosswordDirection>, Pair<Int, Int>>?>? {
         var title = "Crossword"
         val clues = mutableListOf<CrosswordClue>()
@@ -86,8 +99,8 @@ object CrosswordDecoder {
                 line.equals("ACROSS:", ignoreCase = true) -> { direction = CrosswordDirection.ACROSS; inLayout = false }
                 line.equals("DOWN:", ignoreCase = true) -> { direction = CrosswordDirection.DOWN; inLayout = false }
                 line.equals("LAYOUT:", ignoreCase = true) -> inLayout = true
-                inLayout -> parseLayoutLine(line)?.let { (key, position) -> layout[key] = position }
-                else -> direction?.let { dir -> parseClueLine(line, dir)?.let { clues.add(it) } }
+                inLayout -> putLayoutEntry(line, layout)
+                else -> addClue(line, direction, clues)
             }
         }
         return if (clues.isEmpty()) null
@@ -209,22 +222,33 @@ object CrosswordLayoutEngine {
             for (pw in placed) {
                 // Only intersect words running in the opposite direction
                 if (pw.direction == dir) continue
+                crossingAt(grid, clue, pw, dir)?.let { return it }
+            }
+        }
+        return null
+    }
 
-                for ((i, ch) in clue.answer.withIndex()) {
-                    for ((j, pwCh) in pw.answer.withIndex()) {
-                        if (ch != pwCh) continue
+    /** Where [clue] can sit crossing [pw] in [dir], or null when no shared letter fits. */
+    private fun crossingAt(
+        grid: Map<Pair<Int, Int>, Char>,
+        clue: CrosswordClue,
+        pw: PlacedEntry,
+        dir: CrosswordDirection
+    ): Triple<Int, Int, CrosswordDirection>? {
+        for ((i, ch) in clue.answer.withIndex()) {
+            for ((j, pwCh) in pw.answer.withIndex()) {
+                if (ch != pwCh) continue
 
-                        // The intersection cell in absolute coordinates
-                        val (intRow, intCol) = if (pw.direction == CrosswordDirection.ACROSS)
-                            pw.row to pw.col + j else pw.row + j to pw.col
+                // The intersection cell in absolute coordinates
+                val (intRow, intCol) = if (pw.direction == CrosswordDirection.ACROSS)
+                    pw.row to pw.col + j else pw.row + j to pw.col
 
-                        // Start of the new word given the intersection is at index i
-                        val (startRow, startCol) = if (dir == CrosswordDirection.ACROSS)
-                            intRow to intCol - i else intRow - i to intCol
+                // Start of the new word given the intersection is at index i
+                val (startRow, startCol) = if (dir == CrosswordDirection.ACROSS)
+                    intRow to intCol - i else intRow - i to intCol
 
-                        if (isValid(grid, clue.answer, startRow, startCol, dir))
-                            return Triple(startRow, startCol, dir)
-                    }
+                if (isValid(grid, clue.answer, startRow, startCol, dir)) {
+                    return Triple(startRow, startCol, dir)
                 }
             }
         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SongFileParser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SongFileParser.kt
@@ -32,6 +32,8 @@ data class SongCache(
     val cachedSongs: List<CachedSong> = emptyList()
 )
 
+private const val TITLE_KEY_LENGTH = 6
+
 class SongFileParser {
 
     fun parseSongFile(filePath: String, songbook: String = ""): SongItem? {
@@ -43,6 +45,51 @@ class SongFileParser {
             return parseSongContent(content, filePath, songbook)
         } catch (_: Exception) {
             return null
+        }
+    }
+
+    /** The `key: value` lines of a .song header, lowercased keys, unknown keys kept out. */
+    private fun parseHeaderFields(headerBody: List<String>): Map<String, String> {
+        val known = setOf("author", "composer", "tune", "ccli")
+        return headerBody.mapNotNull { raw ->
+            val line = raw.trim()
+            val colonIndex = line.indexOf(':')
+            if (colonIndex <= 0) return@mapNotNull null
+            val key = line.substring(0, colonIndex).trim().lowercase()
+            if (key !in known) null else key to line.substring(colonIndex + 1).trim()
+        }.toMap()
+    }
+
+    /** The [Primary]/[Secondary] halves of a .song body, filled a line at a time. */
+    private class SongBody(
+        private val primaryLyrics: MutableList<String>,
+        private val secondaryLyrics: MutableList<String>,
+    ) {
+        var primaryTitle = ""
+        var secondaryTitle = ""
+        private var section: String? = null // null, "primary", "secondary"
+        private var target: MutableList<String>? = null
+
+        fun consume(line: String) {
+            val trimmed = line.trim()
+            when {
+                trimmed.equals("[Primary]", ignoreCase = true) -> {
+                    section = "primary"
+                    target = primaryLyrics
+                }
+                trimmed.equals("[Secondary]", ignoreCase = true) -> {
+                    section = "secondary"
+                    target = secondaryLyrics
+                }
+                section == null || target == null -> Unit
+                // Title line right after the section tag
+                trimmed.startsWith("title:", ignoreCase = true) -> {
+                    val titleValue = trimmed.substring(TITLE_KEY_LENGTH).trim()
+                    if (section == "primary") primaryTitle = titleValue else secondaryTitle = titleValue
+                }
+                // Lyric lines (including section headers like [Verse 1], empty lines, etc.)
+                else -> target?.add(line)
+            }
         }
     }
 
@@ -63,20 +110,11 @@ class SongFileParser {
 
             if (headerStart >= 0) {
                 val headerBody = lines.subList(headerStart + 1, if (headerClose < 0) lines.size else headerClose)
-                for (raw in headerBody) {
-                    val line = raw.trim()
-                    val colonIndex = line.indexOf(':')
-                    if (colonIndex > 0) {
-                        val key = line.substring(0, colonIndex).trim().lowercase()
-                        val value = line.substring(colonIndex + 1).trim()
-                        when (key) {
-                            "author" -> author = value
-                            "composer" -> composer = value
-                            "tune" -> tune = value
-                            "ccli" -> ccli = value
-                        }
-                    }
-                }
+                val header = parseHeaderFields(headerBody)
+                author = header["author"].orEmpty()
+                composer = header["composer"].orEmpty()
+                tune = header["tune"].orEmpty()
+                ccli = header["ccli"].orEmpty()
             }
 
             // Parse body after header
@@ -87,35 +125,10 @@ class SongFileParser {
             val primaryLyrics = mutableListOf<String>()
             val secondaryLyrics = mutableListOf<String>()
 
-            var currentSection: String? = null // null, "primary", "secondary"
-            var currentTarget: MutableList<String>? = null
-
-            for (line in bodyLines) {
-                val trimmed = line.trim()
-
-                when {
-                    trimmed.equals("[Primary]", ignoreCase = true) -> {
-                        currentSection = "primary"
-                        currentTarget = primaryLyrics
-                    }
-                    trimmed.equals("[Secondary]", ignoreCase = true) -> {
-                        currentSection = "secondary"
-                        currentTarget = secondaryLyrics
-                    }
-                    currentSection == null || currentTarget == null -> Unit
-                    // Title line right after the section tag
-                    trimmed.startsWith("title:", ignoreCase = true) -> {
-                        val titleValue = trimmed.substring(6).trim()
-                        if (currentSection == "primary") {
-                            primaryTitle = titleValue
-                        } else {
-                            secondaryTitle = titleValue
-                        }
-                    }
-                    // Lyric lines (including section headers like [Verse 1], empty lines, etc.)
-                    else -> currentTarget.add(line)
-                }
-            }
+            val body = SongBody(primaryLyrics, secondaryLyrics)
+            for (line in bodyLines) body.consume(line)
+            primaryTitle = body.primaryTitle
+            secondaryTitle = body.secondaryTitle
 
             // Trim leading/trailing blank lines from lyrics
             trimBlankLines(primaryLyrics)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Songs.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/Songs.kt
@@ -366,31 +366,26 @@ class Songs {
             // a name this app has no word for. Matching on a word list here instead would write
             // every unrecognised header back out as a lyric line, brackets and all.
             if (isHeaderLine(trimmedLine)) {
-                // If we have accumulated lines, save them as a section
-                if (currentSection.isNotEmpty()) {
-                    if (result.isNotEmpty()) result.append("@\$")
-                    result.append(currentSection)
-                    currentSection = StringBuilder()
-                }
+                result.appendSection(currentSection)
+                currentSection = StringBuilder()
                 // Start new section with the marker (strip [] or {} wrapping for SPS format)
-                val unwrapped = trimmedLine.removePrefix("[").removePrefix("{").removeSuffix("]").removeSuffix("}")
-                currentSection.append(unwrapped)
+                currentSection.append(
+                    trimmedLine.removePrefix("[").removePrefix("{").removeSuffix("]").removeSuffix("}")
+                )
             } else if (trimmedLine.isNotEmpty()) {
-                // Add line to current section
-                if (currentSection.isNotEmpty()) {
-                    currentSection.append("@%")
-                }
+                if (currentSection.isNotEmpty()) currentSection.append("@%")
                 currentSection.append(trimmedLine)
             }
         }
 
-        // Add last section
-        if (currentSection.isNotEmpty()) {
-            if (result.isNotEmpty()) result.append("@\$")
-            result.append(currentSection)
-        }
-
+        result.appendSection(currentSection)
         return result.toString()
+    }
+
+    private fun StringBuilder.appendSection(section: StringBuilder) {
+        if (section.isEmpty()) return
+        if (isNotEmpty()) append("@\$")
+        append(section)
     }
 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -461,7 +461,12 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
     var mirroredBackgroundSettings by remember { mutableStateOf<BackgroundSettings?>(null) }
     val instanceLinkConnectionStatusForBackgrounds by instanceLinkViewModel.connectionStatus.collectAsState()
     val instanceLinkBackgroundsSignal by instanceLinkViewModel.backgroundsUpdatedSignal.collectAsState()
-    LaunchedEffect(instanceLinkConnectionStatusForBackgrounds, appSettings.instanceLink.mirrorBackgrounds, appSettings.instanceLink.role, instanceLinkBackgroundsSignal) {
+    LaunchedEffect(
+        instanceLinkConnectionStatusForBackgrounds,
+        appSettings.instanceLink.mirrorBackgrounds,
+        appSettings.instanceLink.role,
+        instanceLinkBackgroundsSignal
+    ) {
         if (!shouldMirrorRemoteBackgrounds(
                 status = instanceLinkConnectionStatusForBackgrounds,
                 role = appSettings.instanceLink.role,
@@ -516,7 +521,11 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
         prevTunnelWasConnected.value = isConnected
     }
     var presentationFrozen by remember { mutableStateOf(false) }
-    LaunchedEffect(appSettings.presentationRemoteSettings.remoteControlEnabled, appSettings.serverSettings.apiKeyEnabled, appSettings.serverSettings.apiKey) {
+    LaunchedEffect(
+        appSettings.presentationRemoteSettings.remoteControlEnabled,
+        appSettings.serverSettings.apiKeyEnabled,
+        appSettings.serverSettings.apiKey
+    ) {
         val activeApiKey = activeApiKey(appSettings.serverSettings)
         companionServer.updatePresentationRemoteSettings(appSettings.presentationRemoteSettings, activeApiKey)
     }
@@ -552,7 +561,12 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
             }
             val qaDisplayUrlState = rememberUpdatedState(qaDisplayUrl)
             val bsOutput = browserSourceOutputAt(appSettings.projectionSettings.browserSourceOutputs, i)
-            val renderer = remember(i, bsOutput.browserSourceWidth, bsOutput.browserSourceHeight, bsOutput.browserSourceFps) {
+            val renderer = remember(
+                i,
+                bsOutput.browserSourceWidth,
+                bsOutput.browserSourceHeight,
+                bsOutput.browserSourceFps
+            ) {
                 BrowserSourceVideoRenderer(
                     presenterManager, appSettingsState, screenAssignmentState, effectiveModeState,
                     outputIndex = i,
@@ -1080,7 +1094,9 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
                                             includePrereleases = appSettings.participateInPrereleases
                                         )
                                         pendingUpdateCheckWasManual = true
-                                        appSettings = appSettings.copy(lastUpdateCheckTimestamp = System.currentTimeMillis())
+                                        appSettings = appSettings.copy(
+                                            lastUpdateCheckTimestamp = System.currentTimeMillis()
+                                        )
                                         settingsManager.saveSettings(appSettings)
                                     }
                                 },
@@ -1128,11 +1144,15 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
                                 var showBanner by remember { mutableStateOf(true) }
                                 if (showBanner) {
                                     Box(
-                                        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.errorContainer),
+                                        modifier = Modifier.fillMaxSize().background(
+                                            MaterialTheme.colorScheme.errorContainer
+                                        ),
                                         contentAlignment = Alignment.Center
                                     ) {
                                         Text(
-                                            text = "Video backgrounds disabled after ${CrashReporter.consecutiveCrashes} consecutive crashes.  [Re-enable]  [Dismiss]",
+                                            text =
+                                                "Video backgrounds disabled after ${CrashReporter.consecutiveCrashes}" +
+                                                    " consecutive crashes.  [Re-enable]  [Dismiss]",
                                             style = MaterialTheme.typography.bodySmall,
                                             color = MaterialTheme.colorScheme.onErrorContainer,
                                             modifier = Modifier.onPreviewKeyEvent {
@@ -1154,12 +1174,16 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
                                 shouldUseRemoteContent(instanceLinkStatus, appSettings.instanceLink.role)
                             MainDesktop(
                                 hostWindow = window,
-                                instanceLinkConnectionStatus = instanceLinkViewModel.connectionStatus.collectAsState().value,
+                                instanceLinkConnectionStatus =
+                                    instanceLinkViewModel.connectionStatus.collectAsState().value,
                                 instanceLinkNextRetryAtMs = instanceLinkViewModel.nextRetryAtMs.collectAsState().value,
-                                instanceLinkBibleUpdatedSignal = instanceLinkViewModel.bibleUpdatedSignal.collectAsState().value,
-                                instanceLinkSecondaryBibleUpdatedSignal = instanceLinkViewModel.secondaryBibleUpdatedSignal.collectAsState().value,
+                                instanceLinkBibleUpdatedSignal =
+                                    instanceLinkViewModel.bibleUpdatedSignal.collectAsState().value,
+                                instanceLinkSecondaryBibleUpdatedSignal =
+                                    instanceLinkViewModel.secondaryBibleUpdatedSignal.collectAsState().value,
                                 instanceLinkFollowingHost = appSettings.instanceLink.primaryHost,
-                                connectedInstanceLinkFollowerCount = companionServer.connectedInstanceLinkFollowers.collectAsState().value.size,
+                                connectedInstanceLinkFollowerCount =
+                                    companionServer.connectedInstanceLinkFollowers.collectAsState().value.size,
                                 onInstanceLinkConnect = {
                                     val link = appSettings.instanceLink
                                     setInstanceLinkEnabled(true)
@@ -1172,15 +1196,25 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
                                     setInstanceLinkEnabled(false)
                                     instanceLinkViewModel.disconnect()
                                 },
-                                instanceLinkRemoteSchedule = instanceLinkViewModel.remoteSchedule.collectAsState().value,
-                                instanceLinkRemoteSongCatalog = instanceLinkViewModel.remoteSongCatalog.collectAsState().value,
-                                instanceLinkFetchSongDetail = { number, songbook -> instanceLinkViewModel.fetchSongDetail(number, songbook) },
+                                instanceLinkRemoteSchedule =
+                                    instanceLinkViewModel.remoteSchedule.collectAsState().value,
+                                instanceLinkRemoteSongCatalog =
+                                    instanceLinkViewModel.remoteSongCatalog.collectAsState().value,
+                                instanceLinkFetchSongDetail = { number, songbook ->
+                                    instanceLinkViewModel.fetchSongDetail(number, songbook)
+                                },
                                 instanceLinkFetchBibleFile = { instanceLinkViewModel.fetchBibleFile() },
                                 instanceLinkBibleSyncMode = appSettings.instanceLink.bibleSyncMode,
-                                instanceLinkFetchSecondaryBibleFile = { instanceLinkViewModel.fetchSecondaryBibleFile() },
+                                instanceLinkFetchSecondaryBibleFile = {
+                                    instanceLinkViewModel.fetchSecondaryBibleFile()
+                                },
                                 instanceLinkFetchBibleTranslations = { instanceLinkViewModel.fetchBibleTranslations() },
-                                instanceLinkOnSecondaryBibleFilePathChanged = { path -> companionServer.updateSecondaryBibleFilePath(path) },
-                                instanceLinkOnBibleFilePathsChanged = { paths -> companionServer.updateBibleFilePaths(paths) },
+                                instanceLinkOnSecondaryBibleFilePathChanged = { path ->
+                                    companionServer.updateSecondaryBibleFilePath(path)
+                                },
+                                instanceLinkOnBibleFilePathsChanged = { paths ->
+                                    companionServer.updateBibleFilePaths(paths)
+                                },
                                 instanceLinkSendAddToSchedule = if (canPushToSchedule(appSettings.instanceLink)) {
                                     { item -> instanceLinkViewModel.sendAddToSchedule(item) }
                                 } else null,
@@ -1193,11 +1227,19 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
                                 } else null,
                                 instanceLinkSendVerse = if (instanceLinkIsControllerConnected) {
                                     { bookName, chapter, verseNumber, verseText, verseRange ->
-                                        instanceLinkViewModel.sendSelectBibleVerse(bookName, chapter, verseNumber, verseText, verseRange)
+                                        instanceLinkViewModel.sendSelectBibleVerse(
+                                            bookName,
+                                            chapter,
+                                            verseNumber,
+                                            verseText,
+                                            verseRange
+                                        )
                                     }
                                 } else null,
                                 instanceLinkSendSongSection = if (instanceLinkIsControllerConnected) {
-                                    { number, section, lineIndex -> instanceLinkViewModel.sendSelectSongSection(number, section, lineIndex) }
+                                    { number, section, lineIndex ->
+                                        instanceLinkViewModel.sendSelectSongSection(number, section, lineIndex)
+                                    }
                                 } else null,
                                 instanceLinkSendClear = if (instanceLinkIsControllerConnected) {
                                     { instanceLinkViewModel.sendClear() }
@@ -1270,7 +1312,10 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
                                     companionServer.updateBible(
                                         bible,
                                         translation,
-                                        filePath = bibleFilePath(appSettings.bibleSettings.storageDirectory, translation)
+                                        filePath = bibleFilePath(
+                                            appSettings.bibleSettings.storageDirectory,
+                                            translation
+                                        )
                                     )
                                 },
                                 onScheduleChanged = { items -> companionServer.updateSchedule(items) },
@@ -1322,7 +1367,9 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
                                 qaManager = qaManager,
                                 tunnelStatus = tunnelStatus,
                                 tunnelUrl = tunnelUrl ?: "",
-                                onStartTunnel = { companionServer.tunnelManager.start(appSettings.serverSettings.port) },
+                                onStartTunnel = {
+                                    companionServer.tunnelManager.start(appSettings.serverSettings.port)
+                                },
                                 onStopTunnel = { companionServer.tunnelManager.stop() },
                                 qaDisplayUrl = qaDisplayUrl,
                                 onQaDisplayUrlChanged = { qaDisplayUrl = it },
@@ -1593,7 +1640,8 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
                             )
                             RemoteActivityToastHost(
                                 notifications = remoteActivityNotifications,
-                                connectedInstanceLinkFollowers = companionServer.connectedInstanceLinkFollowers.collectAsState().value,
+                                connectedInstanceLinkFollowers =
+                                    companionServer.connectedInstanceLinkFollowers.collectAsState().value,
                                 onDismiss = { n -> remoteActivityNotifications.remove(n) },
                                 onDismissAll = { remoteActivityNotifications.clear() },
                                 onBlockForSession = { n ->

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BrowserSourceVideoRenderer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/BrowserSourceVideoRenderer.kt
@@ -198,6 +198,24 @@ class BrowserSourceVideoRenderer(
          * columns only within the surviving row band. A full-screen crossfade (nearly every pixel
          * changes) degrades to close to the full frame — expected, not a regression.
          */
+        /** First and last column of one row that differ; (width, -1) when the row is unchanged. */
+        private fun changedColumns(
+            current: IntArray,
+            previous: IntArray,
+            rowStart: Int,
+            width: Int,
+        ): Pair<Int, Int> {
+            var first = width
+            var last = -1
+            for (col in 0 until width) {
+                val idx = rowStart + col
+                if (current[idx] == previous[idx]) continue
+                if (col < first) first = col
+                last = col
+            }
+            return first to last
+        }
+
         internal fun computeDirtyRect(current: IntArray, previous: IntArray, width: Int, height: Int): DirtyRect {
             var minRow = 0
             while (minRow < height && rowsEqual(current, previous, minRow, width)) minRow++
@@ -207,14 +225,9 @@ class BrowserSourceVideoRenderer(
             var minCol = width
             var maxCol = -1
             for (row in minRow..maxRow) {
-                val rowStart = row * width
-                for (col in 0 until width) {
-                    val idx = rowStart + col
-                    if (current[idx] != previous[idx]) {
-                        if (col < minCol) minCol = col
-                        if (col > maxCol) maxCol = col
-                    }
-                }
+                val (first, last) = changedColumns(current, previous, row * width, width)
+                if (first < minCol) minCol = first
+                if (last > maxCol) maxCol = last
             }
             // Defensive fallback — the caller guarantees a diff exists, so this shouldn't trigger,
             // but never emit an inverted rect.

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PicturePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PicturePresenter.kt
@@ -158,13 +158,12 @@ private fun decodePictureBytes(file: File): Image? = try {
     Image.makeFromEncoded(file.readBytes())
 } catch (_: Exception) {
     // A HEIC/HEIF that Skia cannot read is transcoded to JPEG first
-    if (file.extension.lowercase() in listOf("heic", "heif")) {
-        HeicDecoder.toJpegBytes(file)?.let { jpegBytes ->
-            try { Image.makeFromEncoded(jpegBytes) } catch (_: Exception) { null }
-        }
-    } else {
-        null
-    }
+    if (file.extension.lowercase() in listOf("heic", "heif")) decodeHeic(file) else null
+}
+
+private fun decodeHeic(file: File): Image? {
+    val jpegBytes = HeicDecoder.toJpegBytes(file) ?: return null
+    return try { Image.makeFromEncoded(jpegBytes) } catch (_: Exception) { null }
 }
 
 internal fun loadAndDownscaleImage(imagePath: String, maxWidth: Int = 1920, maxHeight: Int = 1080): ImageBitmap? {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenter.kt
@@ -64,7 +64,9 @@ fun STTPresenter(
     val translationColor = if (isKey) Color.White else parseHexColor(sttSettings.translationTextColor)
     val bgOpacity = (sttSettings.backgroundOpacity / 100f).coerceIn(0f, 1f)
     val cardBg = if (isKey) Color.White
-                 else parseHexColor(if (sttSettings.backgroundColor == "transparent") "#1E1E2E" else sttSettings.backgroundColor).copy(alpha = bgOpacity)
+                 else parseHexColor(if (
+                     sttSettings.backgroundColor == "transparent"
+                 ) "#1E1E2E" else sttSettings.backgroundColor).copy(alpha = bgOpacity)
     val fontFamily = systemFontFamilyOrDefault(sttSettings.fontType)
 
     val shadowColorBase = parseHexColor(sttSettings.shadowColor)
@@ -102,8 +104,16 @@ fun STTPresenter(
     // Drip feed: reveal newest segment letter-by-letter
     val dripEnabled = sttSettings.dripFeedEnabled
     val dripSpeed = sttSettings.dripFeedSpeed.toLong().coerceAtLeast(1L)
-    val dripTranscription = useDripFeed(segments, enabled = dripEnabled && !sttSettings.showInProgress, delayMs = dripSpeed)
-    val dripTranslation = useDripFeed(translationSegments, enabled = dripEnabled && !sttSettings.showTranslationInProgress, delayMs = dripSpeed)
+    val dripTranscription = useDripFeed(
+        segments,
+        enabled = dripEnabled && !sttSettings.showInProgress,
+        delayMs = dripSpeed
+    )
+    val dripTranslation = useDripFeed(
+        translationSegments,
+        enabled = dripEnabled && !sttSettings.showTranslationInProgress,
+        delayMs = dripSpeed
+    )
 
     // Build text — pass ALL segments, no filtering by maxSegments
     val transcriptionText = buildDisplayText(
@@ -144,17 +154,37 @@ fun STTPresenter(
                             horizontalArrangement = Arrangement.spacedBy(24.dp),
                             verticalAlignment = Alignment.Bottom
                         ) {
-                            BottomAlignedText(text = first, style = firstStyle, maxLines = maxLines, modifier = Modifier.weight(1f))
-                            BottomAlignedText(text = second, style = secondStyle, maxLines = maxLines, modifier = Modifier.weight(1f))
+                            BottomAlignedText(
+                                text = first,
+                                style = firstStyle,
+                                maxLines = maxLines,
+                                modifier = Modifier.weight(1f)
+                            )
+                            BottomAlignedText(
+                                text = second,
+                                style = secondStyle,
+                                maxLines = maxLines,
+                                modifier = Modifier.weight(1f)
+                            )
                         }
                     } else {
                         Column(modifier = Modifier.fillMaxWidth().fillMaxSize()) {
                             Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = boxAlignment) {
-                                BottomAlignedText(text = first, style = firstStyle, maxLines = maxLines, modifier = Modifier.fillMaxWidth())
+                                BottomAlignedText(
+                                    text = first,
+                                    style = firstStyle,
+                                    maxLines = maxLines,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
                             }
                             Spacer(modifier = Modifier.height(16.dp))
                             Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = boxAlignment) {
-                                BottomAlignedText(text = second, style = secondStyle, maxLines = maxLines, modifier = Modifier.fillMaxWidth())
+                                BottomAlignedText(
+                                    text = second,
+                                    style = secondStyle,
+                                    maxLines = maxLines,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
                             }
                         }
                     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/STTPresenter.kt
@@ -270,39 +270,40 @@ private fun buildDisplayText(
     }
 
     // Apply word highlighting with Unicode word boundaries
-    if (showWordHighlighting && highlightedWords.isNotEmpty()) {
-        for (hw in highlightedWords) {
-            if (hw.word.isBlank()) continue
-            try {
-                val highlightColor = parseHexColor(hw.color)
-                val wb = "(?<![\\p{L}\\p{N}])"
-                val we = "(?![\\p{L}\\p{N}])"
-                val rawPattern = if (hw.isRegex) {
-                    "$wb(?:${hw.word})$we"
-                } else {
-                    val escaped = Regex.escape(hw.word)
-                    "$wb$escaped$we"
-                }
-                var flags = java.util.regex.Pattern.UNICODE_CHARACTER_CLASS
-                if (!hw.caseSensitive) flags = flags or java.util.regex.Pattern.CASE_INSENSITIVE or java.util.regex.Pattern.UNICODE_CASE
-                val regex = java.util.regex.Pattern.compile(rawPattern, flags).toRegex()
-                regex.findAll(fullText).forEach { match ->
-                    for (j in match.range) colors[j] = highlightColor
-                }
-            } catch (_: Exception) {}
-        }
+    if (showWordHighlighting) {
+        highlightedWords.forEach { applyHighlight(it, fullText, colors) }
     }
 
-    // Build AnnotatedString with contiguous color runs
-    return buildAnnotatedString {
-        var i = 0
-        while (i < fullText.length) {
-            val color = colors[i]
-            val start = i
-            while (i < fullText.length && colors[i] == color) i++
-            withStyle(SpanStyle(color = color)) {
-                append(fullText.substring(start, i))
-            }
+    return runsOf(fullText, colors)
+}
+
+/** Paints every match of one highlighted word into [colors]. A pattern that won't compile is skipped. */
+private fun applyHighlight(hw: HighlightedWord, fullText: String, colors: Array<Color>) {
+    if (hw.word.isBlank()) return
+    try {
+        val highlightColor = parseHexColor(hw.color)
+        val wb = "(?<![\\p{L}\\p{N}])"
+        val we = "(?![\\p{L}\\p{N}])"
+        val rawPattern = if (hw.isRegex) "$wb(?:${hw.word})$we" else "$wb${Regex.escape(hw.word)}$we"
+        var flags = java.util.regex.Pattern.UNICODE_CHARACTER_CLASS
+        if (!hw.caseSensitive) {
+            flags = flags or java.util.regex.Pattern.CASE_INSENSITIVE or java.util.regex.Pattern.UNICODE_CASE
+        }
+        java.util.regex.Pattern.compile(rawPattern, flags).toRegex().findAll(fullText).forEach { match ->
+            for (j in match.range) colors[j] = highlightColor
+        }
+    } catch (_: Exception) {}
+}
+
+/** The per-character colours collapsed into contiguous styled runs. */
+private fun runsOf(fullText: String, colors: Array<Color>): AnnotatedString = buildAnnotatedString {
+    var i = 0
+    while (i < fullText.length) {
+        val color = colors[i]
+        val start = i
+        while (i < fullText.length && colors[i] == color) i++
+        withStyle(SpanStyle(color = color)) {
+            append(fullText.substring(start, i))
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemClient.kt
@@ -647,20 +647,7 @@ class AtemClient(val host: String, val port: Int = 9910) {
                         else u16(payload, OFFSET_FTCD_CHUNK_COUNT)
                     var sent = 0
                     while (chunkSize > 0 && sent < chunkCount && bytesSent < data.size) {
-                        var len = minOf(chunkSize, data.size - bytesSent)
-                        // Don't end a chunk mid RLE block: shorten if an RLE header starts
-                        // 8 or 16 bytes before the chunk end (header+count+pattern = 24B unit)
-                        if (bytesSent + len < data.size) {
-                            if (len >= RLE_WORD_BYTES &&
-                                dataBuf.getLong(bytesSent + len - RLE_WORD_BYTES) == AtemFrameEncoder.RLE_HEADER
-                            ) {
-                                len -= RLE_WORD_BYTES
-                            } else if (len >= RLE_TWO_WORDS_BYTES &&
-                                dataBuf.getLong(bytesSent + len - RLE_TWO_WORDS_BYTES) == AtemFrameEncoder.RLE_HEADER
-                            ) {
-                                len -= RLE_TWO_WORDS_BYTES
-                            }
-                        }
+                        val len = chunkLengthAt(dataBuf, data.size, bytesSent, chunkSize)
                         sendCommand("FTDa", buildDataChunkPayload(transferId, data, bytesSent, len))
                         bytesSent += len
                         sent++
@@ -670,29 +657,58 @@ class AtemClient(val host: String, val port: Int = 9910) {
                 "FTDC" -> return
                 "FTDE" -> {
                     val code = payload.getOrNull(OFFSET_FTDE_CODE)?.toInt()?.and(BYTE_MASK) ?: -1
-                    if (code == FTDE_CODE_RETRY && retries < MAX_TRANSFER_RETRIES) {
-                        // Code 1 = "retry": the ATEM is busy (e.g. still clearing the clip
-                        // pool after CMPC). Back off briefly, then restart the same transfer.
-                        retries++
-                        bytesSent = 0
-                        descriptionSent = false
-                        Thread.sleep(RETRY_BACKOFF_MS)
-                        sendCommand("FTSD", buildUploadRequestPayload(transferId, storeId, frameIndex, frame.rawLen))
-                    } else {
-                        // Clip frames past index 0 usually fail because the device's clip
-                        // pool ran out of frame capacity — surface an actionable hint
-                        val what = if (name == null) "clip frame $frameIndex" else "still"
-                        val hint = if (name == null && frameIndex > 0)
-                            " — the clip may exceed the ATEM's clip pool capacity; try a shorter duration or lower fps"
-                        else ""
-                        if (code == FTDE_CODE_RETRY) {
-                            throw Exception("ATEM stayed busy uploading $what after $retries retries$hint")
-                        } else {
-                            throw Exception("ATEM rejected $what (error code $code)$hint")
-                        }
+                    if (code != FTDE_CODE_RETRY || retries >= MAX_TRANSFER_RETRIES) {
+                        throw transferRejected(code, name, frameIndex, retries)
                     }
+                    // Code 1 = "retry": the ATEM is busy (e.g. still clearing the clip pool after
+                    // CMPC). Back off briefly, then restart the same transfer.
+                    retries++
+                    bytesSent = 0
+                    descriptionSent = false
+                    Thread.sleep(RETRY_BACKOFF_MS)
+                    sendCommand("FTSD", buildUploadRequestPayload(transferId, storeId, frameIndex, frame.rawLen))
                 }
             }
+        }
+    }
+
+    /**
+     * The failure for an FTDE the transfer cannot retry past. Clip frames after index 0 usually
+     * fail because the device's clip pool ran out of capacity, which is worth saying outright.
+     */
+    private fun transferRejected(code: Int, name: String?, frameIndex: Int, retries: Int): Exception {
+        val what = if (name == null) "clip frame $frameIndex" else "still"
+        val hint = if (name == null && frameIndex > 0) {
+            " — the clip may exceed the ATEM's clip pool capacity; try a shorter duration or lower fps"
+        } else {
+            ""
+        }
+        return if (code == FTDE_CODE_RETRY) {
+            Exception("ATEM stayed busy uploading $what after $retries retries$hint")
+        } else {
+            Exception("ATEM rejected $what (error code $code)$hint")
+        }
+    }
+
+    /**
+     * How much to put in the next chunk: never ending mid RLE block, so the length is shortened
+     * when an RLE header starts 8 or 16 bytes before the chunk end (header+count+pattern = 24B unit).
+     */
+    private fun chunkLengthAt(
+        dataBuf: java.nio.ByteBuffer,
+        dataSize: Int,
+        bytesSent: Int,
+        chunkSize: Int,
+    ): Int {
+        val len = minOf(chunkSize, dataSize - bytesSent)
+        if (bytesSent + len >= dataSize) return len
+        val endsOnHeader = { back: Int ->
+            len >= back && dataBuf.getLong(bytesSent + len - back) == AtemFrameEncoder.RLE_HEADER
+        }
+        return when {
+            endsOnHeader(RLE_WORD_BYTES) -> len - RLE_WORD_BYTES
+            endsOnHeader(RLE_TWO_WORDS_BYTES) -> len - RLE_TWO_WORDS_BYTES
+            else -> len
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LottieRenderCache.kt
@@ -462,6 +462,12 @@ object LottieRenderCache {
     /** Runs shorter than this stay literal — a run record costs 8 bytes. */
     private const val MIN_RUN = 3
 
+    /** Writes pixels [from, until) as one negative-length literal record. */
+    private fun flushLiteralRun(buf: ByteBuffer, pixels: IntArray, from: Int, until: Int) {
+        buf.putInt(-(until - from))
+        for (j in from until until) buf.putInt(pixels[j])
+    }
+
     internal fun encodeArgbRle(pixels: IntArray): ByteArray {
         // Worst case is alternating length-1 literal records and minimum runs, which stays
         // at parity with raw size; headroom covers record headers.
@@ -474,11 +480,8 @@ object LottieRenderCache {
             while (runEnd < pixels.size && pixels[runEnd] == value) runEnd++
             val runLen = runEnd - i
             if (runLen >= MIN_RUN) {
-                if (literalStart >= 0) {
-                    buf.putInt(-(i - literalStart))
-                    for (j in literalStart until i) buf.putInt(pixels[j])
-                    literalStart = -1
-                }
+                if (literalStart >= 0) flushLiteralRun(buf, pixels, literalStart, i)
+                literalStart = -1
                 buf.putInt(runLen)
                 buf.putInt(value)
             } else if (literalStart < 0) {
@@ -486,10 +489,7 @@ object LottieRenderCache {
             }
             i = if (runLen >= MIN_RUN) runEnd else i + runLen
         }
-        if (literalStart >= 0) {
-            buf.putInt(-(pixels.size - literalStart))
-            for (j in literalStart until pixels.size) buf.putInt(pixels[j])
-        }
+        if (literalStart >= 0) flushLiteralRun(buf, pixels, literalStart, pixels.size)
         return buf.array().copyOf(buf.position())
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdAndAtemRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdAndAtemRoutes.kt
@@ -44,8 +44,13 @@ private fun Route.lowerThirdRoutes(
                 get("/api/lowerthirds") {
                     if (!server.checkApiKey(call)) return@get
                     val items = server.atem.lowerThirdFiles().map { f ->
-                        val dur = try { LottieRenderCache.lottieDurationMs(f.readText()) ?: 0L } catch (_: Exception) { 0L }
-                        val nameJson = json.encodeToString(kotlinx.serialization.serializer<String>(), f.nameWithoutExtension)
+                        val dur = try {
+                            LottieRenderCache.lottieDurationMs(f.readText()) ?: 0L
+                        } catch (_: Exception) { 0L }
+                        val nameJson = json.encodeToString(
+                            kotlinx.serialization.serializer<String>(),
+                            f.nameWithoutExtension
+                        )
                         """{"name":$nameJson,"durationMs":$dur}"""
                     }
                     call.respondText("[${items.joinToString(",")}]", ContentType.Application.Json)
@@ -60,14 +65,24 @@ private fun Route.lowerThirdRoutes(
                 get("/api/lowerthirds/{name}/json") {
                     if (!server.checkApiKey(call)) return@get
                     val rawName = call.parameters["name"] ?: ""
-                    val file = server.atem.lowerThirdFiles().firstOrNull { it.nameWithoutExtension.equals(rawName, ignoreCase = true) }
+                    val file = server.atem.lowerThirdFiles().firstOrNull {
+                        it.nameWithoutExtension.equals(rawName, ignoreCase = true)
+                    }
                     if (file == null) {
-                        server.logRest("/api/lowerthirds/{name}/json", HttpStatusCode.NotFound.value, "lower_third_not_found")
+                        server.logRest(
+                            "/api/lowerthirds/{name}/json",
+                            HttpStatusCode.NotFound.value,
+                            "lower_third_not_found"
+                        )
                         call.respond(HttpStatusCode.NotFound, """{"error":"lower third not found"}""")
                         return@get
                     }
                     val ltJson = try { file.readText() } catch (_: Exception) {
-                        server.logRest("/api/lowerthirds/{name}/json", HttpStatusCode.InternalServerError.value, "could_not_read_lottie_file")
+                        server.logRest(
+                            "/api/lowerthirds/{name}/json",
+                            HttpStatusCode.InternalServerError.value,
+                            "could_not_read_lottie_file"
+                        )
                         call.respond(HttpStatusCode.InternalServerError, """{"error":"could not read lottie file"}""")
                         return@get
                     }
@@ -126,7 +141,9 @@ private fun Route.atemClipRoutes(
                         call.respond(HttpStatusCode.BadRequest, """{"error":"name required"}""")
                         return@post
                     }
-                    val file = server.atem.lowerThirdFiles().firstOrNull { it.nameWithoutExtension.equals(name, ignoreCase = true) }
+                    val file = server.atem.lowerThirdFiles().firstOrNull {
+                        it.nameWithoutExtension.equals(name, ignoreCase = true)
+                    }
                     if (file == null) {
                         call.respond(HttpStatusCode.NotFound, """{"error":"lower third not found"}""")
                         return@post
@@ -166,7 +183,8 @@ private fun Route.atemClipRoutes(
                         else -> ""","me":${key.mixEffect + 1},"key":${key.keyer + 1}"""
                     }
                     call.respondText(
-                        """{"status":"uploading","type":"clip","name":${server.atem.jsonStr(name)},"slot":${slot + 1}$keyInfoClip}""",
+                        """{"status":"uploading","type":"clip","name":${server.atem.jsonStr(name)},"slot":""" +
+                            """${slot + 1}$keyInfoClip}""",
                         ContentType.Application.Json
                     )
                 }
@@ -218,7 +236,8 @@ private suspend fun handleAtemStillUpload(
                     else -> ""","me":${key.mixEffect + 1},"key":${key.keyer + 1}"""
                 }
                 call.respondText(
-                    """{"status":"uploading","type":"still","name":${server.atem.jsonStr(name)},"slot":${slot + 1}$keyInfo}""",
+                    """{"status":"uploading","type":"still","name":${server.atem.jsonStr(name)},"slot":${slot + 1}""" +
+                        """$keyInfo}""",
                     ContentType.Application.Json
                 )
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationRoutes.kt
@@ -49,8 +49,25 @@ internal fun Route.presentationRoutes(
     json: Json,
     scope: CoroutineScope,
 ) {
-    presentationCatalogRoutes(server, _presentationCatalog, _presentationCatalogs, _scheduleItemToPresentationId, _slideBytes, json, scope)
-    presentationUploadRoutes(server, _fileUploadEnabled, _maxMediaUploadMb, _presentationCatalogs, _presentationFilePaths, _slideBytes, json, scope)
+    presentationCatalogRoutes(
+        server,
+        _presentationCatalog,
+        _presentationCatalogs,
+        _scheduleItemToPresentationId,
+        _slideBytes,
+        json,
+        scope
+    )
+    presentationUploadRoutes(
+        server,
+        _fileUploadEnabled,
+        _maxMediaUploadMb,
+        _presentationCatalogs,
+        _presentationFilePaths,
+        _slideBytes,
+        json,
+        scope
+    )
 }
 
 private fun Route.presentationCatalogRoutes(
@@ -87,7 +104,11 @@ private fun Route.presentationCatalogRoutes(
                     val resolvedId = _scheduleItemToPresentationId[id] ?: id
                     val dto = _presentationCatalogs[resolvedId]
                     if (dto == null) {
-                        server.logRest("/api/presentations/{id}", HttpStatusCode.NotFound.value, "not_found_or_not_yet_rendered")
+                        server.logRest(
+                            "/api/presentations/{id}",
+                            HttpStatusCode.NotFound.value,
+                            "not_found_or_not_yet_rendered"
+                        )
                         call.respond(HttpStatusCode.NotFound, "Presentation not found or not yet rendered")
                         return@get
                     }
@@ -112,17 +133,29 @@ private fun Route.presentationSlideRoutes(
 ) {
                 get("${Constants.ENDPOINT_PRESENTATIONS}/{id}/slides/{index}") {
                     if (!server.checkApiKey(call)) return@get
-                    val id    = call.parameters["id"]    ?: run { call.respond(HttpStatusCode.BadRequest, "Missing id"); return@get }
-                    val index = call.parameters["index"]?.toIntOrNull() ?: run { call.respond(HttpStatusCode.BadRequest, "Invalid index"); return@get }
+                    val id    = call.parameters["id"]    ?: run {
+                        call.respond(HttpStatusCode.BadRequest, "Missing id"); return@get
+                    }
+                    val index = call.parameters["index"]?.toIntOrNull() ?: run {
+                        call.respond(HttpStatusCode.BadRequest, "Invalid index"); return@get
+                    }
                     val resolvedId = _scheduleItemToPresentationId[id] ?: id
                     val slides = _slideBytes[resolvedId]
                     if (slides == null) {
-                        server.logRest("/api/presentations/{id}/slides/{index}", HttpStatusCode.NotFound.value, "presentation_not_found")
+                        server.logRest(
+                            "/api/presentations/{id}/slides/{index}",
+                            HttpStatusCode.NotFound.value,
+                            "presentation_not_found"
+                        )
                         call.respond(HttpStatusCode.NotFound, "Presentation not found")
                         return@get
                     }
                     if (index < 0 || index >= slides.size) {
-                        server.logRest("/api/presentations/{id}/slides/{index}", HttpStatusCode.NotFound.value, "slide_index_out_of_range")
+                        server.logRest(
+                            "/api/presentations/{id}/slides/{index}",
+                            HttpStatusCode.NotFound.value,
+                            "slide_index_out_of_range"
+                        )
                         call.respond(HttpStatusCode.NotFound, "Slide index out of range")
                         return@get
                     }
@@ -155,7 +188,8 @@ private fun Route.presentationSlideRoutes(
                     }
                     val clientId = call.request.headers[Constants.HEADER_DEVICE_ID] ?: ""
                     scope.launch { server.onSelectSlide.emit(SelectSlideRequest(id = id, index = index)) }
-                    val presentationName = _presentationCatalogs[_scheduleItemToPresentationId[id] ?: id]?.fileName ?: id
+                    val presentationName =
+                        _presentationCatalogs[_scheduleItemToPresentationId[id] ?: id]?.fileName ?: id
                     scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
                         actionType = "present",
                         title = presentationName,
@@ -229,7 +263,10 @@ private fun Route.mediaUploadRoutes(
                         val maxBytes = _maxMediaUploadMb.value.toLong() * 1024 * 1024
                         val contentLength = call.request.headers["Content-Length"]?.toLongOrNull() ?: 0L
                         if (contentLength > maxBytes) {
-                            call.respond(HttpStatusCode.PayloadTooLarge, """{"error":"file too large (max ${_maxMediaUploadMb.value} MB)"}""")
+                            call.respond(
+                                HttpStatusCode.PayloadTooLarge,
+                                """{"error":"file too large (max ${_maxMediaUploadMb.value} MB)"}"""
+                            )
                             return@post
                         }
                         val rawName = call.request.queryParameters["name"]
@@ -241,10 +278,16 @@ private fun Route.mediaUploadRoutes(
                         val ext = safeName.substringAfterLast('.', "").lowercase()
                         // Accept exactly what the desktop media player (VLC) can play.
                         if (ext !in Constants.VIDEO_EXTENSIONS && ext !in Constants.AUDIO_EXTENSIONS) {
-                            call.respond(HttpStatusCode.UnsupportedMediaType, """{"error":"unsupported file type: $ext"}""")
+                            call.respond(
+                                HttpStatusCode.UnsupportedMediaType,
+                                """{"error":"unsupported file type: $ext"}"""
+                            )
                             return@post
                         }
-                        val uploadDir = File(System.getProperty("user.home"), ".churchpresenter/device_media").also { it.mkdirs() }
+                        val uploadDir = File(
+                            System.getProperty("user.home"),
+                            ".churchpresenter/device_media"
+                        ).also { it.mkdirs() }
                         val uniqueName = if (File(uploadDir, safeName).exists()) {
                             val ts   = System.currentTimeMillis()
                             val base = safeName.substringBeforeLast('.', safeName)
@@ -257,7 +300,9 @@ private fun Route.mediaUploadRoutes(
                                 file.outputStream().use { out -> input.copyTo(out, bufferSize = 1 shl 20) }
                             }
                         }
-                        val mediaType = if (ext in Constants.AUDIO_EXTENSIONS) Constants.MEDIA_TYPE_AUDIO else Constants.MEDIA_TYPE_LOCAL
+                        val mediaType = if (
+                            ext in Constants.AUDIO_EXTENSIONS
+                        ) Constants.MEDIA_TYPE_AUDIO else Constants.MEDIA_TYPE_LOCAL
                         val uploadClientId = call.request.headers[Constants.HEADER_DEVICE_ID] ?: ""
                         scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
                             actionType = "upload",
@@ -267,11 +312,15 @@ private fun Route.mediaUploadRoutes(
                         )) }
                         val escapedPath = file.absolutePath.replace("\\", "\\\\").replace("\"", "\\\"")
                         call.respondText(
-                            """{"ok":true,"path":"$escapedPath","name":"${file.nameWithoutExtension.replace("\"", "\\\"")}","mediaType":"$mediaType"}""",
+                            """{"ok":true,"path":"$escapedPath","name":"""" +
+                                """${file.nameWithoutExtension.replace("\"", "\\\"")}","mediaType":"$mediaType"}""",
                             ContentType.Application.Json
                         )
                     } catch (e: Exception) {
-                        call.respond(HttpStatusCode.InternalServerError, """{"error":"upload failed: ${e.message?.replace("\"", "\\\"")}"}""")
+                        call.respond(
+                            HttpStatusCode.InternalServerError,
+                            """{"error":"upload failed: ${e.message?.replace("\"", "\\\"")}"}"""
+                        )
                     }
                 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
@@ -698,29 +698,8 @@ private suspend fun applyRemotePictures(
     val index = state.pictureIndex
     if (folderId != null && index != null) {
         val cacheFile = File(instanceLinkPictureCacheDir, "${folderId}_$index.jpg")
-        if (!cacheFile.exists()) {
-            val bytes = instanceLinkViewModel.fetchPictureImageBytes(folderId, index)
-            if (bytes != null) {
-                // Temp-file + rename: this apply can be cancelled mid-write by a newer
-                // live state (collectLatest) — a truncated file must never land under the
-                // final name, or the exists() cache gate would trust it forever.
-                val tmp = File(cacheFile.parentFile, "${cacheFile.name}.tmp")
-                tmp.writeBytes(bytes)
-                if (!tmp.renameTo(cacheFile)) tmp.delete()
-                if (!cacheFile.exists()) {
-                    InstanceLinkLogger.log(
-                        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                        mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "cache_write_failed")
-                    )
-                    return false
-                }
-            } else {
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "fetch_failed")
-                )
-                return false
-            }
+        if (!cacheFile.exists() && !cachePictureImage(cacheFile, folderId, index, instanceLinkViewModel)) {
+            return false
         }
         presenterManager.setSelectedImagePath(cacheFile.absolutePath)
         InstanceLinkLogger.log(
@@ -890,4 +869,33 @@ private fun applyRemoteDictionary(
             mapOf("contentType" to "DICTIONARY", "resolved" to false, "reason" to "no_word_in_state")
         )
     }
+}
+
+/** Fetches one picture into the follower's cache; false once the failure has been logged. */
+private suspend fun cachePictureImage(
+    cacheFile: File,
+    folderId: String,
+    index: Int,
+    instanceLinkViewModel: InstanceLinkViewModel,
+): Boolean {
+    val bytes = instanceLinkViewModel.fetchPictureImageBytes(folderId, index)
+    if (bytes == null) {
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "fetch_failed")
+        )
+        return false
+    }
+    // Temp-file + rename: this apply can be cancelled mid-write by a newer live state
+    // (collectLatest) — a truncated file must never land under the final name, or the exists()
+    // cache gate would trust it forever.
+    val tmp = File(cacheFile.parentFile, "${cacheFile.name}.tmp")
+    tmp.writeBytes(bytes)
+    if (!tmp.renameTo(cacheFile)) tmp.delete()
+    if (cacheFile.exists()) return true
+    InstanceLinkLogger.log(
+        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+        mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "cache_write_failed")
+    )
+    return false
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/RemoteApply.kt
@@ -298,44 +298,8 @@ internal suspend fun applyRemoteLiveState(
                 mapOf("contentType" to "WEBSITE", "resolved" to (state.websiteUrl != null))
             )
         }
-        Presenting.PICTURES -> {
-            val folderId = state.pictureFolderId
-            val index = state.pictureIndex
-            if (folderId != null && index != null) {
-                val cacheFile = File(instanceLinkPictureCacheDir, "${folderId}_$index.jpg")
-                if (!cacheFile.exists()) {
-                    val bytes = instanceLinkViewModel.fetchPictureImageBytes(folderId, index)
-                    if (bytes != null) {
-                        // Temp-file + rename: this apply can be cancelled mid-write by a newer
-                        // live state (collectLatest) — a truncated file must never land under the
-                        // final name, or the exists() cache gate would trust it forever.
-                        val tmp = File(cacheFile.parentFile, "${cacheFile.name}.tmp")
-                        tmp.writeBytes(bytes)
-                        if (!tmp.renameTo(cacheFile)) tmp.delete()
-                        if (!cacheFile.exists()) {
-                            InstanceLinkLogger.log(
-                                InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                                mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "cache_write_failed")
-                            )
-                            return
-                        }
-                    } else {
-                        InstanceLinkLogger.log(
-                            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                            mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "fetch_failed")
-                        )
-                        return
-                    }
-                }
-                presenterManager.setSelectedImagePath(cacheFile.absolutePath)
-                InstanceLinkLogger.log(InstanceLinkLogSide.FOLLOWER, "apply_live_state", mapOf("contentType" to "PICTURES", "resolved" to true))
-            } else {
-                InstanceLinkLogger.log(
-                    InstanceLinkLogSide.FOLLOWER, "apply_live_state",
-                    mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "missing_folder_id_or_index")
-                )
-            }
-        }
+        Presenting.PICTURES ->
+            if (!applyRemotePictures(state, presenterManager, instanceLinkViewModel)) return
         Presenting.LOWER_THIRD -> {
             val name = state.lowerThirdName
             if (name != null) {
@@ -783,4 +747,56 @@ internal fun addScheduleItem(
         else -> return false
     }
     return true
+}
+
+private suspend fun applyRemotePictures(
+    state: LiveStateDto,
+    presenterManager: PresenterManager,
+    instanceLinkViewModel: InstanceLinkViewModel,
+): Boolean {
+    val folderId = state.pictureFolderId
+    val index = state.pictureIndex
+    if (folderId == null || index == null) {
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "missing_folder_id_or_index")
+        )
+        return true
+    }
+    val cacheFile = File(instanceLinkPictureCacheDir, "${folderId}_$index.jpg")
+    if (!cacheFile.exists() && !cachePictureImage(cacheFile, folderId, index, instanceLinkViewModel)) return false
+    presenterManager.setSelectedImagePath(cacheFile.absolutePath)
+    InstanceLinkLogger.log(
+        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+        mapOf("contentType" to "PICTURES", "resolved" to true)
+    )
+    return true
+}
+
+private suspend fun cachePictureImage(
+    cacheFile: File,
+    folderId: String,
+    index: Int,
+    instanceLinkViewModel: InstanceLinkViewModel,
+): Boolean {
+    val bytes = instanceLinkViewModel.fetchPictureImageBytes(folderId, index)
+    if (bytes == null) {
+        InstanceLinkLogger.log(
+            InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+            mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "fetch_failed")
+        )
+        return false
+    }
+    // Temp-file + rename: this apply can be cancelled mid-write by a newer live state
+    // (collectLatest) — a truncated file must never land under the final name, or the exists()
+    // cache gate would trust it forever.
+    val tmp = File(cacheFile.parentFile, "${cacheFile.name}.tmp")
+    tmp.writeBytes(bytes)
+    if (!tmp.renameTo(cacheFile)) tmp.delete()
+    if (cacheFile.exists()) return true
+    InstanceLinkLogger.log(
+        InstanceLinkLogSide.FOLLOWER, "apply_live_state",
+        mapOf("contentType" to "PICTURES", "resolved" to false, "reason" to "cache_write_failed")
+    )
+    return false
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/SslCertificateManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/SslCertificateManager.kt
@@ -57,6 +57,8 @@ import java.util.Date
  *     Android: companion app adds it as a custom trust anchor via NetworkSecurityConfig.
  *  3. All subsequent HTTPS connections to the server are accepted without errors.
  */
+private const val CERT_RENEWAL_MARGIN_DAYS = 30L
+
 object SslCertificateManager {
 
     private val baseDir = File(System.getProperty("user.home"), ".churchpresenter").also { it.mkdirs() }
@@ -120,26 +122,43 @@ object SslCertificateManager {
 
     // ── CA generation ─────────────────────────────────────────────────────────
 
+    /** The stored CA when it is ECDSA and still valid for a month; null means regenerate. */
+    private fun reusableCA(): Pair<PrivateKey, X509Certificate>? {
+        try {
+            val ks = loadKeyStore(caKeystoreFile)
+            val key = ks.getKey(CA_ALIAS, PASSWORD) as? PrivateKey ?: return null
+            val cert = ks.getCertificate(CA_ALIAS) as? X509Certificate ?: return null
+            // Only reuse the CA if it already uses ECDSA — migrate away from old RSA keystores
+            val stillUsable = key.algorithm == "EC" &&
+                cert.notAfter.after(Date.from(Instant.now().plus(CERT_RENEWAL_MARGIN_DAYS, ChronoUnit.DAYS)))
+            return if (stillUsable) key to cert else null
+        } catch (e: Exception) {
+            System.err.println("[SslCertificateManager] Existing CA keystore unreadable, regenerating: ${e.message}")
+            CrashReporter.reportWarning(
+                "SSL: Existing CA keystore unreadable, regenerating",
+                throwable = e,
+                tags = mapOf("subsystem" to "ssl")
+            )
+            return null
+        }
+    }
+
+    /** The stored server keystore when it is ECDSA, still valid and covers [serverHost]. */
+    private fun reusableServerKeyStore(serverHost: String): KeyStore? = try {
+        val ks = loadKeyStore(serverKeystoreFile)
+        val key = ks.getKey(SERVER_ALIAS, PASSWORD) as? PrivateKey
+        val cert = ks.getCertificate(SERVER_ALIAS) as? X509Certificate
+        // Only reuse the server cert if it already uses ECDSA — migrate RSA keystores
+        val stillUsable = key != null && cert != null && key.algorithm == "EC" &&
+            cert.notAfter.after(Date.from(Instant.now().plus(CERT_RENEWAL_MARGIN_DAYS, ChronoUnit.DAYS)))
+        if (stillUsable && cert != null && serverHost in extractSanNames(cert)) ks else null
+    } catch (_: Exception) {
+        null
+    }
+
     private fun getOrCreateCA(): Pair<PrivateKey, X509Certificate> {
         if (caKeystoreFile.exists()) {
-            try {
-                val ks   = loadKeyStore(caKeystoreFile)
-                val key  = ks.getKey(CA_ALIAS, PASSWORD) as? PrivateKey
-                val cert = ks.getCertificate(CA_ALIAS) as? X509Certificate
-                // Only reuse the CA if it already uses ECDSA — migrate away from old RSA keystores
-                if (key != null && cert != null) {
-                    val stillUsable = key.algorithm == "EC" &&
-                        cert.notAfter.after(Date.from(Instant.now().plus(30, ChronoUnit.DAYS)))
-                    if (stillUsable) return key to cert
-                }
-            } catch (e: Exception) {
-                System.err.println("[SslCertificateManager] Existing CA keystore unreadable, regenerating: ${e.message}")
-                CrashReporter.reportWarning(
-                    "SSL: Existing CA keystore unreadable, regenerating",
-                    throwable = e,
-                    tags = mapOf("subsystem" to "ssl")
-                )
-            }
+            reusableCA()?.let { return it }
             caKeystoreFile.delete()
         }
 
@@ -179,17 +198,7 @@ object SslCertificateManager {
         caKey: PrivateKey, caCert: X509Certificate, serverHost: String
     ): KeyStore {
         if (serverKeystoreFile.exists()) {
-            try {
-                val ks   = loadKeyStore(serverKeystoreFile)
-                val key  = ks.getKey(SERVER_ALIAS, PASSWORD) as? PrivateKey
-                val cert = ks.getCertificate(SERVER_ALIAS) as? X509Certificate
-                // Only reuse the server cert if it already uses ECDSA — migrate RSA keystores
-                if (key != null && cert != null) {
-                    val stillUsable = key.algorithm == "EC" &&
-                        cert.notAfter.after(Date.from(Instant.now().plus(30, ChronoUnit.DAYS)))
-                    if (stillUsable && serverHost in extractSanNames(cert)) return ks
-                }
-            } catch (_: Exception) { /* fall through */ }
+            reusableServerKeyStore(serverHost)?.let { return it }
             serverKeystoreFile.delete()
         }
         return generateServerKeyStore(caKey, caCert, serverHost)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/WebSocketRoute.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/WebSocketRoute.kt
@@ -55,7 +55,11 @@ internal fun Route.webSocketRoute(
                     if (_apiKeyEnabled.value && _apiKey.value.isNotEmpty()) {
                         val provided = queryKey ?: headerKey ?: ""
                         if (provided != _apiKey.value) {
-                            InstanceLinkLogger.log(InstanceLinkLogSide.PRIMARY, "follower_unauthorized", mapOf("reason" to "bad_api_key"))
+                            InstanceLinkLogger.log(
+                                InstanceLinkLogSide.PRIMARY,
+                                "follower_unauthorized",
+                                mapOf("reason" to "bad_api_key")
+                            )
                             send(Frame.Text("{\"error\":\"Unauthorized\"}"))
                             return@webSocket
                         }
@@ -81,7 +85,11 @@ internal fun Route.webSocketRoute(
                     if (!isInstanceLinkFollower) UsageEvents.recordOncePerRun(UsageEvent.MOBILE_APP_CONNECTED)
                     if (isInstanceLinkFollower && wsClientId.isNotEmpty()) {
                         _connectedInstanceLinkFollowers.value = _connectedInstanceLinkFollowers.value + wsClientId
-                        InstanceLinkLogger.log(InstanceLinkLogSide.PRIMARY, "follower_connected", mapOf("deviceId" to wsClientId))
+                        InstanceLinkLogger.log(
+                            InstanceLinkLogSide.PRIMARY,
+                            "follower_connected",
+                            mapOf("deviceId" to wsClientId)
+                        )
                     }
 
                     // Subscribed to the server.broadcast flow BEFORE the connect snapshot is written, and
@@ -161,7 +169,11 @@ internal fun Route.webSocketRoute(
                         broadcastJob.cancel()
                         if (isInstanceLinkFollower && wsClientId.isNotEmpty()) {
                             _connectedInstanceLinkFollowers.value = _connectedInstanceLinkFollowers.value - wsClientId
-                            InstanceLinkLogger.log(InstanceLinkLogSide.PRIMARY, "follower_disconnected", mapOf("deviceId" to wsClientId))
+                            InstanceLinkLogger.log(
+                                InstanceLinkLogSide.PRIMARY,
+                                "follower_disconnected",
+                                mapOf("deviceId" to wsClientId)
+                            )
                         }
                     }
                 }
@@ -225,20 +237,33 @@ private suspend fun DefaultWebSocketServerSession.handleWsCommand(
                         scope.launch { server.onSelectPicture.emit(req) }
                         val folderName = _pictureCatalogs[req.folderId]?.folderName ?: req.folderId
                         val imageLabel = req.fileName ?: "Image ${req.index}"
-                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", folderName, imageLabel, wsClientId)) }
+                        scope.launch {
+                            server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
+                                "present", folderName, imageLabel, wsClientId
+                            ))
+                        }
                         sendCommandAck(msg.commandId, ok = true, json = json)
                     }
                     Constants.WS_CMD_SELECT_SONG_SECTION -> {
                         val req = json.decodeFromString(SelectSongSectionRequest.serializer(), msg.payload)
                         scope.launch { server.onSelectSongSection.emit(req) }
-                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", "Song ${req.number}", "Section ${req.section}", wsClientId)) }
+                        scope.launch {
+                            server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
+                                "present", "Song ${req.number}", "Section ${req.section}", wsClientId
+                            ))
+                        }
                         sendCommandAck(msg.commandId, ok = true, json = json)
                     }
                     Constants.WS_CMD_SELECT_SLIDE -> {
                         val req = json.decodeFromString(SelectSlideRequest.serializer(), msg.payload)
                         scope.launch { server.onSelectSlide.emit(req) }
-                        val presName = _presentationCatalogs[_scheduleItemToPresentationId[req.id] ?: req.id]?.fileName ?: req.id
-                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", presName, "Slide ${req.index + 1}", wsClientId)) }
+                        val presName =
+                            _presentationCatalogs[_scheduleItemToPresentationId[req.id] ?: req.id]?.fileName ?: req.id
+                        scope.launch {
+                            server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
+                                "present", presName, "Slide ${req.index + 1}", wsClientId
+                            ))
+                        }
                         sendCommandAck(msg.commandId, ok = true, json = json)
                     }
                     Constants.WS_CMD_SELECT_BIBLE_VERSE -> {
@@ -246,12 +271,20 @@ private suspend fun DefaultWebSocketServerSession.handleWsCommand(
                         scope.launch { server.onSelectBibleVerse.emit(req) }
                         val ref = if (req.verseRange.isNotEmpty()) "${req.bookName} ${req.chapter}:${req.verseRange}"
                                   else "${req.bookName} ${req.chapter}:${req.verseNumber}"
-                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("present", ref, req.verseText.take(SUMMARY_PREVIEW_CHARS), wsClientId)) }
+                        scope.launch {
+                            server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
+                                "present", ref, req.verseText.take(SUMMARY_PREVIEW_CHARS), wsClientId
+                            ))
+                        }
                         sendCommandAck(msg.commandId, ok = true, json = json)
                     }
                     Constants.WS_CMD_CLEAR -> {
                         scope.launch { server.onClear.emit(Unit) }
-                        scope.launch { server.onInstantAction.emit(CompanionServer.RemoteInstantAction("clear", "Clear Display", clientId = wsClientId)) }
+                        scope.launch {
+                            server.onInstantAction.emit(CompanionServer.RemoteInstantAction(
+                                "clear", "Clear Display", clientId = wsClientId
+                            ))
+                        }
                         sendCommandAck(msg.commandId, ok = true, json = json)
                     }
                     Constants.WS_CMD_BIBLE_HOLD -> {
@@ -430,7 +463,10 @@ private suspend fun DefaultWebSocketServerSession.sendConnectSnapshot(
     send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),
         WebSocketMessage(
             type = Constants.WS_EVENT_PRESENTATION_SLIDE_CHANGED,
-            payload = """{"id":"${server._currentPresentationId}","index":${server._currentSlideIndex},"total":${server._currentSlideTotalCount},"isPlaying":${server._presentationIsPlaying},"isLive":${server._presentationIsLive}}"""
+            payload =
+                """{"id":"${server._currentPresentationId}","index":${server._currentSlideIndex},"total":""" +
+                    """${server._currentSlideTotalCount},"isPlaying":${server._presentationIsPlaying},"isLive":""" +
+                        """${server._presentationIsLive}}"""
         ))))
     _liveState.value?.let { state ->
         send(Frame.Text(json.encodeToString(WebSocketMessage.serializer(),

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/STTTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/STTTab.kt
@@ -336,26 +336,7 @@ internal fun applyHighlighting(
     }
     // Build per-character color array then construct contiguous runs (no overlapping spans)
     val colors = Array(text.length) { baseColor }
-    for (hw in highlightedWords) {
-        if (hw.word.isBlank()) continue
-        try {
-            val highlightColor = Utils.parseHexColor(hw.color)
-            val wb = "(?<![\\p{L}\\p{N}])"
-            val we = "(?![\\p{L}\\p{N}])"
-            val rawPattern = if (hw.isRegex) {
-                "$wb(?:${hw.word})$we"
-            } else {
-                val escaped = Regex.escape(hw.word)
-                "$wb$escaped$we"
-            }
-            var flags = java.util.regex.Pattern.UNICODE_CHARACTER_CLASS
-            if (!hw.caseSensitive) flags = flags or java.util.regex.Pattern.CASE_INSENSITIVE or java.util.regex.Pattern.UNICODE_CASE
-            val regex = java.util.regex.Pattern.compile(rawPattern, flags).toRegex()
-            regex.findAll(text).forEach { match ->
-                for (j in match.range) colors[j] = highlightColor
-            }
-        } catch (_: Exception) {}
-    }
+    highlightedWords.forEach { paintWord(it, text, colors) }
     return buildAnnotatedString {
         var i = 0
         while (i < text.length) {
@@ -365,4 +346,22 @@ internal fun applyHighlighting(
             withStyle(SpanStyle(color = color)) { append(text.substring(start, i)) }
         }
     }
+}
+
+/** Paints every whole-word match of [hw] into [colors]; a pattern that won't compile is skipped. */
+private fun paintWord(hw: HighlightedWord, text: String, colors: Array<Color>) {
+    if (hw.word.isBlank()) return
+    try {
+        val highlightColor = Utils.parseHexColor(hw.color)
+        val wb = "(?<![\\p{L}\\p{N}])"
+        val we = "(?![\\p{L}\\p{N}])"
+        val rawPattern = if (hw.isRegex) "$wb(?:${hw.word})$we" else "$wb${Regex.escape(hw.word)}$we"
+        var flags = java.util.regex.Pattern.UNICODE_CHARACTER_CLASS
+        if (!hw.caseSensitive) {
+            flags = flags or java.util.regex.Pattern.CASE_INSENSITIVE or java.util.regex.Pattern.UNICODE_CASE
+        }
+        java.util.regex.Pattern.compile(rawPattern, flags).toRegex().findAll(text).forEach { match ->
+            for (j in match.range) colors[j] = highlightColor
+        }
+    } catch (_: Exception) {}
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/AutoFitUtils.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/AutoFitUtils.kt
@@ -90,41 +90,12 @@ fun calculateAutoFitForAllSections(
     while (high - low > 1) {
         val mid = (low + high) / 2
         val style = baseStyle.copy(fontSize = mid.sp)
-        var fits = true
-
-        for ((sectionIdx, section) in sections.withIndex()) {
-            // Check both primary and secondary lines so bilingual text also fits
-            val lineSets = if (section.secondaryLines.isNotEmpty())
-                listOf(section.lines, section.secondaryLines) else listOf(section.lines)
-            for (lines in lineSets.filter { it.isNotEmpty() }) {
-                val measured = lines.map {
-                    textMeasurer.measure(
-                        text = it,
-                        style = style,
-                        constraints = unconstrainedConstraints,
-                        density = referenceDensity
-                    ).size
-                }
-                var sectionHeight = measured.sumOf { it.height }
-                // Reserve space for end-of-song indicator on the last section
-                if (includeEndIndicator && sectionIdx == sections.lastIndex) {
-                    val lineHeight = textMeasurer.measure(
-                        text = "* * *",
-                        style = style,
-                        constraints = unconstrainedConstraints,
-                        density = referenceDensity
-                    ).size.height
-                    // Spacer (4px reference) + indicator line height
-                    sectionHeight += SECTION_INDICATOR_SPACER_PX + lineHeight
-                }
-                // Every line must fit on one row without wrapping, and all of them together
-                // must fit the available height
-                if (measured.any { it.width > availableWidth } || sectionHeight > effectiveHeight) {
-                    fits = false
-                    break
-                }
-            }
-            if (!fits) break
+        val fits = sections.withIndex().all { (sectionIdx, section) ->
+            sectionFits(
+                textMeasurer, section, style, unconstrainedConstraints, referenceDensity,
+                availableWidth, effectiveHeight,
+                withEndIndicator = includeEndIndicator && sectionIdx == sections.lastIndex,
+            )
         }
         if (fits) low = mid else high = mid
     }
@@ -205,4 +176,39 @@ fun calculateChordChartFontSize(
         if (fits(mid)) low = mid else high = mid - 1
     }
     return low.coerceAtLeast(MIN_AUTO_FIT_FONT_SIZE)
+}
+
+/** True when every line of [section] fits on one row and the section fits the height. */
+@Suppress("LongParameterList")
+private fun sectionFits(
+    textMeasurer: TextMeasurer,
+    section: LyricSection,
+    style: TextStyle,
+    constraints: Constraints,
+    density: Density,
+    availableWidth: Int,
+    effectiveHeight: Int,
+    withEndIndicator: Boolean,
+): Boolean {
+    // Check both primary and secondary lines so bilingual text also fits
+    val lineSets = if (section.secondaryLines.isNotEmpty()) {
+        listOf(section.lines, section.secondaryLines)
+    } else {
+        listOf(section.lines)
+    }
+    return lineSets.filter { it.isNotEmpty() }.all { lines ->
+        val measured = lines.map {
+            textMeasurer.measure(text = it, style = style, constraints = constraints, density = density).size
+        }
+        // Reserve space for end-of-song indicator on the last section: spacer + indicator height
+        val indicatorHeight = if (withEndIndicator) {
+            SECTION_INDICATOR_SPACER_PX + textMeasurer.measure(
+                text = "* * *", style = style, constraints = constraints, density = density
+            ).size.height
+        } else {
+            0
+        }
+        val sectionHeight = measured.sumOf { it.height } + indicatorHeight
+        measured.none { it.width > availableWidth } && sectionHeight <= effectiveHeight
+    }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/CrashReporter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/CrashReporter.kt
@@ -393,15 +393,14 @@ object CrashReporter {
         }
     }
 
+    private fun sentryMessage(text: String): Message = Message().apply { message = text }
+
     private fun sendToSentry(throwable: Throwable, context: String, fatal: Boolean) {
         try {
             if (!Sentry.isEnabled()) return
-            val event = SentryEvent(throwable).apply {
-                level = if (fatal) SentryLevel.FATAL else SentryLevel.ERROR
-                if (context.isNotBlank()) {
-                    message = Message().apply { message = context }
-                }
-            }
+            val event = SentryEvent(throwable)
+            event.level = if (fatal) SentryLevel.FATAL else SentryLevel.ERROR
+            if (context.isNotBlank()) event.message = sentryMessage(context)
             Sentry.captureEvent(event)
         } catch (_: Exception) {
             // Never let Sentry errors surface to the user

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelLoading.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelLoading.kt
@@ -126,7 +126,12 @@ internal fun BibleViewModel.setInstanceLinkSource(
             if (bytes == null) {
                 InstanceLinkLogger.log(
                     InstanceLinkLogSide.FOLLOWER, "bible_sync_result",
-                    mapOf("mode" to mode.name, "primaryDownloaded" to false, "secondaryDownloaded" to false, "reason" to "primary_fetch_failed")
+                    mapOf(
+                        "mode" to mode.name,
+                        "primaryDownloaded" to false,
+                        "secondaryDownloaded" to false,
+                        "reason" to "primary_fetch_failed"
+                    )
                 )
                 return@launch
             }
@@ -154,7 +159,11 @@ internal fun BibleViewModel.setInstanceLinkSource(
 
         InstanceLinkLogger.log(
             InstanceLinkLogSide.FOLLOWER, "bible_sync_result",
-            mapOf("mode" to mode.name, "primaryDownloaded" to primaryDownloaded, "secondaryDownloaded" to secondaryDownloaded)
+            mapOf(
+                "mode" to mode.name,
+                "primaryDownloaded" to primaryDownloaded,
+                "secondaryDownloaded" to secondaryDownloaded
+            )
         )
         loadBibles()
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelSelection.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelSelection.kt
@@ -10,15 +10,19 @@ import org.churchpresenter.app.churchpresenter.models.SelectedVerse
  */
 
 internal fun BibleViewModel.getSelectedVerses(): List<SelectedVerse> {
-    val verseList = mutableListOf<SelectedVerse>()
-
-    if (_verses.value.isEmpty()) {
-        return verseList
-    }
+    if (_verses.value.isEmpty()) return emptyList()
 
     val bookId = _primaryBible.value?.getBookId(_selectedBookIndex.value) ?: (_selectedBookIndex.value + 1)
+    return if (_multiVerseEnabled.value && _selectedVerseIndices.isNotEmpty()) {
+        multiVerseSelection(bookId)
+    } else {
+        singleVerseSelection(bookId)
+    }
+}
 
-    if (_multiVerseEnabled.value && _selectedVerseIndices.isNotEmpty()) {
+/** Ctrl/Shift-selected verses, joined into one primary entry plus one per parallel translation. */
+private fun BibleViewModel.multiVerseSelection(bookId: Int): List<SelectedVerse> {
+    val verseList = mutableListOf<SelectedVerse>()
         val sortedIndices = _selectedVerseIndices.sorted()
         val primaryTexts = mutableListOf<String>()
         val parallelTexts = _loadedBibles.value.drop(1).map { mutableListOf<String>() }
@@ -86,8 +90,12 @@ internal fun BibleViewModel.getSelectedVerses(): List<SelectedVerse> {
                 )
             )
         }
-        return verseList
-    }
+    return verseList
+}
+
+/** The single selected verse, with the same verse from every other loaded translation. */
+private fun BibleViewModel.singleVerseSelection(bookId: Int): List<SelectedVerse> {
+    val verseList = mutableListOf<SelectedVerse>()
 
     val safeIndex = _selectedVerseIndex.value.coerceIn(0, _verses.value.size - 1)
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/STTManager.kt
@@ -353,6 +353,26 @@ class STTManager {
      * comes up. `internal` rather than private for the same reason as the `handle*Update` parsers:
      * in production it is only reachable from a socket callback, and it is plain HTTP otherwise.
      */
+    /** The enabled highlighted words in the payload; words in a disabled colour group are dropped. */
+    private fun highlightedWordsFrom(json: JSONObject): List<HighlightedWord> {
+        val disabledArray = json.optJSONArray("disabled_colors")
+        val disabledColors = (0 until (disabledArray?.length() ?: 0))
+            .map { disabledArray!!.stringOr(it) }
+            .toSet()
+        val wordsArray = json.optJSONArray("words") ?: return emptyList()
+        return (0 until wordsArray.length())
+            .map { wordsArray.getJSONObject(it) }
+            .filter { it.stringOr("color", "#ffff00") !in disabledColors }
+            .map { w ->
+                HighlightedWord(
+                    word = w.stringOr("word"),
+                    color = w.stringOr("color", "#ffff00"),
+                    caseSensitive = w.optBoolean("case_sensitive", false),
+                    isRegex = w.optBoolean("is_regex", false)
+                )
+            }
+    }
+
     internal fun fetchWordHighlighting(baseUrl: String) {
         try {
             val client = HttpClient.newHttpClient()
@@ -361,40 +381,14 @@ class STTManager {
                 .GET()
                 .build()
             val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-            if (response.statusCode() == HTTP_OK) {
-                val json = JSONObject(response.body())
-                if (json.optBoolean("success", false)) {
-                    // Collect disabled color groups to filter them out
-                    val disabledColors = mutableSetOf<String>()
-                    val disabledArray = json.optJSONArray("disabled_colors")
-                    if (disabledArray != null) {
-                        for (i in 0 until disabledArray.length()) {
-                            disabledColors.add(disabledArray.stringOr(i))
-                        }
-                    }
-
-                    scope.launch {
-                        _wordHighlightingEnabled.value = json.optBoolean("enabled", true)
-                        val wordsArray = json.optJSONArray("words")
-                        _highlightedWords.clear()
-                        if (wordsArray != null) {
-                            for (i in 0 until wordsArray.length()) {
-                                val w = wordsArray.getJSONObject(i)
-                                val color = w.stringOr("color", "#ffff00")
-                                // Skip words whose color group is disabled
-                                if (color in disabledColors) continue
-                                _highlightedWords.add(
-                                    HighlightedWord(
-                                        word = w.stringOr("word"),
-                                        color = color,
-                                        caseSensitive = w.optBoolean("case_sensitive", false),
-                                        isRegex = w.optBoolean("is_regex", false)
-                                    )
-                                )
-                            }
-                        }
-                    }
-                }
+            if (response.statusCode() != HTTP_OK) return
+            val json = JSONObject(response.body())
+            if (!json.optBoolean("success", false)) return
+            val words = highlightedWordsFrom(json)
+            scope.launch {
+                _wordHighlightingEnabled.value = json.optBoolean("enabled", true)
+                _highlightedWords.clear()
+                _highlightedWords.addAll(words)
             }
         } catch (_: Exception) {
             // Silently ignore — highlighting is optional

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
@@ -357,38 +357,34 @@ class ScheduleViewModel(
             title = dialogTitle,
             selectDirectory = false
         )
-        if (file != null) {
-            if (file.exists()) {
-                try {
-                    val raw = file.readText()
-                    val jsonText = try { decrypt(raw) } catch (_: Exception) { raw }
-                    // Try new format (v2 with notes), fall back to legacy plain array
-                    val (items, notes) = try {
-                        val schedFile = json.decodeFromString(ScheduleFileV2.serializer(), jsonText)
-                        Pair(schedFile.items, schedFile.notes)
-                    } catch (_: Exception) {
-                        Pair(
-                            json.decodeFromString(ListSerializer(ScheduleItem.serializer()), jsonText),
-                            emptyMap()
-                        )
-                    }
-                    _scheduleItems.clear()
-                    _scheduleItems.addAll(items)
-                    _notes.clear()
-                    _notes.putAll(notes)
-                    currentFilePath = file.absolutePathString()
-                    undoStack.clear()
-                    redoStack.clear()
-                    _canUndo.value = false
-                    _canRedo.value = false
-                    clearAutoSave()
-                    notifyChanged()
-                    CrashReporter.breadcrumb("Schedule opened (${file.fileName}, ${items.size} items)", category = "schedule")
-                } catch (e: Exception) {
-                    CrashReporter.reportException(e, "Opening schedule file")
-                }
-            }
+        if (file == null || !file.exists()) return
+        try {
+            val raw = file.readText()
+            val jsonText = try { decrypt(raw) } catch (_: Exception) { raw }
+            val (items, notes) = decodeSchedule(jsonText)
+            _scheduleItems.clear()
+            _scheduleItems.addAll(items)
+            _notes.clear()
+            _notes.putAll(notes)
+            currentFilePath = file.absolutePathString()
+            undoStack.clear()
+            redoStack.clear()
+            _canUndo.value = false
+            _canRedo.value = false
+            clearAutoSave()
+            notifyChanged()
+            CrashReporter.breadcrumb("Schedule opened (${file.fileName}, ${items.size} items)", category = "schedule")
+        } catch (e: Exception) {
+            CrashReporter.reportException(e, "Opening schedule file")
         }
+    }
+
+    /** Try new format (v2 with notes), fall back to legacy plain array. */
+    private fun decodeSchedule(jsonText: String): Pair<List<ScheduleItem>, Map<String, String>> = try {
+        val schedFile = json.decodeFromString(ScheduleFileV2.serializer(), jsonText)
+        schedFile.items to schedFile.notes
+    } catch (_: Exception) {
+        json.decodeFromString(ListSerializer(ScheduleItem.serializer()), jsonText) to emptyMap()
     }
 
     /** Clears the schedule and forgets the current file path. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/SongsViewModel.kt
@@ -739,61 +739,53 @@ class SongsViewModel(
         }
     }
 
-    private fun refreshFilteredSongItems() {
-        var items = _filteredSongsList.value
-
-        if (_sortColumn.value.isNotEmpty()) {
-            items = when (_sortColumn.value) {
-                Constants.SORT_NUMBER -> if (_sortAscending.value)
-                    items.sortedBy { it.number.toIntOrNull() ?: Int.MAX_VALUE }
-                else
-                    items.sortedByDescending { it.number.toIntOrNull() ?: Int.MIN_VALUE }
-
-                Constants.SORT_TITLE -> if (_sortAscending.value)
-                    items.sortedBy { it.title.lowercase() }
-                else
-                    items.sortedByDescending { it.title.lowercase() }
-
-                Constants.SORT_SONGBOOK -> if (_sortAscending.value)
-                    items.sortedBy { it.songbook.lowercase() }
-                else
-                    items.sortedByDescending { it.songbook.lowercase() }
-
-                Constants.SORT_TUNE -> if (_sortAscending.value)
-                    items.sortedBy { it.tune.lowercase() }
-                else
-                    items.sortedByDescending { it.tune.lowercase() }
-
-                Constants.SORT_PLAY_COUNT -> {
-                    val sm = statisticsManager
-                    if (sm != null) {
-                        val counts = items.associate { it.songId to sm.getSongPlayCount(it.songId) }
-                        if (_sortAscending.value) items.sortedBy { counts[it.songId] ?: 0 }
-                        else items.sortedByDescending { counts[it.songId] ?: 0 }
-                    } else items
-                }
-
-                Constants.SORT_FAVORITES -> {
-                    val favIds = _favorites.value
-                    if (_sortAscending.value)
-                        items.sortedBy { if (it.songId in favIds) 0 else 1 }
-                    else
-                        items.sortedByDescending { if (it.songId in favIds) 0 else 1 }
-                }
-
-                Constants.SORT_AUTHOR -> if (_sortAscending.value)
-                    items.sortedBy { it.author.lowercase() }
-                else
-                    items.sortedByDescending { it.author.lowercase() }
-
-                Constants.SORT_COMPOSER -> if (_sortAscending.value)
-                    items.sortedBy { it.composer.lowercase() }
-                else
-                    items.sortedByDescending { it.composer.lowercase() }
-
-                else -> items
-            }
+    /** [items] in the order [column] asks for; the sort itself, without the selection bookkeeping. */
+    private fun sortedBy(column: String, items: List<SongItem>): List<SongItem> = when (column) {
+        Constants.SORT_NUMBER -> if (_sortAscending.value)
+            items.sortedBy { it.number.toIntOrNull() ?: Int.MAX_VALUE }
+        else
+            items.sortedByDescending { it.number.toIntOrNull() ?: Int.MIN_VALUE }
+        Constants.SORT_TITLE -> if (_sortAscending.value)
+            items.sortedBy { it.title.lowercase() }
+        else
+            items.sortedByDescending { it.title.lowercase() }
+        Constants.SORT_SONGBOOK -> if (_sortAscending.value)
+            items.sortedBy { it.songbook.lowercase() }
+        else
+            items.sortedByDescending { it.songbook.lowercase() }
+        Constants.SORT_TUNE -> if (_sortAscending.value)
+            items.sortedBy { it.tune.lowercase() }
+        else
+            items.sortedByDescending { it.tune.lowercase() }
+        Constants.SORT_PLAY_COUNT -> {
+            val sm = statisticsManager
+            if (sm != null) {
+                val counts = items.associate { it.songId to sm.getSongPlayCount(it.songId) }
+                if (_sortAscending.value) items.sortedBy { counts[it.songId] ?: 0 }
+                else items.sortedByDescending { counts[it.songId] ?: 0 }
+            } else items
         }
+        Constants.SORT_FAVORITES -> {
+            val favIds = _favorites.value
+            if (_sortAscending.value)
+                items.sortedBy { if (it.songId in favIds) 0 else 1 }
+            else
+                items.sortedByDescending { if (it.songId in favIds) 0 else 1 }
+        }
+        Constants.SORT_AUTHOR -> if (_sortAscending.value)
+            items.sortedBy { it.author.lowercase() }
+        else
+            items.sortedByDescending { it.author.lowercase() }
+        Constants.SORT_COMPOSER -> if (_sortAscending.value)
+            items.sortedBy { it.composer.lowercase() }
+        else
+            items.sortedByDescending { it.composer.lowercase() }
+        else -> items
+    }
+
+    private fun refreshFilteredSongItems() {
+        val unsorted = _filteredSongsList.value
+        val items = if (_sortColumn.value.isEmpty()) unsorted else sortedBy(_sortColumn.value, unsorted)
 
         _filteredSongItems.value = items
         // A re-sort leaves _selectedSongIndex where it was, so a different song — with a different
@@ -809,6 +801,37 @@ class SongsViewModel(
         }
     }
 
+    /**
+     * Moves the .song file when the songbook, title or number changed, and returns the song with
+     * its new path — or null when nothing had to move.
+     */
+    private fun moveSongFile(oldSong: SongItem, newSong: SongItem, storageDir: String): SongItem? {
+        val oldFile = File(oldSong.sourceFile)
+        if (!oldFile.exists()) return null
+        val songbookChanged = oldSong.songbook != newSong.songbook
+        val titleChanged = oldSong.title != newSong.title
+        val numberChanged = oldSong.number != newSong.number
+        if (!songbookChanged && !titleChanged && !numberChanged) return null
+
+        val targetDir = if (songbookChanged) File(storageDir, newSong.songbook) else oldFile.parentFile
+        if (!targetDir.exists()) targetDir.mkdirs()
+        val newFileName = if (titleChanged || numberChanged) {
+            buildSongFileName(newSong.number, newSong.title)
+        } else {
+            oldFile.name
+        }
+
+        val newFile = File(targetDir, newFileName)
+        oldFile.copyTo(newFile, overwrite = true)
+        if (oldFile.absolutePath != newFile.absolutePath) oldFile.delete()
+        if (songbookChanged) deleteIfEmpty(oldFile.parentFile)
+        return newSong.copy(sourceFile = newFile.absolutePath)
+    }
+
+    private fun deleteIfEmpty(dir: File?) {
+        if (dir != null && dir.isDirectory && dir.listFiles()?.isEmpty() == true) dir.delete()
+    }
+
     fun updateSong(
         oldSong: SongItem,
         newSong: SongItem
@@ -820,41 +843,7 @@ class SongsViewModel(
 
             // Handle .song file moves/renames when songbook, title, or number change
             if (oldSong.sourceFile.isNotEmpty() && storageDir.isNotEmpty()) {
-                val oldFile = File(oldSong.sourceFile)
-                if (oldFile.exists()) {
-                    val songbookChanged = oldSong.songbook != newSong.songbook
-                    val titleChanged = oldSong.title != newSong.title
-                    val numberChanged = oldSong.number != newSong.number
-
-                    if (songbookChanged || titleChanged || numberChanged) {
-                        val targetDir = if (songbookChanged) {
-                            File(storageDir, newSong.songbook)
-                        } else {
-                            oldFile.parentFile
-                        }
-                        if (!targetDir.exists()) targetDir.mkdirs()
-
-                        val newFileName = if (titleChanged || numberChanged) {
-                            buildSongFileName(newSong.number, newSong.title)
-                        } else {
-                            oldFile.name
-                        }
-
-                        val newFile = File(targetDir, newFileName)
-                        oldFile.copyTo(newFile, overwrite = true)
-                        if (oldFile.absolutePath != newFile.absolutePath) {
-                            oldFile.delete()
-                        }
-                        // Clean up empty old directory
-                        if (songbookChanged) {
-                            val oldDir = oldFile.parentFile
-                            if (oldDir != null && oldDir.isDirectory && oldDir.listFiles()?.isEmpty() == true) {
-                                oldDir.delete()
-                            }
-                        }
-                        songToSave = newSong.copy(sourceFile = newFile.absolutePath)
-                    }
-                }
+                songToSave = moveSongFile(oldSong, newSong, storageDir) ?: songToSave
             }
 
             // Update in memory

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -46,7 +46,8 @@ complexity:
   LargeClass:
     active: false
   NestedBlockDepth:
-    active: false
+    active: true
+    ignoreAnnotated: ['Composable']
 
 naming:
   TopLevelPropertyNaming:


### PR DESCRIPTION
Extracted complex inline logic into focused helpers across camera/browser capture, Bible and song parsing, STT highlighting, ATEM transfer handling, remote picture apply, and schedule/song view model flows. This reduces nesting and duplication while preserving behavior and existing logging/error handling. Detekt’s NestedBlockDepth rule is now enabled with `@Composable` ignored, aligning the codebase with stricter complexity checks.