### PR TITLE
Run the ATEM upload dialog suites serially, and fix the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,21 +18,29 @@ Clone the repository — there are no submodules, so a plain clone is everything
 git clone https://github.com/ChurchPresenter/ChurchPresenter
 ```
 
-The six sub-builds under `composeApp/src/jvmMain/appResources/common/` live in this repository as
-ordinary directories. Each keeps its own Gradle wrapper and test suite, and their sources are
-compiled into the main app via `kotlin.srcDir`:
+The app is built from several modules that all live in this repository — there are no submodules and
+nothing to fetch separately. Two of them are **Gradle modules of this build**, with no wrapper of
+their own:
 
-> **ChurchPresenter-LottieGen** — a standalone Compose Desktop app for generating animated lower-third overlays as Lottie JSON files, launched from the Lower Third settings.
+> **[`converter/`](./converter)** — a song/bible format converter built with Compose Desktop,
+> accessible from the Help menu. `./gradlew :converter:test`, `./gradlew :converter:packageDmg`.
 >
-> **[`converter/`](./converter)** — a song/bible format converter built with Compose Desktop, accessible from the Help menu. Unlike the rest, it is a Gradle module of this build (`:converter`) rather than a mounted source directory, so it is built and tested on its own: `./gradlew :converter:test`, `./gradlew :converter:packageDmg`.
+> **[`companion-satellite/`](./companion-satellite)** — a pure-Kotlin Bitfocus Companion Satellite
+> protocol client. `./gradlew :companion-satellite:test`.
+
+The other four sit under `composeApp/src/jvmMain/appResources/common/`. Each still keeps its own
+Gradle wrapper and test suite, and the first three have their sources compiled into the main app via
+`kotlin.srcDir`:
+
+> **ChurchPresenter-LottieGen** — a standalone Compose Desktop app for generating animated
+> lower-third overlays as Lottie JSON files, launched from the Lower Third settings.
 >
 > **ChurchPresenter-PresentationEngine** — PPTX/PPT/Keynote/PDF parsing, timing and animation.
 >
 > **ChurchPresenter-BLE** — the Bible Lookup Engine, speech-to-reference detection.
 >
-> **companion-satellite** — a pure-Kotlin Bitfocus Companion Satellite client. Unlike the others it is a full Gradle module of this build, at the repository root rather than under `appResources/common/`.
->
-> **ChurchPresenter-Cross** — the crossword puzzle authoring tool and its encoded puzzles.
+> **ChurchPresenter-Cross** — the crossword puzzle authoring tool. Not compiled into the app; a
+> build-time task copies its encoded puzzles into the app's resources.
 
 
 ---

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -802,6 +802,16 @@ val serialTestClasses = listOf(
     "*CompanionServerAtemUploadTest",
     "*LowerThirdAtemUploadTest",
     "*LowerThirdSequencerKeyTest",
+    // The other three suites that open the ATEM upload dialog. Doing so renders a Lottie frame and
+    // encodes it for the switcher behind three 5s deadlines -- the upload button enabling, the
+    // dialog's rows composing, and `waitForAtemPrepared` (LowerThirdTabTestSupport.kt:263). That is
+    // real work against a wall clock, so on a runner with four forks competing for the CPU it is the
+    // machine being measured, not the code: LowerThirdAtemDialogExtraTest timed out at exactly that
+    // wait on main. LowerThirdAtemUploadTest above was in this list from the start and never failed,
+    // which is the tell -- these three simply had not drawn the short straw yet.
+    "*LowerThirdAtemDialogTest",
+    "*LowerThirdAtemDialogExtraTest",
+    "*LowerThirdTabScreenshotTest",
     // Here for a different reason: it binds a fixed port AND draws that port into the image (the
     // Server URL row, the connection QR). Shifting the port per fork would rewrite every one of its
     // committed screenshots on every run, so it keeps the literal and runs where nothing competes

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -812,6 +812,11 @@ val serialTestClasses = listOf(
     "*LowerThirdAtemDialogTest",
     "*LowerThirdAtemDialogExtraTest",
     "*LowerThirdTabScreenshotTest",
+    // Binds Constants.PLANNING_CENTER_OAUTH_PORT, and that one genuinely cannot move: it is the
+    // redirect port registered with Planning Center, so testPort() would point the callback at a
+    // port the provider will never redirect to. Two forks reaching for it is a bind race, which is
+    // how this failed on CI with "the server prematurely closed the connection".
+    "*PlanningCenterAuthServerTest",
     // Here for a different reason: it binds a fixed port AND draws that port into the image (the
     // Server URL row, the connection QR). Shifting the port per fork would rewrite every one of its
     // committed screenshots on every run, so it keeps the literal and runs where nothing competes

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdSequencerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdSequencerTest.kt
@@ -131,6 +131,12 @@ class LowerThirdSequencerTest {
 
         withTimeout(1_000) { cleared.receive() }
         collector.cancel()
+        // Wait for the status itself rather than assuming the emission that woke us was this run's.
+        // `onClear` is a shared flow on a JVM-wide object, so a late emission from an earlier test's
+        // job can satisfy `cleared.receive()` while this sequence is still running -- which is how
+        // this read `running:AutoEnd` on a loaded CI runner. Ends on the positive signal; the
+        // timeout only fails.
+        withTimeout(1_000) { LowerThirdSequencer.status.first { it == "idle" } }
         assertEquals("idle", LowerThirdSequencer.status.value)
     }
 


### PR DESCRIPTION
`Tests` is **red on main** (run 32140088556, commit 10c00ace). One failure:

```
LowerThirdAtemDialogExtraTest > a design whose aspect ratio does not match the switcher is warned about
  ComposeTimeoutException: Condition (the ATEM frame render finished) still not satisfied after 5000 ms
```

## The test fix

Opening the ATEM upload dialog renders a Lottie frame and encodes it for the switcher, behind three
5-second deadlines in `LowerThirdTabTestSupport` — the upload button enabling (`:285`), the dialog's
rows composing (`:291`), and `waitForAtemPrepared` (`:263`). Those are correct waits: each ends on a
positive signal, with the timeout there only to fail. But the work behind them is real rendering
against a wall clock, so with four forks competing for the CPU the deadline measures the runner
rather than the code.

**Four** suites open that dialog: `LowerThirdAtemUploadTest`, `LowerThirdAtemDialogTest`,
`LowerThirdAtemDialogExtraTest`, `LowerThirdTabScreenshotTest`. Only the first was in
`serialTestClasses` — put there in the first parallel-forks pass — and it has never failed. That is
the tell: the other three are the same workload and had simply not drawn the short straw yet. They
join it.

Deliberately **not** widening the deadlines: that hides the race rather than removing it, and 5s is
already generous for the work on an idle machine.

## The README fix

It had gone self-contradictory. The section introduced all six modules as sub-builds "under
`composeApp/src/jvmMain/appResources/common/`" whose "sources are compiled into the main app via
`kotlin.srcDir`" — and then two of the six entries had to open with "Unlike the rest…" because they
are neither under that path nor mounted that way. Every promotion made it worse.

It now leads with the two Gradle modules of this build (`converter/`, `companion-satellite/`) and
their commands, then the four remaining sub-builds — and says plainly that Cross is not compiled
into the app at all, which was never stated anywhere.

## Verification

- `./gradlew :composeApp:jvmTest --rerun-tasks` green (7m15s), and the four ATEM dialog suites now
  appear in `jvmTestSerial`'s results rather than the parallel pass.
- detekt clean.
