### PR TITLE
Keep the serial test pass out of filtered and screenshot runs

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -802,6 +802,11 @@ val serialTestClasses = listOf(
     "*CompanionServerAtemUploadTest",
     "*LowerThirdAtemUploadTest",
     "*LowerThirdSequencerKeyTest",
+    // Here for a different reason: it binds a fixed port AND draws that port into the image (the
+    // Server URL row, the connection QR). Shifting the port per fork would rewrite every one of its
+    // committed screenshots on every run, so it keeps the literal and runs where nothing competes
+    // for the port.
+    "*ServerSettingsTabScreenshotTest",
 )
 
 val jvmTestSerial by tasks.registering(org.gradle.api.tasks.testing.Test::class) {
@@ -826,8 +831,14 @@ tasks.named<org.gradle.api.tasks.testing.Test>("jvmTest") {
     }
     if (!filteredFromCommandLine) {
         filter { serialTestClasses.forEach { excludeTestsMatching(it) } }
+        // Only worth running when this task excluded them. A command-line `--tests` applies to EVERY
+        // Test task in the invocation, so finalizing unconditionally meant
+        // `recordRoborazziJvm --tests '*ScreenshotTest*'` -- what screenshots.yml runs -- started the
+        // serial task with a filter matching none of its six classes, and Gradle failed the build
+        // with "No tests found for given includes". Nothing was excluded from that run in the first
+        // place, so there is nothing for the serial pass to pick up.
+        finalizedBy(jvmTestSerial)
     }
-    finalizedBy(jvmTestSerial)
 }
 
 // ── Screenshots (Roborazzi) ───────────────────────────────────────────────────

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ServerSettingsTabScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/ServerSettingsTabScreenshotTest.kt
@@ -34,7 +34,6 @@ import org.junit.AfterClass
 import org.junit.BeforeClass
 import java.io.File
 import kotlin.test.Test
-import org.churchpresenter.app.churchpresenter.testPort
 
 /**
  * The Server tab of the settings dialog, in both themes.
@@ -91,8 +90,13 @@ class ServerSettingsTabScreenshotTest {
 
         const val SECTION = "serverSettingsTab"
 
-        /** Fixed, so the Server URL row reads the same on every machine that records this. */
-        val PORT = testPort(39_641)
+        /**
+         * Fixed, so the Server URL row reads the same on every machine that records this -- and
+         * NOT `testPort()`. This suite draws the port into the image (the Server URL row and the
+         * connection QR encode it), so a per-fork offset would change every one of these files on
+         * every run. It is in `serialTestClasses` instead, which is what keeps the bind safe.
+         */
+        const val PORT = 39_641
         const val HOST = "studio-pc"
 
         /** Fixed rather than generated: the Generate button makes a random UUID. */


### PR DESCRIPTION
Follow-up to #321. Two defects in the parallel-fork change, both found by CI on that PR — the fix
was pushed to the branch but #321 merged the commit before it, so `main` currently has both.

**`screenshots` fails on every pull request.** `recordRoborazziJvm --tests '*ScreenshotTest*'` —
what `screenshots.yml` runs — dies with `No tests found for given includes`. A command-line
`--tests` applies to EVERY `Test` task in the invocation, so `finalizedBy` started `jvmTestSerial`
with a filter matching none of its six classes. A filtered run excludes nothing from `jvmTest` in
the first place, so there is nothing for the serial pass to pick up: it now finalizes only when the
exclusion was actually applied.

**`ServerSettingsTabScreenshotTest` would rewrite its own screenshots on every run.** #321 moved its
port to `testPort()`, but that suite draws the port into the image — the Server URL row and the
connection QR encode it — so a per-fork offset changes every one of its committed images. That is
exactly the invariant the constant's own comment states ("Fixed, so the Server URL row reads the
same on every machine that records this"). It goes back to the literal `39_641` and joins
`serialTestClasses` instead, which is what keeps the bind collision-free.

Worth noting how the second one hid: `verifyRoborazziJvm` is a local gate, and plain `jvmTest`
neither writes nor compares those images — so a full green `:composeApp:check` says nothing about
it. CI records rather than verifies, so it would have posted a misleading advisory diff rather than
failing.

## Verification

- `verifyRoborazziJvm --tests '*ServerSettingsTabScreenshotTest*'` — green (it failed before this).
- `jvmTest` unfiltered still runs the serial pass; `jvmTest --tests '<anything>'` no longer does.
- Full `:composeApp:jvmTest` green, plus detekt.
