### PR TITLE
Let a spec express the logo's aspect, closing the last two port deviations

### DIFF
--- a/lottieGenerator/AGENT.md
+++ b/lottieGenerator/AGENT.md
@@ -157,11 +157,20 @@ agree exactly.
 Note the consequence for a *tall* logo: its plate is now narrower than it is high, hugging the
 logo with even padding, where before it was square with extra room at the sides.
 
-**The spec ports cannot follow this**, and that is a known gap rather than an oversight: `SizeSpec`
-has no logo-derived variant and the layout slot gaps are static em, so neither the plate nor the
-reserved width can track an aspect. Each affected `SpecPort*Test` therefore covers a wide logo for
-layer *structure* only, and says so at the call site. Closing it needs a logo-derived `SizeSpec`
-plus logo-aware slot gaps.
+**The spec ports follow it too.** Three additions made the aspect expressible in a spec, all
+opt-in so no existing spec style moves:
+
+- `LayoutSpec.logoScale` — `longestSide` (the default, and what every spec style was written
+  against) or `height`. It picks both the logo's own scale basis and the width its slot reserves,
+  so the logo and the room made for it cannot disagree.
+- `SizeSpec.LogoPlate(padEm)` — the logo's drawn size plus padding, replacing a static `Em` guess
+  that could not even reference `cfg.logoSize`.
+- `Placement.offsetXLogoHalfWidths` — for an element hung off the logo rather than its slot, whose
+  static em offset previously had to bake half the logo's width in.
+
+The five ports set `logoScale: height`, Style 5's plate is a `logoPlate`, and the `SpecPort*Test`
+matrices are back on a **non-square** 120x80 logo with geometry asserted exactly. Deviations 8 and
+9 in `SpecPort5Test` — the scale basis and the square plate — are closed rather than documented.
 
 ## Dependencies
 

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/editor/ui/ElementInspector.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/editor/ui/ElementInspector.kt
@@ -371,13 +371,15 @@ internal fun SizeEditor(size: SizeSpec, onChange: (SizeSpec) -> Unit) {
             label = Strings.editorSizeType,
             options = listOf(
                 Strings.editorSizeEm, Strings.editorSizeContent,
-                Strings.editorSizeTextWrap, Strings.editorSizeCanvasWidth
+                Strings.editorSizeTextWrap, Strings.editorSizeCanvasWidth,
+                Strings.editorSizeLogoPlate
             ),
             selected = when (size) {
                 is SizeSpec.Em -> Strings.editorSizeEm
                 is SizeSpec.ContentDerived -> Strings.editorSizeContent
                 is SizeSpec.TextWrap -> Strings.editorSizeTextWrap
                 is SizeSpec.CanvasWidth -> Strings.editorSizeCanvasWidth
+                is SizeSpec.LogoPlate -> Strings.editorSizeLogoPlate
             },
             display = { it },
             onSelect = { label ->
@@ -386,6 +388,7 @@ internal fun SizeEditor(size: SizeSpec, onChange: (SizeSpec) -> Unit) {
                         Strings.editorSizeContent -> SizeSpec.ContentDerived()
                         Strings.editorSizeTextWrap -> SizeSpec.TextWrap(TextFieldRef.NAME)
                         Strings.editorSizeCanvasWidth -> SizeSpec.CanvasWidth(NEW_CANVAS_WIDTH_PCT)
+                        Strings.editorSizeLogoPlate -> SizeSpec.LogoPlate()
                         else -> SizeSpec.Em(1.0, 1.0)
                     }
                 )
@@ -434,6 +437,10 @@ internal fun SizeEditor(size: SizeSpec, onChange: (SizeSpec) -> Unit) {
             is SizeSpec.CanvasWidth -> NumberField(
                 Strings.editorHeightEm, size.hEm,
                 onCommit = { onChange(size.copy(hEm = it)) }, modifier = Modifier.fillMaxWidth()
+            )
+            is SizeSpec.LogoPlate -> NumberField(
+                Strings.editorPadX, size.padEm,
+                onCommit = { onChange(size.copy(padEm = it)) }, modifier = Modifier.fillMaxWidth()
             )
         }
     }

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/spec/SpecLayout.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/spec/SpecLayout.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.lottiegen.spec
 import org.churchpresenter.lottiegen.lottie.TextSize
 import org.churchpresenter.lottiegen.lottie.TextMeasurer
 import org.churchpresenter.lottiegen.lottie.emToPx
+import org.churchpresenter.lottiegen.lottie.logoAspect
 import org.churchpresenter.lottiegen.lottie.hexToLottie
 import org.churchpresenter.lottiegen.lottie.remToPx
 import org.churchpresenter.lottiegen.model.LottieGenConfig
@@ -47,6 +48,26 @@ class SpecLayoutContext(private val spec: StyleSpec, private val cfg: LottieGenC
     val canvasH = cfg.canvasH.toDouble()
 
     fun em(v: Double): Double = emToPx(v, baseSize)
+
+    /**
+     * The logo's drawn height — `logoSize` under either basis, since both fix it as the height or
+     * as the square box's side.
+     */
+    val logoDrawnH: Double get() = em(cfg.logoSize.toDouble())
+
+    /**
+     * The logo's drawn WIDTH, which is what any room reserved for it has to be measured against.
+     *
+     * Under [LogoScaleBasis.HEIGHT] the logo is scaled from its height, so a wide logo draws wider
+     * than `logoSize` and the slot has to grow with it. Under the default
+     * [LogoScaleBasis.LONGEST_SIDE] this stays `logoSize` exactly as it always was — a logo can
+     * never exceed the box, so no existing spec style moves.
+     */
+    val logoDrawnW: Double
+        get() = when (spec.layout.logoScale) {
+            LogoScaleBasis.HEIGHT -> logoDrawnH * logoAspect(cfg.logoW, cfg.logoH)
+            LogoScaleBasis.LONGEST_SIDE -> logoDrawnH
+        }
 
     val nameSizePx = em(cfg.nameSize.toDouble())
     val infoSizePx = em(cfg.infoSize.toDouble())
@@ -153,6 +174,7 @@ class SpecLayoutContext(private val spec: StyleSpec, private val cfg: LottieGenC
         val anchorIn = override?.anchorIn ?: placement.anchorIn
         val line = override?.line ?: placement.line
         val offsetXEm = override?.offsetXEm ?: placement.offsetXEm
+        val offsetXLogoHalfW = override?.offsetXLogoHalfWidths ?: placement.offsetXLogoHalfWidths
         val offsetYEm = override?.offsetYEm ?: placement.offsetYEm
 
         val slot = slotFor(placement.slot)
@@ -167,7 +189,8 @@ class SpecLayoutContext(private val spec: StyleSpec, private val cfg: LottieGenC
             LineAnchor.NAME_LINE -> nameLineY
             LineAnchor.INFO_LINE -> infoLineY
         }
-        return SpecPoint(x0 + flowSign * em(offsetXEm), y0 + em(offsetYEm))
+        val offsetX = em(offsetXEm) + offsetXLogoHalfW * (logoDrawnW / 2)
+        return SpecPoint(x0 + flowSign * offsetX, y0 + em(offsetYEm))
     }
 
     /** Flow sign an element's x offsets/vertices use (honors the mirror opt-out). */
@@ -215,6 +238,8 @@ class SpecLayoutContext(private val spec: StyleSpec, private val cfg: LottieGenC
             TextFieldRef.INFO ->
                 (infoMeasured.width + 2 * em(size.padXEm)) to (infoSizePx + 2 * em(size.padYEm))
         }
+        is SizeSpec.LogoPlate ->
+            (logoDrawnW + em(size.padEm)) to (logoDrawnH + em(size.padEm))
         is SizeSpec.CanvasWidth -> canvasW to em(size.hEm)
     }
 
@@ -239,7 +264,7 @@ class SpecLayoutContext(private val spec: StyleSpec, private val cfg: LottieGenC
     }
 
     private fun coreWidth(slot: SlotSpec): Double = when (slot.kind) {
-        SlotKind.LOGO -> em(cfg.logoSize.toDouble())
+        SlotKind.LOGO -> logoDrawnW
         SlotKind.FIXED -> em(slot.widthEm)
         SlotKind.TEXT -> max(nameMeasured.width, infoMeasured.width) + TEXT_CORE_PAD_PX
     }

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/spec/SpecStyleGenerator.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/spec/SpecStyleGenerator.kt
@@ -116,7 +116,14 @@ internal class SpecBuild(
 
         val (w, h) = layout.resolveSize(element)
         val logoSizeEm = element.sizeEm ?: cfg.logoSize.toDouble()
-        val baseScale = layout.em(logoSizeEm) / max(cfg.logoW, cfg.logoH).toDouble() * 100
+        // Which dimension logoSize measures — the same choice the slot reserves width from, so the
+        // logo and the room made for it cannot disagree. LONGEST_SIDE is the default and is what
+        // every spec style was written against.
+        val scaleBasis = when (spec.layout.logoScale) {
+            LogoScaleBasis.HEIGHT -> cfg.logoH.toDouble()
+            LogoScaleBasis.LONGEST_SIDE -> max(cfg.logoW, cfg.logoH).toDouble()
+        }
+        val baseScale = layout.em(logoSizeEm) / scaleBasis * 100
         val rest = layout.resolve(element.placement)
 
         builder.addImageLayer(

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/spec/StyleSpec.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/spec/StyleSpec.kt
@@ -60,6 +60,13 @@ data class LayoutSpec(
     /** Nominal content-block height in em (drives baseY and content-derived heights). */
     val blockHeightEm: Double = 3.5,
     /**
+     * How the logo is scaled, which decides how wide it draws and so how much room it needs.
+     *
+     * Defaults to [LogoScaleBasis.LONGEST_SIDE] — what every spec style was written against — so
+     * omitting it leaves a style's output unchanged.
+     */
+    val logoScale: LogoScaleBasis = LogoScaleBasis.LONGEST_SIDE,
+    /**
      * When true and only one of name/info is visible, that line recenters vertically on
      * the block. False matches the classic styles (hiding a line leaves the other in place).
      */
@@ -82,6 +89,23 @@ data class SlotSpec(
     /** ANDed; empty = always visible. */
     val visibleWhen: List<VisibilityRule> = emptyList()
 )
+
+/**
+ * What a style's `logoSize` measures, and so how the logo's drawn width is derived.
+ *
+ * The compiled styles disagree on this, and the difference is exactly what decides how much
+ * horizontal room a logo needs — see the logo section of `lottieGenerator/AGENT.md`.
+ */
+@Serializable
+enum class LogoScaleBasis {
+    /** `logoSize` is the longest side: the logo fits inside a square box and never exceeds it. */
+    @SerialName("longestSide")
+    LONGEST_SIDE,
+
+    /** `logoSize` is the HEIGHT: a logo wider than it is tall draws wider than `logoSize`. */
+    @SerialName("height")
+    HEIGHT,
+}
 
 @Serializable
 enum class SlotKind {
@@ -141,6 +165,16 @@ data class Placement(
     val line: LineAnchor = LineAnchor.BLOCK_CENTER,
     /** Flow-signed horizontal offset in em. */
     val offsetXEm: Double = 0.0,
+    /**
+     * Flow-signed horizontal offset in multiples of the logo's drawn HALF-width, added to
+     * [offsetXEm].
+     *
+     * For an element positioned relative to the logo rather than to its slot — a centre-aligned
+     * badge hung off the text block, say — a static em offset has to bake the logo's half-width in,
+     * which is only right while the logo is square. This term tracks it instead: under
+     * [LogoScaleBasis.HEIGHT] the logo's drawn width follows its aspect, and so does this.
+     */
+    val offsetXLogoHalfWidths: Double = 0.0,
     /** Vertical offset in em, +down, never mirrored. */
     val offsetYEm: Double = 0.0,
     val mirror: MirrorMode = MirrorMode.FLIP_ON_RIGHT,
@@ -160,6 +194,7 @@ data class PlacementOverride(
     val anchorIn: AnchorIn? = null,
     val line: LineAnchor? = null,
     val offsetXEm: Double? = null,
+    val offsetXLogoHalfWidths: Double? = null,
     val offsetYEm: Double? = null,
     /** true = the element is not built at all for this alignment. */
     val hidden: Boolean? = null
@@ -209,6 +244,16 @@ sealed interface SizeSpec {
     @Serializable
     @SerialName("textWrap")
     data class TextWrap(val field: TextFieldRef, val padXEm: Double = 0.5, val padYEm: Double = 0.3) : SizeSpec
+
+    /**
+     * The logo's drawn size plus [padEm] on every side — the plate behind a logo.
+     *
+     * Unlike [Em] this tracks both `cfg.logoSize` and, under [LogoScaleBasis.HEIGHT], the logo's
+     * aspect, so the plate stays around the logo instead of being a square guess.
+     */
+    @Serializable
+    @SerialName("logoPlate")
+    data class LogoPlate(val padEm: Double = 0.0) : SizeSpec
 
     /** Full canvas width (banner/ticker bands); always horizontally centered on the canvas. */
     @Serializable

--- a/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/ui/Strings.kt
+++ b/lottieGenerator/src/main/kotlin/org/churchpresenter/lottiegen/ui/Strings.kt
@@ -190,6 +190,7 @@ object Strings {
     val editorSizeContent: String get() = bundle.getString("editor_size_content")
     val editorSizeTextWrap: String get() = bundle.getString("editor_size_text_wrap")
     val editorSizeCanvasWidth: String get() = bundle.getString("editor_size_canvas_width")
+    val editorSizeLogoPlate: String get() = bundle.getString("editor_size_logo_plate")
     val editorWidthEm: String get() = bundle.getString("editor_width_em")
     val editorHeightEm: String get() = bundle.getString("editor_height_em")
     val editorPadX: String get() = bundle.getString("editor_pad_x")

--- a/lottieGenerator/src/main/resources/lottiegen_strings.properties
+++ b/lottieGenerator/src/main/resources/lottiegen_strings.properties
@@ -226,6 +226,7 @@ editor_size_em=Fixed (em)
 editor_size_content=Content block + padding
 editor_size_text_wrap=Wrap text field
 editor_size_canvas_width=Full canvas width
+editor_size_logo_plate=Logo plate (logo size + pad)
 editor_width_em=Width (em)
 editor_height_em=Height (em)
 editor_pad_x=Pad X (em)

--- a/lottieGenerator/src/main/resources/styles/style10_double_line_port.json
+++ b/lottieGenerator/src/main/resources/styles/style10_double_line_port.json
@@ -16,6 +16,7 @@
             }
         ],
         "blockHeightEm": 3.4666666666666667,
+        "logoScale": "height",
         "centerSingleLine": false
     },
     "elements": [
@@ -284,7 +285,7 @@
                 "line": "BLOCK_CENTER",
                 "offsetYEm": -0.65,
                 "alignOverrides": {
-                    "center": { "offsetXEm": -2.0416666666666667 }
+                    "center": { "offsetXEm": -0.2916666666666665, "offsetXLogoHalfWidths": -1.0 }
                 }
             },
             "tracks": [

--- a/lottieGenerator/src/main/resources/styles/style5_gradient_bar_port.json
+++ b/lottieGenerator/src/main/resources/styles/style5_gradient_bar_port.json
@@ -17,6 +17,7 @@
             }
         ],
         "blockHeightEm": 4.05,
+        "logoScale": "height",
         "centerSingleLine": false
     },
     "elements": [
@@ -132,7 +133,7 @@
                     "center": { "offsetXEm": -2.2916666666666665 }
                 }
             },
-            "size": { "type": "em", "wEm": 4.3, "hEm": 4.3 },
+            "size": { "type": "logoPlate", "padEm": 0.8 },
             "paint": {
                 "fill": { "role": "ACCENT" },
                 "stroke": { "role": "BORDER", "width": { "type": "fromConfig" } }

--- a/lottieGenerator/src/main/resources/styles/style6_line_split_port.json
+++ b/lottieGenerator/src/main/resources/styles/style6_line_split_port.json
@@ -16,6 +16,7 @@
             }
         ],
         "blockHeightEm": 3.5,
+        "logoScale": "height",
         "centerSingleLine": false
     },
     "elements": [

--- a/lottieGenerator/src/main/resources/styles/style7_random_fade_port.json
+++ b/lottieGenerator/src/main/resources/styles/style7_random_fade_port.json
@@ -16,6 +16,7 @@
             }
         ],
         "blockHeightEm": 2.15,
+        "logoScale": "height",
         "centerSingleLine": false
     },
     "elements": [

--- a/lottieGenerator/src/main/resources/styles/style9_diagonal_wipe_port.json
+++ b/lottieGenerator/src/main/resources/styles/style9_diagonal_wipe_port.json
@@ -16,6 +16,7 @@
             }
         ],
         "blockHeightEm": 2.3,
+        "logoScale": "height",
         "centerSingleLine": false
     },
     "elements": [
@@ -415,7 +416,7 @@
                 "line": "BLOCK_CENTER",
                 "offsetYEm": 0.075,
                 "alignOverrides": {
-                    "center": { "offsetXEm": -2.0416666666666665 }
+                    "center": { "offsetXEm": -0.2916666666666665, "offsetXLogoHalfWidths": -1.0 }
                 }
             },
             "tracks": [

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort10Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort10Test.kt
@@ -105,7 +105,7 @@ class SpecPort10Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 80 else 0,
+                            logoW = if (logo) 120 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             // The port is tuned at the default hairline (linePx = 2 px);
@@ -186,47 +186,6 @@ class SpecPort10Test {
                     }
                 }
             }
-        }
-    }
-
-
-    /**
-     * A logo wider than it is tall: layer structure only, deliberately not geometry.
-     *
-     * The matrix above uses a square logo because that is where the two models agree exactly. The
-     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
-     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
-     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
-     * static em, so neither the reserved width nor the plate can track the logo's aspect.
-     *
-     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
-     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
-     * logo, which is that both models build the same layers in the same order, and leaves the
-     * geometry to the square configs above rather than pretending the numbers agree.
-     */
-    @Test
-    fun portMatchesCompiledStructureWithAWideLogo() {
-        val cfg = LottieGenConfig(
-            logoEnabled = true,
-            logoData = "data:image/png;base64,iVBORw0KGgo=",
-            logoW = 120,
-            logoH = 80,
-            // Same shape as the matrix's logo configs above, so this isolates the aspect and
-            // nothing else — a bare default config reaches a combination the matrix never covers.
-            bgEnabled = true,
-            borderThickness = 4f,
-        )
-        val expected = LottieGenerator.generate(cfg, Style10DoubleLine())
-        val actual = LottieGenerator.generate(cfg, port())
-
-        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
-        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
-
-        assertEquals(expectedLayers.map { it.name() }, actualLayers.map { it.name() }, "layer names/order")
-        for ((exp, act) in expectedLayers.zip(actualLayers)) {
-            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
-            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
-            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort5Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort5Test.kt
@@ -72,23 +72,20 @@ import kotlin.test.assertEquals
  *    port's offsetXEm −2.2916666666666665 = −2.5 + (TEXT_CORE_PAD_PX/2)/24 em
  *    (maxTextW and logoSize cancel exactly) — the 5 px term is the layout
  *    engine's fixed text-core pad, exact only at baseSize 24.
- * 8. Logo scale basis (spec-model gap): compiled scales the logo HEIGHT to
- *    logoSize em, so its drawn width follows the aspect; the spec engine's
- *    buildLogo normalizes by max(logoW, logoH) (fit-longest-side). The two agree
- *    exactly for a SQUARE logo and disagree for any other, which is why the
- *    matrix below uses one — see deviation 9.
- * 9. Logo BG size and the gutter: compiled sizes the plate as the logo's drawn
- *    width × its height, plus 0.8 em, and reserves a gutter to match — so both
- *    track the logo's aspect. The spec cannot: SizeSpec has no logo-derived
- *    variant (it cannot even reference cfg.logoSize, hence the static
- *    Em(4.3, 4.3), exact at default logoSize) and the slot gaps 0.4/0.9 that
- *    encode the badge overhang + 0.5 em margin are static em too.
+ * 8. Logo scale basis: BOTH now scale the logo from its HEIGHT. The spec's
+ *    buildLogo used to normalize by max(logoW, logoH) (fit-longest-side), which
+ *    matched only for a square logo; the layout's `logoScale: height` now selects
+ *    the same basis the compiled style uses, so the rendered logo is identical
+ *    for any aspect. (`longestSide` stays the default, so no other spec style
+ *    moves.)
+ * 9. Logo BG size and the gutter: both track the logo's drawn width. The plate is
+ *    a `logoPlate` SizeSpec (the logo's drawn size + 0.8 em) rather than a static
+ *    Em, so it is exact for every logoSize AND every aspect; the LOGO slot's core
+ *    is the drawn width, so the gutter follows too. The 0.4/0.9 gaps still encode
+ *    the badge overhang + 0.5 em margin, which are aspect-independent.
  *
- *    So the matrix uses a square logo, where compiled and spec agree exactly, and
- *    `portMatchesCompiledStructureWithAWideLogo` covers the non-square case for
- *    layer structure only. Closing the gap properly needs two spec-engine
- *    features — a logo-derived SizeSpec and logo-aware slot gaps — which is its
- *    own piece of work, not a re-baselining.
+ *    This is why the matrix below uses a NON-square 120x80 logo: geometry is
+ *    asserted exactly for it, which is the case that used to be inexpressible.
  * 10. Spec-model gap: compiled gates Logo AND Logo BG on
  *     `logoEnabled && logoData != null`; a RectElement can only test
  *     LOGO_ENABLED, so with logoEnabled=true but logoData=null the port would
@@ -124,7 +121,7 @@ class SpecPort5Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 80 else 0,
+                            logoW = if (logo) 120 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             borderThickness = 4f
@@ -174,47 +171,6 @@ class SpecPort5Test {
                     assertEquals(e, a, eps, "rest origin[$i] $layerLabel")
                 }
             }
-        }
-    }
-
-
-    /**
-     * A logo wider than it is tall: layer structure only, deliberately not geometry.
-     *
-     * The matrix above uses a square logo because that is where the two models agree exactly. The
-     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
-     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
-     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
-     * static em, so neither the reserved width nor the plate can track the logo's aspect.
-     *
-     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
-     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
-     * logo, which is that both models build the same layers in the same order, and leaves the
-     * geometry to the square configs above rather than pretending the numbers agree.
-     */
-    @Test
-    fun portMatchesCompiledStructureWithAWideLogo() {
-        val cfg = LottieGenConfig(
-            logoEnabled = true,
-            logoData = "data:image/png;base64,iVBORw0KGgo=",
-            logoW = 120,
-            logoH = 80,
-            // Same shape as the matrix's logo configs above, so this isolates the aspect and
-            // nothing else — a bare default config reaches a combination the matrix never covers.
-            bgEnabled = true,
-            borderThickness = 4f,
-        )
-        val expected = LottieGenerator.generate(cfg, Style5GradientBar())
-        val actual = LottieGenerator.generate(cfg, port())
-
-        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
-        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
-
-        assertEquals(expectedLayers.map { it.name() }, actualLayers.map { it.name() }, "layer names/order")
-        for ((exp, act) in expectedLayers.zip(actualLayers)) {
-            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
-            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
-            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort6Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort6Test.kt
@@ -89,7 +89,7 @@ class SpecPort6Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 80 else 0,
+                            logoW = if (logo) 120 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             borderThickness = 4f
@@ -174,47 +174,6 @@ class SpecPort6Test {
                     }
                 }
             }
-        }
-    }
-
-
-    /**
-     * A logo wider than it is tall: layer structure only, deliberately not geometry.
-     *
-     * The matrix above uses a square logo because that is where the two models agree exactly. The
-     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
-     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
-     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
-     * static em, so neither the reserved width nor the plate can track the logo's aspect.
-     *
-     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
-     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
-     * logo, which is that both models build the same layers in the same order, and leaves the
-     * geometry to the square configs above rather than pretending the numbers agree.
-     */
-    @Test
-    fun portMatchesCompiledStructureWithAWideLogo() {
-        val cfg = LottieGenConfig(
-            logoEnabled = true,
-            logoData = "data:image/png;base64,iVBORw0KGgo=",
-            logoW = 120,
-            logoH = 80,
-            // Same shape as the matrix's logo configs above, so this isolates the aspect and
-            // nothing else — a bare default config reaches a combination the matrix never covers.
-            bgEnabled = true,
-            borderThickness = 4f,
-        )
-        val expected = LottieGenerator.generate(cfg, Style6LineSplit())
-        val actual = LottieGenerator.generate(cfg, port())
-
-        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
-        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
-
-        assertEquals(expectedLayers.map { it.name() }, actualLayers.map { it.name() }, "layer names/order")
-        for ((exp, act) in expectedLayers.zip(actualLayers)) {
-            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
-            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
-            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort7Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort7Test.kt
@@ -66,7 +66,7 @@ class SpecPort7Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 80 else 0,
+                            logoW = if (logo) 120 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             borderThickness = 4f
@@ -126,47 +126,6 @@ class SpecPort7Test {
                     )
                 }
             }
-        }
-    }
-
-
-    /**
-     * A logo wider than it is tall: layer structure only, deliberately not geometry.
-     *
-     * The matrix above uses a square logo because that is where the two models agree exactly. The
-     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
-     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
-     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
-     * static em, so neither the reserved width nor the plate can track the logo's aspect.
-     *
-     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
-     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
-     * logo, which is that both models build the same layers in the same order, and leaves the
-     * geometry to the square configs above rather than pretending the numbers agree.
-     */
-    @Test
-    fun portMatchesCompiledStructureWithAWideLogo() {
-        val cfg = LottieGenConfig(
-            logoEnabled = true,
-            logoData = "data:image/png;base64,iVBORw0KGgo=",
-            logoW = 120,
-            logoH = 80,
-            // Same shape as the matrix's logo configs above, so this isolates the aspect and
-            // nothing else — a bare default config reaches a combination the matrix never covers.
-            bgEnabled = true,
-            borderThickness = 4f,
-        )
-        val expected = LottieGenerator.generate(cfg, Style7RandomFade())
-        val actual = LottieGenerator.generate(cfg, port())
-
-        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
-        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
-
-        assertEquals(expectedLayers.map { it.name() }, actualLayers.map { it.name() }, "layer names/order")
-        for ((exp, act) in expectedLayers.zip(actualLayers)) {
-            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
-            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
-            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 

--- a/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort9Test.kt
+++ b/lottieGenerator/src/test/kotlin/org/churchpresenter/lottiegen/spec/SpecPort9Test.kt
@@ -94,7 +94,7 @@ class SpecPort9Test {
                             align = align,
                             logoEnabled = logo,
                             logoData = if (logo) logoData else null,
-                            logoW = if (logo) 80 else 0,
+                            logoW = if (logo) 120 else 0,
                             logoH = if (logo) 80 else 0,
                             bgEnabled = bg,
                             borderThickness = 4f
@@ -242,52 +242,6 @@ class SpecPort9Test {
                 "$label: reveal mask must cover its text at rest " +
                     "(mask [$maskMin, $maskMax] vs text [$textMin, $textMax])"
             )
-        }
-    }
-
-
-    /**
-     * A logo wider than it is tall: layer structure only, deliberately not geometry.
-     *
-     * The matrix above uses a square logo because that is where the two models agree exactly. The
-     * compiled style scales the logo by HEIGHT, so a wide logo draws wider than `logoSize` and the
-     * compiled geometry now widens the gutter (and, in Style 5, the plate) to match it. The spec
-     * engine cannot follow: `SizeSpec` has no logo-derived variant and the layout slots' gaps are
-     * static em, so neither the reserved width nor the plate can track the logo's aspect.
-     *
-     * Closing that needs two spec-engine features — a logo-derived `SizeSpec` and logo-aware slot
-     * gaps — which is its own piece of work. Until then this asserts what still holds for a wide
-     * logo, which is that both models build the same layers in the same order, and leaves the
-     * geometry to the square configs above rather than pretending the numbers agree.
-     */
-    @Test
-    fun portMatchesCompiledStructureWithAWideLogo() {
-        val cfg = LottieGenConfig(
-            logoEnabled = true,
-            logoData = "data:image/png;base64,iVBORw0KGgo=",
-            logoW = 120,
-            logoH = 80,
-            // Same shape as the matrix's logo configs above, so this isolates the aspect and
-            // nothing else — a bare default config reaches a combination the matrix never covers.
-            bgEnabled = true,
-            borderThickness = 4f,
-        )
-        val expected = LottieGenerator.generate(cfg, Style9DiagonalWipe())
-        val actual = LottieGenerator.generate(cfg, port())
-
-        val expectedLayers = expected["layers"]!!.jsonArray.map { it.jsonObject }
-        val actualLayers = actual["layers"]!!.jsonArray.map { it.jsonObject }
-
-        // Through mappedName, as the matrix above does: this port names two layers differently
-        // from the compiled style by design, which is unrelated to the logo.
-        assertEquals(
-            expectedLayers.map { mappedName(it.name()) }, actualLayers.map { it.name() },
-            "layer names/order",
-        )
-        for ((exp, act) in expectedLayers.zip(actualLayers)) {
-            assertEquals(exp["ty"]!!.jsonPrimitive.int, act["ty"]!!.jsonPrimitive.int, "layer type ${exp.name()}")
-            assertEquals(exp["td"]?.jsonPrimitive?.int, act["td"]?.jsonPrimitive?.int, "td ${exp.name()}")
-            assertEquals(exp["tt"]?.jsonPrimitive?.int, act["tt"]?.jsonPrimitive?.int, "tt ${exp.name()}")
         }
     }
 


### PR DESCRIPTION
Follow-up to #382, which you asked for. That PR made the **compiled** styles size the logo plate and gutter from the logo's drawn width — but the spec engine couldn't follow, so the `SpecPort` matrices fell back to a square logo with the non-square case covered for layer structure only. This closes that properly.

## Why the spec couldn't express it

Three separate gaps, all now closed:

| gap | before | now |
|---|---|---|
| plate size | `SizeSpec` had no logo-derived variant — a static `Em(4.3, 4.3)` that couldn't even reference `cfg.logoSize` | `SizeSpec.LogoPlate(padEm)` — the logo's drawn size + padding |
| reserved gutter | `SlotKind.LOGO` core width was `em(cfg.logoSize)` regardless of aspect | the logo's drawn width |
| logo scale | `buildLogo` always normalised by `max(logoW, logoH)` | follows the style's declared basis |

The basis is the crux, and it's now explicit: **`LayoutSpec.logoScale`** is either `longestSide` or `height`, and it picks *both* the logo's scale basis and the width its slot reserves — so the logo and the room made for it cannot disagree. That's the same distinction #382 documented between `Style1Bar` and the five height-scaled styles.

The last piece was subtler. Styles 9 and 10 centre their logo relative to the **text block**, not its slot, so their static `offsetXEm` had *baked in half the logo's width* — right only while the logo was square. `Placement.offsetXLogoHalfWidths` makes that a term that tracks the drawn logo. It was worth exactly 21px at the test's 120×80 logo, which is `(126 − 84) / 2` — the arithmetic confirmed the diagnosis before the test did.

## Result

The five ports set `logoScale: height`, Style 5's plate is a `logoPlate`, and **the `SpecPort` matrices are back on a non-square 120×80 logo with geometry asserted exactly**. `SpecPort5Test`'s deviations 8 and 9 are now *closed* rather than documented.

The structure-only tests #382 added are removed as **subsumed** — the matrix now asserts strictly more (structure *and* geometry) at the same config.

## Nothing else moved — measured, not assumed

`longestSide` is the default and resolves to exactly the previous arithmetic, so no existing spec style changes. I verified that rather than trusting it: rendering **all 82 shipped spec styles** with a wide 120×80 logo and diffing against the same dump from the unmodified code —

```
identical: 77   changed: 5
```

— the 5 being exactly the ports that opted in.

## Verification

- `:lottieGenerator:test` green on **three consecutive `--rerun-tasks`** runs
- coverage floor and `:lottieGenerator:detekt` green; `:composeApp:detekt` green, run last
- the editor's `SizeEditor` gained the new variant (the compiler required exhaustiveness) with its own English string — **no non-English locale touched**
- port JSON diffs are 7 inserted lines, not a reformat: my first pass rewrote the files wholesale (2,415 lines) and I redid it as minimal edits so the change is reviewable