### PR TITLE
Cut a hung CI run from 22 minutes to 150 seconds (instrumented, not fixed)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,9 +196,20 @@ jobs:
         # Gradle-side cap came to be proposed that would have failed both of those healthy runs.
         # Re-measure before quoting a band. Two other things now fire before this budget does:
         # jvmTest's own 30-minute task timeout, and HungTestReporter, which halts a fork whose
-        # single test has been running five minutes and writes a thread dump into the results.
+        # single test has outlived the threshold below and writes a thread dump into the results.
+        #
+        # That threshold is 150s HERE rather than the five-minute default, and it is the whole
+        # point of this line: the suite has hung outright three times, each occurrence costing a
+        # ~22-minute run that ends with NO failing assertion and NO diagnosis. At 150s the reporter
+        # halts the fork with a full thread dump instead, and the dump travels in `test-reports`.
+        #
+        # 150s is measured, not guessed. In a full local run the slowest CLASS is 37.1s for all of
+        # its tests together (InstanceLinkClientTest), so no single test -- which is what the
+        # reporter times -- comes close; 150s leaves four times that class's entire runtime as
+        # headroom for a slower runner. If a legitimate test ever trips this, the answer is to fix
+        # the test, not to raise the number: AGENT.md budgets ~1s a test.
         timeout-minutes: 40
-        run: ./gradlew :composeApp:jvmTest
+        run: ./gradlew :composeApp:jvmTest -PhangThresholdMs=150000
 
       # So an outlier explains itself instead of needing a guess: the one killed run above was
       # attributed to the wrong fixture precisely because nothing recorded where the time went.

--- a/AGENT.md
+++ b/AGENT.md
@@ -386,8 +386,10 @@ produces a failure that only appears under load and only sometimes:
   serial task is not the one that ran.
 - **A fork that stops making progress is killed with a diagnosis.** `HungTestReporter`, a
   `TestExecutionListener`, watches whichever test is running and, once one has been running past its
-  threshold (five minutes by default — minutes past anything this suite legitimately does), dumps
-  every thread in the fork and `halt`s it with exit code 93. The dump goes to stderr *and* to
+  threshold (five minutes by default, **150s in CI** — far past anything this suite legitimately
+  does; the slowest class is 37.1s for all of its tests together), dumps every thread in the fork
+  and `halt`s it with exit code 93. **The hang it exists for is still unexplained**; that class's
+  KDoc records what has been ruled out, so the next attempt does not repeat it. The dump goes to stderr *and* to
   `build/test-results/<task>/hung-test-dump.txt`, which is inside what the workflow already uploads
   as `test-reports`, so it survives the halt losing Gradle's buffered output. Chasing a hang, tighten
   it with `./gradlew :composeApp:jvmTest -PhangThresholdMs=30000`. It exists because the suite has

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/HungTestReporter.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/HungTestReporter.kt
@@ -17,10 +17,32 @@ import java.util.concurrent.atomic.AtomicReference
  * not in the class name.** A dump of every thread is, and that is what this writes.
  *
  * It is deliberately NOT a per-test timeout in the assertion sense: nothing here decides whether a
- * test passes, [THRESHOLD_MS] is minutes past anything this suite legitimately does (`AGENT.md`
- * budgets ~1s a test, and the slowest screenshot class is ~33s for all of its tests together), and
- * a test that trips it was never going to finish. Halting rather than merely reporting is the point
- * -- the fork stops in five minutes with a diagnosis instead of being killed at thirty with none.
+ * test passes, the threshold is far past anything this suite legitimately does (`AGENT.md` budgets
+ * ~1s a test, and the slowest class is 37.1s for all of its tests together), and a test that trips
+ * it was never going to finish. Halting rather than merely reporting is the point -- the fork stops
+ * with a diagnosis instead of being killed at thirty minutes with none.
+ *
+ * ## What has been ruled out
+ *
+ * The hang has not been reproduced locally, on macOS, as of 2026-08-22. Recorded here so the next
+ * attempt starts further along than this one did:
+ *
+ * - **`LowerThirdTabTest` alone does not do it.** Six consecutive runs of just that class under
+ *   six-way CPU load, all green in ~82s. Note that passing `--tests` both stands the serial-class
+ *   exclusion down *and* drops `jvmTest` to a single fork, so an isolated run is not the shape CI
+ *   hangs in; do not read a green isolated run as evidence.
+ * - **The full suite on four forks under load does not do it either** -- one clean run.
+ * - **It is not the frozen test clock.** Twenty-four sites across the suite set
+ *   `mainClock.autoAdvance = false` and none restore it, including the last test in
+ *   `LowerThirdTabTest`, which leaves an animation live with the clock stopped. That looked like
+ *   the answer and is not: a probe that tears down with (a) a ten-minute animation running and the
+ *   clock frozen, (b) an unbounded `delay` loop with the clock frozen, and (c) the same loop with
+ *   the clock auto-advancing, completes all three in under three seconds.
+ *
+ * The lead that remains unexamined is the recorded stack itself: `runComposeUiTest` teardown ->
+ * `waitForIdle` -> `advanceTimeByFrame` -> `SwingUtilities.invokeAndWait`, blocked on the AWT event
+ * queue. Whatever the event queue was busy with is the thing to find, and that is what the dump
+ * this class writes is for.
  */
 class HungTestReporter internal constructor(
     private val thresholdMs: Long,


### PR DESCRIPTION
**Instrumented, not fixed.** The hang did not reproduce locally in three attempts, so this lands the diagnosis rather than a cure — and records what has been eliminated so the next attempt starts further along.

## What this changes

The App unit tests step passes `-PhangThresholdMs=150000`. `HungTestReporter` already halts a stuck fork and writes a full thread dump into `test-reports`; it just did not fire until five minutes, and nothing set it lower in CI. The suite has hung outright three times, and each occurrence costs a ~22-minute run ending with no failing assertion and no diagnosis. The next one yields a dump in 150 seconds.

**150s is measured, not guessed.** In a full local run the slowest *class* is 37.1s for all of its tests together (`InstanceLinkClientTest`), and the reporter times a *single test*, so 150s leaves four times that class's entire runtime as headroom for a slower runner. If a legitimate test ever trips it, the fix is the test — AGENT.md budgets ~1s a test — not a bigger number.

**No timeout was widened.** That response has been taken twice already (25→40 on the step, 45→60 on the job) and only made each occurrence more expensive.

## What was ruled out

Recorded in `HungTestReporter`'s own KDoc, where the next person will look:

- **`LowerThirdTabTest` alone does not do it** — six consecutive runs of that class under six-way CPU load, all green in ~82s. Worth knowing: passing `--tests` both stands the serial-class exclusion down *and* drops `jvmTest` to a single fork, so an isolated run is **not** the shape CI hangs in. A green isolated run is not evidence.
- **The full suite on four forks under load does not do it either** — one clean run.
- **It is not the frozen test clock.** Twenty-four sites across the suite set `mainClock.autoAdvance = false` and none restore it, including the last test in `LowerThirdTabTest`, which leaves an animation live with the clock stopped. That looked like the answer and is not: a probe tearing down with (a) a ten-minute animation running and the clock frozen, (b) an unbounded `delay` loop with the clock frozen, and (c) the same loop auto-advancing, completes all three in under three seconds.

The unexamined lead is the recorded stack itself: `runComposeUiTest` teardown → `waitForIdle` → `advanceTimeByFrame` → `SwingUtilities.invokeAndWait`, blocked on the AWT event queue. What that queue was busy with is the thing to find, and the dump is what will say it.

## Verification

`:composeApp:detekt` and `HungTestReporterTest` green; the full suite was run twice locally during the investigation.