### PR TITLE
Use camelCase DTO fields with SerialName - ConstructorParameterNaming

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/PlanningCenterClient.kt
@@ -15,6 +15,7 @@ import io.ktor.http.contentType
 import io.ktor.http.encodeURLParameter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -86,9 +87,9 @@ object PlanningCenterClient {
 
     @Serializable
     internal data class TokenResponse(
-        val access_token: String = "",
-        val refresh_token: String = "",
-        val expires_in: Long = 0L
+        @SerialName("access_token") val accessToken: String = "",
+        @SerialName("refresh_token") val refreshToken: String = "",
+        @SerialName("expires_in") val expiresIn: Long = 0L
     )
 
     suspend fun exchangeCodeForToken(
@@ -157,12 +158,12 @@ object PlanningCenterClient {
                 return@withContext TokenOutcome.Failure
             }
             val parsed = json.decodeFromString(TokenResponse.serializer(), response.body())
-            if (parsed.access_token.isBlank()) return@withContext TokenOutcome.InvalidCredentials
+            if (parsed.accessToken.isBlank()) return@withContext TokenOutcome.InvalidCredentials
             TokenOutcome.Success(
                 TokenSet(
-                    accessToken = parsed.access_token,
-                    refreshToken = parsed.refresh_token,
-                    expiresAtEpochMs = System.currentTimeMillis() + parsed.expires_in * 1000
+                    accessToken = parsed.accessToken,
+                    refreshToken = parsed.refreshToken,
+                    expiresAtEpochMs = System.currentTimeMillis() + parsed.expiresIn * 1000
                 )
             )
         } catch (e: Exception) {
@@ -178,8 +179,8 @@ object PlanningCenterClient {
     @Serializable
     internal data class PersonAttributes(
         val name: String? = null,
-        val first_name: String? = null,
-        val last_name: String? = null
+        @SerialName("first_name") val firstName: String? = null,
+        @SerialName("last_name") val lastName: String? = null
     )
 
     @Serializable
@@ -206,7 +207,7 @@ object PlanningCenterClient {
             val parsed = json.decodeFromString(PersonResponse.serializer(), response.body())
             val attrs = parsed.data.attributes
             val name = attrs.name
-                ?: listOfNotNull(attrs.first_name, attrs.last_name).joinToString(" ").ifBlank { "Connected" }
+                ?: listOfNotNull(attrs.firstName, attrs.lastName).joinToString(" ").ifBlank { "Connected" }
             PersonOutcome.Success(ConnectedPerson(displayName = name))
         } catch (e: Exception) {
             CrashReporter.reportWarning(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/StockMediaClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/data/StockMediaClient.kt
@@ -11,6 +11,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.churchpresenter.app.churchpresenter.utils.CrashReporter
@@ -72,19 +73,28 @@ object StockMediaClient {
     @Serializable
     internal data class PexelsPhotoResponse(
         val photos: List<PexelsPhoto> = emptyList(),
-        val next_page: String? = null
+        @SerialName("next_page") val nextPage: String? = null
     )
 
     @Serializable
-    internal data class PexelsVideoFile(val link: String, val quality: String? = null, val file_type: String? = null, val width: Int? = null)
+    internal data class PexelsVideoFile(
+        val link: String,
+        val quality: String? = null,
+        @SerialName("file_type") val fileType: String? = null,
+        val width: Int? = null,
+    )
 
     @Serializable
-    internal data class PexelsVideo(val id: Long, val image: String, val video_files: List<PexelsVideoFile> = emptyList())
+    internal data class PexelsVideo(
+        val id: Long,
+        val image: String,
+        @SerialName("video_files") val videoFiles: List<PexelsVideoFile> = emptyList(),
+    )
 
     @Serializable
     internal data class PexelsVideoResponse(
         val videos: List<PexelsVideo> = emptyList(),
-        val next_page: String? = null
+        @SerialName("next_page") val nextPage: String? = null
     )
 
     // --- Pixabay DTOs ---
@@ -110,7 +120,11 @@ object StockMediaClient {
     )
 
     @Serializable
-    internal data class PixabayVideo(val id: Long, val videos: PixabayVideoFiles, val picture_id: String? = null)
+    internal data class PixabayVideo(
+        val id: Long,
+        val videos: PixabayVideoFiles,
+        @SerialName("picture_id") val pictureId: String? = null,
+    )
 
     @Serializable
     internal data class PixabayVideoResponse(
@@ -217,16 +231,16 @@ object StockMediaClient {
                                 downloadUrl = it.src.original
                             )
                         },
-                        hasMore = parsed.next_page != null
+                        hasMore = parsed.nextPage != null
                     )
                 }
                 StockMediaType.VIDEO -> {
                     val parsed = json.decodeFromString(PexelsVideoResponse.serializer(), body)
                     SearchOutcome.Success(
                         items = parsed.videos.mapNotNull { video ->
-                            val file = video.video_files.firstOrNull { it.quality == "hd" }
-                                ?: video.video_files.firstOrNull { it.file_type == "video/mp4" }
-                                ?: video.video_files.firstOrNull()
+                            val file = video.videoFiles.firstOrNull { it.quality == "hd" }
+                                ?: video.videoFiles.firstOrNull { it.fileType == "video/mp4" }
+                                ?: video.videoFiles.firstOrNull()
                             file?.let {
                                 StockMediaItem(
                                     id = video.id.toString(),
@@ -237,7 +251,7 @@ object StockMediaClient {
                                 )
                             }
                         },
-                        hasMore = parsed.next_page != null
+                        hasMore = parsed.nextPage != null
                     )
                 }
             }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SerializationDtoConstructionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/data/SerializationDtoConstructionTest.kt
@@ -23,24 +23,24 @@ class SerializationDtoConstructionTest {
         assertEquals(12345L, photo.id)
         assertEquals(src, photo.src)
 
-        val photoResponse = StockMediaClient.PexelsPhotoResponse(photos = listOf(photo), next_page = "p2")
+        val photoResponse = StockMediaClient.PexelsPhotoResponse(photos = listOf(photo), nextPage = "p2")
         assertEquals(listOf(photo), photoResponse.photos)
-        assertEquals("p2", photoResponse.next_page)
+        assertEquals("p2", photoResponse.nextPage)
 
-        val file = StockMediaClient.PexelsVideoFile(link = "https://v/hd.mp4", quality = "hd", file_type = "video/mp4", width = 1920)
+        val file = StockMediaClient.PexelsVideoFile(link = "https://v/hd.mp4", quality = "hd", fileType = "video/mp4", width = 1920)
         assertEquals("https://v/hd.mp4", file.link)
         assertEquals("hd", file.quality)
-        assertEquals("video/mp4", file.file_type)
+        assertEquals("video/mp4", file.fileType)
         assertEquals(1920, file.width)
 
-        val video = StockMediaClient.PexelsVideo(id = 77L, image = "https://img/thumb.jpg", video_files = listOf(file))
+        val video = StockMediaClient.PexelsVideo(id = 77L, image = "https://img/thumb.jpg", videoFiles = listOf(file))
         assertEquals(77L, video.id)
         assertEquals("https://img/thumb.jpg", video.image)
-        assertEquals(listOf(file), video.video_files)
+        assertEquals(listOf(file), video.videoFiles)
 
-        val videoResponse = StockMediaClient.PexelsVideoResponse(videos = listOf(video), next_page = null)
+        val videoResponse = StockMediaClient.PexelsVideoResponse(videos = listOf(video), nextPage = null)
         assertEquals(listOf(video), videoResponse.videos)
-        assertEquals(null, videoResponse.next_page)
+        assertEquals(null, videoResponse.nextPage)
     }
 
     @Test
@@ -64,10 +64,10 @@ class SerializationDtoConstructionTest {
         assertEquals(null, files.small)
         assertEquals(null, files.tiny)
 
-        val video = StockMediaClient.PixabayVideo(id = 55L, videos = files, picture_id = "abc123")
+        val video = StockMediaClient.PixabayVideo(id = 55L, videos = files, pictureId = "abc123")
         assertEquals(55L, video.id)
         assertEquals(files, video.videos)
-        assertEquals("abc123", video.picture_id)
+        assertEquals("abc123", video.pictureId)
 
         val videoResponse = StockMediaClient.PixabayVideoResponse(hits = listOf(video), totalHits = 1)
         assertEquals(listOf(video), videoResponse.hits)
@@ -76,15 +76,15 @@ class SerializationDtoConstructionTest {
 
     @Test
     fun `planning center token and person dtos round-trip their fields`() {
-        val token = PlanningCenterClient.TokenResponse(access_token = "tok", refresh_token = "ref", expires_in = 7200L)
-        assertEquals("tok", token.access_token)
-        assertEquals("ref", token.refresh_token)
-        assertEquals(7200L, token.expires_in)
+        val token = PlanningCenterClient.TokenResponse(accessToken = "tok", refreshToken = "ref", expiresIn = 7200L)
+        assertEquals("tok", token.accessToken)
+        assertEquals("ref", token.refreshToken)
+        assertEquals(7200L, token.expiresIn)
 
-        val attrs = PlanningCenterClient.PersonAttributes(name = "Pat Ringer", first_name = "Pat", last_name = "Ringer")
+        val attrs = PlanningCenterClient.PersonAttributes(name = "Pat Ringer", firstName = "Pat", lastName = "Ringer")
         assertEquals("Pat Ringer", attrs.name)
-        assertEquals("Pat", attrs.first_name)
-        assertEquals("Ringer", attrs.last_name)
+        assertEquals("Pat", attrs.firstName)
+        assertEquals("Ringer", attrs.lastName)
 
         val data = PlanningCenterClient.PersonData(id = "1", attributes = attrs)
         assertEquals("1", data.id)
@@ -99,13 +99,13 @@ class SerializationDtoConstructionTest {
         assertEquals(PlanningCenterClient.PersonData(), PlanningCenterClient.PersonResponse().data)
         assertEquals("", PlanningCenterClient.PersonData().id)
         assertEquals(null, PlanningCenterClient.PersonAttributes().name)
-        assertEquals("", PlanningCenterClient.TokenResponse().access_token)
+        assertEquals("", PlanningCenterClient.TokenResponse().accessToken)
 
         assertEquals(null, StockMediaClient.PixabayVideoFile(url = "u").thumbnail)
         assertEquals(null, StockMediaClient.PixabayVideoFiles().large)
-        assertEquals(null, StockMediaClient.PixabayVideo(id = 1L, videos = StockMediaClient.PixabayVideoFiles()).picture_id)
+        assertEquals(null, StockMediaClient.PixabayVideo(id = 1L, videos = StockMediaClient.PixabayVideoFiles()).pictureId)
         assertEquals(null, StockMediaClient.PexelsVideoFile(link = "l").quality)
-        assertEquals(emptyList(), StockMediaClient.PexelsVideo(id = 1L, image = "i").video_files)
+        assertEquals(emptyList(), StockMediaClient.PexelsVideo(id = 1L, image = "i").videoFiles)
         assertEquals(emptyList(), StockMediaClient.PexelsPhotoResponse().photos)
         assertEquals(emptyList(), StockMediaClient.PexelsVideoResponse().videos)
         assertEquals(0, StockMediaClient.PixabayPhotoResponse().totalHits)

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -67,7 +67,7 @@ naming:
     active: true
     parameterPattern: '(_)?[a-z][A-Za-z0-9]*'
     privateParameterPattern: '(_)?[a-z][A-Za-z0-9]*'
-    excludes: ['**/test/**', '**/jvmTest/**', '**/PlanningCenterClient.kt', '**/StockMediaClient.kt']
+
   FunctionNaming:
     active: true
     ignoreAnnotated: ['Composable']


### PR DESCRIPTION
Refactored Planning Center and Stock Media serialization DTOs to use camelCase property names while preserving API compatibility via `@SerialName` mappings for snake_case JSON fields. Updated all client usages and DTO construction tests accordingly. Also removed file-level naming exclusions from `detekt.yml`, since these DTOs now comply with parameter naming rules.