### PR TITLE
Converter: fix Quelea imports, and hold three new formats back from the rail

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,7 +11,7 @@
 - **Bilingual worship** — show two languages at once, side-by-side or stacked, or switch between primary and secondary on the fly.
 - **Look-ahead for the band** — see the current and next section in advance so transitions stay smooth.
 - **Favorites & play counts** — star the songs you use most and see how often each has been sung.
-- **Bring your existing library** — the bundled converter reads SongBeamer, OpenLP (the `songs.sqlite` database itself or an OpenLyrics export), OpenSong, FreeShow, Free Worship, EasySlides, Quelea and SoftProjector libraries, plus lyrics pulled out of PDF, Word and PowerPoint files — several files or a whole folder at a time — and ready-to-use sample songs ship with the app.
+- **Bring your existing library** — the bundled converter reads ProPresenter (versions 4 to 7), EasyWorship (both the modern `Songs.db` library and the older Paradox one, plus `.ews`/`.ewsx` schedules), MediaShout 7 scripts, SongBeamer, OpenLP (the `songs.sqlite` database itself or an OpenLyrics export), OpenSong, FreeShow, Free Worship, EasySlides, Quelea and SoftProjector libraries, plus lyrics pulled out of PDF, Word and PowerPoint files — several files or a whole folder at a time — and ready-to-use sample songs ship with the app.
 - **Flexible display** — one verse or one line at a time, optional title slides, and full control over how numbers and titles appear.
 
 **Source locations:**

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -11,7 +11,7 @@
 - **Bilingual worship** — show two languages at once, side-by-side or stacked, or switch between primary and secondary on the fly.
 - **Look-ahead for the band** — see the current and next section in advance so transitions stay smooth.
 - **Favorites & play counts** — star the songs you use most and see how often each has been sung.
-- **Bring your existing library** — the bundled converter reads ProPresenter (versions 4 to 7), EasyWorship (both the modern `Songs.db` library and the older Paradox one, plus `.ews`/`.ewsx` schedules), MediaShout 7 scripts, SongBeamer, OpenLP (the `songs.sqlite` database itself or an OpenLyrics export), OpenSong, FreeShow, Free Worship, EasySlides, Quelea and SoftProjector libraries, plus lyrics pulled out of PDF, Word and PowerPoint files — several files or a whole folder at a time — and ready-to-use sample songs ship with the app.
+- **Bring your existing library** — the bundled converter reads SongBeamer, OpenLP (the `songs.sqlite` database itself or an OpenLyrics export), OpenSong, FreeShow, Free Worship, EasySlides, Quelea and SoftProjector libraries, plus lyrics pulled out of PDF, Word and PowerPoint files — several files or a whole folder at a time — and ready-to-use sample songs ship with the app.
 - **Flexible display** — one verse or one line at a time, optional title slides, and full control over how numbers and titles appear.
 
 **Source locations:**


### PR DESCRIPTION
Submodule pointer bumps plus the FEATURES.md line that goes with them.

**Depends on ChurchPresenter/ChurchPresenter-Converter#10** — merge that first, then this branch needs re-pointing at the merged submodule commit.

### Quelea imported songs wrong

Quelea's `title=` attribute is not the section's name — it numbers the sections in order, so a chorus in third place is stored as `Verse 3`, and the name whoever entered the song wrote is the first line of the body. The heading was sung as a lyric and every section carried the wrong label. **570 of the 3,134 songs in Quelea's own English pack** import wrong that way.

Chord rows are written above the words with nothing marking them as chords, so they were read as lines to sing; they now become the app's own inline `[Bb]` markers. A section that is nothing but `[Chorus]` points at one written out elsewhere and is dropped.

Verified by converting all 3,134 songs and confirming every source line still has a home in the output.

### ProPresenter, EasyWorship and MediaShout are held back

The three converters land with their tests, but none has been run against enough real exported libraries to be offered as a way in yet, so the rail does not list them (`hidden = true`, so the converters keep their tests and the rail can still be checked against the registry) and FEATURES.md no longer claims them.