### PR TITLE
Cap the reg_actions branch's growth

### DIFF
--- a/.github/workflows/reg-actions-prune.yml
+++ b/.github/workflows/reg-actions-prune.yml
@@ -1,0 +1,140 @@
+name: Collapse reg_actions history
+
+# Keeps the `reg_actions` branch's *history* from growing forever. Which run directories live on
+# that branch is not decided here — see `retention-days` on the reg-actions step in
+# `screenshots.yml`, which is the action's own setting and the only place to change the window.
+#
+# The two are separate problems and it matters that they stay separate. reg-actions prunes expired
+# directories itself, but it does so with `git add -A` and a normal commit, so every earlier commit
+# still references the blobs of every run ever recorded. Deleting the files reclaims nothing: the
+# pack only shrinks if the history goes too. Measured 2026-08-15, nine days after the branch was
+# created, with the default 30-day retention that had not yet expired anything: 123 commits and
+# 549.7 MB, against 206.3 MB for the whole of `main`.
+#
+# So this rebuilds the branch as a single root commit holding **exactly what the tip already has**.
+# It applies no policy of its own and drops no directory the action meant to keep, which is why it
+# can run on a blunt schedule without coordinating with anything.
+#
+# What it costs: the inline images in reg-actions PR comments are served from this branch by URL.
+# Collapsing history does not remove any file the tip still has, so live comments keep their
+# pictures; only directories the action itself already expired become unrecoverable. The images
+# reviewers actually approve are committed under `composeApp/screenshots` and are untouched.
+#
+# Note the branch is NOT the comparison baseline, despite the name suggesting it. reg-actions
+# resolves the expected images from the workflow *artifact* attached to the run matching the
+# merge-base commit (`findRunAndArtifact` in the action's `run.ts`); the branch only hosts images
+# for the comment. Nothing here can affect whether a comparison works.
+on:
+  schedule:
+    # Monthly, off-peak UTC. It only has to outpace pack growth, and each run rewrites the branch,
+    # so there is no reason to do it often.
+    - cron: '17 4 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  # To check whether a Screenshots run is in flight before force-pushing — see the pre-flight step.
+  actions: read
+
+concurrency:
+  # One at a time, and never cancel one midway: it force-pushes, so a half-run is worse than a
+  # late one.
+  group: reg-actions-collapse
+  cancel-in-progress: false
+
+jobs:
+  collapse:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # Concurrent Screenshots runs are fine with each other: each writes to its own
+      # `<date>_<runId>_reg` directory, so their commits touch disjoint paths, and the action
+      # rebases and retries on a non-fast-forward push. This job is the one thing that rewrites
+      # rather than appends, so it is the one thing that has to stay out of their way.
+      #
+      # Waiting for a quiet moment is belt-and-braces on top of --force-with-lease below: the lease
+      # makes a collision safe, this makes it unlikely. Neither is load-bearing for correctness —
+      # a run that does lose its upload still reports the right comparison, because that is
+      # computed from the artifact and not from this branch, and it re-uploads on the PR's next
+      # push anyway.
+      - name: Wait for any in-flight Screenshots run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 10); do
+            active=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/screenshots.yml/runs?status=in_progress&per_page=1" \
+              --jq '.total_count' 2>/dev/null || echo 0)
+            queued=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/screenshots.yml/runs?status=queued&per_page=1" \
+              --jq '.total_count' 2>/dev/null || echo 0)
+            if [ "$active" = "0" ] && [ "$queued" = "0" ]; then
+              echo "No Screenshots run in flight."
+              exit 0
+            fi
+            echo "Screenshots busy (in_progress=$active queued=$queued); waiting (attempt $attempt/10)."
+            sleep 60
+          done
+          echo "Still busy after 10 minutes — going ahead; --force-with-lease makes this safe."
+
+      # No actions/checkout: the working tree is never needed. The new commit is assembled with
+      # plumbing from the fetched tree, which avoids materialising a few hundred MB of PNGs.
+      - name: Rebuild the branch as a single root commit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: |
+          set -euo pipefail
+
+          git init -q work
+          cd work
+          git remote add origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # Re-read and rebuild on each attempt. A Screenshots run that lands between the fetch and
+          # the push trips the lease; the answer is to start again from its commit, not to give up
+          # for a month or to push over it.
+          for attempt in $(seq 1 5); do
+            rm -rf .git/shallow
+            git fetch -q --prune --depth=2 origin reg_actions 2>/dev/null || {
+              echo "No reg_actions branch yet — reg-actions creates it on its next run."
+              exit 0
+            }
+            OLD=$(git rev-parse FETCH_HEAD)
+
+            # Depth 2, not 1. The tip's whole tree comes with either, and that is all that is
+            # reused below — but under --depth=1 a commit has no parent present whether or not it
+            # has one, so a branch already collapsed to a root commit is indistinguishable from a
+            # shallow fetch of a long history. At depth 2 the commit count tells them apart.
+            if [ "$(git rev-list --count FETCH_HEAD)" = "1" ]; then
+              echo "Tip is already a root commit. Nothing to collapse."
+              exit 0
+            fi
+
+            TREE=$(git rev-parse FETCH_HEAD^{tree})
+            ENTRIES=$(git ls-tree FETCH_HEAD | wc -l)
+            echo "Attempt $attempt: collapsing to a root commit over $ENTRIES top-level entries."
+
+            NEW=$(git commit-tree "$TREE" \
+              -m "Collapse reg_actions history" \
+              -m "Rebuilt as a root commit over the $ENTRIES top-level entries the branch already had. No directory is dropped here; retention is the reg-actions step's retention-days in screenshots.yml." \
+              -m "See .github/workflows/reg-actions-prune.yml for why deleting files alone never shrinks the pack.")
+
+            # --force-with-lease so a run that pushed since the fetch is never silently clobbered:
+            # the push is refused and the loop rebuilds on top of whatever it wrote.
+            if git push --force-with-lease=refs/heads/reg_actions:"$OLD" \
+                 origin "$NEW:refs/heads/reg_actions"; then
+              echo "Collapsed. Tree unchanged; history is now one commit."
+              exit 0
+            fi
+
+            echo "Branch moved under us — refetching and retrying."
+            sleep $((attempt * 15))
+          done
+
+          echo "Could not collapse: the branch kept moving. Harmless, and the next run retries." >&2
+          exit 1

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -82,9 +82,12 @@ jobs:
         timeout-minutes: 20
         run: ./gradlew :composeApp:recordRoborazziJvm --tests '*ScreenshotTest*'
 
-      # So the rendered set can be fetched without running Gradle locally — this is where the
-      # website's screenshots come from now that none are committed. Uploaded before the comparison
-      # so a visual difference, which is advisory and never fails the job, cannot cost the artifact.
+      # So the rendered set can be fetched without running Gradle locally, and the source the
+      # website's screenshots should be taken from — not because the images are uncommitted (they
+      # are committed, under composeApp/screenshots, and AGENT.md is emphatic that they stay that
+      # way), but because these are the Linux renders and so are consistent with each other, which
+      # a set recorded on someone's macOS checkout is not. Uploaded before the comparison so a
+      # visual difference, which is advisory and never fails the job, cannot cost the artifact.
       - name: Upload the rendered screenshots
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -107,3 +107,16 @@ jobs:
           # Edits the existing comment in place instead of stacking one per push, and marks it
           # resolved once a difference is fixed.
           outdated-comment-action: update
+          # How long a run's images stay on the `reg_actions` branch, which is where the pictures
+          # in the comment above are served from — so this is how long an old comment keeps them.
+          # **This is the only place that window is set.** The action prunes expired directories
+          # itself on its next run; nothing else decides what the branch holds.
+          #
+          # Below the default of 30 because the cost is uneven: an ordinary run stores only what
+          # changed (~1 MB), but one that moves the whole set stores actual+expected+diff for all
+          # 247 images at once — which is what a cross-platform re-record does, and what took the
+          # branch past 500 MB in its first nine days.
+          #
+          # Note this prunes files, not history, so it alone never shrinks the pack — see
+          # .github/workflows/reg-actions-prune.yml.
+          retention-days: 14

--- a/AGENT.md
+++ b/AGENT.md
@@ -107,6 +107,19 @@ image to `composeApp/build/outputs/roborazzi/<name>_compare.png` and names it in
 essentially every file differs — see the table below. CI still records and posts the advisory
 `reg-actions` comparison; it does not verify.
 
+The pictures in that comment are served from a `reg_actions` branch, one directory per run. **How
+long they live is `retention-days` on the reg-actions step in `screenshots.yml` — the only place
+that window is set**; the action prunes expired directories itself. It prunes files and not history,
+though, so the pack grows regardless, which is what
+`.github/workflows/reg-actions-prune.yml` is for: monthly it rebuilds the branch as a single root
+commit over whatever the tip already holds, applying no retention of its own. Left alone the branch
+outgrew all of `main` in nine days.
+
+That branch is **not** the comparison baseline, despite the name. reg-actions resolves the expected
+images from the workflow *artifact* attached to the merge-base commit's run, so nothing done to the
+branch can affect whether a comparison works. Nothing under `composeApp/screenshots/` is affected
+either; those are the images reviewers approve.
+
 Known red, both pre-existing and neither a regression: `previewApp/about_*` draws
 `BuildConfig.VERSION_DISPLAY`, which carries the git hash and so changes on every commit, and
 `previewApp/dictionary_light` renders a 14,197-row list whose row heights are not stable between


### PR DESCRIPTION
The `reg_actions` branch — where reg-actions serves the images in its PR comments from — was growing
without bound. Nine days after it was created it held **123 commits and 549.7 MB**, against 206.3 MB
for the whole of `main`, making it the largest and fastest-growing thing in the repository.

Two separate causes, so two separate fixes.

### 1. Set `retention-days` on the reg-actions step

The action prunes expired run directories itself and always could — this repo just never set the
input, and the 30-day default had not come due on a nine-day-old branch. Set to 14 rather than the
default because the cost is uneven: an ordinary run stores only what changed (~1 MB), but one that
moves the whole set stores actual+expected+diff for all 247 images at once. That is what a
cross-platform re-record does, and what took the branch past 500 MB in week one.

**This is now the only place that window is set.**

### 2. Collapse the history monthly

Retention alone never shrinks the pack. The action prunes with `git add -A` and a normal commit, so
every earlier commit still references the blobs of every run ever recorded — deleting the files
reclaims nothing.

So `.github/workflows/reg-actions-prune.yml` rebuilds the branch monthly as a single root commit over
**exactly what the tip already holds**. It applies no retention of its own and drops nothing the
action meant to keep, which is why it needs no coordination with the runs writing to that branch.

It uses git plumbing on a `--depth=2` fetch rather than `actions/checkout`, so it never materialises
a few hundred MB of PNGs. Depth 2 and not 1 because under `--depth=1` a commit has no parent present
whether or not it has one, making an already-collapsed branch indistinguishable from a shallow fetch
of a long history.

### Concurrency

Concurrent Screenshots runs are already safe with each other: each writes to its own
`<date>_<runId>_reg` directory, so their commits touch disjoint paths. The new job is the only thing
that rewrites rather than appends, so it gets three layers:

1. A pre-flight step waits for any in-progress or queued Screenshots run.
2. `--force-with-lease`, so a run landing in the gap is refused, never overwritten.
3. On refusal it refetches and rebuilds on top of whatever that run wrote, up to 5 attempts.

### Worth recording: the branch is not the baseline

Despite the name, `reg_actions` is **not** the comparison baseline. reg-actions resolves the expected
images from the workflow *artifact* attached to the merge-base commit's run (`findRunAndArtifact` in
its `run.ts`). Nothing done to this branch can affect whether a comparison works — only how long an
old comment keeps its pictures. Nothing under `composeApp/screenshots/` is touched; those remain the
images reviewers approve.

### Also here

The `upload-artifact` step claimed the artifact is where the website's screenshots come from "now
that none are committed". They are committed — line 14 of that same file says so, and AGENT.md makes
it a standing rule that has already been reversed and restored three times. The artifact is still the
right source, but for the reason AGENT.md gives: it holds the Linux renders, which are consistent
with each other. Corrected, because a stale comment asserting the opposite of a rule is what someone
reads before deciding it is safe to stop committing the images.

### Testing

Neither workflow can run until it is on the default branch, so the collapse script was extracted and
run verbatim against a local bare repo via a URL rewrite:

- **collapses** 4 commits → 1, with the resulting tree SHA byte-identical to the original
- **no-ops** on an already-collapsed tip
- **exits 0** when the branch does not exist yet
- **survives a race**: with a competing push injected into the exact gap between fetch and push,
  attempt 1 was rejected with `stale info`, attempt 2 refetched and collapsed over 4 entries instead
  of 3, and the competing run's directory survived

Both workflows parse as YAML and both `run` bodies pass `bash -n`.

### Note

Scheduled workflows only fire from the default branch, so the collapse job does nothing until this
merges. A one-off manual truncation has already been applied to the branch, which took it to a single
root commit at 31.3 MB and local `.git` from 858 MB to 343 MB.
