### PR TITLE
Fix a racing Bible test that asserted the opposite of what the code does

### DIFF
--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelBranchTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleViewModelBranchTest.kt
@@ -411,15 +411,48 @@ class BibleViewModelBranchTest {
         assertNull(vm.moduleRefFor(43, 99, 1))
     }
 
+    /**
+     * A book id below the module's first is refused outright, and nothing is scheduled.
+     *
+     * This is the only half of the old `a book this module lacks changes nothing` test that was
+     * ever true. `getDisplayIndexForBookId` falls back to `bookId - 1` when no book carries the id,
+     * so a *negative* id degrades to a negative index and `selectVerseByBookId` returns before it
+     * launches anything — which is what makes it safe to assert on the state immediately.
+     */
     @Test
-    fun `selecting by book id for a book this module lacks changes nothing`() {
+    fun `selecting by a book id below the module's range is refused`() {
         openChapter(vm, 0, 1)
         val before = vm.verses.value
 
-        vm.selectVerseByBookId(35, 1, 1)
         vm.selectVerseByBookId(-5, 1, 1)
 
         assertEquals(before, vm.verses.value)
+    }
+
+    /**
+     * A book id the module lacks does **not** change nothing: it lands on the last book.
+     *
+     * `getDisplayIndexForBookId` returns `bookId - 1` for an id no book carries — the canonical
+     * ordering assumption — so id 35 becomes index 34, which `selectVerseByBookId` clamps to the
+     * last of this three-book fixture (John). John has only chapter 3 here, so chapter 1 reads
+     * empty and the verse list is replaced rather than left alone.
+     *
+     * The old test asserted the opposite, and passed only by racing: `selectVerseByBookId` does the
+     * read in a coroutine, and the assertion normally ran first. On a loaded CI runner the
+     * coroutine won and the suite failed with `expected:<[1. In the beginning...]> but was:<[]>`.
+     * Waiting for the selection token is the positive signal that the coroutine has landed, so what
+     * is asserted here is the settled state either way.
+     */
+    @Test
+    fun `selecting by a book id the module lacks falls back to the last book`() {
+        openChapter(vm, 0, 1)
+        val token = vm.verseSelectionToken.value
+
+        vm.selectVerseByBookId(35, 1, 1)
+
+        awaitUntil("the fallback selection to land") { vm.verseSelectionToken.value > token }
+        assertEquals(2, vm.selectedBookIndex.value, "clamped to the last book of the module")
+        assertEquals(emptyList(), vm.verses.value, "John has no chapter 1 in this fixture")
     }
 
     @Test


### PR DESCRIPTION
`BibleViewModelBranchTest > selecting by book id for a book this module lacks changes nothing` failed the App job on #377 with:

```
expected:<[1. In the beginning God created the heaven and the earth., ...]> but was:<[]>
```

It is unrelated to that PR — `main` is green over its last nine runs, so this is a low-rate flake. Its **premise was wrong**, not just its timing.

### What actually happens

`Bible.getDisplayIndexForBookId` falls back to `bookId - 1` when no book carries the id — the canonical-ordering assumption:

```kotlin
val direct = books.indexOfFirst { it.bookId == bookId.toString() }
return if (direct >= 0) direct else (bookId - 1)
```

The fixture is a three-book module (Genesis `1`, Psalms `19`, John `43`). So id **35 does not degrade to "not found"**: it becomes index **34**, which `selectVerseByBookId` clamps to the last book — John. John has only chapter 3 in the fixture, so chapter 1 reads **empty** and the verse list is replaced.

`selectVerseByBookId` does that read in a `viewModelScope.launch`, and the test asserted state immediately afterwards. It passed only by beating its own coroutine; on a loaded runner the coroutine won. That is exactly the shape `AGENT.md` forbids — asserting that nothing happened, with nothing waited on.

### The fix

Split into the two cases, neither of which can race:

- **A negative id genuinely is refused.** `-5 - 1` is negative, so the method returns before launching anything — which is what makes asserting the unchanged state immediately *correct* here rather than lucky.
- **An absent id lands on the last book.** Asserted after waiting on `verseSelectionToken` — the positive signal that the coroutine has landed — so the settled state is what gets checked either way.

The second test passing is itself the proof of the diagnosis: it asserts the verse list **is** emptied, which the old test asserted it was not.

### Not done here

No timeout widened, no assertion loosened, no retry added, no production code changed.

Whether `getDisplayIndexForBookId`'s `bookId - 1` fallback *should* silently navigate to the last book of a short module is a real question — it means asking for a book the translation lacks quietly shows an unrelated book with a blank verse list. But that is production behaviour with other callers, and changing it belongs in its own PR with its own review.

### Verification

- the changed class green on three consecutive `--rerun-tasks` runs
- `./gradlew :composeApp:check` green (5m23s)
- `./gradlew :composeApp:detekt` green, run last