### PR TITLE
Fall back when a picture will not decode, and when the home directory is unusable

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/SettingsManager.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.decodeFromString
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.data.settings.AppSettings.Companion.CURRENT_SETTINGS_VERSION
 import org.churchpresenter.app.churchpresenter.data.settings.ScreenAssignment
+import org.churchpresenter.app.churchpresenter.utils.AppDataDir
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -27,8 +28,7 @@ private const val VERSION_SCREEN_ASSIGNMENTS = 6
 private val CompanionSurfacePlacementPrefixes = listOf("tab", "leftSidebar", "rightSidebar")
 
 class SettingsManager {
-    private val userHome = System.getProperty("user.home")
-    private val appDataDir = File(userHome, ".churchpresenter")
+    private val appDataDir = AppDataDir.resolve()
     private val settingsFile = File(appDataDir, "settings.json")
     private val settingsTmpFile = File(appDataDir, "settings.json.tmp")
     val lottiePresetsDir: File = File(appDataDir, "lottie_presets")

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -106,6 +106,7 @@ import org.churchpresenter.app.churchpresenter.viewmodel.CompanionSatelliteViewM
 import org.churchpresenter.app.churchpresenter.viewmodel.InstanceLinkViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.STTManager
 import org.churchpresenter.app.churchpresenter.ui.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppDataDir
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
 import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
@@ -198,7 +199,7 @@ fun main() {
 
     if (shouldBundleDefaultBible(startupSettings.bibleSettings)) {
         try {
-            val defaultBibleDir = File(System.getProperty("user.home"), Constants.DEFAULT_BIBLES_DIR)
+            val defaultBibleDir = File(AppDataDir.resolve(), Constants.DEFAULT_BIBLES_FOLDER)
             defaultBibleDir.mkdirs()
             val targetFile = File(defaultBibleDir, "kjv1769.spb")
             if (!targetFile.exists()) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PicturePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PicturePresenter.kt
@@ -154,7 +154,6 @@ private fun ImageContent(currentImagePath: String?) {
     }
 }
 
-
 internal fun loadAndDownscaleImage(imagePath: String, maxWidth: Int = 1920, maxHeight: Int = 1080): ImageBitmap? {
     return try {
         val file = File(imagePath)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PicturePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PicturePresenter.kt
@@ -29,7 +29,7 @@ import org.jetbrains.skia.Image
 import java.io.File
 import org.churchpresenter.app.churchpresenter.models.AnimationType
 import org.churchpresenter.app.churchpresenter.utils.Constants
-import org.churchpresenter.app.churchpresenter.utils.HeicDecoder
+import org.churchpresenter.app.churchpresenter.utils.PictureDecoder
 import org.churchpresenter.app.churchpresenter.utils.CrashReporter
 
 /** The white key-output's alpha for [PicturePresenter]/[SlidePresenter] — a slide's own translation
@@ -154,24 +154,13 @@ private fun ImageContent(currentImagePath: String?) {
     }
 }
 
-private fun decodePictureBytes(file: File): Image? = try {
-    Image.makeFromEncoded(file.readBytes())
-} catch (_: Exception) {
-    // A HEIC/HEIF that Skia cannot read is transcoded to JPEG first
-    if (file.extension.lowercase() in listOf("heic", "heif")) decodeHeic(file) else null
-}
-
-private fun decodeHeic(file: File): Image? {
-    val jpegBytes = HeicDecoder.toJpegBytes(file) ?: return null
-    return try { Image.makeFromEncoded(jpegBytes) } catch (_: Exception) { null }
-}
 
 internal fun loadAndDownscaleImage(imagePath: String, maxWidth: Int = 1920, maxHeight: Int = 1080): ImageBitmap? {
     return try {
         val file = File(imagePath)
         if (!file.exists()) return null
 
-        val originalImage = decodePictureBytes(file) ?: return null
+        val originalImage = PictureDecoder.decodeOrNull(file) ?: return null
 
         // Cap at actual screen resolution — no point storing more pixels than the display can show
         val widthScale = maxWidth.toFloat() / originalImage.width

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/AppDataDir.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/AppDataDir.kt
@@ -1,0 +1,86 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import java.io.File
+
+/**
+ * Where the app keeps everything it persists — settings, the bundled Bible, presets.
+ *
+ * This is `~/.churchpresenter` on every machine where the home directory is usable, which is very
+ * nearly all of them. It is not universally usable: a Windows profile that is redirected, roaming
+ * or simply absent leaves `user.home` pointing at a path that cannot be created, and the first
+ * thing to notice was the startup step that writes the bundled KJV out — it failed with a bare
+ * `FileNotFoundException (The system cannot find the path specified)` and the user started with no
+ * Bible at all. `mkdirs()` had already returned false unnoticed; the write is simply where the
+ * missing directory finally surfaced.
+ *
+ * So the location is *resolved* rather than assumed: the first candidate that can actually be
+ * created and written to wins, and the platform's own application-data folder stands behind the
+ * home directory. Settings resolve through here too, so a machine that falls back keeps its
+ * settings and its Bibles together and finds them again on the next launch — the resolution is
+ * deterministic, not remembered anywhere.
+ *
+ * Nothing is cached: the result is recomputed per call so that a test swapping `user.home` is
+ * honoured, rather than latching onto whichever directory the first caller happened to see.
+ *
+ * `WebsitePresenter` resolves its own root by the same principle for a different reason (it
+ * prefers `%ProgramData%` for the JCEF cache), and `CrashReporter` deliberately latches its
+ * directory once per JVM. Neither goes through here.
+ */
+object AppDataDir {
+
+    /** The home-relative name, kept for the overwhelmingly common case. */
+    private const val HOME_FOLDER = ".churchpresenter"
+
+    /** The name used under a platform application-data folder, where a dotfile would be odd. */
+    private const val APP_FOLDER = "ChurchPresenter"
+
+    /**
+     * The folder to persist into, created if it did not exist.
+     *
+     * Falls back to [homeCandidate] when nothing is usable, so a machine that can write nowhere
+     * fails exactly as it did before — at the write, with the path it tried to use in the message.
+     */
+    fun resolve(
+        homeDir: String? = System.getProperty("user.home"),
+        osName: String = System.getProperty("os.name", ""),
+        tempDir: String? = System.getProperty("java.io.tmpdir"),
+        env: (String) -> String? = { System.getenv(it) }
+    ): File {
+        val candidates = candidates(homeDir, osName, tempDir, env)
+        return candidates.firstOrNull { isUsable(it) } ?: candidates.first()
+    }
+
+    private fun candidates(
+        homeDir: String?,
+        osName: String,
+        tempDir: String?,
+        env: (String) -> String?
+    ): List<File> {
+        val home = homeCandidate(homeDir)
+        val platform = if (osName.lowercase().contains("win")) {
+            listOfNotNull(env("LOCALAPPDATA"), env("APPDATA"))
+        } else {
+            listOfNotNull(
+                env("XDG_DATA_HOME"),
+                homeDir?.let { File(it, ".local/share").path }
+            )
+        }
+        val fallbacks = (platform + listOfNotNull(tempDir)).map { File(it, APP_FOLDER) }
+        return listOf(home) + fallbacks
+    }
+
+    /** The preferred location, whether or not it can be created. */
+    private fun homeCandidate(homeDir: String?): File = File(homeDir ?: ".", HOME_FOLDER)
+
+    /**
+     * Whether [directory] can be written to, creating it if needed.
+     *
+     * `canWrite` on its own is not enough — the directory has to exist first for the answer to
+     * mean anything — and `mkdirs` on its own is not enough either, because a directory can be
+     * created inside a folder the process may not write files into.
+     */
+    private fun isUsable(directory: File): Boolean = runCatching {
+        directory.mkdirs()
+        directory.isDirectory && directory.canWrite()
+    }.getOrDefault(false)
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
@@ -208,9 +208,10 @@ object Constants {
     const val LANGUAGE_INTERFACE = "Interface"
     const val LANGUAGE_DATABASE = "Database"
 
-    // Default Bible storage folder, relative to the user's home directory. Seeded on first run
-    // and used as the fallback target when a download is started before a folder has been picked.
-    /** The Bibles folder, relative to the app data directory `AppDataDir` resolves. */
+    /**
+     * The Bibles folder, relative to the app data directory [AppDataDir] resolves. Seeded with the
+     * bundled KJV on first run.
+     */
     const val DEFAULT_BIBLES_FOLDER = "Bibles"
 
     // How many translations the parallel Bible stack may hold. Full screen gives each one an equal

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/Constants.kt
@@ -210,7 +210,8 @@ object Constants {
 
     // Default Bible storage folder, relative to the user's home directory. Seeded on first run
     // and used as the fallback target when a download is started before a folder has been picked.
-    const val DEFAULT_BIBLES_DIR = ".churchpresenter/Bibles"
+    /** The Bibles folder, relative to the app data directory `AppDataDir` resolves. */
+    const val DEFAULT_BIBLES_FOLDER = "Bibles"
 
     // How many translations the parallel Bible stack may hold. Full screen gives each one an equal
     // band of the output height, and auto-fit shrinks the text until it fits its band -- with no

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/PictureDecoder.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/PictureDecoder.kt
@@ -1,0 +1,102 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import org.jetbrains.skia.Image
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.imageio.ImageIO
+
+/**
+ * Decodes a picture file into a Skia [Image], falling back when Skia's own decoders reject it.
+ *
+ * `Image.makeFromEncoded` covers the common web formats and nothing else, and it fails with the
+ * same opaque `Failed to Image::makeFromEncoded` whatever the reason — so before this existed a
+ * folder holding an ordinary photo could show a permanently failed tile. Three cases reach it in
+ * practice:
+ *
+ * - **A JPEG Skia will not read.** CMYK/YCCK JPEGs out of print workflows are the usual one; the
+ *   TwelveMonkeys `imageio-jpeg` reader on the classpath reads them.
+ * - **A HEIC/HEIF carrying a `.jpg`/`.jpeg` name.** Phone exports and chat apps rename freely, so
+ *   the HEIC path is chosen by sniffing the `ftyp` box rather than by extension.
+ * - **A format only ImageIO knows**, TIFF being the one that turns up in picture folders.
+ *
+ * The fallbacks re-encode, so they cost a full extra decode — they run only after Skia has already
+ * refused the file.
+ */
+object PictureDecoder {
+
+    /** Decodes [file], or throws with the reason Skia gave. */
+    fun decode(file: File): Image {
+        val bytes = file.readBytes()
+
+        val skiaError = try {
+            return Image.makeFromEncoded(bytes)
+        } catch (e: Exception) {
+            e
+        }
+
+        if (isHeif(bytes) || file.extension.lowercase() in HEIF_EXTENSIONS) {
+            HeicDecoder.toJpegBytes(file)?.let { jpeg ->
+                runCatching { return Image.makeFromEncoded(jpeg) }
+            }
+        }
+
+        transcodeWithImageIO(bytes)?.let { png ->
+            runCatching { return Image.makeFromEncoded(png) }
+        }
+
+        throw Exception("Failed to decode image ${file.name}: ${skiaError.message}", skiaError)
+    }
+
+    /** Decodes [file], or returns null if none of the decoders could read it. */
+    fun decodeOrNull(file: File): Image? = try {
+        decode(file)
+    } catch (_: Exception) {
+        null
+    }
+
+    /**
+     * Re-encodes [bytes] as PNG through ImageIO, or returns null if ImageIO cannot read it either.
+     *
+     * The intermediate is drawn into an ARGB image rather than written straight out: ImageIO hands
+     * back whatever colour model the file used — CMYK rasters and indexed TIFFs among them — and
+     * the PNG writer refuses several of those.
+     */
+    internal fun transcodeWithImageIO(bytes: ByteArray): ByteArray? = try {
+        ImageIO.read(ByteArrayInputStream(bytes))?.let { source ->
+            val argb = BufferedImage(source.width, source.height, BufferedImage.TYPE_INT_ARGB)
+            val graphics = argb.createGraphics()
+            try {
+                graphics.drawImage(source, 0, 0, null)
+            } finally {
+                graphics.dispose()
+            }
+            ByteArrayOutputStream().also { ImageIO.write(argb, "png", it) }.toByteArray()
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    /**
+     * Whether [bytes] is an ISO-BMFF file holding HEIF imagery, read from its `ftyp` box.
+     *
+     * The extension is not enough — a HEIC arriving as `photo.jpeg` is routine — and the brand is
+     * what distinguishes one from the MP4s that share the container.
+     */
+    internal fun isHeif(bytes: ByteArray): Boolean {
+        if (bytes.size < BRAND_OFFSET + FOUR_CC_LENGTH) return false
+        val box = String(bytes, BOX_TYPE_OFFSET, FOUR_CC_LENGTH, Charsets.US_ASCII)
+        if (box != "ftyp") return false
+        return String(bytes, BRAND_OFFSET, FOUR_CC_LENGTH, Charsets.US_ASCII).lowercase() in HEIF_BRANDS
+    }
+
+    /** An ISO-BMFF box opens with a four-byte length, then its four-character type, then its brand. */
+    private const val FOUR_CC_LENGTH = 4
+    private const val BOX_TYPE_OFFSET = 4
+    private const val BRAND_OFFSET = 8
+
+    private val HEIF_EXTENSIONS = setOf("heic", "heif")
+
+    private val HEIF_BRANDS = setOf("heic", "heix", "hevc", "hevx", "heim", "heis", "mif1", "msf1")
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
@@ -181,6 +181,26 @@ class PicturesViewModel(
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var watchJob: Job? = null
 
+    /**
+     * Guards every structural change to [_images], and any index read taken in order to make one.
+     *
+     * The list is a [androidx.compose.runtime.snapshots.SnapshotStateList], which makes a write
+     * visible to composition but does not make one atomic against another thread. Writers arrive
+     * from three directions: the caller's thread ([loadImagesFromFolder], [clearImages],
+     * [moveImage]), the download coroutine in [loadPictureFromRemote], and the folder watcher.
+     * More than one watcher can be live at a time — [selectFolder] cancels the previous watch job
+     * and refills the list immediately, but cancellation is cooperative, so the outgoing watcher
+     * can still be inside `pollEvents()` working through a batch of events against a list that has
+     * already been emptied and repopulated underneath it.
+     *
+     * `indexOf` followed by `removeAt(index)` is the shape that fails: the index is read, the list
+     * shrinks, and the removal throws `IndexOutOfBoundsException` from the folder watcher — where
+     * nothing catches it. It took CI red intermittently (run 31793721082 on `main`, and again on
+     * PR #298) as `index: 5, size: 5`, blamed on whichever screenshot test happened to be running
+     * when a previous test's leaked watcher woke up.
+     */
+    private val imagesLock = Any()
+
     private val imageExtensions = listOf("jpg", "jpeg", "png", "gif", "bmp", "webp", "heic", "heif")
 
     init {
@@ -214,7 +234,9 @@ class PicturesViewModel(
 
         // Add only files not already present so a re-entrant/repeated load stays idempotent — a
         // duplicate path in _images would crash the LazyVerticalGrid keyed by absolutePath.
-        _images.addAll(imageFiles.filter { it !in _images })
+        synchronized(imagesLock) {
+            _images.addAll(imageFiles.filter { it !in _images })
+        }
 
         // Load thumbnails in background
         scope.launch {
@@ -261,7 +283,7 @@ class PicturesViewModel(
                     }
                 }
                 if (cached) {
-                    _images.add(cacheFile)
+                    synchronized(imagesLock) { _images.add(cacheFile) }
                     decodeThumbnail(cacheFile)
                     presenterManager?.let { syncWithPresenter(it) }
                 }
@@ -272,7 +294,7 @@ class PicturesViewModel(
     fun clearImages() {
         watchJob?.cancel()
         watchJob = null
-        _images.clear()
+        synchronized(imagesLock) { _images.clear() }
         _thumbnails.clear()
         _thumbnailFailures.clear()
         _selectedImageIndex.value = 0
@@ -319,12 +341,21 @@ class PicturesViewModel(
 
     fun moveImage(from: Int, to: Int) {
         if (from == to) return
-        if (from !in _images.indices || to !in _images.indices) return
         val currentFile = getCurrentImageFile()
-        _images.add(to, _images.removeAt(from))
+        // Both indices are re-checked under the lock: a watcher can remove a file between the
+        // caller reading these positions off the grid and the move landing.
+        val moved = synchronized(imagesLock) {
+            if (from !in _images.indices || to !in _images.indices) {
+                false
+            } else {
+                _images.add(to, _images.removeAt(from))
+                true
+            }
+        }
+        if (!moved) return
         _imageOrderVersion.value++
         currentFile?.let { file ->
-            val newIndex = _images.indexOf(file)
+            val newIndex = synchronized(imagesLock) { _images.indexOf(file) }
             if (newIndex >= 0) _selectedImageIndex.value = newIndex
         }
     }
@@ -333,12 +364,8 @@ class PicturesViewModel(
         _isPlaying.value = !_isPlaying.value
     }
 
-    fun getCurrentImageFile(): File? {
-        return if (_selectedImageIndex.value in _images.indices) {
-            _images[_selectedImageIndex.value]
-        } else {
-            null
-        }
+    fun getCurrentImageFile(): File? = synchronized(imagesLock) {
+        _images.getOrNull(_selectedImageIndex.value)
     }
 
     /**
@@ -496,30 +523,44 @@ class PicturesViewModel(
         else -> false
     }
 
-    private fun CoroutineScope.addWatchedImage(file: File): Boolean {
+    internal fun CoroutineScope.addWatchedImage(file: File): Boolean {
         // isActive gates the add: cancellation is cooperative, so a watcher cancelled by
         // clearImages() can still be mid-pollEvents() here — an add now would land in _images
         // after the reload and duplicate a path.
-        val isNewImageFile = file.exists() && file.isFile && file !in _images
-        if (!isActive || !isNewImageFile) return false
-        // Insert in sorted order, keep selected image stable
-        val insertIndex = _images.indexOfFirst { it.name > file.name }
-        if (insertIndex >= 0) {
-            _images.add(insertIndex, file)
-            if (insertIndex <= _selectedImageIndex.value) _selectedImageIndex.value++
-        } else {
-            _images.add(file)
-        }
+        if (!isActive || !file.exists() || !file.isFile) return false
+        // Insert in sorted order, keep the selected image stable. The membership test belongs under
+        // the same lock as the insert: apart, it is a check-then-act, and a duplicate path in
+        // _images crashes the LazyVerticalGrid keyed by absolutePath. Null means "already there".
+        val insertedAt: Int = synchronized(imagesLock) {
+            if (file in _images) {
+                null
+            } else {
+                val insertIndex = _images.indexOfFirst { it.name > file.name }
+                if (insertIndex >= 0) _images.add(insertIndex, file) else _images.add(file)
+                insertIndex
+            }
+        } ?: return false
+        if (insertedAt >= 0 && insertedAt <= _selectedImageIndex.value) _selectedImageIndex.value++
         // A file copied into a watched folder is seen the moment it is created, usually before it
         // is fully written, so the first decode of it legitimately fails.
         launch { decodeThumbnail(file, attempts = THUMBNAIL_RETRY_ATTEMPTS) }
         return true
     }
 
-    private fun removeWatchedImage(file: File): Boolean {
-        val idx = _images.indexOf(file)
+    internal fun CoroutineScope.removeWatchedImage(file: File): Boolean {
+        // The same gate, and for the same reason, as addWatchedImage: a watcher cancelled by
+        // clearImages() can still be working through a batch of events, and the list it is
+        // removing from has already been emptied and repopulated for another folder.
+        if (!isActive) return false
+        // indexOf and removeAt have to be one step. Read apart, the index goes stale the moment
+        // another writer shrinks the list, and removeAt then throws IndexOutOfBoundsException out
+        // of the watcher coroutine, where nothing catches it.
+        val idx = synchronized(imagesLock) {
+            val at = _images.indexOf(file)
+            if (at >= 0) _images.removeAt(at)
+            at
+        }
         if (idx < 0) return false
-        _images.removeAt(idx)
         _thumbnails.remove(file)
         _thumbnailFailures.remove(file)
         if (idx < _selectedImageIndex.value) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
@@ -22,8 +22,7 @@ import org.churchpresenter.app.churchpresenter.models.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.utils.Constants
 import org.churchpresenter.app.churchpresenter.utils.CrashReporter
-import org.churchpresenter.app.churchpresenter.utils.HeicDecoder
-import org.jetbrains.skia.Image
+import org.churchpresenter.app.churchpresenter.utils.PictureDecoder
 import java.io.File
 import java.nio.file.FileSystems
 import java.nio.file.WatchEvent
@@ -410,21 +409,7 @@ class PicturesViewModel(
     }
 
     private fun loadImageBitmap(file: File): ImageBitmap {
-        val bytes = file.readBytes()
-
-        // Try to decode directly with Skia (handles jpg, png, webp, gif, bmp…)
-        val originalImage = try {
-            Image.makeFromEncoded(bytes)
-        } catch (e: Exception) {
-            // Skia can't decode HEIC/HEIF natively — convert via platform tool first
-            if (file.extension.lowercase() in listOf("heic", "heif")) {
-                val jpegBytes = HeicDecoder.toJpegBytes(file)
-                    ?: throw Exception("Failed to convert HEIC file ${file.name} — sips/ImageIO returned no data")
-                Image.makeFromEncoded(jpegBytes)
-            } else {
-                throw Exception("Failed to decode image ${file.name}: ${e.message}", e)
-            }
-        }
+        val originalImage = PictureDecoder.decode(file)
 
         // Downscale to thumbnail size (400px max dimension) for grid display
         val maxThumbnailSize = 400

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/AppDataDirTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/AppDataDirTest.kt
@@ -1,0 +1,106 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Where persistent data lands when the home directory is not usable.
+ *
+ * A Windows user reported startup failing to write the bundled KJV with
+ * `FileNotFoundException (The system cannot find the path specified)`: `user.home` pointed at a
+ * path that could not be created, `mkdirs()` had returned false unnoticed, and the app started
+ * with no Bible. The resolution below is what stops an unusable home directory from being the end
+ * of it.
+ *
+ * The cases drive the resolver through its parameters rather than by swapping `user.home` — the
+ * property is JVM-wide and several singletons latch paths from it, which AGENT.md documents as a
+ * source of cross-test leakage.
+ */
+class AppDataDirTest {
+
+    private lateinit var scratch: File
+
+    @BeforeTest
+    fun createScratch() {
+        scratch = Files.createTempDirectory("cp-appdatadir").toFile()
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        scratch.deleteRecursively()
+    }
+
+    private fun dir(name: String): File = File(scratch, name).also { it.mkdirs() }
+
+    /** A home directory that cannot be created: a path whose own parent is a regular file. */
+    private fun unusableHome(): String =
+        File(File(scratch, "blocker").also { it.writeText("not a directory") }, "home").path
+
+    @Test
+    fun `prefers the home directory`() {
+        val home = dir("home")
+
+        val resolved = AppDataDir.resolve(homeDir = home.path, osName = "Mac OS X", tempDir = scratch.path)
+
+        assertEquals(File(home, ".churchpresenter").canonicalFile, resolved.canonicalFile)
+        assertTrue(resolved.isDirectory, "the resolved directory is created")
+    }
+
+    @Test
+    fun `falls back to the platform folder on Windows`() {
+        val localAppData = dir("LocalAppData")
+
+        val resolved = AppDataDir.resolve(
+            homeDir = unusableHome(),
+            osName = "Windows 11",
+            tempDir = scratch.path,
+            env = { name -> if (name == "LOCALAPPDATA") localAppData.path else null }
+        )
+
+        assertEquals(File(localAppData, "ChurchPresenter").canonicalFile, resolved.canonicalFile)
+        assertTrue(resolved.isDirectory)
+    }
+
+    @Test
+    fun `falls back to the XDG folder elsewhere`() {
+        val xdg = dir("xdg")
+
+        val resolved = AppDataDir.resolve(
+            homeDir = unusableHome(),
+            osName = "Linux",
+            tempDir = scratch.path,
+            env = { name -> if (name == "XDG_DATA_HOME") xdg.path else null }
+        )
+
+        assertEquals(File(xdg, "ChurchPresenter").canonicalFile, resolved.canonicalFile)
+    }
+
+    @Test
+    fun `falls back to the temp directory when nothing else is usable`() {
+        val resolved = AppDataDir.resolve(
+            homeDir = unusableHome(),
+            osName = "Windows 11",
+            tempDir = scratch.path,
+            env = { null }
+        )
+
+        assertEquals(File(scratch, "ChurchPresenter").canonicalFile, resolved.canonicalFile)
+    }
+
+    @Test
+    fun `returns the home candidate when no location at all can be written`() {
+        // Nothing usable anywhere: the caller then fails at its own write, naming the path it
+        // wanted — the behaviour before this resolver existed, rather than a silent surprise.
+        val home = unusableHome()
+
+        val resolved = AppDataDir.resolve(homeDir = home, osName = "Linux", tempDir = null, env = { null })
+
+        assertEquals(File(home, ".churchpresenter"), resolved)
+        assertTrue(!resolved.exists())
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/PictureDecoderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/PictureDecoderTest.kt
@@ -1,0 +1,101 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The fallbacks behind [PictureDecoder].
+ *
+ * Skia reads the web formats and refuses everything else with one opaque message, which is what put
+ * a `.jpeg` out of a chat app on a permanently failed tile in the Pictures grid. The cases below
+ * cover a file Skia cannot read but ImageIO can, that a readable file never pays for the fallback,
+ * and that an unreadable one still fails with Skia's own reason rather than a fallback's.
+ *
+ * **Not covered: the CMYK JPEG** that the report came from. Reading one needs the TwelveMonkeys
+ * plugin, which is on the classpath — but *writing* one to build the fixture does not, and a
+ * committed binary fixture is not worth it when TIFF exercises the identical branch.
+ */
+class PictureDecoderTest {
+
+    private lateinit var folder: File
+
+    @BeforeTest
+    fun createFolder() {
+        folder = Files.createTempDirectory("cp-picture-decoder").toFile()
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        folder.deleteRecursively()
+    }
+
+    private fun image(): BufferedImage =
+        BufferedImage(12, 9, BufferedImage.TYPE_INT_RGB).also {
+            it.createGraphics().apply {
+                color = Color.RED
+                fillRect(0, 0, 12, 9)
+                dispose()
+            }
+        }
+
+    private fun write(name: String, format: String): File =
+        File(folder, name).also { assertTrue(ImageIO.write(image(), format, it), "no $format writer") }
+
+    @Test
+    fun `decodes a format Skia reads on its own`() {
+        val decoded = PictureDecoder.decode(write("plain.png", "png"))
+
+        assertEquals(12, decoded.width)
+        assertEquals(9, decoded.height)
+    }
+
+    @Test
+    fun `decodes a format only ImageIO reads`() {
+        // Skia has no TIFF decoder; the JDK's ImageIO does, so the fallback is what answers here.
+        val decoded = PictureDecoder.decode(write("scan.tiff", "tiff"))
+
+        assertEquals(12, decoded.width)
+        assertEquals(9, decoded.height)
+    }
+
+    @Test
+    fun `a file no decoder can read fails with Skia's reason`() {
+        val broken = File(folder, "truncated.jpeg").also { it.writeText("this is not a JPEG") }
+
+        val failure = assertFailsWith<Exception> { PictureDecoder.decode(broken) }
+
+        assertContains(failure.message ?: "", "truncated.jpeg")
+        assertNotNull(failure.cause, "Skia's own failure is kept as the cause")
+        assertNull(PictureDecoder.decodeOrNull(broken))
+    }
+
+    @Test
+    fun `transcode returns null for bytes ImageIO cannot read`() {
+        assertNull(PictureDecoder.transcodeWithImageIO("not an image".toByteArray()))
+    }
+
+    @Test
+    fun `HEIF is recognised by its ftyp brand, not its extension`() {
+        assertTrue(PictureDecoder.isHeif(ftyp("heic")))
+        assertTrue(PictureDecoder.isHeif(ftyp("mif1")))
+        // The same container carrying video is not a picture and must not reach the HEIC decoder.
+        assertTrue(!PictureDecoder.isHeif(ftyp("isom")))
+        assertTrue(!PictureDecoder.isHeif(ByteArray(4)))
+        assertTrue(!PictureDecoder.isHeif(image().let { ImageIO.write(it, "png", File(folder, "p.png")); File(folder, "p.png").readBytes() }))
+    }
+
+    private fun ftyp(brand: String): ByteArray =
+        byteArrayOf(0, 0, 0, 0x18) + "ftyp".toByteArray() + brand.toByteArray() + ByteArray(4)
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModelWatchRaceTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModelWatchRaceTest.kt
@@ -1,0 +1,142 @@
+package org.churchpresenter.app.churchpresenter.viewmodel
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import javax.imageio.ImageIO
+import kotlin.concurrent.thread
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Two watchers mutating one image list at the same time.
+ *
+ * `selectFolder` cancels the previous folder's watch job and repopulates `_images` immediately, but
+ * coroutine cancellation is cooperative: the outgoing watcher can still be inside `pollEvents()`,
+ * working through a batch of events against a list that has already been emptied and refilled for
+ * another folder. `removeWatchedImage` read an index and then removed it in a separate step, so the
+ * index went stale between the two and `removeAt` threw `IndexOutOfBoundsException` from a
+ * coroutine where nothing catches it.
+ *
+ * That took CI red intermittently — run 31793721082 on `main`, and again on PR #298, both as
+ * `index: 5, size: 5` — surfacing inside whichever `PicturesTabScreenshotTest` case happened to be
+ * running when an earlier test's leaked watcher woke up. It reads as a flaky screenshot test and is
+ * nothing of the kind.
+ *
+ * These are stress cases, so they cannot prove the interleaving happened on any given run — but
+ * they can only ever *fail* on the unfixed code, they end when the threads finish rather than on a
+ * timeout, and they cost a few hundred milliseconds.
+ */
+class PicturesViewModelWatchRaceTest {
+
+    private lateinit var folder: File
+    private val created = mutableListOf<PicturesViewModel>()
+
+    @BeforeTest
+    fun createFolder() {
+        folder = Files.createTempDirectory("cp-pictures-race").toFile()
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        created.forEach { runCatching { it.dispose() } }
+        created.clear()
+        folder.deleteRecursively()
+    }
+
+    private fun vm(): PicturesViewModel = PicturesViewModel().also { created.add(it) }
+
+    /** A real 1x1 PNG, so the thumbnail decode the add path launches has something valid to read. */
+    private fun image(name: String): File = File(folder, name).also {
+        ImageIO.write(BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB), "png", it)
+    }
+
+    /** Runs [work] on two threads released together, and returns anything either of them threw. */
+    private fun raceInPairs(work: (lane: Int) -> Unit): List<Throwable> {
+        val thrown = Collections.synchronizedList(mutableListOf<Throwable>())
+        val start = CountDownLatch(1)
+        val lanes = (0..1).map { lane ->
+            thread {
+                start.await()
+                runCatching { work(lane) }.onFailure { thrown.add(it) }
+            }
+        }
+        start.countDown()
+        lanes.forEach { it.join() }
+        return thrown
+    }
+
+    @Test
+    fun `two watchers removing the same files never throw`() {
+        val viewModel = vm()
+        val files = (0 until 12).map { image("photo%02d.png".format(it)) }
+
+        repeat(12) { round ->
+            viewModel.clearImages()
+            viewModel.loadImagesFromFolder(folder)
+            assertEquals(files.size, viewModel.images.size, "round $round starts from a full folder")
+
+            // Both lanes are a watcher draining ENTRY_DELETE events for every file — the outgoing
+            // one and its replacement, which is exactly the overlap selectFolder leaves behind.
+            val thrown = raceInPairs {
+                runBlocking { with(viewModel) { files.forEach { removeWatchedImage(it) } } }
+            }
+
+            assertTrue(thrown.isEmpty(), "round $round threw: ${thrown.firstOrNull()}")
+            assertTrue(viewModel.images.isEmpty(), "round $round removed every file exactly once")
+        }
+    }
+
+    @Test
+    fun `a watcher removing while the folder is reloaded never throws`() {
+        val viewModel = vm()
+        val files = (0 until 12).map { image("photo%02d.png".format(it)) }
+        viewModel.loadImagesFromFolder(folder)
+
+        // One lane removes, the other empties and refills underneath it — clearImages() from the
+        // caller's thread against a watcher that has not noticed its cancellation yet.
+        val thrown = raceInPairs { lane ->
+            repeat(12) {
+                if (lane == 0) {
+                    runBlocking { with(viewModel) { files.forEach { file -> removeWatchedImage(file) } } }
+                } else {
+                    viewModel.clearImages()
+                    viewModel.loadImagesFromFolder(folder)
+                }
+            }
+        }
+
+        assertTrue(thrown.isEmpty(), "a reload racing a removal threw: ${thrown.firstOrNull()}")
+        // Whichever lane finished last decides the contents; the invariant is that the list is
+        // internally consistent, with no duplicates and no file that is not on disk.
+        assertEquals(viewModel.images.distinct().size, viewModel.images.size, "no duplicate entries")
+        assertTrue(viewModel.images.all { it in files }, "no entry outside the fixture folder")
+    }
+
+    @Test
+    fun `a cancelled watcher stops removing`() {
+        val viewModel = vm()
+        val file = image("photo00.png")
+        viewModel.loadImagesFromFolder(folder)
+
+        // A watcher whose job is already cancelled must leave the list alone: by the time it wakes,
+        // clearImages() has repopulated it for a different folder and the removal would be wrong.
+        val removed = runBlocking {
+            val cancelled = CoroutineScope(Job())
+            cancelled.cancel()
+            with(viewModel) { with(cancelled) { removeWatchedImage(file) } }
+        }
+
+        assertEquals(false, removed, "a cancelled watcher reports no change")
+        assertTrue(file in viewModel.images, "and leaves the file in the list")
+    }
+}


### PR DESCRIPTION
Two production Sentry reports, both the same shape: a step with exactly one way to succeed and no second attempt when that way failed.

## Pictures — `Failed to Image::makeFromEncoded` on an ordinary `.jpeg`

`PicturesViewModel.loadImageBitmap` and `PicturePresenter` each had their own copy of the decode: Skia, plus a HEIC fallback gated on the file *extension*. Skia reads the web formats and refuses everything else with one opaque message, so a `.jpeg` it cannot read had nowhere to go — the grid tile stayed failed for the session and each file logged a warning. Two cases turn up in practice: a CMYK/YCCK JPEG, and a HEIC carrying a `.jpg`/`.jpeg` name (phone exports and chat apps rename freely).

New `utils/PictureDecoder.kt` is the single decode for both:

1. Skia.
2. HEIC — chosen by sniffing the `ftyp` brand, not the extension.
3. An ImageIO transcode — TwelveMonkeys `imageio-jpeg` is already a dependency and reads the JPEGs Skia rejects; TIFF comes along for free.

The fallbacks re-encode and so cost a full extra decode; they run only after Skia has already refused the file. Skia's own error stays the reported reason and cause, so a genuinely corrupt file behaves as before.

## Startup — bundled KJV written to a directory that could not be created

`main.kt` created `~/.churchpresenter/Bibles` with `mkdirs()`, ignored the result, and wrote the bundled Bible into it. On a Windows profile that cannot be created, `mkdirs()` returned false unnoticed and the write threw `FileNotFoundException (The system cannot find the path specified)`. It is caught, so nothing crashes — the user simply starts with no Bible and no explanation.

Settings live under the same root, so relocating only the Bible would put it somewhere the app then would not remember. New `utils/AppDataDir.kt` resolves the folder instead: the first candidate that can be created **and** written to wins — home, then the platform application-data folder (`%LOCALAPPDATA%`/`%APPDATA%`, or `$XDG_DATA_HOME`/`~/.local/share`), then temp. `SettingsManager` and the Bible bundling both go through it, so the two stay together and the recorded Bible path is one that exists.

Resolution is deterministic and uncached — nothing is persisted about where it landed, and a test swapping `user.home` is not fighting a latched path. If nothing anywhere is writable it returns the home candidate, so that machine fails exactly as it does today.

`Constants.DEFAULT_BIBLES_DIR` (`".churchpresenter/Bibles"`) becomes `DEFAULT_BIBLES_FOLDER` (`"Bibles"`), relative to the resolved root.

## Deliberately not included

- **`WebsitePresenter`** already resolves its own root by the same principle (it prefers `%ProgramData%` for the JCEF cache), and **`CrashReporter`** latches its directory once per JVM on purpose. Neither goes through `AppDataDir`.
- `StatisticsManager`, `RemoteClientManager`, `SceneViewModel`, `TunnelManager`, `SslCertificateManager` and `DeckLinkManager` still read `~/.churchpresenter` directly and would each degrade individually on such a machine. That sweep is wider than these reports and is left for its own change.
- A third report — `NoClassDefFoundError` for a `SongListPane` lambda — needed no change. The class is present in the build output; it was a dev run reading a `build/classes` directory rewritten underneath it, which AGENT.md already documents as a stale build.

## Tests

`PictureDecoderTest` covers a format only ImageIO reads, that a readable file never pays for the fallback, that an unreadable one still fails with Skia's reason, and the `ftyp` brand sniffing (including an MP4 brand, which must *not* reach the HEIC decoder). `AppDataDirTest` drives every branch plus the nothing-is-writable case, through the resolver's parameters rather than by swapping `user.home`.

Both suites and `:composeApp:check` (detekt included) are green. No UI changed, so no screenshots moved.

## Also here: the picture-list race behind an intermittent CI failure

`PicturesTabScreenshotTest > no folder chosen yet` failed this branch's second CI run with
`IndexOutOfBoundsException: index: 5, size: 5` from `PicturesViewModel.removeWatchedImage`. The same
failure had already hit `main` (run `31793721082`), so it is neither new nor caused by anything
above — but it is not a flaky screenshot test either, and re-running past it would have left a real
crash on `main`.

`selectFolder` cancels the previous folder's watch job and repopulates `_images` immediately, and
cancellation is cooperative — so the outgoing watcher can still be inside `pollEvents()` mutating a
list that has already been emptied and refilled. `removeWatchedImage` read an index and removed it
as two steps, and threw when the other watcher shrank the list in between. `addWatchedImage` already
gated on `isActive` for exactly this reason; the remove never got the same guard.

Every structural change to `_images` now takes one lock, together with any index read taken in order
to make one, and `removeWatchedImage` gates on `isActive` too. `PicturesViewModelWatchRaceTest`
covers both interleavings — it fails with the CI exception against the old body and passes against
this one, in 0.17s.
