### PR TITLE
Stop two ATEM test suites paying a timeout in teardown

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AtemUploadTracedTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/AtemUploadTracedTest.kt
@@ -23,6 +23,10 @@ class AtemUploadTracedTest {
             options.isEnableUncaughtExceptionHandler = false
             options.isEnableAutoSessionTracking = false
             options.tracesSampleRate = 1.0
+            // Sentry.close() blocks for this long draining its queue, and the default is 2000ms —
+            // paid by every test in this class, which is the whole of its runtime. There is nothing
+            // to drain: the transport above is NoOp, so the wait is pure teardown cost.
+            options.shutdownTimeoutMillis = 0
         }
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdSequencerKeyTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdSequencerKeyTest.kt
@@ -30,6 +30,28 @@ class LowerThirdSequencerKeyTest {
         keyPostRollMs = 0,
     )
 
+    /**
+     * A fake switcher for one test, torn down in the order the sequencer requires: stopped while
+     * the switcher is still answering, and only then closed.
+     *
+     * [LowerThirdSequencer.stop] drives a key-off at the switcher and awaits its ack, deliberately
+     * — preemption is only deterministic if the previous key is off before the next goes on. A
+     * switcher that has already been closed acks nothing, so that wait runs out the client's full
+     * `CMD_TIMEOUT_MS` (8s) and `releaseKeyLocked` swallows the resulting failure. Closing the fake
+     * first therefore cost 8 seconds per test that left a sequence running — three of them here,
+     * 24 of this suite's 24 seconds — and bought a teardown that exercised the timeout path rather
+     * than the key-off it is meant to perform.
+     */
+    private fun withSwitcher(block: (FakeAtemSwitcher) -> Unit) {
+        FakeAtemSwitcher().use { fake ->
+            try {
+                block(fake)
+            } finally {
+                runBlocking { LowerThirdSequencer.stop() }
+            }
+        }
+    }
+
     private fun dskCommands(fake: FakeAtemSwitcher) =
         fake.commandsNamed("CDsL") + fake.commandsNamed("DDsA")
 
@@ -69,7 +91,7 @@ class LowerThirdSequencerKeyTest {
 
     @Test
     fun `going live cuts the upstream key on air`() {
-        FakeAtemSwitcher().use { fake ->
+        withSwitcher { fake ->
             val keyError = runAndAwaitShow(fake, mixEffect = 1, keyer = 2)
 
             assertNull(keyError, "the switcher answered, so there is nothing to report")
@@ -82,7 +104,7 @@ class LowerThirdSequencerKeyTest {
 
     @Test
     fun `stopping cuts the same key back off`() {
-        FakeAtemSwitcher().use { fake ->
+        withSwitcher { fake ->
             runAndAwaitShow(fake, mixEffect = 1, keyer = 2)
             fake.awaitCommandsNamed("CKOn", 1)
 
@@ -97,7 +119,7 @@ class LowerThirdSequencerKeyTest {
 
     @Test
     fun `a downstream key is driven as a DSK rather than an upstream keyer`() {
-        FakeAtemSwitcher().use { fake ->
+        withSwitcher { fake ->
             runAndAwaitShow(fake, mixEffect = 0, keyer = 1, useDownstreamKey = true)
 
             assertEquals(1, awaitDsk(fake).first()[0].toInt(), "byte 0 is the DSK index")
@@ -107,7 +129,7 @@ class LowerThirdSequencerKeyTest {
 
     @Test
     fun `a downstream key is taken off the same way`() {
-        FakeAtemSwitcher().use { fake ->
+        withSwitcher { fake ->
             runAndAwaitShow(fake, mixEffect = 0, keyer = 1, useDownstreamKey = true)
             awaitDsk(fake)
 
@@ -120,7 +142,7 @@ class LowerThirdSequencerKeyTest {
 
     @Test
     fun `a sequence with no keyer configured never opens a connection`() {
-        FakeAtemSwitcher().use { fake ->
+        withSwitcher { fake ->
             val keyError = runAndAwaitShow(fake, mixEffect = null, keyer = null)
 
             assertNull(keyError)
@@ -130,7 +152,7 @@ class LowerThirdSequencerKeyTest {
 
     @Test
     fun `a keyer with no mix effect is not driven either`() {
-        FakeAtemSwitcher().use { fake ->
+        withSwitcher { fake ->
             val keyError = runAndAwaitShow(fake, mixEffect = null, keyer = 2)
 
             assertNull(keyError)
@@ -140,7 +162,7 @@ class LowerThirdSequencerKeyTest {
 
     @Test
     fun `a preempting sequence takes the previous key off before its own goes on`() {
-        FakeAtemSwitcher().use { fake ->
+        withSwitcher { fake ->
             runAndAwaitShow(fake, mixEffect = 1, keyer = 2)
             fake.awaitCommandsNamed("CKOn", 1)
 
@@ -156,7 +178,7 @@ class LowerThirdSequencerKeyTest {
 
     @Test
     fun `a sequence that ends on its own takes the key off with it`() {
-        FakeAtemSwitcher().use { fake ->
+        withSwitcher { fake ->
             val cleared = Channel<Unit>(capacity = 1)
             runBlocking {
                 val collector = launch { LowerThirdSequencer.onClear.collect { cleared.trySend(Unit) } }


### PR DESCRIPTION
Two suites in `jvmTestSerial` ended tests by waiting out a timeout rather than on a signal — what `AGENT.md` rules out in as many words: *"It must never end by the timeout expiring; the timeout exists only to fail the test."* Between them they cost **33 seconds of every run**.

Both were found by measuring, not by reading: `./gradlew :composeApp:jvmTest` then the `time=` attributes in `composeApp/build/test-results/`. The giveaway in each case was a suspiciously round per-test number.

## `LowerThirdSequencerKeyTest` — 24.04s → 0.15s

Three tests took exactly 8.00s each; the other five took ~0.00s. The split is exactly whether a test leaves its sequence running.

The tests wrap the fake switcher in `use {}`, so it closes when the test body ends. But the sequence is still on air, and `@AfterTest` then calls `LowerThirdSequencer.stop()`. `stop()` drives a key-off at the switcher and *awaits its ack* — deliberately, because preemption is only deterministic if the previous key is off before the next goes on. A switcher that has already been closed acks nothing, so that wait ran out `AtemClient.CMD_TIMEOUT_MS` (8s) and `releaseKeyLocked` swallowed the resulting failure.

So teardown was exercising the timeout path rather than the key-off it exists to perform, and the three tests that left a sequence running paid 8s each.

A `withSwitcher` helper now stops the sequencer *inside* the `use` block, while the switcher is still answering, then lets it close.

## `AtemUploadTracedTest` — 11.7s → 1.7s

Five tests at a uniform ~2.3s. `Sentry.close()` blocks draining its queue for `shutdownTimeoutMillis` — default 2000ms — once per test. The transport is already `NoOpTransportFactory`, so there was never anything to drain; the wait was pure teardown cost. Set to 0.

## Why this is filed as a flake fix

`CompanionServerAtemUploadTest` has been failing on CI with `timed out after 5000ms waiting for N commands, got 0` — all five tests at once, the failure the `serialTestClasses` comment in `composeApp/build.gradle.kts` already documents. `AtemConnectionManager` is a singleton, and `@AfterTest` only invalidates it *after* `stop()` returns. While a teardown sat in that 8-second timeout, the shared client was in a failing state that the next suite could inherit.

I want to be straight that this is a plausible mechanism rather than a proven one: I could not reproduce the `got 0` failure locally, including under full CPU saturation. What is measured and certain is that both suites no longer wait on a dead socket, and that 33s of wall clock is gone.

## Not fixed here

A CI run on #357 hung for 22 minutes and took the 40-minute job timeout. The last logged test was `AppPreviewWebScreenshotTest`; in local ordering the class immediately after it is `LowerThirdTabScreenshotTest` — one of the three suites the build file already flags for opening the ATEM upload dialog behind three 5-second deadlines. I could not reproduce the hang (that suite exits cleanly here, and there are no non-daemon threads in `jvmMain`), so I have left it alone rather than guess at a fix. Recording the lead so the next occurrence starts further along.

## Verification

- Three consecutive `--rerun-tasks` runs of all five ATEM suites, green each time with stable timings
- The whole `:composeApp:jvmTestSerial` task passes
- `./gradlew :composeApp:detekt` clean