### PR TITLE
Stop the app-preview suites racing their shared fixture library

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -807,6 +807,15 @@ val serialTestClasses = listOf(
     // committed screenshots on every run, so it keeps the literal and runs where nothing competes
     // for the port.
     "*ServerSettingsTabScreenshotTest",
+    // And these for a third: all thirteen seed one fixed directory on disk -- AppPreviewSupport's
+    // `library()` writes songs, bibles, a Gallery of PNGs and a deck into LIBRARY
+    // (/Users/Shared/ChurchPresenter, else /tmp/ChurchPresenter) with copyTo(overwrite = true).
+    // That was safe while nothing ran at the same time; across forks it is one process reading a
+    // file another is rewriting, which surfaced on CI as `AppPreviewPicturesScreenshotTest` failing
+    // to find the "04 Church" thumbnail it had just been shown. LIBRARY cannot move per fork the way
+    // user.home does -- these previews draw those paths into the images (the schedule rows read
+    // "/Users/Shared/ChurchPresenter/..."), so a per-fork root would rewrite every screenshot.
+    "*AppPreview*ScreenshotTest",
 )
 
 val jvmTestSerial by tasks.registering(org.gradle.api.tasks.testing.Test::class) {
@@ -838,6 +847,13 @@ tasks.named<org.gradle.api.tasks.testing.Test>("jvmTest") {
         // with "No tests found for given includes". Nothing was excluded from that run in the first
         // place, so there is nothing for the serial pass to pick up.
         finalizedBy(jvmTestSerial)
+    } else {
+        // The other half of standing the exclusion down: those classes now run HERE, in this task,
+        // and several of them are in that list precisely because they cannot run beside anything.
+        // `recordRoborazziJvm --tests '*ScreenshotTest*'` -- what screenshots.yml runs on every push
+        // and pull request -- is exactly that case, and it raced the shared AppPreview library.
+        // A named subset is small enough that one JVM costs little, and correctness is not optional.
+        maxParallelForks = 1
     }
 }
 


### PR DESCRIPTION
`screenshots` is red on `main` (run 32093963109): `AppPreviewPicturesScreenshotTest` could not find
the "04 Church" thumbnail it had just waited for. Same root cause as the parallel-fork work, one
layer deeper than the last fix.

## What is actually wrong

All thirteen app-preview suites seed **one fixed directory**. `AppPreviewSupport.library()` writes
songs, bibles, a Gallery of PNGs and a deck into `LIBRARY` —
`/Users/Shared/ChurchPresenter`, else `/tmp/ChurchPresenter` — using `copyTo(overwrite = true)` and
`ImageIO.write`. Safe for as long as nothing else ran at the same time. Under parallel forks it is
one process reading a file another process is part-way through rewriting, and the symptom is exactly
what CI reported: the picture list is briefly missing a file that `writePictures` creates.

`LIBRARY` cannot move per fork the way `user.home` did. These previews **draw those paths into the
images** — the schedule rows read `/Users/Shared/ChurchPresenter/...` — so a per-fork root would
rewrite every committed screenshot on every run. They join `serialTestClasses` instead.

**That alone would not have fixed the failing job.** A command-line `--tests` stands the exclusion
down, and `screenshots.yml` runs precisely that form (`recordRoborazziJvm --tests '*ScreenshotTest*'`),
so those suites would have kept running in parallel in the one job where it matters. A filtered run
is therefore single-fork now: the subset is named and small, so one JVM costs little, and this
removes the whole class of "a filtered run bypasses an isolation rule" bug rather than this instance
of it.

## Honesty about the evidence

**This does not reproduce on macOS.** `LIBRARY` lands on `/Users/Shared` here and the disk is fast;
four consecutive filtered runs stayed green. What is verified is the mechanism (thirteen suites,
one shared directory, overwriting writes, concurrent readers) and the configuration change
(measured: a filtered run is now `forks=1`, an unfiltered run is still `forks=4` and the
app-preview suites appear in `jvmTestSerial`). If `screenshots` goes red again after this, the next
suspect is thumbnail-decode timing inside the preview harness, not the fixture root.

## Verification

- `:composeApp:check` green (7m08s), detekt clean.
- Fork counts confirmed by probe on both paths, not assumed.
- The 21 `AppPreview*ScreenshotTest` suites now run in `jvmTestSerial` on an unfiltered run.
