### PR TITLE
Dump every thread when a test stops making progress

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,10 +180,14 @@ jobs:
       - name: App unit tests
         id: unit_tests
         # Tighter than the job's own deadline so a hang here is attributed to this step and the
-        # module suites below (`if: always()`) and the report upload still get to run. Runs land
-        # around 11-14 minutes; one run was killed at a 25-minute budget with no diagnosis that
-        # survived scrutiny, so the budget is set well clear of the observed band rather than
-        # doubling as an alarm on a suite that is still growing.
+        # module suites below (`if: always()`) and the report upload still get to run.
+        #
+        # Runs land around 19 minutes (18m45s and 19m24s, measured 2026-08-21) -- they used to be
+        # 11-14, and this comment said so long after it stopped being true, which is how a 20-minute
+        # Gradle-side cap came to be proposed that would have failed both of those healthy runs.
+        # Re-measure before quoting a band. Two other things now fire before this budget does:
+        # jvmTest's own 30-minute task timeout, and HungTestReporter, which halts a fork whose
+        # single test has been running five minutes and writes a thread dump into the results.
         timeout-minutes: 40
         run: ./gradlew :composeApp:jvmTest
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -119,7 +119,7 @@ they must be set **above everything else** in the file:
   counters that need a different number (usually the one or two that cannot reach 85%), never all
   six. `:converter`, `:companion-satellite`, `:bible-engine`, `:presentation-engine` and `:atem`
   name two each; `:theme`, `:core-models`, `:lottieGenerator`, `:crossword`, `:songlibrary`,
-  `:settings`, `:diagnostics` and `:planning-center` name none.
+  `:settings`, `:diagnostics`, `:planning-center` and `:bible-formats` name none.
   Each module's own `AGENT.md` says which, and why.
 - `extra["coverageExcludes"]` — class-directory excludes, replacing the default
   `**/ComposableSingletons*` outright. **Read the rule below before adding one.**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,12 @@ subprojects {
             tasks.withType<Test>().configureEach {
                 useJUnitPlatform()
                 finalizedBy("jacocoTestReport")
+                // A watchdog on the harness, not a wait inside a test: nothing asserts on it, and
+                // every module suite here runs in seconds to a couple of minutes. It exists so a
+                // hung suite ends as a failure with the log intact rather than running until the CI
+                // step gives up -- the same reason :composeApp has one, applied to the modules that
+                // were left unbounded when it was added.
+                timeout.set(java.time.Duration.ofMinutes(10))
             }
 
             tasks.withType<JacocoReport>().configureEach {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -788,6 +788,21 @@ tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
     // the suite grows rather than leaving it to bite a green run.
     timeout.set(Duration.ofMinutes(30))
 
+    // Lets a session chasing a hang tighten HungTestReporter's threshold:
+    //   ./gradlew :composeApp:jvmTest -PhangThresholdMs=30000
+    // Absent, the reporter uses its own five-minute default. A Gradle `-D` would set the property on
+    // the daemon, not on the forked test JVM, which is the whole reason this line exists.
+    providers.gradleProperty("hangThresholdMs").orNull?.let {
+        systemProperty("churchpresenter.test.hangThresholdMs", it)
+    }
+
+    // Where HungTestReporter writes its thread dump. Inside test-results so the workflow's existing
+    // upload carries it off a CI runner that would otherwise take the diagnosis to the grave.
+    systemProperty(
+        "churchpresenter.test.hangDumpDir",
+        layout.buildDirectory.dir("test-results/" + name).get().asFile.absolutePath,
+    )
+
     testLogging {
         events("failed")
         exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/HungTestReporter.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/HungTestReporter.kt
@@ -1,0 +1,103 @@
+package org.churchpresenter.app.churchpresenter
+
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.launcher.TestExecutionListener
+import org.junit.platform.launcher.TestIdentifier
+import org.junit.platform.launcher.TestPlan
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Kills a fork that has stopped making progress, and says what it was doing when it stopped.
+ *
+ * The suite has hung outright three times (2026-07-30, then twice on 2026-08-21), each time ending
+ * as a timeout rather than a failure. PR #361's per-class `START` line finally named the class --
+ * `LowerThirdTabTest` -- but a class name is not a cause: the one stack captured shows the hang
+ * inside `runComposeUiTest` teardown, blocked in `SwingUtilities.invokeAndWait` on the AWT event
+ * queue, which means the thread that had to answer was not answering. **Which thread, and why, is
+ * not in the class name.** A dump of every thread is, and that is what this writes.
+ *
+ * It is deliberately NOT a per-test timeout in the assertion sense: nothing here decides whether a
+ * test passes, [THRESHOLD_MS] is minutes past anything this suite legitimately does (`AGENT.md`
+ * budgets ~1s a test, and the slowest screenshot class is ~33s for all of its tests together), and
+ * a test that trips it was never going to finish. Halting rather than merely reporting is the point
+ * -- the fork stops in five minutes with a diagnosis instead of being killed at thirty with none.
+ */
+class HungTestReporter : TestExecutionListener {
+
+    private val running = AtomicReference<Pair<String, Long>?>(null)
+
+    override fun testPlanExecutionStarted(testPlan: TestPlan) {
+        val watchdog = Thread {
+            while (true) {
+                try {
+                    Thread.sleep(minOf(POLL_MS, thresholdMs()))
+                } catch (_: InterruptedException) {
+                    return@Thread
+                }
+                val (name, startedAt) = running.get() ?: continue
+                val elapsed = System.currentTimeMillis() - startedAt
+                if (elapsed > thresholdMs()) {
+                    dump(name, elapsed)
+                    Runtime.getRuntime().halt(HUNG_EXIT_CODE)
+                }
+            }
+        }
+        watchdog.isDaemon = true
+        watchdog.name = "hung-test-watchdog"
+        watchdog.start()
+    }
+
+    override fun executionStarted(testIdentifier: TestIdentifier) {
+        if (testIdentifier.isTest) running.set(testIdentifier.displayName to System.currentTimeMillis())
+    }
+
+    override fun executionFinished(testIdentifier: TestIdentifier, testExecutionResult: TestExecutionResult) {
+        if (testIdentifier.isTest) running.set(null)
+    }
+
+    private fun dump(name: String, elapsedMs: Long) {
+        val out = StringBuilder()
+        out.appendLine()
+        out.appendLine("=== HUNG TEST: $name has been running ${elapsedMs / 1000}s ===")
+        out.appendLine("=== Every thread in this fork follows. The one blocked in Compose's")
+        out.appendLine("=== teardown, and whatever the AWT event queue is doing, are the two to read.")
+        Thread.getAllStackTraces().toSortedMap(compareBy { it.name }).forEach { (thread, stack) ->
+            out.appendLine()
+            out.appendLine("--- \"${thread.name}\" ${thread.state}${if (thread.isDaemon) " (daemon)" else ""}")
+            stack.take(STACK_DEPTH).forEach { out.appendLine("        at $it") }
+        }
+        System.err.println(out)
+        System.err.flush()
+        // Also to disk, because halting the JVM can lose whatever Gradle had buffered of its
+        // output -- and on CI the console is the only other copy. This directory is what the
+        // workflow already uploads as `test-reports`, so the dump travels with the run.
+        System.getProperty(DUMP_DIR_PROPERTY)?.let { dir ->
+            runCatching {
+                val file = java.io.File(dir).apply { mkdirs() }.resolve("hung-test-dump.txt")
+                file.writeText(out.toString())
+                System.err.println("=== the dump above is also at ${'$'}{file.absolutePath}")
+            }
+        }
+    }
+
+    private companion object {
+        /**
+         * Minutes past anything real, so tripping it means stuck rather than slow.
+         *
+         * Overridable with `-Dchurchpresenter.test.hangThresholdMs=` so a session chasing a hang can
+         * tighten it, and so this class can be tested without waiting five minutes for it.
+         */
+        fun thresholdMs(): Long =
+            System.getProperty("churchpresenter.test.hangThresholdMs")?.toLongOrNull() ?: DEFAULT_THRESHOLD_MS
+
+        const val DEFAULT_THRESHOLD_MS = 5 * 60 * 1000L
+        const val POLL_MS = 10_000L
+        const val STACK_DEPTH = 25
+
+        /** Distinctive, so the exit code alone says what happened. */
+        const val HUNG_EXIT_CODE = 93
+
+        /** Set by the Test task; where the dump is written so CI uploads it with the results. */
+        const val DUMP_DIR_PROPERTY = "churchpresenter.test.hangDumpDir"
+    }
+}

--- a/composeApp/src/jvmTest/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/composeApp/src/jvmTest/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+org.churchpresenter.app.churchpresenter.HungTestReporter


### PR DESCRIPTION
Follow-up to #361, which named the class the suite hangs in. This is about getting the rest of the way.

## Why this and not a fix for the hang

#361's `START` lines identified **`LowerThirdTabTest`** — and disproved two earlier guesses of `LowerThirdTabScreenshotTest` made by elimination. The one stack I captured shows the hang inside `runComposeUiTest` teardown, blocked in `SwingUtilities.invokeAndWait` on the AWT event queue: the thread that had to answer wasn't answering.

**A class name is not a cause**, and I could not turn it into one. What I ruled out, so nobody repeats it:

- Not reproducible in isolation (2.1s), under a deliberately loaded machine (8 spinning processes), or across three consecutive `--rerun-tasks` runs.
- **Not the frozen test clock** — a control probe hangs identically with auto-advance left on, so freezing it is not the trigger.
- **Not the tab's ATEM poll loop** — `LowerThirdTabTest` never sets `atemReachable`, so `host` is blank and that `LaunchedEffect` returns before looping.
- **Not the play animation** — `startPlaying` runs a finite tween and clears `isPlaying` at the end.

That the blocked call is `invokeAndWait` on the AWT queue points away from this class and towards whatever ran before it in the same fork, which is exactly the kind of thing a guess gets wrong. So: no speculative fix, and the probes I wrote to test those hypotheses are deleted rather than left behind as misleading tests.

## What lands instead

`HungTestReporter`, a platform `TestExecutionListener` registered beside `PerForkTestHome`. It tracks the running test and, five minutes in, writes **every thread's stack** — the blocked test thread and whatever the AWT queue is doing included — to stderr and to `test-results/`, which the workflow already uploads. Then it halts the fork.

So the next occurrence ends in five minutes with a full diagnosis instead of thirty with none, and names the exact test rather than the class. `-PhangThresholdMs=` tightens it for a session chasing one.

Verified with a temporary test that never returns: threshold tripped, dump written naming the test, fork halted with the distinctive exit code 93.

## Three other things found while merging #360 and #361

- **Module suites had no timeout at all.** The 30-minute watchdog was `:composeApp`'s alone, so a hang in any module ran to its CI step limit. They get 10 minutes — minutes past what any of them costs.
- **The `App unit tests` comment still claimed runs "land around 11-14 minutes".** They land around 19 (18m45s, 19m24s, measured). That stale band is what a 20-minute Gradle cap was first sized against, and it would have failed both of those healthy runs. Corrected, with a note to re-measure before quoting a band.
- **`:bible-formats` names no coverage floors**, so it belongs in `AGENT.md`'s list of modules taking the default 85%.

One thing I flagged on #360 and am explicitly *not* changing: `ZefaniaSource.parseModule`'s catch list has no `UnresolvedAddressException`, but it parses a local file with no network involved, so its clauses are right as they stand.

## Testing

`:composeApp:jvmTestSerial` and `:atem:test` green with the listener installed; `:composeApp:detekt` clean.