### PR TITLE
Give the screenshots job headroom, and make a stall name itself

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -55,7 +55,7 @@ concurrency:
 jobs:
   screenshots:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,8 +74,14 @@ jobs:
 
       # Only the screenshot class: the rest of the suite is the `test` workflow's job and would
       # add ~14 minutes here for nothing.
+      #
+      # 35, not 20. A green run of this step lands at 13-14.5 minutes, so the old ceiling left barely
+      # five minutes of slack and killed the step twice -- once on a pull request, once on main --
+      # without either being a real failure. The budget is not an alarm on how long the suite takes;
+      # the job's own `timeout-minutes` below is the backstop for a genuine hang, and the per-class
+      # log lines the build now prints will name the offender if that is what it turns out to be.
       - name: Render screenshots
-        timeout-minutes: 20
+        timeout-minutes: 35
         run: ./gradlew :composeApp:recordRoborazziJvm --tests '*ScreenshotTest*'
 
       # So the rendered set can be fetched without running Gradle locally, and the source the

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -746,6 +746,29 @@ tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
     }
 
+    // Name every test class as it finishes, with its duration. Gradle prints nothing while a suite
+    // runs, so when the screenshots job hit its 20-minute step timeout twice there was no way to say
+    // WHICH class was on screen when the clock ran out -- the log simply stopped after
+    // "> Task :composeApp:jvmTest" and a killed step uploads no XML to read afterwards. One line per
+    // class (772 in the screenshot run, ~2500 for the whole suite) is a cheap price for the next
+    // occurrence naming itself. `-Pquiet` turns it off.
+    if (!project.hasProperty("quietTests")) {
+        addTestListener(object : TestListener {
+            override fun beforeSuite(suite: TestDescriptor) = Unit
+            override fun beforeTest(testDescriptor: TestDescriptor) = Unit
+            override fun afterTest(testDescriptor: TestDescriptor, result: TestResult) = Unit
+            override fun afterSuite(suite: TestDescriptor, result: TestResult) {
+                // Only class-level suites have a parent; the root and the JVM-level ones do not.
+                if (suite.parent != null && suite.className != null) {
+                    val seconds = (result.endTime - result.startTime) / 1000.0
+                    logger.lifecycle(
+                        "  %6.1fs  %-5s %s".format(seconds, result.resultType, suite.displayName)
+                    )
+                }
+            }
+        })
+    }
+
     // The tests are JUnit 4 and stay JUnit 4 -- junit-vintage runs them verbatim, rules and
     // @BeforeClass included. The platform launcher is here for one reason: it is the only hook that
     // runs BEFORE test discovery, which is what PerForkTestHome needs to give each fork its own


### PR DESCRIPTION
`Screenshots` has now been killed by its 20-minute step timeout **twice** — once on #325 after a
rebase, once on `main` at `f5b5c619` — with no failing test either time. The first was written off as
a runner blip because a re-run passed. The second says otherwise.

## Headroom

A green run of that step lands at **13–14.5 minutes**, so a 20-minute ceiling left roughly five
minutes of slack. The step goes to 35 and the job to 45. The job deadline is the backstop for a
genuine hang; the step budget should not double as an alarm on how long the suite legitimately takes.

Part of why it grew: #323 made command-line-filtered runs single-fork, and `screenshots.yml` runs
exactly that form (`recordRoborazziJvm --tests '*ScreenshotTest*'`). That was the right call — those
suites share one on-disk fixture library and cannot run concurrently — but it roughly doubled this
job and nothing adjusted the budget to match.

## Making the next one diagnosable

Two investigations produced no culprit, and the reason is that **nothing recorded what was running.**
Gradle prints only failures while a suite executes, so the log stops dead after
`> Task :composeApp:jvmTest`, and a step killed by a timeout uploads no XML to read afterwards. Both
times all I could establish was that the task ran ~16 minutes instead of ~7 and said nothing about
where.

The build now logs one line per test class as it finishes — duration, result, name. If the next
occurrence is a stall rather than a slow runner, **the last line printed names the class**. That is
the entire question, and a bigger timeout alone would never have answered it. `-PquietTests` turns it
off.

## What is still open, honestly

Whether this is a stall or ordinary variance is **not settled**. Successful runs put `jvmTest` at
~7 minutes; both failures ran past 16 with no output. That is bimodal enough to suspect a stall — a
suite waiting on something that never arrives — rather than a uniformly slow machine. This PR does
not fix that. It stops the symptom from failing green runs, and guarantees the next occurrence
identifies itself instead of costing another investigation that ends in "the log stops here".

## Verification

- `./gradlew :composeApp:jvmTest --tests '*ScreenshotTest*'` green locally (2m55s) with the new
  per-class lines, e.g. `4.3s  SUCCESS AppPreviewBibleScreenshotTest[jvm]`.
- detekt clean; workflow YAML parses.
