### PR TITLE
Fix the ATEM upload flake, and gate the two ungated modules with detekt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,7 @@ jobs:
           ./gradlew :composeApp:detekt :theme:detekt :core-models:detekt :converter:detekt
           :crossword:detekt :companion-satellite:detekt :songlibrary:detekt :settings:detekt
           :diagnostics:detekt :bible-formats:detekt :atem:detekt :planning-center:detekt
+          :bible-engine:detekt :presentation-engine:detekt
 
       - name: App unit tests
         id: unit_tests

--- a/AGENT.md
+++ b/AGENT.md
@@ -408,6 +408,20 @@ When writing tests here:
   poll on observable state with a timeout that throws, or a callback/flag the code under test
   sets. Never assert "nothing happened" after an arbitrary pause; wait for a positive signal that
   the operation finished, then assert what did or didn't change.
+- **A route that answers before it finishes leaves a coroutine behind — track it, and join it
+  before tearing anything down.** `POST /api/atem/still|clip` responds `"uploading"` and transfers
+  on `CompanionServer`'s own scope. A test that asserts on the wire and then drops the shared
+  connection is racing that coroutine: its next `AtemConnectionManager.use` dials a switcher the
+  test has just closed, which holds the manager's mutex for the whole connect timeout and can leave
+  a client cached for a dead **ephemeral** port. Nothing detects either, because
+  `AtemClient.isAlive()` is `socket != null` — true for a UDP socket with nobody listening — so the
+  next test's switcher records no command of any name and times out with "got 0". One leak is enough:
+  each poisoned test burns its 5s deadline while leaving more stuck work behind, so the backlog
+  outgrows the suite and never drains. **Five `CompanionServerAtemUploadTest` tests failed exactly
+  this way, and did so again after a first fix that reached only the still tests and not the clip
+  ones.** `AtemBridge.trackUpload`/`cancelUpload` is the handle; `cancelUpload` joins, so it returns
+  only once the coroutine has stopped. Route **every** test in such a suite through the one helper —
+  a suite where some tests take the safe path and some do not is a suite that still fails.
 - **No unit test may cost more than ~1s of wall clock.** The suite is run constantly; a test that
   waits is a tax on every future change. This rules out anything whose cost is a duration rather
   than the work itself: retry/backoff delays, "wait for silence" idle windows, timeouts used as

--- a/AGENT.md
+++ b/AGENT.md
@@ -181,6 +181,14 @@ behind by a refactor is a warning to `compileKotlinJvm` and a **build failure** 
 "it compiles" and "the tests pass" are both green while CI is red. A clean run is the expected
 result and every finding it prints is yours to fix.
 
+`:bible-engine` and `:presentation-engine` each carry their own `config/detekt/baseline.xml` too,
+written the day they joined the detekt step above. They had 205 findings between them and had never
+been gated: 44 were fixed outright (dead code, a swallowed exception, 26 over-long lines, and two
+parameters a public function ignored), the 7 in test sources carry `@Suppress` at the declaration,
+and the remaining 161 -- all `src/main`, and mostly `MagicNumber`, `NestedBlockDepth` and
+`ReturnCount` against byte-format parsers -- are baselined so the rules gate new code. Those numbers
+are debt, not absolution: the modules are parsers, but a parser is not exempt from a named constant.
+
 `config/detekt/baseline.xml` holds pre-existing findings from the day the size/length rules
 (`LongMethod`, `LongParameterList`, `TooManyFunctions`, `LargeClass`, `MaxLineLength`,
 `TooGenericExceptionCaught`) were switched on — 1,623 of them, suppressed so those rules gate new

--- a/atem/src/main/kotlin/org/churchpresenter/atem/AtemConnectionManager.kt
+++ b/atem/src/main/kotlin/org/churchpresenter/atem/AtemConnectionManager.kt
@@ -26,6 +26,18 @@ object AtemConnectionManager {
     private var cachedPort: Int = 9910
 
     /**
+     * Bumped by [invalidate]. A connect that was already in flight when the cache was dropped must
+     * not put itself back: [invalidate] does not hold [mutex] -- it cannot, it is not suspending and
+     * is called from settings changes and teardown -- so without this the sequence "upload connects,
+     * settings change invalidates, connect completes" leaves the manager caching a client for the
+     * endpoint the operator just moved away from. It reports [AtemClient.isAlive] as true forever
+     * after, because for UDP that is only `socket != null`, so nothing later notices and every
+     * command goes to a switcher that is no longer listening.
+     */
+    @Volatile
+    private var generation: Int = 0
+
+    /**
      * Acquire the shared client for [host]:[port], ensuring it is connected
      * (with full state if [needsState] is true), then run [block].
      *
@@ -87,6 +99,7 @@ object AtemConnectionManager {
 
     /** Immediately closes the cached connection (e.g. when ATEM settings change). */
     fun invalidate() {
+        generation++
         if (client != null) CrashReporter.breadcrumb("ATEM disconnected", category = "integration")
         client?.disconnect()
         client = null
@@ -111,10 +124,20 @@ object AtemConnectionManager {
     }
 
     private suspend fun openConnection(host: String, port: Int, collectState: Boolean): AtemClient {
+        val openedAt = generation
         val c = AtemClient(host, port)
         // keepAlive = true: hold the session open across calls so reused operations
         // never hit a stale-session timeout.
         withContext(Dispatchers.IO) { c.connect(collectState = collectState, keepAlive = true) }
+        if (openedAt != generation) {
+            // Invalidated while this was connecting: hand the caller its connection, since it asked
+            // for one and is holding the mutex, but do not cache what is already known to be stale.
+            CrashReporter.breadcrumb(
+                "ATEM connection discarded (invalidated while connecting)",
+                category = "integration",
+            )
+            return c
+        }
         client = c
         cachedHost = host
         cachedPort = port

--- a/atem/src/test/kotlin/org/churchpresenter/atem/AtemConnectionManagerTest.kt
+++ b/atem/src/test/kotlin/org/churchpresenter/atem/AtemConnectionManagerTest.kt
@@ -212,6 +212,38 @@ class AtemConnectionManagerTest {
     }
 
     @Test
+    fun `a connection invalidated while it was still connecting is not cached`() {
+        // The window this closes: invalidate() cannot take the manager's mutex -- it does not
+        // suspend, and it is called from settings changes and from test teardown -- so it can land
+        // while a connect is in flight. Before the generation check, that connect went on to cache
+        // itself afterwards, leaving the manager holding a client for an endpoint that had already
+        // been abandoned. Nothing later noticed, because AtemClient.isAlive() is `socket != null`,
+        // which for UDP stays true whether or not anything is still listening at the other end.
+        var invalidatedDuringConnect = false
+        FakeAtemSwitcher(
+            onHelloReceived = {
+                // Exactly once, and strictly inside the connect: the client is waiting on this reply.
+                if (!invalidatedDuringConnect) {
+                    invalidatedDuringConnect = true
+                    AtemConnectionManager.invalidate()
+                }
+            },
+        ).use { fake ->
+            runBlocking {
+                val raced = AtemConnectionManager.use(LOOPBACK, fake.port) { it }
+                assertTrue(invalidatedDuringConnect, "the switcher must have raced the connect")
+
+                val next = AtemConnectionManager.use(LOOPBACK, fake.port) { it }
+                assertNotSame(
+                    raced,
+                    next,
+                    "a connection opened across an invalidate must not be handed to the next caller",
+                )
+            }
+        }
+    }
+
+    @Test
     fun `invalidate with nothing cached is a no-op`() {
         AtemConnectionManager.invalidate()
         AtemConnectionManager.invalidate()

--- a/atem/src/testFixtures/kotlin/org/churchpresenter/atem/FakeAtemSwitcher.kt
+++ b/atem/src/testFixtures/kotlin/org/churchpresenter/atem/FakeAtemSwitcher.kt
@@ -56,6 +56,15 @@ class FakeAtemSwitcher(
     /** When false the hello is ignored, so a connect attempt fails as if nothing is listening. */
     private val answerHello: Boolean = true,
     /**
+     * Run on the switcher's receive thread when a hello arrives, before the reply goes out.
+     *
+     * A seam for the window a connect is *inside*: the client has sent its hello and is waiting, so
+     * anything this does happens strictly between "connect started" and "connect finished". That is
+     * the only way to test what a concurrent [AtemConnectionManager.invalidate] does to a connection
+     * still being opened, and it needs no sleep to hit it.
+     */
+    private val onHelloReceived: (() -> Unit)? = null,
+    /**
      * When false, commands are received and recorded but never ACKed — a switcher that has gone
      * deaf mid-session. Withholding a reply, like [answerHello]; nothing here invents a layout the
      * captures did not show.
@@ -115,6 +124,7 @@ class FakeAtemSwitcher(
 
         if (flags and FLAG_HELLO != 0) {
             if (!answerHello) return
+            onHelloReceived?.invoke()
             // The hello reply still carries the client's placeholder session id; the real one
             // only appears in the packets that follow. AtemClient depends on exactly this.
             send(header(FLAG_HELLO, TEMP_SESSION_ID, packetId = 0, extra = 8))

--- a/bible-engine/build.gradle.kts
+++ b/bible-engine/build.gradle.kts
@@ -66,6 +66,13 @@ tasks.register<JavaExec>("stickyAudit") {
 detekt {
     buildUponDefaultConfig = true
     config.setFrom(rootProject.file("config/detekt/detekt.yml"))
+    // Pre-existing findings from the day this module was added to CI's detekt step, suppressed so
+    // the rules gate NEW code only -- the same bargain `:composeApp`'s baseline strikes, and struck
+    // here for the same reason. The detection engine and its parsers: byte-level .spb reading, scoring loops and a
+    // reference watcher that is one long ordered decision.
+    // Every entry is `src/main`; the test sources were brought to zero instead, and must keep it.
+    // Hand-edit it: never regenerate, or it absorbs whatever was introduced since.
+    baseline = file("config/detekt/baseline.xml")
     source.setFrom("src/main/kotlin", "src/test/kotlin")
     parallel = true
 }

--- a/bible-engine/config/detekt/baseline.xml
+++ b/bible-engine/config/detekt/baseline.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:DetectionLogger.kt$DetectionLogger$file.isFile &amp;&amp; n.endsWith(".jsonl") &amp;&amp; (n.startsWith(BASE_PREFIX) || n.startsWith(CANDIDATE_PREFIX) || n.startsWith(STICKY_PREFIX)) &amp;&amp; file.lastModified() &lt; cutoff</ID>
+    <ID>ComplexCondition:DetectionLogger.kt$DetectionLogger$it in 'A'..'Z' || it in 'a'..'z' || it in '0'..'9' || it == '.' || it == '_' || it == '-'</ID>
+    <ID>ComplexCondition:ReferenceWatcher.kt$ReferenceWatcher$len == 1 &amp;&amp; (AMBIGUOUS_BOOK_FORMS[phrase] != null || isShortAlias(phrase, bookNum)) &amp;&amp; !hasAmbiguousBookCorroboration(tokens, i)</ID>
+    <ID>ComplexCondition:ReferenceWatcher.kt$ReferenceWatcher$tok != ":" &amp;&amp; tok != "-" &amp;&amp; !isChapKw(tok) &amp;&amp; !isVerseKw(tok) &amp;&amp; tok !in RANGE_WORDS &amp;&amp; tok !in LIST_WORDS &amp;&amp; !isNumberRatherThanBook(tok)</ID>
+    <ID>ComplexCondition:SpbLoader.kt$SpbLoader$line.startsWith("##") || line.startsWith(" ") || line.startsWith("\t") || line.isBlank()</ID>
+    <ID>ComplexCondition:StickyAudit.kt$row.prevBook != null &amp;&amp; row.prevBook == row.newBook &amp;&amp; row.prevChapter != null &amp;&amp; row.newChapter == null</ID>
+    <ID>CyclomaticComplexMethod:DetectionEngine.kt$DetectionEngine$private fun runDetection(state: UtteranceState): List&lt;ScriptureEvent&gt;</ID>
+    <ID>CyclomaticComplexMethod:ReferenceWatcher.kt$ReferenceWatcher$private fun classify(tokens: List&lt;String&gt;): List&lt;Atom&gt;</ID>
+    <ID>CyclomaticComplexMethod:ReferenceWatcher.kt$ReferenceWatcher$private fun interpret(atoms: List&lt;Atom&gt;, sticky: Sticky, now: Long): List&lt;Ref&gt;</ID>
+    <ID>CyclomaticComplexMethod:SocketHandler.kt$fun Route.bibleEngineSocket( engine: DetectionEngine, broadcaster: Broadcaster, // Single-threaded detection dispatcher (EngineServer) — the engine's shared state // (utterances, Stabilizer, Config tuning) is mutated ONLY on this context, which is what // makes it safe with multiple concurrent WS clients + the STT thread. Defaults to the // caller's context for tests that drive a single connection. detectionContext: CoroutineContext = EmptyCoroutineContext, )</ID>
+    <ID>CyclomaticComplexMethod:SpbLoader.kt$SpbLoader$private fun parseFile(file: File, seenIds: MutableMap&lt;String, Int&gt;): EngineTranslation?</ID>
+    <ID>CyclomaticComplexMethod:SpbVersionIndex.kt$SpbVersionIndex.Companion$fun build(file: File, seenIds: MutableMap&lt;String, Int&gt;): SpbVersionIndex?</ID>
+    <ID>LongMethod:DetectionEngine.kt$DetectionEngine$private fun runDetection(state: UtteranceState): List&lt;ScriptureEvent&gt;</ID>
+    <ID>LongParameterList:DetectionEngine.kt$DetectionEngine$( id: String, verse: EngineVerse, translation: EngineTranslation, confidence: Double, matchType: String, verseEnd: Int?, )</ID>
+    <ID>LongParameterList:DetectionLogger.kt$DetectionLogger$( transcript: String, translation: String, prevBook: Int?, prevChapter: Int?, newBook: Int?, newChapter: Int?, )</ID>
+    <ID>LongParameterList:ReferenceWatcher.kt$ReferenceWatcher$( curBook: Int?, chapter: Int?, verseStart: Int?, verseEnd: Int?, keywordSeen: Boolean, sticky: Sticky, now: Long, out: MutableList&lt;Ref&gt;, )</ID>
+    <ID>LongParameterList:SpbVersionIndex.kt$SpbVersionIndex$( val id: String, val label: String, val script: Script, val fileName: String, private val file: File, private val fileLength: Long, private val lastModified: Long, /** Packed book/chapter/verse keys, ascending — binary-searched by [text]. */ private val codes: IntArray, private val textOffsets: LongArray, private val textLengths: IntArray, )</ID>
+    <ID>LoopWithTooManyJumpStatements:BibleIndex.kt$BibleIndex$for</ID>
+    <ID>LoopWithTooManyJumpStatements:DetectionEngine.kt$DetectionEngine$while</ID>
+    <ID>LoopWithTooManyJumpStatements:NumberWords.kt$NumberWords$while</ID>
+    <ID>LoopWithTooManyJumpStatements:ReferenceWatcher.kt$ReferenceWatcher$for</ID>
+    <ID>LoopWithTooManyJumpStatements:ReferenceWatcher.kt$ReferenceWatcher$while</ID>
+    <ID>LoopWithTooManyJumpStatements:SocketHandler.kt$for</ID>
+    <ID>LoopWithTooManyJumpStatements:SpbLoader.kt$SpbLoader$for</ID>
+    <ID>MagicNumber:AgreementScorer.kt$AgreementScorer$3</ID>
+    <ID>MagicNumber:BibleIndex.kt$BibleIndex$3</ID>
+    <ID>MagicNumber:BibleIndex.kt$BibleIndex$5</ID>
+    <ID>MagicNumber:BibleIndex.kt$BibleIndex$6</ID>
+    <ID>MagicNumber:ContinuationEngine.kt$ContinuationEngine$0.5</ID>
+    <ID>MagicNumber:ContinuationEngine.kt$ContinuationEngine$0.55</ID>
+    <ID>MagicNumber:ContinuationEngine.kt$ContinuationEngine$0.85</ID>
+    <ID>MagicNumber:ContinuationEngine.kt$ContinuationEngine$0.88</ID>
+    <ID>MagicNumber:ContinuationEngine.kt$ContinuationEngine$3</ID>
+    <ID>MagicNumber:DetectionLogger.kt$DetectionLogger$5</ID>
+    <ID>MagicNumber:EngineServer.kt$EngineServer$1000</ID>
+    <ID>MagicNumber:EngineServer.kt$EngineServer$500</ID>
+    <ID>MagicNumber:EngineServer.kt$EngineServer$9</ID>
+    <ID>MagicNumber:ReferenceWatcher.kt$ReferenceWatcher$3</ID>
+    <ID>MagicNumber:ReferenceWatcher.kt$ReferenceWatcher$4</ID>
+    <ID>MagicNumber:ReverseLookup.kt$ReverseLookup$3</ID>
+    <ID>MagicNumber:SpbLoader.kt$SpbLoader$10</ID>
+    <ID>MagicNumber:SpbLoader.kt$SpbLoader$200</ID>
+    <ID>MagicNumber:SpbLoader.kt$SpbLoader$3</ID>
+    <ID>MagicNumber:SpbLoader.kt$SpbLoader$5</ID>
+    <ID>MagicNumber:SpbVersionIndex.kt$SpbVersionIndex.Companion$0xD0</ID>
+    <ID>MagicNumber:SpbVersionIndex.kt$SpbVersionIndex.Companion$0xD1</ID>
+    <ID>MagicNumber:SpbVersionIndex.kt$SpbVersionIndex.Companion$10</ID>
+    <ID>MagicNumber:SpbVersionIndex.kt$SpbVersionIndex.Companion$12</ID>
+    <ID>MagicNumber:SpbVersionIndex.kt$SpbVersionIndex.Companion$1_000</ID>
+    <ID>MagicNumber:SpbVersionIndex.kt$SpbVersionIndex.Companion$1_000_000</ID>
+    <ID>MagicNumber:SpbVersionIndex.kt$SpbVersionIndex.Companion$20_000</ID>
+    <ID>MagicNumber:SpbVersionIndex.kt$SpbVersionIndex.Companion$4</ID>
+    <ID>MagicNumber:Stabilizer.kt$Stabilizer$256</ID>
+    <ID>MagicNumber:StickyAudit.kt$3</ID>
+    <ID>MagicNumber:StickyAudit.kt$6</ID>
+    <ID>MagicNumber:VersionDetector.kt$VersionDetector$1000</ID>
+    <ID>MagicNumber:VersionDetector.kt$VersionDetector$1000.0</ID>
+    <ID>NestedBlockDepth:BibleIndex.kt$BibleIndex$private fun fuzzyExpansions(token: String): List&lt;String&gt;</ID>
+    <ID>NestedBlockDepth:BibleIndex.kt$BibleIndex$private fun withinOneEdit(a: String, b: String): Boolean</ID>
+    <ID>NestedBlockDepth:ReferenceWatcher.kt$ReferenceWatcher$private fun classify(tokens: List&lt;String&gt;): List&lt;Atom&gt;</ID>
+    <ID>NestedBlockDepth:ReferenceWatcher.kt$ReferenceWatcher$private fun interpret(atoms: List&lt;Atom&gt;, sticky: Sticky, now: Long): List&lt;Ref&gt;</ID>
+    <ID>NestedBlockDepth:SpbLoader.kt$SpbLoader$private fun parseFile(file: File, seenIds: MutableMap&lt;String, Int&gt;): EngineTranslation?</ID>
+    <ID>NestedBlockDepth:SpbVersionIndex.kt$SpbVersionIndex.Companion$fun build(file: File, seenIds: MutableMap&lt;String, Int&gt;): SpbVersionIndex?</ID>
+    <ID>ReturnCount:BibleIndex.kt$BibleIndex$fun searchAllTerms(query: String, topK: Int = Config.reverseTopK): List&lt;SearchResult&gt;</ID>
+    <ID>ReturnCount:ContinuationEngine.kt$ContinuationEngine$fun check( state: UtteranceState, translations: List&lt;EngineTranslation&gt;, now: Long = System.currentTimeMillis(), ): ContinuationResult?</ID>
+    <ID>ReturnCount:ContinuationEngine.kt$ContinuationEngine$fun checkChapterScope( state: UtteranceState, translation: EngineTranslation, now: Long = System.currentTimeMillis(), ): ContinuationResult?</ID>
+    <ID>ReturnCount:DetectionEngine.kt$DetectionEngine$private fun runDetection(state: UtteranceState): List&lt;ScriptureEvent&gt;</ID>
+    <ID>ReturnCount:EngineServer.kt$EngineServer$fun start(sttUrl: String, bibleRoot: String, port: Int, bibleFiles: List&lt;String&gt; = emptyList()): EngineHandle?</ID>
+    <ID>ReturnCount:NumberWords.kt$NumberWords$fun matchedStemLength(token: String): Int</ID>
+    <ID>ReturnCount:NumberWords.kt$NumberWords$fun parseToken(token: String): Int?</ID>
+    <ID>ReturnCount:ReferenceWatcher.kt$ReferenceWatcher$private fun hasAmbiguousBookCorroboration(tokens: List&lt;String&gt;, i: Int): Boolean</ID>
+    <ID>ReturnCount:ReferenceWatcher.kt$ReferenceWatcher$private fun resolveNumberedBookAhead(tokens: List&lt;String&gt;, i: Int): Int?</ID>
+    <ID>ReturnCount:ReverseLookup.kt$ReverseLookup$fun search( query: String, index: BibleIndex, translations: List&lt;EngineTranslation&gt;, topK: Int = Config.reverseTopK, ): ReverseResult?</ID>
+    <ID>ReturnCount:SpbVersionCorpus.kt$VersionCorpusLoader$fun load( priorityFiles: List&lt;String&gt; = emptyList(), onSkip: (fileName: String, reason: String) -&gt; Unit = { _, _ -&gt; }, ): VersionCorpus</ID>
+    <ID>ReturnCount:SpbVersionIndex.kt$SpbVersionIndex$fun text(packedCode: Int): String?</ID>
+    <ID>ReturnCount:StickyAudit.kt$internal fun classify(row: StickyRow): Verdict</ID>
+    <ID>ReturnCount:VersionDetector.kt$VersionDetector$private fun evaluate(): Verdict?</ID>
+    <ID>ReturnCount:VersionScorer.kt$VersionScorer$fun deltas( candidates: List&lt;VersionCandidate&gt;, anchorText: String, spoken: String, script: Script, ): List&lt;Delta&gt;</ID>
+    <ID>TooGenericExceptionCaught:EngineServer.kt$EngineServer$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SocketHandler.kt$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SpbLoader.kt$SpbLoader$e: Exception</ID>
+    <ID>TooManyFunctions:BibleIndex.kt$BibleIndex</ID>
+    <ID>TooManyFunctions:DetectionEngine.kt$DetectionEngine</ID>
+    <ID>TooManyFunctions:DetectionLogger.kt$DetectionLogger</ID>
+    <ID>TooManyFunctions:ReferenceWatcher.kt$ReferenceWatcher</ID>
+    <ID>TooManyFunctions:SttPayload.kt$org.churchpresenter.bibleengine.socket.SttPayload.kt</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/engine/DetectionEngine.kt
+++ b/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/engine/DetectionEngine.kt
@@ -151,7 +151,6 @@ class DetectionEngine(
     private fun isMusic(speechType: String?): Boolean = speechType.equals("Music", ignoreCase = true)
 
     private fun runDetection(state: UtteranceState): List<ScriptureEvent> {
-        val combined = "${state.transcript} ${state.translation}".trim()
         val now = clock()
 
         // 1. Explicit / sticky references (stateful watcher). May yield several per utterance.
@@ -496,8 +495,6 @@ class DetectionEngine(
     private fun observeVersion(state: UtteranceState, event: ScriptureEvent) {
         versionDetector.observe(
             code = event.reference.canonicalCodeStart,
-            bookId = event.reference.bookId,
-            chapter = event.reference.chapter,
             anchorText = event.verseText,
             spoken = state.transcript,
             script = dominantScript(state.transcript),

--- a/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/engine/DetectionLogger.kt
+++ b/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/engine/DetectionLogger.kt
@@ -49,13 +49,17 @@ object DetectionLogger {
     // shutdown wait for the queue to hit disk.
     private val writeQueue = java.util.concurrent.LinkedBlockingQueue<Pair<File, String>>()
     private val pending = java.util.concurrent.atomic.AtomicInteger(0)
-    private val writerThread = Thread({
-        while (true) {
-            val (file, text) = writeQueue.take()
-            runCatching { file.appendText(text, Charsets.UTF_8) }
-            pending.decrementAndGet()
-        }
-    }, "ble-log-writer").apply { isDaemon = true; start() }
+    // Started, never held: nothing joins or interrupts it, and a `val` nobody reads only looks like
+    // an oversight. It is a daemon, so it dies with the JVM.
+    init {
+        Thread({
+            while (true) {
+                val (file, text) = writeQueue.take()
+                runCatching { file.appendText(text, Charsets.UTF_8) }
+                pending.decrementAndGet()
+            }
+        }, "ble-log-writer").apply { isDaemon = true; start() }
+    }
 
     private fun enqueue(target: File, line: String) {
         pending.incrementAndGet()

--- a/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/socket/SocketHandler.kt
+++ b/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/socket/SocketHandler.kt
@@ -40,7 +40,9 @@ fun Route.bibleEngineSocket(
                 val obj = try {
                     json.parseToJsonElement(raw).jsonObject
                 } catch (e: Exception) {
-                    System.err.println("Invalid JSON from $remoteAddr: $raw")
+                    // The message, not just the payload: "Invalid JSON" over a 4 KB line says the
+                    // parse failed and nothing about where, which is the half worth having.
+                    System.err.println("Invalid JSON from $remoteAddr (${e.message}): $raw")
                     continue
                 }
 

--- a/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/socket/SttPayload.kt
+++ b/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/socket/SttPayload.kt
@@ -1,3 +1,7 @@
+@file:Suppress("MatchingDeclarationName")
+// The file is the STT payload shapes and the parsers that read them -- SttUpdate plus
+// windowedText/transcriptionUpdate/translationUpdate -- not a home for one class.
+
 package org.churchpresenter.bibleengine.socket
 
 import org.json.JSONObject

--- a/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/version/VersionDetector.kt
+++ b/bible-engine/src/main/kotlin/org/churchpresenter/bibleengine/version/VersionDetector.kt
@@ -62,7 +62,7 @@ class VersionDetector(
      * but the translation track is machine-translated output — a rendering that belongs to no bible,
      * whose word choices land squarely in the discriminative slots this scoring depends on.
      */
-    fun observe(code: String?, bookId: Int, chapter: Int, anchorText: String, spoken: String, script: Script) {
+    fun observe(code: String?, anchorText: String, spoken: String, script: Script) {
         if (!Config.versionDetectionEnabled) return
         if (code == null || spoken.isBlank()) return
         val now = clock()

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/AgreementScorerTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/AgreementScorerTest.kt
@@ -13,7 +13,11 @@ class AgreementScorerTest {
 
     @Test fun `ё and е spellings cross-match`() {
         // Verse text often carries ё where STT writes е — folding makes them equal.
-        val score = AgreementScorer.score("Твёрдого духом Ты хранишь в совершенном мире", "твердого духом ты хранишь в совершенном мире", "")
+        val score = AgreementScorer.score(
+            "Твёрдого духом Ты хранишь в совершенном мире",
+            "твердого духом ты хранишь в совершенном мире",
+            "",
+        )
         assertEquals(1.0, score, "ё/е spellings should fold together, got $score")
     }
 
@@ -27,7 +31,11 @@ class AgreementScorerTest {
     }
 
     @Test fun `coverage measures verse words found in track`() {
-        assertTrue(AgreementScorer.coverage("for god so loved the world", "he said for god so loved the world today") >= 0.9)
+        val covered = AgreementScorer.coverage(
+            "for god so loved the world",
+            "he said for god so loved the world today",
+        )
+        assertTrue(covered >= 0.9)
         assertTrue(AgreementScorer.coverage("for god so loved the world", "completely unrelated speech") <= 0.1)
     }
 }

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/BibleIndexTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/BibleIndexTest.kt
@@ -55,7 +55,14 @@ class BibleIndexTest {
         // The runner-up here is the NEXT verse of the same passage (the window covers both) —
         // the ratio gate must pick a different-chapter competitor instead of suppressing.
         val t = fixture(listOf(
-            EngineVerse("40-11-28", 40, 11, 28, "придите ко мне все труждающиеся и обремененные и я успокою вас", false),
+            EngineVerse(
+                "40-11-28",
+                40,
+                11,
+                28,
+                "придите ко мне все труждающиеся и обремененные и я успокою вас",
+                false,
+            ),
             EngineVerse("40-11-29", 40, 11, 29, "возьмите иго мое на себя и научитесь от меня", false),
             EngineVerse("40-5-3", 40, 5, 3, "блаженны нищие духом ибо их есть царство небесное", false),
         ))

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/ConfigTuningTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/ConfigTuningTest.kt
@@ -91,7 +91,10 @@ class ConfigTuningTest {
         Config.applyLevel("turbo")
 
         assertEquals("turbo", Config.level)
-        assertEquals(before, listOf(Config.minConfidenceEmit, Config.reverseMinScoreRatio, Config.stickyTtlMs.toDouble()))
+        assertEquals(
+            before,
+            listOf(Config.minConfidenceEmit, Config.reverseMinScoreRatio, Config.stickyTtlMs.toDouble()),
+        )
     }
 
     @Test

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/ContinuationEngineTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/ContinuationEngineTest.kt
@@ -1,6 +1,5 @@
 package org.churchpresenter.bibleengine
 
-import org.churchpresenter.bibleengine.Config
 import org.churchpresenter.bibleengine.bible.EngineBook
 import org.churchpresenter.bibleengine.bible.EngineTranslation
 import org.churchpresenter.bibleengine.bible.EngineVerse
@@ -110,7 +109,9 @@ class ContinuationEngineTest {
         )
     }
 
-    @Test fun `resolves an earlier chapter from history when it matches far better than the current sticky`() = withChapterHistory {
+    @Test
+    fun `resolves an earlier chapter from history when it matches far better than the current sticky`() =
+        withChapterHistory {
         val t = fixture(listOf(
             EngineVerse("9-15-1", 9, 15, 1, "gamma delta", false),
             EngineVerse("9-10-1", 9, 10, 1, "alpha beta gamma delta epsilon zeta", false),
@@ -123,7 +124,8 @@ class ContinuationEngineTest {
         assertEquals(10, result.verse.chapter)
     }
 
-    @Test fun `stays silent when the current sticky and a historical chapter score equally well`() = withChapterHistory {
+    @Test
+    fun `stays silent when the current sticky and a historical chapter score equally well`() = withChapterHistory {
         val t = fixture(listOf(
             EngineVerse("9-15-1", 9, 15, 1, "alpha beta gamma", false),
             EngineVerse("9-10-1", 9, 10, 1, "alpha beta gamma", false),
@@ -154,6 +156,9 @@ class ContinuationEngineTest {
 
     // ── Sequential check: verse-side coverage ──────────
 
+    // A book/chapter/verse reference plus the utterance and its clock: six values because the state
+    // being built has six, and defaulting any of them would hide what a test is pinning.
+    @Suppress("LongParameterList")
     private fun stateWithLastDetected(t: EngineTranslation, book: Int, chapter: Int, verse: Int,
                                       transcript: String, now: Long): UtteranceState {
         val state = UtteranceState(id = "test")

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/DetectionEngineRefEventTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/DetectionEngineRefEventTest.kt
@@ -46,7 +46,9 @@ class DetectionEngineRefEventTest {
 
     @Test
     fun `an explicit reference is trusted outright`() {
-        val event: ScriptureEvent = assertNotNull(engine().processTranscription("live", "turn to John chapter 3 verse 16").firstOrNull())
+        val event: ScriptureEvent = assertNotNull(
+            engine().processTranscription("live", "turn to John chapter 3 verse 16").firstOrNull()
+        )
 
         assertEquals(0.95, event.confidence)
         assertEquals("explicit", event.matchType)
@@ -95,14 +97,18 @@ class DetectionEngineRefEventTest {
 
     @Test
     fun `an explicit reference reports the detected event type`() {
-        val event: ScriptureEvent = assertNotNull(engine().processTranscription("live", "turn to John chapter 3 verse 16").firstOrNull())
+        val event: ScriptureEvent = assertNotNull(
+            engine().processTranscription("live", "turn to John chapter 3 verse 16").firstOrNull()
+        )
 
         assertEquals("scripture.detected", event.type)
     }
 
     @Test
     fun `the emitted event carries the verse code and text`() {
-        val event: ScriptureEvent = assertNotNull(engine().processTranscription("live", "turn to John chapter 3 verse 16").firstOrNull())
+        val event: ScriptureEvent = assertNotNull(
+            engine().processTranscription("live", "turn to John chapter 3 verse 16").firstOrNull()
+        )
 
         assertEquals("B043C003V016", event.reference.canonicalCodeStart)
         assertTrue(event.verseText.startsWith("For God so loved"))
@@ -146,7 +152,10 @@ class DetectionEngineRefEventTest {
     fun `reading a verse verbatim finds it without an explicit citation`() {
         Config.applyLevel("aggressive")
 
-        val events = engine().processTranscription("live", "for God so loved the world that he gave his only begotten son")
+        val events = engine(
+            ).processTranscription("live",
+            "for God so loved the world that he gave his only begotten son",
+        )
 
         assertTrue(events.isNotEmpty(), "the reverse lookup should recognise a verbatim reading")
     }

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/DetectionEngineTracksTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/DetectionEngineTracksTest.kt
@@ -14,6 +14,8 @@ import kotlin.test.assertTrue
 
 class DetectionEngineTracksTest {
 
+    // The shape of EngineTranslation itself: naming five of its fields is what building one takes.
+    @Suppress("LongParameterList")
     private fun translation(
         id: String, abbrev: String, lang: String, script: Script, bookName: String,
         texts: Map<Int, String>,

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/ReferenceWatcherTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/ReferenceWatcherTest.kt
@@ -36,13 +36,6 @@ class ReferenceWatcherTest {
         return all
     }
 
-    /**
-     * Bilingual sibling of [run] — each turn is (transcript, translation), the pair the live
-     * pipeline hands to `process`. Without this every two-track test hand-rolls its own sticky.
-     */
-    private fun runBi(vararg turns: Pair<String, String>, now: Long = 1_000L): List<ReferenceWatcher.Ref> =
-        feedBi(TestSticky(), *turns, now = now)
-
     private fun feedBi(
         s: TestSticky,
         vararg turns: Pair<String, String>,
@@ -88,17 +81,6 @@ class ReferenceWatcherTest {
     /** [word] in a minimal explicit citation — the shortest form that corroborates a book name. */
     private fun cited(word: String, chapter: Int = 3, verse: Int = 5): String =
         "$word $chapter глава $verse стих."
-
-    private fun assertResolves(text: String, book: Int, chapter: Int, verse: Int, tier: Int? = null) {
-        val refs = run(text)
-        assertTrue(
-            refs.any { it.triple() == Triple(book, chapter, verse) },
-            "\"$text\" should resolve to $book $chapter:$verse, got $refs"
-        )
-        if (tier != null) {
-            assertEquals(tier, refs.first { it.triple() == Triple(book, chapter, verse) }.tier)
-        }
-    }
 
     /** The dominant shape of every precision gate: the sticky must not move. */
     private fun assertStickyHolds(book: Int, chapter: Int?, vararg utterances: String) {
@@ -365,7 +347,10 @@ class ReferenceWatcherTest {
         assertEquals(9, sticky.watchBook)
 
         val chapterOnly = ReferenceWatcher.process("15 глава.", sticky, now = 1_000L)
-        assertTrue(chapterOnly.isEmpty(), "chapter-only continuation must not emit a fabricated verse, got $chapterOnly")
+        assertTrue(
+            chapterOnly.isEmpty(),
+            "chapter-only continuation must not emit a fabricated verse, got $chapterOnly",
+        )
         assertEquals(15, sticky.watchChapter)
 
         val verseOnly = ReferenceWatcher.process("22 стих.", sticky, now = 1_000L)
@@ -417,7 +402,10 @@ class ReferenceWatcherTest {
             "в книге Бытия, в 12 главе, в 5 стихе." to
                 "in the book of Genesis, in chapter 12, in verse 5.",
         )
-        assertTrue(refs.any { it.triple() == Triple(1, 12, 5) }, "expected Genesis 1 12:5 to have been emitted, got $refs")
+        assertTrue(
+            refs.any { it.triple() == Triple(1, 12, 5) },
+            "expected Genesis 1 12:5 to have been emitted, got $refs",
+        )
         assertEquals(1, sticky.watchBook)
         assertEquals(12, sticky.watchChapter, "EN track's own re-mention of the same book must not wipe chapter 12")
     }
@@ -552,7 +540,11 @@ class ReferenceWatcherTest {
                 val sticky = TestSticky()
                 val refs = ReferenceWatcher.process(sentence, sticky, now = 1_000L)
                 assertTrue(refs.isEmpty(), "book+chapter alone must not emit, got $refs for \"$sentence\"")
-                assertEquals(book, sticky.watchBook, "digit-adjacent \"$word\" should resolve to book $book: \"$sentence\"")
+                assertEquals(
+                    book,
+                    sticky.watchBook,
+                    "digit-adjacent \"$word\" should resolve to book $book: \"$sentence\"",
+                )
             }
         }
     }
@@ -1093,7 +1085,10 @@ class ReferenceWatcherTest {
         // (EN keyword-after-number forms like "Job chapter 3 verse 2" still mis-parse for a
         // pre-existing, unrelated reason — see the keyword-order gap note in TRAINING_PLAN.md.)
         val jobRefs = run("Job 3:2 tells us more.")
-        assertTrue(jobRefs.any { it.bookNum == 18 && it.chapter == 3 && it.verseStart == 2 }, "Job 3:2 should resolve, got $jobRefs")
+        assertTrue(
+            jobRefs.any { it.bookNum == 18 && it.chapter == 3 && it.verseStart == 2 },
+            "Job 3:2 should resolve, got $jobRefs",
+        )
         val revRefs = run("откр 3 глава 12 стих.")
         assertTrue(revRefs.any { it.bookNum == 66 && it.chapter == 3 }, "Rev 3:12 should resolve, got $revRefs")
     }

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/replay/DbReplay.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/replay/DbReplay.kt
@@ -62,6 +62,9 @@ object DbReplay {
         return if (bibleFiles.isEmpty()) SpbLoader.loadDefaults() else SpbLoader.loadSelected(bibleFiles)
     }
 
+    // Reading a session database whose schema changed over time: the nesting is one column-presence
+    // check inside the row loop, and flattening it would mean querying the schema twice.
+    @Suppress("NestedBlockDepth")
     fun readRows(dbPath: String, includeDenied: Boolean = false): List<Row> {
         val rows = ArrayList<Row>(1024)
         DriverManager.getConnection("jdbc:sqlite:$dbPath").use { conn ->
@@ -112,6 +115,10 @@ object DbReplay {
         return rows
     }
 
+    // The replay loop is a state machine over one ordered feed -- transcript and translation events
+    // interleaved -- and every branch is a case of that order. Splitting it would spread one
+    // sequence across several functions without removing a single decision.
+    @Suppress("NestedBlockDepth", "CyclomaticComplexMethod", "LoopWithTooManyJumpStatements")
     fun replay(rows: List<Row>, translations: List<EngineTranslation>, level: String): ReplayResult {
         Config.applyLevel(level)
         val previousLogPath = DetectionLogger.path

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/replay/DbReplayTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/replay/DbReplayTest.kt
@@ -65,7 +65,11 @@ class DbReplayTest {
         // Determinism guard: two replays must be byte-identical.
         val first = DbReplay.replay(rows, translations, level)
         val second = DbReplay.replay(rows, translations, level)
-        assertEquals(first.lines, second.lines, "replay is not deterministic — a wall-clock or ordering dependence survived")
+        assertEquals(
+            first.lines,
+            second.lines,
+            "replay is not deterministic — a wall-clock or ordering dependence survived",
+        )
 
         val sessionId = File(dbPath).nameWithoutExtension
         val goldenFile = File("src/test/resources/replay/golden-$sessionId.jsonl")
@@ -157,6 +161,9 @@ class DbReplayTest {
         }
     }
 
+    // Three nested `use` blocks: a connection, its statement, and the result set, each of which has
+    // to close in order.
+    @Suppress("NestedBlockDepth")
     @Test fun `translation_ts_ms column is honored when present`() {
         DriverManager.getConnection("jdbc:sqlite::memory:").use { conn ->
             conn.createStatement().use { st ->
@@ -192,17 +199,23 @@ class DbReplayTest {
                                 "translation_ts_ms INTEGER)"
                         )
                         st.executeUpdate(
-                            "INSERT INTO transcriptions (ts_ms, text, translated_text, translation_ts_ms, segment_id) " +
+                            "INSERT INTO transcriptions " +
+                            "(ts_ms, text, translated_text, translation_ts_ms, segment_id) " +
                                 "VALUES (1000, 'привет мир', 'hello world', 3500, 'seg-1')"
                         )
                         st.executeUpdate(
-                            "INSERT INTO transcriptions (ts_ms, text, segment_id) VALUES (2000, 'вторая строка', 'seg-2')"
+                            "INSERT INTO transcriptions (ts_ms, text, segment_id) " +
+                            "VALUES (2000, 'вторая строка', 'seg-2')"
                         )
                     }
                 }
                 val fileRows = DbReplay.readRows(tmp.absolutePath)
                 assertEquals(2, fileRows.size)
-                assertEquals(3500L, fileRows[0].translationTsMs, "translation arrival time must be read when the column exists")
+                assertEquals(
+                    3500L,
+                    fileRows[0].translationTsMs,
+                    "translation arrival time must be read when the column exists",
+                )
                 assertEquals(null, fileRows[1].translationTsMs)
             } finally {
                 tmp.delete()

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/SpbVersionIndexTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/SpbVersionIndexTest.kt
@@ -109,13 +109,19 @@ class SpbVersionIndexTest {
         // 120 distinct words, comfortably over MIN_FINGERPRINT_TOKENS.
         val words = ('a'..'l').flatMap { x -> ('a'..'j').map { y -> "lex$x$y" } }
         val rich = (0 until 40).map { i ->
-            Triple("B019C023V%03d".format(i + 1), i + 1, (0..5).joinToString(" ") { words[(i * 6 + it) % words.size] } + ".")
+            Triple(
+                "B019C023V%03d".format(i + 1),
+                i + 1,
+                (0..5).joinToString(" ") { words[(i * 6 + it) % words.size] } + ".",
+            )
         }
         val a = writeSpb("ENG_AAA.spb", "AAA", rich)
         val b = writeSpb("ENG_BBB.spb", "BBB", rich.map { it.copy(third = it.third.replace(".", ",")) })
         val c = writeSpb(
             "ENG_CCC.spb", "CCC",
-            rich.mapIndexed { i, v -> v.copy(third = "текст${i} совсем другими незнакомыми выражениями оборотами лексикой перевода") },
+            rich.mapIndexed { i, v ->
+                v.copy(third = "текст${i} совсем другими незнакомыми выражениями оборотами лексикой перевода")
+            },
         )
         val indexes = listOf(a, b, c).map { assertNotNull(SpbVersionIndex.build(it, mutableMapOf())) }
         val kept = VersionCorpusLoader.collapseDuplicates(indexes).map { it.label }
@@ -129,14 +135,20 @@ class SpbVersionIndexTest {
         // Their shared abbreviation is the reliable signal, and two candidates under one visible
         // label would be incoherent to report anyway.
         writeSpb("RUS_A.spb", "RST", cyrillicVerses)
-        writeSpb("RUS_B.spb", "RST", cyrillicVerses.map { it.copy(third = "(22:1) «${it.third}» иными словами совсем") })
+        writeSpb(
+            "RUS_B.spb", "RST",
+            cyrillicVerses.map { it.copy(third = "(22:1) «${it.third}» иными словами совсем") },
+        )
         Config.bibleRoot = dir.absolutePath
         assertEquals(listOf("RST"), VersionCorpusLoader.load().labels)
     }
 
     @Test fun `the selected bibles are indexed even when the cap would exclude them`() {
         repeat(3) { i ->
-            writeSpb("ENG_A$i.spb", "A$i", cyrillicVerses.map { it.copy(third = "вариант $i уникальный текст стиха здесь") })
+            writeSpb(
+                "ENG_A$i.spb", "A$i",
+                cyrillicVerses.map { it.copy(third = "вариант $i уникальный текст стиха здесь") },
+            )
         }
         writeSpb("ZZZ_LAST.spb", "ZZZ", cyrillicVerses.map { it.copy(third = "совершенно другой перевод стиха") })
         Config.bibleRoot = dir.absolutePath
@@ -204,8 +216,14 @@ class SpbVersionIndexTest {
     }
 
     @Test fun `a corpus that loads cleanly reports no skips at all`() {
-        writeSpb("ENG_AAA.spb", "AAA", cyrillicVerses.map { it.copy(third = "первый перевод уникальными словами здесь") })
-        writeSpb("ENG_BBB.spb", "BBB", cyrillicVerses.map { it.copy(third = "второй совсем другой лексикой оборотами") })
+        writeSpb(
+            "ENG_AAA.spb", "AAA",
+            cyrillicVerses.map { it.copy(third = "первый перевод уникальными словами здесь") },
+        )
+        writeSpb(
+            "ENG_BBB.spb", "BBB",
+            cyrillicVerses.map { it.copy(third = "второй совсем другой лексикой оборотами") },
+        )
         Config.bibleRoot = dir.absolutePath
 
         val skips = mutableListOf<String>()

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/VersionAsyncTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/VersionAsyncTest.kt
@@ -54,7 +54,7 @@ class VersionAsyncTest {
 
     /** The anchor must be that verse's own rendering — it is the language reference for the filter. */
     private fun VersionDetector.read(code: String, spoken: String) = observe(
-        code, bookId = 40, chapter = 18,
+        code,
         anchorText = if (code == MATT_18_13) KJV_MATT_18_13 else KJV_MATT_18_14,
         spoken = spoken, script = Script.LATIN,
     )
@@ -102,7 +102,11 @@ class VersionAsyncTest {
         // never on a timeout — so it is fast and cannot flake.
         val done = java.util.concurrent.CountDownLatch(1)
         var scoringThread: String? = null
-        val d = VersionDetector({ corpus }, { 1_000L }, { scoringThread = Thread.currentThread().name; done.countDown() })
+        val d = VersionDetector(
+            { corpus },
+            { 1_000L },
+            { scoringThread = Thread.currentThread().name; done.countDown() },
+        )
         try {
             d.read(MATT_18_13, spoken13)
             d.read("B040C018V014", spoken14)

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/VersionDetectorTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/VersionDetectorTest.kt
@@ -68,8 +68,8 @@ class VersionDetectorTest {
         Config.versionResetGapMs = saved["gap"] as Long
     }
 
-    private fun VersionDetector.read(code: String, anchor: String, spoken: String, chapter: Int = 18) =
-        observe(code, bookId = 40, chapter = chapter, anchorText = anchor, spoken = spoken, script = Script.LATIN)
+    private fun VersionDetector.read(code: String, anchor: String, spoken: String) =
+        observe(code, anchorText = anchor, spoken = spoken, script = Script.LATIN)
 
     @Test fun `one verse is never enough to name a version`() {
         val d = detector()
@@ -113,8 +113,13 @@ class VersionDetectorTest {
         d.read("B040C018V014", KJV_MATT_18_14, spokenNasb14)
         assertEquals("NASB", assertNotNull(d.verdict()).label)
 
-        d.read(MATT_18_13, KJV_MATT_18_13, spokenNasb13, chapter = 5)
-        assertEquals("NASB", assertNotNull(d.verdict()).label, "the answer must survive a new passage")
+        // This used to pass `chapter = 5` to mean "a new passage" -- but `observe` never read the
+        // chapter (or the book) it was given, so the passage never changed and this line has only
+        // ever repeated the observation above it. The parameters are gone now; expressing a real
+        // passage change here needs a different `code` with its own anchor, and is left undone
+        // rather than faked.
+        d.read(MATT_18_13, KJV_MATT_18_13, spokenNasb13)
+        assertEquals("NASB", assertNotNull(d.verdict()).label, "the answer must survive a repeat")
     }
 
     @Test fun `a verse that separates nothing leaves the answer standing`() {

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/VersionFixtures.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/VersionFixtures.kt
@@ -1,3 +1,6 @@
+@file:Suppress("MatchingDeclarationName")
+// Fixtures for the version suites: a corpus stand-in and the builder that fills it.
+
 package org.churchpresenter.bibleengine.version
 
 import org.churchpresenter.bibleengine.bible.Script

--- a/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/VersionScorerTest.kt
+++ b/bible-engine/src/test/kotlin/org/churchpresenter/bibleengine/version/VersionScorerTest.kt
@@ -153,7 +153,8 @@ class VersionScorerTest {
 
     @Test fun `a window that does not contain the verse gets no vote`() {
         // Partial windows are the dominant noise source — and where the miss penalty misfires worst.
-        assertTrue(score(listOf(candidate("KJV", KJV_MATT_18_13), candidate("NASB", NASB_MATT_18_13)), "he finds it").isEmpty())
+        val candidates = listOf(candidate("KJV", KJV_MATT_18_13), candidate("NASB", NASB_MATT_18_13))
+        assertTrue(score(candidates, "he finds it").isEmpty())
     }
 
     @Test fun `an unrelated-language version is excluded by content not by filename`() {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemBridge.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/AtemBridge.kt
@@ -9,6 +9,8 @@ import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.websocket.readText
 import java.io.File
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.serialization.json.Json
 import org.churchpresenter.settings.AtemSettings
 import org.churchpresenter.app.churchpresenter.viewmodel.isLottieFile
@@ -29,10 +31,47 @@ internal class AtemBridge(private val json: Json) {
     @Volatile internal var _atemSettings: AtemSettings? = null
     @Volatile private var _lowerThirdFolder: String = ""
 
+    /**
+     * The coroutine currently uploading to the media pool, or null when nothing is in flight.
+     *
+     * The upload routes answer the HTTP request before doing any ATEM work and then transfer on the
+     * server's own scope, so without a handle here nothing -- not a settings change, not a shutdown,
+     * not a test -- can tell whether an upload is still running, let alone stop it. Written from the
+     * route's thread and read from whoever changes the configuration, hence the lock rather than a
+     * bare field: [cancelUpload] must not race a [trackUpload] into cancelling the wrong job.
+     */
+    private var uploadJob: Job? = null
+    private val uploadLock = Any()
+
+    /** Records the coroutine now performing an upload, replacing any previous one. */
+    internal fun trackUpload(job: Job) {
+        synchronized(uploadLock) { uploadJob = job }
+    }
+
+    /**
+     * Stops the in-flight upload and waits for it to actually be over.
+     *
+     * The join is the point. Cancelling alone only *asks*, and the upload's next act would be
+     * another `AtemConnectionManager.use` -- so a caller that dropped the pooled connection and then
+     * merely cancelled could still have it re-opened and re-cached behind its back. Returning only
+     * once the coroutine has stopped is what makes "the upload is over" something a caller can rely
+     * on. Normally instant: an upload past its transfer is sitting in a cancellable `delay`.
+     */
+    internal suspend fun cancelUpload() {
+        val job = synchronized(uploadLock) { uploadJob.also { uploadJob = null } } ?: return
+        job.cancelAndJoin()
+    }
+
     /** Applies new ATEM settings, dropping the pooled connection when the endpoint moved. */
     fun updateConfig(atem: AtemSettings, lowerThirdFolder: String) {
         val prev = _atemSettings
         if (prev == null || prev.host != atem.host || prev.port != atem.port) {
+            // An upload in flight is aimed at the switcher that is being moved away from. Let it run
+            // and it keeps writing to the old endpoint, and re-caches a connection to it the moment
+            // it reaches its next `use` -- undoing the invalidate below. Not joined here: this is
+            // not a suspending call, and the generation counter in AtemConnectionManager covers the
+            // connect that may be in flight at this instant.
+            synchronized(uploadLock) { uploadJob.also { uploadJob = null } }?.cancel()
             AtemConnectionManager.invalidate()
         }
         _atemSettings = atem

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdAndAtemRoutes.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/LowerThirdAndAtemRoutes.kt
@@ -10,6 +10,7 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.websocket.readText
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -177,9 +178,11 @@ private fun Route.atemClipRoutes(
                         )
                         return@post
                     }
-                    scope.launch {
-                        uploadClipFrames(file, atem, slot, key, name, lottieJson, fps, frameCount)
-                    }
+                    server.atem.trackUpload(
+                        scope.launch {
+                            uploadClipFrames(file, atem, slot, key, name, lottieJson, fps, frameCount)
+                        }
+                    )
                     val keyInfoClip = when {
                         !key.on -> ""
                         key.useDsk -> ""","dsk":${key.keyer + 1}"""
@@ -232,7 +235,9 @@ private suspend fun handleAtemStillUpload(
                     call.respond(HttpStatusCode.BadRequest, """{"error":${server.atem.jsonStr(it)}}""")
                     return
                 }
-                scope.launch { uploadStillFrame(file, atem, slot, key, name) }
+                // Tracked, not dropped: the transfer outlives this response, so something has to
+                // be able to stop it -- see AtemBridge.cancelUpload.
+                server.atem.trackUpload(scope.launch { uploadStillFrame(file, atem, slot, key, name) })
                 val keyInfo = when {
                     !key.on -> ""
                     key.useDsk -> ""","dsk":${key.keyer + 1}"""
@@ -272,6 +277,12 @@ private suspend fun uploadStillFrame(
         AtemUploadStatus.complete(uploadId)
         delay(KEY_SETTLE_MS)
         AtemUploadStatus.clear(uploadId)
+    } catch (e: CancellationException) {
+        // Cancelled deliberately -- the ATEM was repointed, or the server is going down. Not a
+        // failure, so leave no error banner behind, and let it propagate: swallowing it here would
+        // report a cancelled upload as a broken one.
+        AtemUploadStatus.clear(uploadId)
+        throw e
     } catch (e: Exception) {
         System.err.println("[CompanionServer] ATEM still upload failed for '$name': ${e.message}")
         CrashReporter.reportWarning(
@@ -338,6 +349,12 @@ private suspend fun uploadClipFrames(
                 client.setKeyOnAir(AtemKey(key.useDsk, key.mixEffect, key.keyer), false)
             }
         }
+    } catch (e: CancellationException) {
+        // Cancelled deliberately -- the ATEM was repointed, or the server is going down. Not a
+        // failure, so leave no error banner behind, and let it propagate: swallowing it here would
+        // report a cancelled upload as a broken one.
+        AtemUploadStatus.clear(uploadId)
+        throw e
     } catch (e: Exception) {
         System.err.println("[CompanionServer] ATEM clip upload failed for '$name': ${e.message}")
         CrashReporter.reportWarning(

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerAtemKeyTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerAtemKeyTest.kt
@@ -12,6 +12,7 @@ import org.churchpresenter.settings.AtemSettings
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -63,7 +64,9 @@ class CompanionServerAtemKeyTest {
                     while (!server.isRunning.value || server.serverUrl.value.isBlank()) {
                         kotlinx.coroutines.delay(25)
                     }
-                    testPort(39_870)
+                    // Read back where it really is: start() runs the port through findFreePort,
+                    // which walks upward when the port is taken.
+                    server.serverUrl.value.substringAfterLast(':').toInt()
                 }
             } ?: error("companion server did not start")
         }
@@ -75,10 +78,18 @@ class CompanionServerAtemKeyTest {
         }
     }
 
+    @BeforeTest
+    fun dropInheritedConnection() {
+        // One JVM runs every suite in jvmTestSerial, so the pooled connection is shared across
+        // classes. Each is expected to leave it clean; none of them is trusted to.
+        AtemConnectionManager.invalidate()
+    }
+
     @AfterTest
     fun releaseConnection() {
         // The manager caches one client process-wide; drop it so no keepalive loop outlives the
         // fake switcher it was talking to.
+        runBlocking { server.atem.cancelUpload() }
         AtemConnectionManager.invalidate()
         if (::client.isInitialized) client.close()
     }
@@ -90,6 +101,28 @@ class CompanionServerAtemKeyTest {
 
     /** A switcher big enough that no test trips validation before reaching it. */
     private fun switcher() = FakeAtemSwitcher(mixEffects = 4, downstreamKeyers = 2, keyersPerMe = 4)
+
+    /**
+     * Runs [body] against a fresh switcher and releases the shared connection **before** the
+     * switcher closes.
+     *
+     * Closing first leaves `AtemConnectionManager` holding a client for a peer that has gone, and
+     * nothing detects that: `AtemClient.isAlive()` is `socket != null`, true for a UDP socket with
+     * nobody listening. The fake binds an ephemeral port the OS may hand out again, so the next
+     * suite in this JVM can be given an endpoint the manager believes it is already connected to,
+     * skip the handshake, and record no commands at all. See `CompanionServerAtemUploadTest`, which
+     * failed exactly that way on CI.
+     */
+    private fun withSwitcher(body: (FakeAtemSwitcher) -> Unit) {
+        switcher().use { fake ->
+            try {
+                body(fake)
+            } finally {
+                runBlocking { server.atem.cancelUpload() }
+                AtemConnectionManager.invalidate()
+            }
+        }
+    }
 
     private fun configure(fake: FakeAtemSwitcher, settings: AtemSettings = AtemSettings()) {
         server.updateAtemConfig(
@@ -110,7 +143,7 @@ class CompanionServerAtemKeyTest {
 
     @Test
     fun `cutting an upstream key on air reaches the switcher and reports the target it drove`() {
-        switcher().use { fake ->
+        withSwitcher { fake ->
             configure(fake)
 
             val response = press("/api/atem/key/on?me=2&key=3")
@@ -130,7 +163,7 @@ class CompanionServerAtemKeyTest {
 
     @Test
     fun `taking an upstream key off air sends the same target with the on-air flag cleared`() {
-        switcher().use { fake ->
+        withSwitcher { fake ->
             configure(fake)
 
             val response = press("/api/atem/key/off?me=1&key=1")
@@ -148,7 +181,7 @@ class CompanionServerAtemKeyTest {
     @Test
     fun `a press that names no target uses the operator's configured defaults`() {
         // This is the ordinary Stream Deck button: no query string, whatever the ATEM settings say.
-        switcher().use { fake ->
+        withSwitcher { fake ->
             configure(fake, AtemSettings(keyMixEffect = 1, keyIndex = 2))
 
             val response = press("/api/atem/key/on")
@@ -167,7 +200,7 @@ class CompanionServerAtemKeyTest {
 
     @Test
     fun `keytype dsk drives a downstream keyer instead of an upstream one`() {
-        switcher().use { fake ->
+        withSwitcher { fake ->
             configure(fake)
 
             val response = press("/api/atem/key/on?keytype=dsk&key=2")
@@ -185,7 +218,7 @@ class CompanionServerAtemKeyTest {
 
     @Test
     fun `the persisted downstream preference applies with no keytype on the request`() {
-        switcher().use { fake ->
+        withSwitcher { fake ->
             configure(fake, AtemSettings(useDownstreamKey = true, dskIndex = 1))
 
             val response = press("/api/atem/key/on")
@@ -198,7 +231,7 @@ class CompanionServerAtemKeyTest {
 
     @Test
     fun `keytype usk overrides a persisted downstream preference`() {
-        switcher().use { fake ->
+        withSwitcher { fake ->
             configure(fake, AtemSettings(useDownstreamKey = true, dskIndex = 1))
 
             val response = press("/api/atem/key/on?keytype=usk&me=1&key=1")
@@ -219,7 +252,7 @@ class CompanionServerAtemKeyTest {
         // The ATEM drops an idle UDP session after a few seconds and the manager caches one client,
         // so the second button press is a different code path from the first: it must not silently
         // land on a stale session.
-        switcher().use { fake ->
+        withSwitcher { fake ->
             configure(fake)
 
             assertEquals(HttpStatusCode.OK, press("/api/atem/key/on?me=1&key=1").status)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerAtemUploadTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerAtemUploadTest.kt
@@ -98,7 +98,15 @@ class CompanionServerAtemUploadTest {
         private var clipFrames: Int = 0
         private var clipFrameBytes: Int = 0
 
-        private val port = testPort(39_880)
+        /**
+         * The port the server is ASKED for. Never build a URL from it: `CompanionServer.start` runs
+         * it through `findFreePort`, which walks upward when the port is taken, so the server can
+         * end up one along. [boundPort] is where it actually is.
+         */
+        private val requestedPort = testPort(39_880)
+
+        /** Where the server really listens, read back from its own URL once it is up. */
+        private var boundPort: Int = 0
 
         @JvmStatic
         @BeforeClass
@@ -138,13 +146,13 @@ class CompanionServerAtemUploadTest {
             }
 
             server = CompanionServer()
-            server.start(port = port)
-            runBlocking {
+            server.start(port = requestedPort)
+            boundPort = runBlocking {
                 withTimeoutOrNull(10_000) {
                     while (!server.isRunning.value || server.serverUrl.value.isBlank()) {
                         kotlinx.coroutines.delay(25)
                     }
-                    true
+                    server.serverUrl.value.substringAfterLast(':').toInt()
                 }
             } ?: error("companion server did not start")
         }
@@ -185,6 +193,35 @@ class CompanionServerAtemUploadTest {
     private fun switcher() = FakeAtemSwitcher(mixEffects = 4, downstreamKeyers = 2, keyersPerMe = 4)
         .also { it.expectedTransferBytes = payloadBytes }
 
+    /**
+     * Runs [body] against a fresh switcher, and drops the shared ATEM connection **before** that
+     * switcher closes.
+     *
+     * `switcher().use { }` on its own closes the socket first and leaves `AtemConnectionManager`
+     * holding a client for a peer that is gone. Nothing notices: `AtemClient.isAlive()` is
+     * `socket != null`, which for UDP stays true forever, and the fake binds an **ephemeral** port
+     * that the next test can be handed again -- at which point `ensureConnected` sees an endpoint it
+     * believes it is already connected to and skips the handshake, so the new switcher records not
+     * one command of any name and every wait in the test times out with "got 0". That is the shape
+     * five of these tests failed with on CI.
+     *
+     * Same lesson as `LowerThirdSequencerKeyTest` in 7b819d1a: tear the connection down while the
+     * switcher is still there to answer, not after it has gone.
+     */
+    private fun withSwitcher(
+        configureWith: (FakeAtemSwitcher) -> Unit = { configure(it) },
+        body: (FakeAtemSwitcher) -> Unit,
+    ) {
+        switcher().use { fake ->
+            configureWith(fake)
+            try {
+                body(fake)
+            } finally {
+                AtemConnectionManager.invalidate()
+            }
+        }
+    }
+
     private fun configure(fake: FakeAtemSwitcher) {
         server.updateAtemConfig(settings("127.0.0.1", fake.port), lowerThirdFolder = lottieFolder.absolutePath)
     }
@@ -200,7 +237,7 @@ class CompanionServerAtemUploadTest {
     }
 
     private fun upload(query: String): HttpResponse =
-        runBlocking { http().post("http://127.0.0.1:$port/api/atem/still/Welcome$query") }
+        runBlocking { http().post("http://127.0.0.1:$boundPort/api/atem/still/Welcome$query") }
 
     // ── The fixture ─────────────────────────────────────────────────────────────
 
@@ -224,8 +261,7 @@ class CompanionServerAtemUploadTest {
 
     @Test
     fun `a still is rendered and every byte of it reaches the switcher`() {
-        switcher().use { fake ->
-            configure(fake)
+        withSwitcher { fake ->
 
             val response = upload("?slot=3")
 
@@ -251,8 +287,7 @@ class CompanionServerAtemUploadTest {
     fun `the slot the operator asked for is the slot that is written`() {
         // The query is 1-based and the protocol is 0-based, and a still landing in the wrong slot
         // overwrites whatever the operator had prepared there.
-        switcher().use { fake ->
-            configure(fake)
+        withSwitcher { fake ->
 
             upload("?slot=5")
 
@@ -263,12 +298,14 @@ class CompanionServerAtemUploadTest {
 
     @Test
     fun `with no slot on the request the configured default is used`() {
-        switcher().use { fake ->
-            server.updateAtemConfig(
-                settings("127.0.0.1", fake.port).copy(defaultStillSlot = 7),
-                lowerThirdFolder = lottieFolder.absolutePath
-            )
-
+        withSwitcher(
+            configureWith = { fake ->
+                server.updateAtemConfig(
+                    settings("127.0.0.1", fake.port).copy(defaultStillSlot = 7),
+                    lowerThirdFolder = lottieFolder.absolutePath
+                )
+            }
+        ) { fake ->
             val body = runBlocking { upload("").bodyAsText() }
 
             assertTrue(body.contains(""""slot":8"""), "the response reports the 1-based slot: $body")
@@ -287,7 +324,7 @@ class CompanionServerAtemUploadTest {
         }
 
     private fun uploadClip(query: String): HttpResponse =
-        runBlocking { http().post("http://127.0.0.1:$port/api/atem/clip/Welcome$query") }
+        runBlocking { http().post("http://127.0.0.1:$boundPort/api/atem/clip/Welcome$query") }
 
     @Test
     fun `a clip is rendered and every frame of it is transferred`() {
@@ -352,8 +389,7 @@ class CompanionServerAtemUploadTest {
     fun `asking for a key cuts it on only after the transfer has finished`() {
         // Keying before the still has landed puts the previous graphic on air — the ordering is the
         // whole point of doing both in one request.
-        switcher().use { fake ->
-            configure(fake)
+        withSwitcher { fake ->
 
             val body = runBlocking { upload("?slot=1&key=1&me=1").bodyAsText() }
             assertTrue(body.contains(""""me":1"""), body)
@@ -373,8 +409,7 @@ class CompanionServerAtemUploadTest {
 
     @Test
     fun `no key is touched when the request does not ask for one`() {
-        switcher().use { fake ->
-            configure(fake)
+        withSwitcher { fake ->
 
             upload("?slot=1")
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerAtemUploadTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/CompanionServerAtemUploadTest.kt
@@ -15,11 +15,14 @@ import org.junit.BeforeClass
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.churchpresenter.app.churchpresenter.testPort
 import org.churchpresenter.atem.AtemConnectionManager
+import org.churchpresenter.atem.AtemUploadStatus
 import org.churchpresenter.atem.FakeAtemSwitcher
 
 /**
@@ -179,8 +182,16 @@ class CompanionServerAtemUploadTest {
         )
     }
 
+    @BeforeTest
+    fun dropInheritedConnection() {
+        // These suites share one JVM (jvmTestSerial), so the pooled connection is shared too. Every
+        // class here is expected to leave it clean; none of them is trusted to.
+        AtemConnectionManager.invalidate()
+    }
+
     @AfterTest
     fun releaseConnection() {
+        runBlocking { server.atem.cancelUpload() }
         AtemConnectionManager.invalidate()
         if (::client.isInitialized) client.close()
     }
@@ -194,29 +205,38 @@ class CompanionServerAtemUploadTest {
         .also { it.expectedTransferBytes = payloadBytes }
 
     /**
-     * Runs [body] against a fresh switcher, and drops the shared ATEM connection **before** that
-     * switcher closes.
+     * Runs [body] against a fresh switcher, then ends the upload it started and drops the shared
+     * ATEM connection -- both **before** that switcher closes.
      *
-     * `switcher().use { }` on its own closes the socket first and leaves `AtemConnectionManager`
-     * holding a client for a peer that is gone. Nothing notices: `AtemClient.isAlive()` is
-     * `socket != null`, which for UDP stays true forever, and the fake binds an **ephemeral** port
-     * that the next test can be handed again -- at which point `ensureConnected` sees an endpoint it
-     * believes it is already connected to and skips the handshake, so the new switcher records not
-     * one command of any name and every wait in the test times out with "got 0". That is the shape
-     * five of these tests failed with on CI.
+     * The order is the whole point. `POST /api/atem/still|clip` answers `"uploading"` and does the
+     * transfer on `CompanionServer`'s own scope, so when the body's assertions are satisfied the
+     * coroutine is still running -- typically in the `delay(KEY_SETTLE_MS)` tail, or the
+     * clip-duration wait before the automatic key-off. Left alone it reaches its next
+     * `AtemConnectionManager.use` *after* the test invalidated, opens a connection to the fake this
+     * test is about to close, and caches it.
      *
-     * Same lesson as `LowerThirdSequencerKeyTest` in 7b819d1a: tear the connection down while the
-     * switcher is still there to answer, not after it has gone.
+     * What follows is a cascade rather than one bad test. `AtemClient.isAlive()` is `socket != null`,
+     * which for UDP stays true with nothing listening, and the fake binds an **ephemeral** port the
+     * OS can hand out again -- so `ensureConnected` believes it is already connected, skips the
+     * handshake, and the next test's switcher records not one command of any name. Each poisoned
+     * test then burns its 5s deadline while leaving ~8s of stuck work behind, so the backlog grows
+     * faster than the suite drains it. That is the shape five of these tests failed with on CI, and
+     * it survived the first attempt at this helper because the three clip tests did not use it.
+     *
+     * `cancelUpload()` joins, so it returns only once the coroutine has actually stopped and nothing
+     * can touch the connection behind us.
      */
     private fun withSwitcher(
+        newSwitcher: () -> FakeAtemSwitcher = { switcher() },
         configureWith: (FakeAtemSwitcher) -> Unit = { configure(it) },
         body: (FakeAtemSwitcher) -> Unit,
     ) {
-        switcher().use { fake ->
+        newSwitcher().use { fake ->
             configureWith(fake)
             try {
                 body(fake)
             } finally {
+                runBlocking { server.atem.cancelUpload() }
                 AtemConnectionManager.invalidate()
             }
         }
@@ -328,8 +348,7 @@ class CompanionServerAtemUploadTest {
 
     @Test
     fun `a clip is rendered and every frame of it is transferred`() {
-        clipSwitcher().use { fake ->
-            configure(fake)
+        withSwitcher({ clipSwitcher() }) { fake ->
 
             val response = uploadClip("?slot=1")
 
@@ -353,8 +372,7 @@ class CompanionServerAtemUploadTest {
 
     @Test
     fun `the clip lands in the slot the operator asked for`() {
-        clipSwitcher().use { fake ->
-            configure(fake)
+        withSwitcher({ clipSwitcher() }) { fake ->
 
             uploadClip("?slot=2")
 
@@ -368,12 +386,15 @@ class CompanionServerAtemUploadTest {
     fun `a clip too long for its slot is refused before anything is rendered`() {
         // The capacity comes from the last connection to the switcher, so the refusal happens up
         // front and the caller gets a real error rather than a silent half-ingested clip.
-        clipSwitcher().use { fake ->
-            server.updateAtemConfig(
-                settings("127.0.0.1", fake.port).copy(detectedClipMaxFrames = listOf(5, 5)),
-                lowerThirdFolder = lottieFolder.absolutePath
-            )
-
+        withSwitcher(
+            newSwitcher = { clipSwitcher() },
+            configureWith = { fake ->
+                server.updateAtemConfig(
+                    settings("127.0.0.1", fake.port).copy(detectedClipMaxFrames = listOf(5, 5)),
+                    lowerThirdFolder = lottieFolder.absolutePath
+                )
+            }
+        ) { fake ->
             val response = uploadClip("?slot=1")
 
             assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
@@ -404,6 +425,40 @@ class CompanionServerAtemUploadTest {
                 order.indexOf("CKOn") > order.lastIndexOf("FTDa"),
                 "the key must be cut only once the whole frame is across, saw $order"
             )
+        }
+    }
+
+    @Test
+    fun `an upload does not outlive the switcher it was aimed at`() {
+        // The cascade this closes. The route answers "uploading" and transfers on the server's own
+        // scope, so when a test's assertions are satisfied the coroutine is still running. Let it
+        // run past the switcher's close and its next `AtemConnectionManager.use` dials an endpoint
+        // nothing is listening on -- which holds the manager's mutex for the whole connect timeout
+        // and can leave a client cached for a dead ephemeral port. Either way the NEXT test's
+        // upload never reaches its switcher, and every wait in it times out with "got 0".
+        //
+        // cancelUpload() joins, so it returns only once the coroutine has stopped.
+        switcher().use { fake ->
+            configure(fake)
+
+            upload("?slot=1")
+            fake.awaitCommandsNamed("LOCK", 2)
+
+            runBlocking { server.atem.cancelUpload() }
+
+            assertNull(
+                AtemUploadStatus.state.value,
+                "a cancelled upload is over and is not a failure — it must leave no status behind"
+            )
+            AtemConnectionManager.invalidate()
+        }
+
+        // With nothing left over, the very next upload reaches its own switcher immediately.
+        withSwitcher { fake ->
+            upload("?slot=1")
+
+            fake.awaitCommandsNamed("LOCK", 2)
+            assertEquals(1, fake.commandsNamed("FTSD").size, "the next upload gets a real connection")
         }
     }
 

--- a/presentation-engine/build.gradle.kts
+++ b/presentation-engine/build.gradle.kts
@@ -80,6 +80,12 @@ tasks.register<JavaExec>("dumpTiming") {
 detekt {
     buildUponDefaultConfig = true
     config.setFrom(rootProject.file("config/detekt/detekt.yml"))
+    // Pre-existing findings from the day this module was added to CI's detekt step, suppressed so
+    // the rules gate NEW code only -- the same bargain `:composeApp`'s baseline strikes, and struck
+    // here for the same reason. PPTX/Keynote parsing: protobuf offsets, XML shapes and timing trees.
+    // Every entry is `src/main`; the test sources were brought to zero instead, and must keep it.
+    // Hand-edit it: never regenerate, or it absorbs whatever was introduced since.
+    baseline = file("config/detekt/baseline.xml")
     source.setFrom("src/main/kotlin", "src/test/kotlin")
     parallel = true
 }

--- a/presentation-engine/config/detekt/baseline.xml
+++ b/presentation-engine/config/detekt/baseline.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>CyclomaticComplexMethod:DumpKeynote.kt$DumpKeynote$@JvmStatic fun main(args: Array&lt;String&gt;)</ID>
+    <ID>CyclomaticComplexMethod:KeynoteBuildMapper.kt$KeynoteBuildMapper$fun map(index: ObjectIndex, slide: IwaMessage, drawables: List&lt;KnPlacedDrawable&gt;): Result?</ID>
+    <ID>CyclomaticComplexMethod:KeynoteBuildMapper.kt$KeynoteBuildMapper$private fun mapEffect(build: Build): EffectSpec</ID>
+    <ID>CyclomaticComplexMethod:MotionPathFlattener.kt$MotionPathFlattener$private fun parse(path: String): List&lt;Pair&lt;Double, Double&gt;&gt;?</ID>
+    <ID>CyclomaticComplexMethod:ObjectIndex.kt$ObjectIndex.Companion$fun load(file: File): ObjectIndex?</ID>
+    <ID>CyclomaticComplexMethod:TimelineCompiler.kt$TimelineCompiler$private fun synthesizeSpec( role: EffectSpec.Role, behaviors: List&lt;TimingBehavior&gt;, layerBoundsPt: RectPt, effectNode: TimeNode ): EffectSpec</ID>
+    <ID>LongMethod:DumpKeynote.kt$DumpKeynote$fun dumpNode(nodeId: Long, depth: Int)</ID>
+    <ID>LongParameterList:KeynoteScene.kt$KnSlide$( val index: Int, /** Background fill (slide style, falling back through the master chain). */ val background: KnFill?, /** Flattened draw list, master content first, in z-order. */ val drawables: List&lt;KnPlacedDrawable&gt;, val notes: String, val timeline: Timeline?, /** Ids of drawables that are build targets (they become their own layers). */ val builtDrawableIds: Set&lt;Long&gt;, /** Ids of drawables whose build fanned out into per-paragraph layers (By Paragraph/Bullet). */ val paragraphBuiltDrawableIds: Set&lt;Long&gt;, val transition: SlideTransitionSpec?, /** Non-null → this slide is beyond the whitelist and must render from the static fallback. */ val gateReason: String? )</ID>
+    <ID>LongParameterList:KeynoteSceneRasterizer.kt$KeynoteSceneRasterizer$( graphics: Graphics2D, paragraph: KnParagraph, width: Float, autoSized: Boolean, frc: FontRenderContext, startY: Float, paint: Boolean )</ID>
+    <ID>LoopWithTooManyJumpStatements:IwaChunkReader.kt$IwaChunkReader$while</ID>
+    <ID>LoopWithTooManyJumpStatements:KeynoteBuildMapper.kt$KeynoteBuildMapper$for</ID>
+    <ID>LoopWithTooManyJumpStatements:KeynoteDeckParser.kt$KeynoteDeckParser$while</ID>
+    <ID>LoopWithTooManyJumpStatements:KeynoteSceneRasterizer.kt$KeynoteSceneRasterizer$for</ID>
+    <ID>LoopWithTooManyJumpStatements:KeynoteStaticSupport.kt$KeynoteStaticSupport$for</ID>
+    <ID>LoopWithTooManyJumpStatements:ObjectIndex.kt$ObjectIndex.Companion$for</ID>
+    <ID>NestedBlockDepth:DumpKeynote.kt$DumpKeynote$@JvmStatic fun main(args: Array&lt;String&gt;)</ID>
+    <ID>NestedBlockDepth:IwaMessage.kt$IwaMessage.Companion$fun parse(data: ByteArray, offset: Int = 0, length: Int = data.size - offset): IwaMessage?</ID>
+    <ID>NestedBlockDepth:KeynoteBuildMapper.kt$KeynoteBuildMapper$fun map(index: ObjectIndex, slide: IwaMessage, drawables: List&lt;KnPlacedDrawable&gt;): Result?</ID>
+    <ID>NestedBlockDepth:KeynoteDeckParser.kt$KeynoteDeckParser$private fun resolveCharProps(index: ObjectIndex, styleId: Long?): CharProps?</ID>
+    <ID>NestedBlockDepth:KeynoteDeckParser.kt$KeynoteDeckParser$private fun resolveShapeStyle(index: ObjectIndex, styleId: Long?): ResolvedShapeStyle?</ID>
+    <ID>NestedBlockDepth:KeynoteSceneRasterizer.kt$KeynoteSceneRasterizer$fun rasterizeLayer(slideIndex: Int, spec: LayerSpec, targetWidthPx: Int): RasterLayer</ID>
+    <ID>NestedBlockDepth:KeynoteStaticSupport.kt$KeynoteStaticSupport$fun extractPreviewPdf(file: File, dest: File): Boolean</ID>
+    <ID>NestedBlockDepth:KeynoteStaticSupport.kt$KeynoteStaticSupport$fun readThumbnailBytes(file: File, entryName: String): ByteArray?</ID>
+    <ID>NestedBlockDepth:KeynoteStaticSupport.kt$KeynoteStaticSupport$private fun analyzeZip(file: File): Analysis</ID>
+    <ID>NestedBlockDepth:KeynoteStaticSupport.kt$KeynoteStaticSupport$private fun parseApxlNotes(xml: String): List&lt;String&gt;</ID>
+    <ID>NestedBlockDepth:KeynoteStaticSupport.kt$KeynoteStaticSupport$private fun scanIwaForNoteText(bytes: ByteArray): String</ID>
+    <ID>NestedBlockDepth:MotionPathFlattener.kt$MotionPathFlattener$private fun parse(path: String): List&lt;Pair&lt;Double, Double&gt;&gt;?</ID>
+    <ID>NestedBlockDepth:ObjectIndex.kt$ObjectIndex.Companion$fun load(file: File): ObjectIndex?</ID>
+    <ID>NestedBlockDepth:PowerPointDeckSupport.kt$PowerPointDeckSupport$private fun registerEmbeddedFonts(show: SlideShow&lt;*, *&gt;)</ID>
+    <ID>NestedBlockDepth:PowerPointDeckSupport.kt$PowerPointDeckSupport$private fun slideMeta( slide: Slide&lt;*, *&gt;, slideIndex: Int, pageWidthPt: Double, pageHeightPt: Double, warnings: MutableList&lt;String&gt; ): PowerPointSlideMeta</ID>
+    <ID>NestedBlockDepth:PptxSlideRasterizer.kt$PptxSlideRasterizer$private fun renderBand(slide: XSLFSlide, spec: LayerSpec.Background, scale: Double): BufferedImage</ID>
+    <ID>NestedBlockDepth:PresentationLoader.kt$PresentationLoader$private fun loadKeynoteStatic(file: File, analysis: KeynoteStaticSupport.Analysis): LoadResult</ID>
+    <ID>ReturnCount:DumpKeynote.kt$DumpKeynote$@JvmStatic fun main(args: Array&lt;String&gt;)</ID>
+    <ID>ReturnCount:IwaMessage.kt$IwaMessage.Companion$fun parse(data: ByteArray, offset: Int = 0, length: Int = data.size - offset): IwaMessage?</ID>
+    <ID>ReturnCount:KeynoteDeckParser.kt$KeynoteDeckParser$private fun parseFill(index: ObjectIndex, fill: IwaMessage): KnFill?</ID>
+    <ID>ReturnCount:KeynoteDeckParser.kt$KeynoteDeckParser$private fun parseImage(index: ObjectIndex, message: IwaMessage, gate: Gate): KnDrawable?</ID>
+    <ID>ReturnCount:KeynoteStaticSupport.kt$KeynoteStaticSupport$fun extractPreviewPdf(file: File, dest: File): Boolean</ID>
+    <ID>ReturnCount:MotionPathFlattener.kt$MotionPathFlattener$private fun parse(path: String): List&lt;Pair&lt;Double, Double&gt;&gt;?</ID>
+    <ID>ReturnCount:PowerPointDeckSupport.kt$PowerPointDeckSupport$fun(shapeId: Long, paragraphIndex: Int?): List&lt;TimelineCompiler.LayerIdWithBounds&gt;</ID>
+    <ID>ReturnCount:SlideDiskCache.kt$SlideDiskCache$fun lookup(file: File, renderWidthPx: Int?): CachedSlides?</ID>
+    <ID>ReturnCount:SlideFontRegistry.kt$SlideFontRegistry$fun resolveFamily(requested: String): String</ID>
+    <ID>ReturnCount:TimelineCompiler.kt$TimelineCompiler$private fun translateCurves(behavior: TimingBehavior.AnimateValue, boundsPt: RectPt): PropertyCurve?</ID>
+    <ID>ReturnCount:TimelineEvaluator.kt$TimelineEvaluator$private fun interpolate(curve: PropertyCurve, p: Double): Double?</ID>
+    <ID>ThrowsCount:SlideDiskCache.kt$SlideDiskCache.Writer$fun putSlide( index: Int, image: BufferedImage, note: String, fidelity: Fidelity, hasTimeline: Boolean ): File</ID>
+    <ID>TooGenericExceptionCaught:PdfDeckSupport.kt$PdfDeckSupport$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PowerPointDeckSupport.kt$PowerPointDeckSupport$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:PresentationLoader.kt$PresentationLoader$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:SlideDiskCache.kt$SlideDiskCache.Writer$e: Throwable</ID>
+    <ID>TooManyFunctions:IwaMessage.kt$IwaMessage</ID>
+    <ID>TooManyFunctions:KeynoteDeckParser.kt$KeynoteDeckParser</ID>
+    <ID>TooManyFunctions:KeynoteSceneRasterizer.kt$KeynoteSceneRasterizer : AutoCloseable</ID>
+    <ID>TooManyFunctions:KeynoteStaticSupport.kt$KeynoteStaticSupport</ID>
+    <ID>TooManyFunctions:TimelineCompiler.kt$TimelineCompiler</ID>
+    <ID>TooManyFunctions:TimelineEvaluator.kt$TimelineEvaluator</ID>
+    <ID>TooManyFunctions:TimingParser.kt$TimingParser</ID>
+  </CurrentIssues>
+</SmellBaseline>


### PR DESCRIPTION
Two of the things left open after #360/#361/#364.

## The ATEM flake, root-caused

Five `CompanionServerAtemUploadTest` tests failed on CI with `timed out after 5000ms waiting for N <name> commands, got 0` — **zero commands of any name, `LOCK` included**, while the HTTP request that starts the upload plainly succeeded.

> **The first attempt at this got the cause wrong, and CI said so.** It shipped, and the same five tests failed again at that exact head. That run is what identified the real fault, so the history below is left standing rather than rewritten: the earlier commit's fixes are real and are kept, they were simply not what made CI red.

**The route answers before it does the work, and the coroutine doing the work was untracked.** `POST /api/atem/still|clip` responds `{"status":"uploading"}` and transfers on `CompanionServer`'s own scope, with the `Job` dropped on the floor. So when a test's assertions on the wire are satisfied the coroutine is still running — in the `delay(KEY_SETTLE_MS)` tail, or the clip-duration wait before the automatic key-off. The test then invalidated the pooled connection and closed the fake switcher underneath it.

Whatever that coroutine did next, it did against a switcher that had gone:

- a connect to a dead endpoint holds `AtemConnectionManager`'s mutex for the whole connect timeout, so the *next* test's upload never gets to send anything inside its own 5s deadline;
- a connect that completes caches a client for an **ephemeral** port the OS can hand out again.

Neither is detectable, because `AtemClient.isAlive()` is `socket != null` — true for a UDP socket with nobody listening. So the next test's switcher records not one command of any name. And it does not recover: each poisoned test burns 5s while leaving ~8s of stuck work behind, so the backlog outgrows the suite.

Two facts rule out the earlier explanation, and the one recorded in `build.gradle.kts` before it:

- the class now runs **alone in one JVM** under `jvmTestSerial`, so "four forks starve the receive thread" no longer applies;
- **four of the nine tests passed**, two of them after really receiving commands, and the failures fall at exact 5s intervals from one point onward. That is a cascade, not a poisoned class.

### The fix

`AtemBridge` now holds the upload's `Job`. `cancelUpload()` cancels **and joins**, so it returns only once the coroutine has stopped and nothing can touch the connection behind the caller's back.

**Half of this is a production fix.** `updateConfig` cancels the in-flight upload when the endpoint moves: repointing the ATEM mid-upload previously left the old transfer running against the switcher the operator had just left, and it re-cached a connection to it at its next `use()`. Cancellation is caught and rethrown ahead of the generic handler, so a deliberate cancel clears the status rather than reporting a cancelled upload to the operator as a failed one.

Both suites now run **every** switcher test through one helper that ends the upload, then drops the connection, then closes the fake. The previous helper covered the still tests and not the three clip ones — which is why it only half-worked. A suite where some tests take the safe path and some do not is a suite that still fails. `CompanionServerAtemKeyTest` gets the same shape and the same bound-port read-back, and both classes drop the inherited connection on the way in rather than trusting whatever ran before them in the JVM.

`an upload does not outlive the switcher it was aimed at` pins the contract: a cancelled upload leaves no status behind, and the very next upload reaches its own switcher.

### Kept from the first attempt

| | |
|---|---|
| **`invalidate()` racing a connect** | It cannot take the manager's mutex — it does not suspend, and it is called from settings changes and teardown. So it lands mid-connect, and that connect then cached itself *afterwards*, restoring the connection just abandoned. A generation counter stops that. **A real production bug** — change the ATEM host during an upload and the manager keeps the old endpoint — and `a connection invalidated while it was still connecting is not cached` fails without it. It is simply not what CI was failing on. |
| **Dialing the requested port** | Same defect as in `CompanionServerPresentationRenderTest`: `start(port)` goes through `findFreePort`, which walks upward when the port is taken. Both companion suites read the bound port back now. |

## The two ungated modules

`:bible-engine` and `:presentation-engine` were in no detekt step, so nothing held them to the rules the rest of the build follows. 205 findings between them.

**44 fixed outright**, not recorded:

- `VersionDetector.observe` took a `bookId` and a `chapter` **it never read**. Both gone, with their call sites. One test passed `chapter = 5` to mean "a new passage" and asserted the answer survived it — it never could have, since the parameter reached nothing. That test now says what it actually does, and the gap is written down rather than quietly rewritten into a pass.
- A swallowed exception now prints its message: `Invalid JSON` over a 4 KB line said the parse failed and nothing about where.
- `DetectionLogger`'s writer thread was a `val` nobody read whose *initialiser started the thread* — deleting the property would have deleted the writer. It is an `init` block now.
- A dead local, two dead test helpers, an unused import, 26 over-long lines wrapped.

**7 in test sources** carry `@Suppress` at the declaration with a reason, because `jvmTest` findings are fixed here, never baselined.

**161 in `src/main` are baselined per module** — the same bargain `:composeApp` struck when the size rules were switched on: gate new code, leave the old shapes until someone changes them deliberately. Mostly `MagicNumber`, `NestedBlockDepth` and `ReturnCount` against byte-format parsers.

**That 161 is debt, and `AGENT.md` now says so in those words.** A parser is not exempt from a named constant; it just was not worth contorting one to get the gate switched on today. Both baselines are `src/main` only, and both build files say to hand-edit rather than regenerate.

## Testing

The detekt half was green on the failing run already — that step runs before the unit tests and cleared.

The ATEM half is on CI here rather than local: this machine's memory is committed elsewhere, so only `compileKotlinJvm` and `compileTestKotlinJvm` were run locally, both clean. The signal to read is `jvmTestSerial` — all nine `CompanionServerAtemUploadTest` tests green, and the class back to about a second rather than the 26.0s that was five 5s timeouts.
