### PR TITLE
Size the logo plate and gutter from the logo's aspect, not its height

### DIFF
--- a/lottieGenerator/AGENT.md
+++ b/lottieGenerator/AGENT.md
@@ -135,27 +135,33 @@ Both CI steps are gated on this directory or the shared build files changing.
 - Tests run with `java.awt.headless=true`; `TextMeasurer` and `FontRegistry` use AWT and must keep
   working headless.
 
-## Known limitation: the logo plate and gutter are square
+## The logo plate and gutter follow the logo's aspect
 
-The logo *image* is never distorted -- every style scales it uniformly from its height
-(`scale = logoSizePx / cfg.logoH`). But the space reserved for it is sized from that height
-alone, so a logo wider than it is tall overhangs whatever sits behind it:
+Two different things are called "the logo size", and mixing them up is what made wide logos
+overhang their plate:
 
-- `Style5GradientBar` -- the accent plate is `makeRect(g.logoBgSize, g.logoBgSize, ...)`, square
-  by construction, and the gutter `logoSpace = logoBgSize + logoMargin` is square with it. A logo
-  of aspect > 1 overhangs the plate horizontally and can collide with the text bar.
-- `Style9DiagonalWipe` -- no plate, but `logoSpace = logoSizePx + logoMargin` and the centring
-  arithmetic uses `logoSizePx / 2`, so the reserved gutter has the same blind spot.
+- **`Style1Bar` fits the longest side** — `scale = logoSizePx / max(logoW, logoH)` — so the logo
+  always draws inside a `logoSizePx` square and a square gutter is exactly right for it.
+- **Styles 5, 6, 7, 9 and 10 scale by HEIGHT** — `scale = logoSizePx / cfg.logoH` — so `logoSize`
+  is the logo's *height* and its drawn width is `logoSizePx * aspect`. A logo wider than it is
+  tall draws wider than the space reserved for it.
 
-The other styles that reserve space from `logoSizePx` share the shape. `cfg.logoW` is known --
-it is passed to the image asset and its anchor -- it is simply not consulted when the layout is
-computed. `Style5GradientBar` once computed `lW = lH * logoAspect`, which is the number this
-needs, and never plumbed it in; it was removed as an unused local in `d54ed3e4`.
+Those five used to reserve a square gutter regardless (and Style 5 drew a square
+`makeRect(logoBgSize, logoBgSize)` plate), so a wide logo overhung the plate and could collide
+with the text bar. They now size both from `logoAspect(cfg.logoW, cfg.logoH)` (`ColorUtils.kt`),
+which returns exactly `1.0` for a square logo — so **the generated JSON is bit-for-bit unchanged
+for square logos**, and only non-square ones move. That invariant is what the `SpecPort*Test`
+matrices rely on: they were switched to a square logo, where the compiled style and the spec port
+agree exactly.
 
-**This is a tracking note, not a bug being left in silently.** Fixing it changes the geometry and
-therefore the generated JSON, which the `SpecPort*Test` suites compare byte for byte -- so it is a
-deliberate change with its own review and its own re-baselining, not a cleanup to fold into
-something else.
+Note the consequence for a *tall* logo: its plate is now narrower than it is high, hugging the
+logo with even padding, where before it was square with extra room at the sides.
+
+**The spec ports cannot follow this**, and that is a known gap rather than an oversight: `SizeSpec`
+has no logo-derived variant and the layout slot gaps are static em, so neither the plate nor the
+reserved width can track an aspect. Each affected `SpecPort*Test` therefore covers a wide logo for
+layer *structure* only, and says so at the call site. Closing it needs a logo-derived `SizeSpec`
+plus logo-aware slot gaps.
 
 ## Dependencies
 

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/ColorUtils.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/ColorUtils.kt
@@ -51,3 +51,19 @@ fun emToPx(em: Double, baseSizePx: Double): Double = em * baseSizePx
 
 /** Convert rem to px (same as em for our purposes) */
 fun remToPx(rem: Double, baseSizePx: Double): Double = rem * baseSizePx
+
+/**
+ * The logo's width-to-height ratio, for the styles that scale it by **height**.
+ *
+ * Those styles set `scale = logoSizePx / cfg.logoH`, so `logoSize` is the logo's height and its
+ * drawn width is `logoSizePx * logoAspect`. Anything reserving room for it — a plate behind it, a
+ * gutter beside the text — has to use that width, or a logo wider than it is tall overhangs.
+ *
+ * Returns exactly `1.0` for a square logo, so the arithmetic downstream is bit-for-bit unchanged
+ * for one; and for a missing or degenerate size, where there is nothing to scale from.
+ *
+ * Not for the fit-longest-side styles (`Style1Bar`), which normalise by `max(logoW, logoH)` and so
+ * already draw inside a square box.
+ */
+fun logoAspect(logoW: Int, logoH: Int): Double =
+    if (logoW <= 0 || logoH <= 0 || logoW == logoH) 1.0 else logoW.toDouble() / logoH.toDouble()

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style10DoubleLine.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style10DoubleLine.kt
@@ -10,6 +10,7 @@ import org.churchpresenter.lottiegen.lottie.PERCENT_SCALE
 import org.churchpresenter.lottiegen.lottie.TextMeasurer
 import org.churchpresenter.lottiegen.lottie.buildKeyframes
 import org.churchpresenter.lottiegen.lottie.emToPx
+import org.churchpresenter.lottiegen.lottie.logoAspect
 import org.churchpresenter.lottiegen.lottie.hexToLottie
 import org.churchpresenter.lottiegen.lottie.jsonArrayOf
 import org.churchpresenter.lottiegen.lottie.makeAnimatedRect
@@ -98,7 +99,16 @@ private class DoubleLineGeometry(builder: LottieBuilder, val cfg: LottieGenConfi
     val logoSizePx = emToPx(cfg.logoSize.toDouble(), baseSize)
     val logoMargin = emToPx(LOGO_MARGIN_EM, baseSize)
     val hasLogo = cfg.logoEnabled && cfg.logoData != null
-    private val logoSpace = if (hasLogo) logoSizePx + logoMargin else 0.0
+
+    /**
+     * The logo's drawn width. [logoSizePx] is its *height* — the scale in `addLogo` is
+     * `logoSizePx / cfg.logoH` — so a logo wider than it is tall draws wider than [logoSizePx]
+     * and needs the gutter beside the text to widen with it, or it overhangs into the text.
+     *
+     * Exactly [logoSizePx] for a square logo, so its generated JSON is unchanged.
+     */
+    val logoRenderW = logoSizePx * logoAspect(cfg.logoW, cfg.logoH)
+    private val logoSpace = if (hasLogo) logoRenderW + logoMargin else 0.0
 
     private val nameContentW = if (cfg.hideName) 0.0 else nameM.width + paddingX * 2
     private val infoContentW = if (cfg.hideInfo) 0.0 else infoM.width + paddingX * 2
@@ -273,10 +283,10 @@ private fun LottieBuilder.addLogo(g: DoubleLineGeometry) {
                 if (cfg.hideName) 0.0 else g.nameM.width.toDouble(),
                 if (cfg.hideInfo) 0.0 else g.infoM.width.toDouble(),
             )
-            g.canvasW / 2 - maxW / 2 - g.logoMargin - g.logoSizePx / 2
+            g.canvasW / 2 - maxW / 2 - g.logoMargin - g.logoRenderW / 2
         }
-        g.isRight -> g.canvasW - g.marginHPx - g.logoSizePx / 2
-        else -> g.marginHPx + g.logoSizePx / 2
+        g.isRight -> g.canvasW - g.marginHPx - g.logoRenderW / 2
+        else -> g.marginHPx + g.logoRenderW / 2
     }
     val scaleKFs = g.keyframes(
         KeyframeInput(0.0, jsonArrayOf(0.0, 0.0, FULL_PERCENT_D)),

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style5GradientBar.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style5GradientBar.kt
@@ -15,6 +15,7 @@ import org.churchpresenter.lottiegen.lottie.buildKeyframes
 import org.churchpresenter.lottiegen.lottie.emToPx
 import org.churchpresenter.lottiegen.lottie.hexToLottie
 import org.churchpresenter.lottiegen.lottie.jsonArrayOf
+import org.churchpresenter.lottiegen.lottie.logoAspect
 import org.churchpresenter.lottiegen.lottie.makeAnimatedRect
 import org.churchpresenter.lottiegen.lottie.makeFill
 import org.churchpresenter.lottiegen.lottie.makeGradientFill
@@ -122,8 +123,19 @@ private class GradientGeometry(builder: LottieBuilder, val cfg: LottieGenConfig)
     val logoSizePx = emToPx(cfg.logoSize.toDouble(), baseSize)
     val logoMargin = emToPx(LOGO_MARGIN_EM, baseSize)
     val hasLogo = cfg.logoEnabled && cfg.logoData != null
+
+    /**
+     * The logo's drawn width. [logoSizePx] is its *height* — the scale in `addLogo` is
+     * `logoSizePx / cfg.logoH` — so a logo wider than it is tall draws wider than [logoSizePx]
+     * and needs the plate and the gutter to widen with it, or it overhangs both.
+     *
+     * A square logo gives an aspect of exactly 1.0, so this is bit-for-bit [logoSizePx] and the
+     * generated JSON is unchanged for it.
+     */
+    val logoRenderW = logoSizePx * logoAspect(cfg.logoW, cfg.logoH)
     val logoBgSize = logoSizePx + emToPx(LOGO_PLATE_PAD_EM, baseSize)
-    val logoSpace = if (hasLogo) logoBgSize + logoMargin else 0.0
+    val logoBgW = logoRenderW + emToPx(LOGO_PLATE_PAD_EM, baseSize)
+    val logoSpace = if (hasLogo) logoBgW + logoMargin else 0.0
 
     /**
      * Written per branch, in the original term order: factoring the shared prefix out would
@@ -321,9 +333,9 @@ private fun LottieBuilder.addLogo(g: GradientGeometry) {
     val cx = when {
         g.isCenter ->
             g.canvasW / 2 + g.logoSpace / 2 - max(g.nameBarW, g.infoBarW) / 2 -
-                g.logoMargin - g.logoBgSize / 2
-        g.isRight -> g.canvasW - g.marginHPx - g.logoBgSize / 2
-        else -> g.marginHPx + g.logoBgSize / 2
+                g.logoMargin - g.logoBgW / 2
+        g.isRight -> g.canvasW - g.marginHPx - g.logoBgW / 2
+        else -> g.marginHPx + g.logoBgW / 2
     }
     val cy = (g.nameBgCY + g.infoBarCY) / 2
 
@@ -348,7 +360,7 @@ private fun LottieBuilder.addLogo(g: GradientGeometry) {
         KeyframeInput(END_PCT, jsonArrayOf(FULL_PERCENT_D, FULL_PERCENT_D, FULL_PERCENT_D)),
     )
     val items = mutableListOf(
-        makeRect(g.logoBgSize, g.logoBgSize, g.cornerPx),
+        makeRect(g.logoBgW, g.logoBgSize, g.cornerPx),
         makeFill(g.accentLottie, cfg.accentColorAlpha.toDouble()),
     )
     if (g.borderPx > 0) {

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style6LineSplit.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style6LineSplit.kt
@@ -10,6 +10,7 @@ import org.churchpresenter.lottiegen.lottie.PERCENT_SCALE
 import org.churchpresenter.lottiegen.lottie.TextMeasurer
 import org.churchpresenter.lottiegen.lottie.buildKeyframes
 import org.churchpresenter.lottiegen.lottie.emToPx
+import org.churchpresenter.lottiegen.lottie.logoAspect
 import org.churchpresenter.lottiegen.lottie.hexToLottie
 import org.churchpresenter.lottiegen.lottie.jsonArrayOf
 import org.churchpresenter.lottiegen.lottie.makeAnimatedRect
@@ -94,7 +95,16 @@ private class SplitGeometry(builder: LottieBuilder, val cfg: LottieGenConfig) {
     val logoSizePx = emToPx(cfg.logoSize.toDouble(), baseSize)
     val logoMargin = emToPx(LOGO_MARGIN_EM, baseSize)
     val hasLogo = cfg.logoEnabled && cfg.logoData != null
-    private val logoSpace = if (hasLogo) logoSizePx + logoMargin else 0.0
+
+    /**
+     * The logo's drawn width. [logoSizePx] is its *height* — the scale in `addLogo` is
+     * `logoSizePx / cfg.logoH` — so a logo wider than it is tall draws wider than [logoSizePx]
+     * and needs the gutter beside the text to widen with it, or it overhangs into the text.
+     *
+     * Exactly [logoSizePx] for a square logo, so its generated JSON is unchanged.
+     */
+    val logoRenderW = logoSizePx * logoAspect(cfg.logoW, cfg.logoH)
+    private val logoSpace = if (hasLogo) logoRenderW + logoMargin else 0.0
 
     private val nameContentW = if (cfg.hideName) 0.0 else nameM.width + paddingX * 2
     private val infoContentW = if (cfg.hideInfo) 0.0 else infoM.width + paddingX * 2
@@ -177,9 +187,9 @@ private fun LottieBuilder.addLogo(g: SplitGeometry) {
     if (!g.hasLogo || cfg.logoData == null) return
     val scale = (g.logoSizePx / cfg.logoH.toDouble()) * PERCENT_SCALE
     val cx = when {
-        g.isCenter -> g.canvasW / 2 - g.lineW / 2 - g.logoMargin - g.logoSizePx / 2
-        g.isRight -> g.canvasW - g.marginHPx - g.logoSizePx / 2
-        else -> g.marginHPx + g.logoSizePx / 2
+        g.isCenter -> g.canvasW / 2 - g.lineW / 2 - g.logoMargin - g.logoRenderW / 2
+        g.isRight -> g.canvasW - g.marginHPx - g.logoRenderW / 2
+        else -> g.marginHPx + g.logoRenderW / 2
     }
     val scaleKFs = g.keyframes(
         KeyframeInput(0.0, jsonArrayOf(0.0, 0.0, FULL_PERCENT_D)),

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style7RandomFade.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style7RandomFade.kt
@@ -9,6 +9,7 @@ import org.churchpresenter.lottiegen.lottie.PERCENT_SCALE
 import org.churchpresenter.lottiegen.lottie.TextMeasurer
 import org.churchpresenter.lottiegen.lottie.buildKeyframes
 import org.churchpresenter.lottiegen.lottie.emToPx
+import org.churchpresenter.lottiegen.lottie.logoAspect
 import org.churchpresenter.lottiegen.lottie.hexToLottie
 import org.churchpresenter.lottiegen.lottie.jsonArrayOf
 import org.churchpresenter.lottiegen.lottie.makeRandomFadeAnimator
@@ -74,7 +75,16 @@ private class FadeGeometry(builder: LottieBuilder, val cfg: LottieGenConfig) {
     val logoSizePx = emToPx(cfg.logoSize.toDouble(), baseSize)
     val logoMargin = emToPx(LOGO_MARGIN_EM, baseSize)
     val hasLogo = cfg.logoEnabled && cfg.logoData != null
-    private val logoSpace = if (hasLogo) logoSizePx + logoMargin else 0.0
+
+    /**
+     * The logo's drawn width. [logoSizePx] is its *height* — the scale in `addLogo` is
+     * `logoSizePx / cfg.logoH` — so a logo wider than it is tall draws wider than [logoSizePx]
+     * and needs the gutter beside the text to widen with it, or it overhangs into the text.
+     *
+     * Exactly [logoSizePx] for a square logo, so its generated JSON is unchanged.
+     */
+    val logoRenderW = logoSizePx * logoAspect(cfg.logoW, cfg.logoH)
+    private val logoSpace = if (hasLogo) logoRenderW + logoMargin else 0.0
 
     /** A hidden line takes no vertical space, and there is no gap unless both lines are shown. */
     private val nameBlockH = if (cfg.hideName) 0.0 else nameSizePx
@@ -154,10 +164,10 @@ private fun LottieBuilder.addLogo(g: FadeGeometry) {
                 if (cfg.hideName) 0.0 else g.nameM.width.toDouble(),
                 if (cfg.hideInfo) 0.0 else g.infoM.width.toDouble(),
             )
-            g.canvasW / 2 - maxW / 2 - g.logoMargin - g.logoSizePx / 2
+            g.canvasW / 2 - maxW / 2 - g.logoMargin - g.logoRenderW / 2
         }
-        g.isRight -> g.canvasW - g.marginHPx - g.logoSizePx / 2
-        else -> g.marginHPx + g.logoSizePx / 2
+        g.isRight -> g.canvasW - g.marginHPx - g.logoRenderW / 2
+        else -> g.marginHPx + g.logoRenderW / 2
     }
     val scaleKFs = g.keyframes(
         KeyframeInput(0.0, jsonArrayOf(0.0, 0.0, FULL_PERCENT_D)),

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style9DiagonalWipe.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/lottie/styles/Style9DiagonalWipe.kt
@@ -11,6 +11,7 @@ import org.churchpresenter.lottiegen.lottie.PERCENT_SCALE
 import org.churchpresenter.lottiegen.lottie.TextMeasurer
 import org.churchpresenter.lottiegen.lottie.buildKeyframes
 import org.churchpresenter.lottiegen.lottie.emToPx
+import org.churchpresenter.lottiegen.lottie.logoAspect
 import org.churchpresenter.lottiegen.lottie.hexToLottie
 import org.churchpresenter.lottiegen.lottie.jsonArrayOf
 import org.churchpresenter.lottiegen.lottie.kf
@@ -94,7 +95,16 @@ private class WipeGeometry(builder: LottieBuilder, val cfg: LottieGenConfig) {
     val logoSizePx = emToPx(cfg.logoSize.toDouble(), baseSize)
     val logoMargin = emToPx(LOGO_MARGIN_EM, baseSize)
     val hasLogo = cfg.logoEnabled && cfg.logoData != null
-    private val logoSpace = if (hasLogo) logoSizePx + logoMargin else 0.0
+
+    /**
+     * The logo's drawn width. [logoSizePx] is its *height* — the scale in `addLogo` is
+     * `logoSizePx / cfg.logoH` — so a logo wider than it is tall draws wider than [logoSizePx]
+     * and needs the gutter beside the text to widen with it, or it overhangs into the text.
+     *
+     * Exactly [logoSizePx] for a square logo, so its generated JSON is unchanged.
+     */
+    val logoRenderW = logoSizePx * logoAspect(cfg.logoW, cfg.logoH)
+    private val logoSpace = if (hasLogo) logoRenderW + logoMargin else 0.0
 
     private val nameBlockH = if (cfg.hideName) 0.0 else nameSizePx
     private val infoBlockH = if (cfg.hideInfo) 0.0 else infoSizePx
@@ -346,10 +356,10 @@ private fun LottieBuilder.addLogo(g: WipeGeometry) {
                 if (cfg.hideName) 0.0 else g.nameM.width.toDouble(),
                 if (cfg.hideInfo) 0.0 else g.infoM.width.toDouble(),
             )
-            g.canvasW / 2 - maxW / 2 - g.logoMargin - g.logoSizePx / 2
+            g.canvasW / 2 - maxW / 2 - g.logoMargin - g.logoRenderW / 2
         }
-        g.isRight -> g.canvasW - g.marginHPx - g.logoSizePx / 2
-        else -> g.marginHPx + g.logoSizePx / 2
+        g.isRight -> g.canvasW - g.marginHPx - g.logoRenderW / 2
+        else -> g.marginHPx + g.logoRenderW / 2
     }
     val scaleKFs = g.keyframes(
         KeyframeInput(0.0, jsonArrayOf(0.0, 0.0, FULL_PERCENT_D)),

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort10Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort10Test.kt
@@ -105,7 +105,7 @@ class SpecPort10Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 120 else 0,
+                            logoW = if (logo) 80 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             // The port is tuned at the default hairline (linePx = 2 px);
@@ -186,6 +186,47 @@ class SpecPort10Test {
                     }
                 }
             }
+        }
+    }
+
+
+    /**
+     * A logo wider than it is tall: layer structure only, deliberately not geometry.
+     *
+     * The matrix above uses a square logo because that is where the two models agree exactly. The
+     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
+     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
+     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
+     * static em, so neither the reserved width nor the plate can track the logo's aspect.
+     *
+     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
+     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
+     * logo, which is that both models build the same layers in the same order, and leaves the
+     * geometry to the square configs above rather than pretending the numbers agree.
+     */
+    @Test
+    fun portMatchesCompiledStructureWithAWideLogo() {
+        val cfg = LottieGenConfig(
+            logoEnabled = true,
+            logoData = "data:image/png;base64,iVBORw0KGgo=",
+            logoW = 120,
+            logoH = 80,
+            // Same shape as the matrix's logo configs above, so this isolates the aspect and
+            // nothing else — a bare default config reaches a combination the matrix never covers.
+            bgEnabled = true,
+            borderThickness = 4f,
+        )
+        val expected = LottieGenerator.generate(cfg, Style10DoubleLine())
+        val actual = LottieGenerator.generate(cfg, port())
+
+        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
+        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
+
+        assertEquals(expectedLayers.map { it.name() }, actualLayers.map { it.name() }, "layer names/order")
+        for ((exp, act) in expectedLayers.zip(actualLayers)) {
+            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
+            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
+            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort5Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort5Test.kt
@@ -72,15 +72,23 @@ import kotlin.test.assertEquals
  *    port's offsetXEm −2.2916666666666665 = −2.5 + (TEXT_CORE_PAD_PX/2)/24 em
  *    (maxTextW and logoSize cancel exactly) — the 5 px term is the layout
  *    engine's fixed text-core pad, exact only at baseSize 24.
- * 8. Logo scale basis (spec-model gap, not asserted — rest origin p−a is
- *    unaffected): compiled scales the logo HEIGHT to logoSize em (width follows
- *    aspect: scale = logoSizePx/logoH = 105% for 120×80); the spec engine's
- *    buildLogo normalizes by max(logoW, logoH) (fit-longest-side: 70%). The
- *    rendered logo is smaller than compiled whenever logoW > logoH.
- * 9. Logo BG size: compiled is (logoSize + 0.8) em square; SizeSpec cannot
- *    reference cfg.logoSize, so it is a static Em(4.3, 4.3) — exact at default
- *    logoSize. Slot gaps 0.4/0.9 encode the badge overhang (0.4 each side of the
- *    logo core) + 0.5 em logo margin, exact for ALL logoSize values.
+ * 8. Logo scale basis (spec-model gap): compiled scales the logo HEIGHT to
+ *    logoSize em, so its drawn width follows the aspect; the spec engine's
+ *    buildLogo normalizes by max(logoW, logoH) (fit-longest-side). The two agree
+ *    exactly for a SQUARE logo and disagree for any other, which is why the
+ *    matrix below uses one — see deviation 9.
+ * 9. Logo BG size and the gutter: compiled sizes the plate as the logo's drawn
+ *    width × its height, plus 0.8 em, and reserves a gutter to match — so both
+ *    track the logo's aspect. The spec cannot: SizeSpec has no logo-derived
+ *    variant (it cannot even reference cfg.logoSize, hence the static
+ *    Em(4.3, 4.3), exact at default logoSize) and the slot gaps 0.4/0.9 that
+ *    encode the badge overhang + 0.5 em margin are static em too.
+ *
+ *    So the matrix uses a square logo, where compiled and spec agree exactly, and
+ *    `portMatchesCompiledStructureWithAWideLogo` covers the non-square case for
+ *    layer structure only. Closing the gap properly needs two spec-engine
+ *    features — a logo-derived SizeSpec and logo-aware slot gaps — which is its
+ *    own piece of work, not a re-baselining.
  * 10. Spec-model gap: compiled gates Logo AND Logo BG on
  *     `logoEnabled && logoData != null`; a RectElement can only test
  *     LOGO_ENABLED, so with logoEnabled=true but logoData=null the port would
@@ -116,7 +124,7 @@ class SpecPort5Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 120 else 0,
+                            logoW = if (logo) 80 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             borderThickness = 4f
@@ -166,6 +174,47 @@ class SpecPort5Test {
                     assertEquals(e, a, eps, "rest origin[$i] $layerLabel")
                 }
             }
+        }
+    }
+
+
+    /**
+     * A logo wider than it is tall: layer structure only, deliberately not geometry.
+     *
+     * The matrix above uses a square logo because that is where the two models agree exactly. The
+     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
+     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
+     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
+     * static em, so neither the reserved width nor the plate can track the logo's aspect.
+     *
+     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
+     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
+     * logo, which is that both models build the same layers in the same order, and leaves the
+     * geometry to the square configs above rather than pretending the numbers agree.
+     */
+    @Test
+    fun portMatchesCompiledStructureWithAWideLogo() {
+        val cfg = LottieGenConfig(
+            logoEnabled = true,
+            logoData = "data:image/png;base64,iVBORw0KGgo=",
+            logoW = 120,
+            logoH = 80,
+            // Same shape as the matrix's logo configs above, so this isolates the aspect and
+            // nothing else — a bare default config reaches a combination the matrix never covers.
+            bgEnabled = true,
+            borderThickness = 4f,
+        )
+        val expected = LottieGenerator.generate(cfg, Style5GradientBar())
+        val actual = LottieGenerator.generate(cfg, port())
+
+        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
+        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
+
+        assertEquals(expectedLayers.map { it.name() }, actualLayers.map { it.name() }, "layer names/order")
+        for ((exp, act) in expectedLayers.zip(actualLayers)) {
+            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
+            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
+            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort6Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort6Test.kt
@@ -89,7 +89,7 @@ class SpecPort6Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 120 else 0,
+                            logoW = if (logo) 80 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             borderThickness = 4f
@@ -174,6 +174,47 @@ class SpecPort6Test {
                     }
                 }
             }
+        }
+    }
+
+
+    /**
+     * A logo wider than it is tall: layer structure only, deliberately not geometry.
+     *
+     * The matrix above uses a square logo because that is where the two models agree exactly. The
+     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
+     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
+     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
+     * static em, so neither the reserved width nor the plate can track the logo's aspect.
+     *
+     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
+     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
+     * logo, which is that both models build the same layers in the same order, and leaves the
+     * geometry to the square configs above rather than pretending the numbers agree.
+     */
+    @Test
+    fun portMatchesCompiledStructureWithAWideLogo() {
+        val cfg = LottieGenConfig(
+            logoEnabled = true,
+            logoData = "data:image/png;base64,iVBORw0KGgo=",
+            logoW = 120,
+            logoH = 80,
+            // Same shape as the matrix's logo configs above, so this isolates the aspect and
+            // nothing else — a bare default config reaches a combination the matrix never covers.
+            bgEnabled = true,
+            borderThickness = 4f,
+        )
+        val expected = LottieGenerator.generate(cfg, Style6LineSplit())
+        val actual = LottieGenerator.generate(cfg, port())
+
+        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
+        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
+
+        assertEquals(expectedLayers.map { it.name() }, actualLayers.map { it.name() }, "layer names/order")
+        for ((exp, act) in expectedLayers.zip(actualLayers)) {
+            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
+            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
+            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort7Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort7Test.kt
@@ -66,7 +66,7 @@ class SpecPort7Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 120 else 0,
+                            logoW = if (logo) 80 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             borderThickness = 4f
@@ -126,6 +126,47 @@ class SpecPort7Test {
                     )
                 }
             }
+        }
+    }
+
+
+    /**
+     * A logo wider than it is tall: layer structure only, deliberately not geometry.
+     *
+     * The matrix above uses a square logo because that is where the two models agree exactly. The
+     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
+     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
+     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
+     * static em, so neither the reserved width nor the plate can track the logo's aspect.
+     *
+     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
+     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
+     * logo, which is that both models build the same layers in the same order, and leaves the
+     * geometry to the square configs above rather than pretending the numbers agree.
+     */
+    @Test
+    fun portMatchesCompiledStructureWithAWideLogo() {
+        val cfg = LottieGenConfig(
+            logoEnabled = true,
+            logoData = "data:image/png;base64,iVBORw0KGgo=",
+            logoW = 120,
+            logoH = 80,
+            // Same shape as the matrix's logo configs above, so this isolates the aspect and
+            // nothing else — a bare default config reaches a combination the matrix never covers.
+            bgEnabled = true,
+            borderThickness = 4f,
+        )
+        val expected = LottieGenerator.generate(cfg, Style7RandomFade())
+        val actual = LottieGenerator.generate(cfg, port())
+
+        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
+        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
+
+        assertEquals(expectedLayers.map { it.name() }, actualLayers.map { it.name() }, "layer names/order")
+        for ((exp, act) in expectedLayers.zip(actualLayers)) {
+            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
+            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
+            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort9Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort9Test.kt
@@ -94,7 +94,7 @@ class SpecPort9Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 120 else 0,
+                            logoW = if (logo) 80 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             borderThickness = 4f
@@ -242,6 +242,52 @@ class SpecPort9Test {
                 "$label: reveal mask must cover its text at rest " +
                     "(mask [$maskMin, $maskMax] vs text [$textMin, $textMax])"
             )
+        }
+    }
+
+
+    /**
+     * A logo wider than it is tall: layer structure only, deliberately not geometry.
+     *
+     * The matrix above uses a square logo because that is where the two models agree exactly. The
+     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
+     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
+     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
+     * static em, so neither the reserved width nor the plate can track the logo's aspect.
+     *
+     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
+     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
+     * logo, which is that both models build the same layers in the same order, and leaves the
+     * geometry to the square configs above rather than pretending the numbers agree.
+     */
+    @Test
+    fun portMatchesCompiledStructureWithAWideLogo() {
+        val cfg = LottieGenConfig(
+            logoEnabled = true,
+            logoData = "data:image/png;base64,iVBORw0KGgo=",
+            logoW = 120,
+            logoH = 80,
+            // Same shape as the matrix's logo configs above, so this isolates the aspect and
+            // nothing else — a bare default config reaches a combination the matrix never covers.
+            bgEnabled = true,
+            borderThickness = 4f,
+        )
+        val expected = LottieGenerator.generate(cfg, Style9DiagonalWipe())
+        val actual = LottieGenerator.generate(cfg, port())
+
+        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
+        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
+
+        // Through mappedName, as the matrix above does: this port names two layers differently
+        // from the compiled style by design, which is unrelated to the logo.
+        assertEquals(
+            expectedLayers.map { mappedName(it.name()) }, actualLayers.map { it.name() },
+            "layer names/order",
+        )
+        for ((exp, act) in expectedLayers.zip(actualLayers)) {
+            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
+            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
+            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 


### PR DESCRIPTION
Fixes the limitation filed as a tracking note in #379. You asked for it in its own PR — this is it.

## The bug

Five styles scale the logo by **height** (`scale = logoSizePx / cfg.logoH`), so `logoSize` is the logo's *height* and its drawn width is `logoSizePx × aspect`. All five reserved a **square** gutter regardless, and `Style5GradientBar` drew a square `makeRect(logoBgSize, logoBgSize)` plate behind it. A logo wider than it is tall overhung its plate and could collide with the text bar.

**`Style1Bar` is deliberately untouched.** It normalises by `max(logoW, logoH)`, so its logo always draws inside a square box and a square gutter is correct for it. The tracking note in #379 claimed *every* style scaled by height — it doesn't, and that distinction is the whole fix. The note is corrected here.

## The fix, and why it's safe

Styles 5, 6, 7, 9 and 10 derive the reserved width — and Style 5's plate — from `logoAspect(cfg.logoW, cfg.logoH)`, which returns **exactly `1.0`** for a square logo and for a missing or degenerate size.

So **the generated JSON is bit-for-bit unchanged for a square logo**, and only non-square logos move. That isn't an assumption: with the `SpecPort` matrices switched to a square logo, all 314 pre-existing tests pass untouched. The five that failed before that switch were exactly the five styles changed — no collateral.

Measured on Style 5's plate at default size:

| logo | plate (w × h) |
|---|---|
| 80×80 (square) | 103.2 × 103.2 — unchanged |
| 120×80 (wide) | **145.2** × 103.2 |
| 80×120 (tall) | **75.2** × 103.2 |

Note the third row: a tall logo now gets a plate that **hugs it with even padding** rather than a square one with slack at the sides. That's a deliberate consequence of sizing from the drawn width, and it's written down in the module's `AGENT.md`.

## The spec ports

They cannot follow the aspect. `SizeSpec` has no logo-derived variant — it cannot even reference `cfg.logoSize`, which is why the plate is a static `Em(4.3, 4.3)` — and the layout slot gaps that position the text are static em too. So compiled and spec now genuinely disagree for non-square logos.

Rather than loosen the existing exact-geometry assertions, each matrix now uses a **square** logo, where the two models agree exactly, and a new `portMatchesCompiledStructureWithAWideLogo` covers the non-square case for **layer structure alone** — saying at the call site why the geometry is not compared and what would close the gap (a logo-derived `SizeSpec` plus logo-aware slot gaps, which is its own piece of work).

Worth knowing: the two models were never equivalent for non-square logos anyway — documented deviation 8 already recorded that the spec renders a wide logo at a different *size* than compiled. The old exact-origin assertions only held because both happened to use a square box.

## Verification

- `:lottieGenerator:test` green on **three consecutive `--rerun-tasks`** runs (319 tests, 5 new)
- `:lottieGenerator:jacocoTestCoverageVerification` and `:lottieGenerator:detekt` green
- `:composeApp:detekt` green, run last
- no coverage exclude added, no floor lowered, no baseline touched