### PR TITLE
Extract shortcuts into dedicated module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,6 +251,12 @@ jobs:
               - 'ui-components/**'      # implementation(projects.uiComponents)
               - 'theme/**'              # implementation(projects.theme)
               - 'diagnostics/**'        # implementation(projects.diagnostics)
+            shortcuts:
+              - *shared
+              - 'shortcuts/**'
+              - 'settings/**'           # api(projects.settings) — the saved bindings
+              - 'core-models/**'        # api(projects.coreModels) — KeyChord, Tabs
+              - 'resources/**'          # api(projects.resources) — every action name and key alias
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -286,7 +292,7 @@ jobs:
           :bible-engine:detekt :presentation-engine:detekt :song-chords:detekt :bible:detekt
           :dictionary:detekt :companion-server:detekt :lottieGenerator:detekt
           :statistics:detekt
-          :ui-components:detekt :dictionary-tab:detekt :dictionary-settings-tab:detekt
+          :shortcuts:detekt :ui-components:detekt :dictionary-tab:detekt :dictionary-settings-tab:detekt
           :announcements-tab:detekt :qa-tab:detekt :lower-third-tab:detekt
           :lower-third-settings-tab:detekt :stt-tab:detekt :web-tab:detekt
 
@@ -457,6 +463,14 @@ jobs:
       - name: UI components coverage floor
         if: always() && steps.modules.outputs.uicomponents == 'true'
         run: ./gradlew :ui-components:jacocoTestCoverageVerification -x test
+
+      - name: Shortcuts tests
+        if: always() && steps.modules.outputs.shortcuts == 'true'
+        run: ./gradlew :shortcuts:test
+
+      - name: Shortcuts coverage floor
+        if: always() && steps.modules.outputs.shortcuts == 'true'
+        run: ./gradlew :shortcuts:jacocoTestCoverageVerification -x test
 
       - name: Dictionary tab tests
         if: always() && steps.modules.outputs.dictionarytab == 'true'
@@ -670,6 +684,7 @@ jobs:
             song-chords/build/test-results/**/TEST-*.xml
             statistics/build/test-results/**/TEST-*.xml
             ui-components/build/test-results/**/TEST-*.xml
+            shortcuts/build/test-results/**/TEST-*.xml
             bible/build/test-results/**/TEST-*.xml
             dictionary/build/test-results/**/TEST-*.xml
             dictionary-tab/build/test-results/**/TEST-*.xml
@@ -704,6 +719,7 @@ jobs:
             Song chords
             Statistics
             UI components
+            Shortcuts
             Bible
             Dictionary
             Dictionary tab
@@ -865,6 +881,8 @@ jobs:
             statistics/build/test-results/
             ui-components/build/reports/tests/
             ui-components/build/test-results/
+            shortcuts/build/reports/tests/
+            shortcuts/build/test-results/
             bible/build/reports/tests/
             bible/build/test-results/
             dictionary/build/reports/tests/

--- a/AGENT.md
+++ b/AGENT.md
@@ -44,7 +44,7 @@ All source under `composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpr
 | `remote/`        | What a remote request *does* to the app — the server itself is `:companion-server` |
 | `data/`          | File I/O, database, song parsing, Bible data                        |
 | `data/settings/` | Only `ObsSceneSelection.kt` — the rest is the `:settings` module    |
-| `models/`        | Only what needs the app: ShortcutAction, the two Companion UI states |
+| `models/`        | Only the two Companion UI states — ShortcutAction moved to `:shortcuts` |
 | `composables/`   | Reusable UI components (VideoPlayer, SceneCanvas, etc.)             |
 | `dialogs/`       | All dialogs and settings dialog tabs — except the Dictionary and Lower Third ones, in `:dictionary-settings-tab` and `:lower-third-settings-tab` |
 | `utils/`         | Stateless helpers (AutoFit, UpdateChecker, CrashReporter, etc.)     |
@@ -88,6 +88,7 @@ file before changing it, and **put module-specific notes there, not here.**
 | `dictionary/`          | `:dictionary`          | The bundled Strong's dictionary and the interlinear index over it — 18 MB of data  | [AGENT.md](dictionary/AGENT.md)          |
 | `resources/`           | `:resources`           | Every asset the app draws or reads — icons, the 35 locales, fonts, bundled files   | [AGENT.md](resources/AGENT.md)           |
 | `ui-components/`       | `:ui-components`       | The app's own widget library — the custom composables tabs and dialogs are built from | [AGENT.md](ui-components/AGENT.md)     |
+| `shortcuts/`           | `:shortcuts`           | The keyboard shortcuts — the actions, what they are bound to, and how a binding reads | [AGENT.md](shortcuts/AGENT.md)           |
 | `dictionary-tab/`      | `:dictionary-tab`      | The Dictionary tab — its browser, its view model and its presenter                | [AGENT.md](dictionary-tab/AGENT.md)      |
 | `dictionary-settings-tab/` | `:dictionary-settings-tab` | The options-dialog page that styles a Strong's entry for the screen           | [AGENT.md](dictionary-settings-tab/AGENT.md) |
 | `lower-third-settings-tab/` | `:lower-third-settings-tab` | The options-dialog page that picks a Lottie preset and places the band        | [AGENT.md](lower-third-settings-tab/AGENT.md) |
@@ -134,7 +135,8 @@ they must be set **above everything else** in the file:
   `:lottieGenerator`, `:crossword`, `:songlibrary`, `:settings`, `:diagnostics`, `:atem`,
   `:planning-center`, `:bible-formats`, `:song-chords`, `:bible`, `:dictionary`, `:ui-components`,
   `:dictionary-tab`, `:dictionary-settings-tab`, `:lower-third-settings-tab`,
-  `:announcements-tab`, `:qa-tab`, `:stt-tab`, `:companion-server` and `:statistics` name none.
+  `:announcements-tab`, `:qa-tab`, `:stt-tab`, `:shortcuts`, `:companion-server` and
+  `:statistics` name none.
   Each module's own `AGENT.md` says which, and why.
 - `extra["coverageExcludes"]` — class-directory excludes, replacing the default
   `**/ComposableSingletons*` outright. **Read the rule below before adding one.**

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ wrapper of its own — one `./gradlew` at the repo root builds and tests the lot
 > `[G]lyric` markup. Depends on nothing, so the app and the converter share one rule instead of two.
 > `./gradlew :song-chords:test`.
 >
+> **[`shortcuts/`](./shortcuts)** — the keyboard shortcuts: every action the app can be driven
+> by, what each is currently bound to once the operator's overrides are applied, and how a
+> binding is written out — as a label, as individual keycaps, and as the text the shortcuts
+> search matches. Its own module because every tab reads it. `./gradlew :shortcuts:test`.
+>
 > **[`songlibrary/`](./songlibrary)** — the Song Library Manager: every song in the library folder in one editable grid, opened from the Help menu. It reads and writes through **[`core-models/`](./core-models)**, which holds the song model and the `.song` file format the app itself uses.
 >
 > **[`converter/`](./converter)** — a song/bible format converter built with Compose Desktop,

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -352,6 +352,7 @@ kotlin {
             api(projects.resources)
             // The custom composables the tabs and dialogs are built from.
             implementation(projects.uiComponents)
+            implementation(projects.shortcuts)
             implementation(projects.songlibrary)
             implementation(projects.songChords)
             // The Companion Satellite protocol client: a real module rather than a mounted source

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktop.kt
@@ -112,8 +112,8 @@ import org.churchpresenter.app.churchpresenter.dialogs.AddLabelDialog
 import org.churchpresenter.app.churchpresenter.dialogs.AddWebsiteDialog
 import org.churchpresenter.app.churchpresenter.dialogs.CrashFeedbackDialog
 import org.churchpresenter.app.churchpresenter.dialogs.KonamiEasterEggDialog
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutScope
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.companionserver.InstanceLinkStatus
 import org.churchpresenter.companionserver.ScheduleItemDto
@@ -136,11 +136,11 @@ import org.churchpresenter.app.churchpresenter.tabs.ScheduleTab
 import org.churchpresenter.app.churchpresenter.tabs.ScheduleTabActions
 import org.churchpresenter.app.churchpresenter.tabs.SongsTab
 import org.churchpresenter.app.churchpresenter.tabs.TabSection
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterWebOutput
 import org.churchpresenter.web.WebTab
 import org.churchpresenter.app.churchpresenter.tabs.getStringName
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
+import org.churchpresenter.shortcuts.LocalShortcuts
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleEngineClient
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.CompanionSatelliteViewModel

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopLogic.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopLogic.kt
@@ -20,7 +20,7 @@ import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.companionserver.InstanceLinkStatus
 import org.churchpresenter.companionserver.SelectBibleVerseRequest
 import org.churchpresenter.app.churchpresenter.tabs.ScheduleToolbarButton
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import org.churchpresenter.settings.utils.Constants
 import java.io.File
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/NavigationTopBar.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/NavigationTopBar.kt
@@ -88,8 +88,8 @@ import org.churchpresenter.resources.generated.resources.menu_settings
 import org.churchpresenter.resources.generated.resources.menu_statistics
 import org.churchpresenter.resources.generated.resources.system_theme
 import org.churchpresenter.app.churchpresenter.data.Language
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.LocalShortcuts
 import org.churchpresenter.theme.ThemeMode
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/RemoteCommandEffects.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/RemoteCommandEffects.kt
@@ -13,7 +13,7 @@ import org.churchpresenter.core.models.songs.SongItem
 import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.companionserver.SelectBibleVerseRequest
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PicturesViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresentationViewModel

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsDialog.kt
@@ -1,5 +1,8 @@
 package org.churchpresenter.app.churchpresenter.dialogs
 
+import org.churchpresenter.shortcuts.label
+import org.churchpresenter.shortcuts.searchText
+
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -86,11 +89,9 @@ import org.churchpresenter.ui.centeredOnMainWindow
 import org.churchpresenter.ui.SearchField
 import org.churchpresenter.settings.AppSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
-import org.churchpresenter.app.churchpresenter.utils.label
-import org.churchpresenter.app.churchpresenter.utils.searchText
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutScope
+import org.churchpresenter.shortcuts.ShortcutMap
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/ShortcutBindingRow.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/ShortcutBindingRow.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.dialogs
 
+import org.churchpresenter.shortcuts.keyCaps
+
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -55,8 +57,7 @@ import org.churchpresenter.resources.generated.resources.shortcut_unbound
 import org.churchpresenter.ui.ConditionalTooltipArea
 import org.churchpresenter.ui.TooltipIconButton
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.utils.keyCaps
+import org.churchpresenter.shortcuts.ShortcutAction
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/ShortcutCategoryRail.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/ShortcutCategoryRail.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
+import org.churchpresenter.shortcuts.ShortcutScope
 
 /** Wide enough for "Presentation Tab" at the rail's text size without ellipsis. */
 internal val RAIL_WIDTH = 178.dp

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -116,8 +116,8 @@ import org.churchpresenter.stt.STTManager
 import org.churchpresenter.theme.AppThemeWrapper
 import org.churchpresenter.settings.utils.AppDataDir
 import org.churchpresenter.settings.utils.Constants
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
+import org.churchpresenter.shortcuts.LocalShortcuts
+import org.churchpresenter.shortcuts.ShortcutMap
 import org.churchpresenter.app.churchpresenter.utils.isSongLineMode
 import org.churchpresenter.ui.presenterScreenBounds
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTab.kt
@@ -73,9 +73,9 @@ import org.churchpresenter.settings.swapBibleTranslations
 import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.core.models.bible.SelectedVerse
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutAction
 import org.churchpresenter.diagnostics.CrashReporter
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
+import org.churchpresenter.shortcuts.LocalShortcuts
 import org.churchpresenter.app.churchpresenter.utils.UsageEvent
 import org.churchpresenter.app.churchpresenter.utils.UsageEvents
 import org.churchpresenter.app.churchpresenter.utils.isMultiTranslationPresentation

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/CanvasTab.kt
@@ -99,8 +99,8 @@ import org.churchpresenter.ui.ColorPickerField
 import org.churchpresenter.app.churchpresenter.composables.SceneCanvas
 import org.churchpresenter.app.churchpresenter.composables.SourcePropertiesPanel
 import org.churchpresenter.settings.AppSettings
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.LocalShortcuts
 import org.churchpresenter.app.churchpresenter.utils.assignedDisplayBounds
 import org.churchpresenter.ui.formatAspectRatio
 import org.churchpresenter.core.models.scene.SceneSource

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/MediaTab.kt
@@ -141,9 +141,9 @@ import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.remote.followerMediaUrl
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutAction
 import org.churchpresenter.settings.utils.Constants
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
+import org.churchpresenter.shortcuts.LocalShortcuts
 import org.churchpresenter.ui.presenterAspectRatio
 import org.churchpresenter.app.churchpresenter.viewmodel.LocalMediaViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
+import org.churchpresenter.shortcuts.pairLabel
+
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.foundation.Image
@@ -135,10 +137,9 @@ import org.churchpresenter.ui.DropdownSelector
 import org.churchpresenter.settings.AppSettings
 import org.churchpresenter.core.models.presentation.AnimationType
 import org.churchpresenter.core.models.schedule.ScheduleItem
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutAction
 import org.churchpresenter.settings.utils.Constants
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
-import org.churchpresenter.app.churchpresenter.utils.pairLabel
+import org.churchpresenter.shortcuts.LocalShortcuts
 import org.churchpresenter.app.churchpresenter.viewmodel.PicturesViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
 import org.jetbrains.compose.resources.painterResource

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
@@ -1,5 +1,8 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
+import org.churchpresenter.shortcuts.label
+import org.churchpresenter.shortcuts.pairLabel
+
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.material3.Surface
 import androidx.compose.foundation.Image
@@ -167,12 +170,10 @@ import org.churchpresenter.core.models.presentation.AnimationType
 import org.churchpresenter.core.models.presentation.PresentationLoadError
 import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutAction
 import org.churchpresenter.settings.utils.Constants
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
-import org.churchpresenter.app.churchpresenter.utils.label
-import org.churchpresenter.app.churchpresenter.utils.pairLabel
+import org.churchpresenter.shortcuts.LocalShortcuts
+import org.churchpresenter.shortcuts.ShortcutMap
 import org.churchpresenter.app.churchpresenter.viewmodel.PresentationViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
 import org.jetbrains.compose.resources.painterResource

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleHeader.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleHeader.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
+import org.churchpresenter.shortcuts.label
+
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.TooltipPlacement
@@ -8,9 +10,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.shape.RoundedCornerShape
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
-import org.churchpresenter.app.churchpresenter.utils.label
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.LocalShortcuts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleItemRow.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/ScheduleItemRow.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import org.churchpresenter.ui.finalPassCombinedClickable
-import org.churchpresenter.app.churchpresenter.utils.label
+import org.churchpresenter.shortcuts.label
 import org.churchpresenter.ui.initialPassCombinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTab.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
+import org.churchpresenter.shortcuts.pairLabel
+
 import androidx.compose.ui.window.WindowPlacement
 import org.churchpresenter.ui.LocalMainWindowState
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -75,10 +77,9 @@ import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.core.models.songs.SongTuning
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.theme.ThemeMode
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutAction
 import org.churchpresenter.settings.utils.Constants
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
-import org.churchpresenter.app.churchpresenter.utils.pairLabel
+import org.churchpresenter.shortcuts.LocalShortcuts
 import org.churchpresenter.app.churchpresenter.utils.availableSongColumns
 import org.churchpresenter.app.churchpresenter.utils.UsageEvent
 import org.churchpresenter.app.churchpresenter.utils.UsageEvents

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/TabSection.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/TabSection.kt
@@ -1,5 +1,7 @@
 package org.churchpresenter.app.churchpresenter.tabs
 
+import org.churchpresenter.core.models.tabs.Tabs
+
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.MaterialTheme

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/Tabs.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/Tabs.kt
@@ -1,5 +1,0 @@
-package org.churchpresenter.app.churchpresenter.tabs
-
-enum class Tabs {
-    BIBLE, SONGS, PICTURES, PRESENTATION, MEDIA, LOWER_THIRD, ANNOUNCEMENTS, WEB, CANVAS, QA, STT, CROSSWORD, DICTIONARY, COMPANION_SURFACE
-}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopBackgroundMediaTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopBackgroundMediaTest.kt
@@ -1,7 +1,7 @@
 package org.churchpresenter.app.churchpresenter
 
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertFalse

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopComposeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopComposeTest.kt
@@ -35,7 +35,7 @@ import org.churchpresenter.companionserver.SelectBibleVerseRequest
 import org.churchpresenter.qa.QAManager
 import org.churchpresenter.stt.STTManager
 import org.churchpresenter.settings.utils.Constants
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import org.churchpresenter.theme.ThemeMode
 import org.churchpresenter.app.churchpresenter.viewmodel.CompanionSatelliteViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopFunctionKeyTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopFunctionKeyTest.kt
@@ -1,13 +1,14 @@
 package org.churchpresenter.app.churchpresenter
 
+import org.churchpresenter.core.utils.keyDown
+
 import androidx.compose.ui.input.key.Key
 import org.churchpresenter.settings.KeyboardShortcutSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
-import org.churchpresenter.app.churchpresenter.utils.keyDown
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutScope
+import org.churchpresenter.core.models.tabs.Tabs
+import org.churchpresenter.shortcuts.ShortcutMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopScheduleItemTabTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopScheduleItemTabTest.kt
@@ -2,7 +2,7 @@ package org.churchpresenter.app.churchpresenter
 
 import org.churchpresenter.core.models.songs.SongItem
 import org.churchpresenter.core.models.schedule.ScheduleItem
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopTabVisibilityMenuTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopTabVisibilityMenuTest.kt
@@ -1,6 +1,6 @@
 package org.churchpresenter.app.churchpresenter
 
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopTabsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/MainDesktopTabsTest.kt
@@ -1,6 +1,6 @@
 package org.churchpresenter.app.churchpresenter
 
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/RemoteCommandEffectsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/RemoteCommandEffectsTest.kt
@@ -11,7 +11,7 @@ import org.churchpresenter.settings.AppSettings
 import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.companionserver.SelectBibleVerseRequest
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import org.churchpresenter.app.churchpresenter.viewmodel.BibleViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PicturesViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresentationViewModel

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsConflictsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsConflictsTest.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.test.withKeyDown
 import org.churchpresenter.settings.AppSettings
 import org.churchpresenter.settings.KeyboardShortcutSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutAction
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsContentTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsContentTest.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.test.runComposeUiTest
 import org.churchpresenter.settings.AppSettings
 import org.churchpresenter.settings.KeyboardShortcutSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsEditingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsEditingTest.kt
@@ -19,9 +19,9 @@ import androidx.compose.ui.test.withKeyDown
 import org.churchpresenter.settings.AppSettings
 import org.churchpresenter.settings.KeyboardShortcutSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutScope
+import org.churchpresenter.shortcuts.ShortcutMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsSearchTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/KeyboardShortcutsSearchTest.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.test.withKeyDown
 import org.churchpresenter.settings.AppSettings
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/ShortcutCaptureLogicTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/ShortcutCaptureLogicTest.kt
@@ -1,13 +1,14 @@
 package org.churchpresenter.app.churchpresenter.dialogs
 
+import org.churchpresenter.core.utils.keyDown
+
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
-import org.churchpresenter.app.churchpresenter.utils.keyDown
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewAnnouncementsScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewAnnouncementsScreenshotTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 
 class AppPreviewAnnouncementsScreenshotTest {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewBibleScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewBibleScreenshotTest.kt
@@ -4,7 +4,7 @@ package org.churchpresenter.app.churchpresenter.screenshot
 
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 
 class AppPreviewBibleScreenshotTest {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewCanvasScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewCanvasScreenshotTest.kt
@@ -2,7 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.screenshot
 
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 
 class AppPreviewCanvasScreenshotTest {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewDictionaryScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewDictionaryScreenshotTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 import org.churchpresenter.ui.screenshot.RENDER_TIMEOUT_MS
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewLowerThirdScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewLowerThirdScreenshotTest.kt
@@ -4,7 +4,7 @@ package org.churchpresenter.app.churchpresenter.screenshot
 
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Ignore
 import kotlin.test.Test
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewMediaScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewMediaScreenshotTest.kt
@@ -2,7 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.screenshot
 
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 
 class AppPreviewMediaScreenshotTest {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewPicturesScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewPicturesScreenshotTest.kt
@@ -5,7 +5,7 @@ package org.churchpresenter.app.churchpresenter.screenshot
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 import org.churchpresenter.ui.screenshot.RENDER_TIMEOUT_MS
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewPresentationScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewPresentationScreenshotTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.doubleClick
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 import org.churchpresenter.ui.screenshot.RENDER_TIMEOUT_MS
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewQAScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewQAScreenshotTest.kt
@@ -2,7 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.screenshot
 
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 
 class AppPreviewQAScreenshotTest {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSongsScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSongsScreenshotTest.kt
@@ -4,7 +4,7 @@ package org.churchpresenter.app.churchpresenter.screenshot
 
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.performClick
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 
 class AppPreviewSongsScreenshotTest {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSttScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSttScreenshotTest.kt
@@ -2,7 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.screenshot
 
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 
 class AppPreviewSttScreenshotTest {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewSupport.kt
@@ -37,7 +37,7 @@ import org.churchpresenter.core.models.scene.SourceTransform
 import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.tabs.RecentMediaFiles
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import org.churchpresenter.settings.utils.Constants
 import org.churchpresenter.theme.ChurchPresenterTheme
 import org.churchpresenter.app.churchpresenter.viewmodel.CompanionSatelliteViewModel

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewTimersScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewTimersScreenshotTest.kt
@@ -3,7 +3,7 @@
 package org.churchpresenter.app.churchpresenter.screenshot
 
 import org.churchpresenter.settings.AnnouncementsSettings
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import org.churchpresenter.settings.utils.Constants
 import kotlin.test.Test
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewWebScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/AppPreviewWebScreenshotTest.kt
@@ -2,7 +2,7 @@
 
 package org.churchpresenter.app.churchpresenter.screenshot
 
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 
 class AppPreviewWebScreenshotTest {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/KeyboardShortcutsDialogScreenshotTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/screenshot/KeyboardShortcutsDialogScreenshotTest.kt
@@ -27,8 +27,8 @@ import org.churchpresenter.app.churchpresenter.dialogs.SHORTCUT_PRESS_PANEL_TAG
 import org.churchpresenter.app.churchpresenter.dialogs.shortcutCategoryTag
 import org.churchpresenter.app.churchpresenter.dialogs.shortcutChipTag
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutScope
 import org.churchpresenter.theme.ChurchPresenterTheme
 import kotlin.test.Test
 import org.churchpresenter.ui.screenshot.captureTo

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabVerseClickTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/BibleTabVerseClickTest.kt
@@ -2,6 +2,8 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
+import org.churchpresenter.core.utils.keyDown
+
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.SemanticsNodeInteraction

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabKeyboardTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabKeyboardTest.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.pressKey
 import org.churchpresenter.settings.KeyboardShortcutSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTabTestSupport.kt
@@ -25,8 +25,8 @@ import org.churchpresenter.settings.PictureSettings
 import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.theme.ChurchPresenterTheme
 import org.churchpresenter.theme.ThemeMode
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
+import org.churchpresenter.shortcuts.LocalShortcuts
+import org.churchpresenter.shortcuts.ShortcutMap
 import org.churchpresenter.app.churchpresenter.viewmodel.PicturesViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
 import java.awt.image.BufferedImage

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabKeyboardTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabKeyboardTest.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.test.onNodeWithText
 import org.churchpresenter.settings.KeyboardShortcutSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
 import org.churchpresenter.core.models.schedule.ScheduleItem
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
+import org.churchpresenter.shortcuts.ShortcutAction
+import org.churchpresenter.shortcuts.ShortcutMap
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabTestSupport.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/SongsTabTestSupport.kt
@@ -27,8 +27,8 @@ import org.churchpresenter.settings.SongSettings
 import org.churchpresenter.core.models.songs.LyricSection
 import org.churchpresenter.core.models.schedule.ScheduleItem
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
-import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
-import org.churchpresenter.app.churchpresenter.utils.ShortcutMap
+import org.churchpresenter.shortcuts.LocalShortcuts
+import org.churchpresenter.shortcuts.ShortcutMap
 import org.churchpresenter.app.churchpresenter.viewmodel.SongsViewModel
 import java.io.File
 import java.nio.file.Files

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/TabSectionTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/tabs/TabSectionTest.kt
@@ -2,6 +2,8 @@
 
 package org.churchpresenter.app.churchpresenter.tabs
 
+import org.churchpresenter.core.models.tabs.Tabs
+
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.width
 import androidx.compose.ui.Modifier

--- a/core-models/src/main/kotlin/org/churchpresenter/core/models/tabs/Tabs.kt
+++ b/core-models/src/main/kotlin/org/churchpresenter/core/models/tabs/Tabs.kt
@@ -1,0 +1,25 @@
+package org.churchpresenter.core.models.tabs
+
+/**
+ * The tabs the app can show.
+ *
+ * Here rather than in `:composeApp` because `ShortcutAction` names one as its `targetTab` — the
+ * F-keys that jump straight to a tab — and `:shortcuts` cannot depend on the app. Every module that
+ * needs to say "this belongs to the Bible tab" refers to this one list.
+ */
+enum class Tabs {
+    BIBLE,
+    SONGS,
+    PICTURES,
+    PRESENTATION,
+    MEDIA,
+    LOWER_THIRD,
+    ANNOUNCEMENTS,
+    WEB,
+    CANVAS,
+    QA,
+    STT,
+    CROSSWORD,
+    DICTIONARY,
+    COMPANION_SURFACE,
+}

--- a/core-models/src/test/kotlin/org/churchpresenter/core/models/shortcuts/KeyChordTest.kt
+++ b/core-models/src/test/kotlin/org/churchpresenter/core/models/shortcuts/KeyChordTest.kt
@@ -1,9 +1,10 @@
 package org.churchpresenter.core.models.shortcuts
 
+import org.churchpresenter.core.utils.keyDown
+
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyShortcut
 import kotlinx.serialization.json.Json
-import org.churchpresenter.app.churchpresenter.utils.keyDown
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/core-models/src/testFixtures/kotlin/org/churchpresenter/core/utils/KeyEventFixture.kt
+++ b/core-models/src/testFixtures/kotlin/org/churchpresenter/core/utils/KeyEventFixture.kt
@@ -1,4 +1,4 @@
-package org.churchpresenter.app.churchpresenter.utils
+package org.churchpresenter.core.utils
 
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.input.key.Key

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -107,6 +107,11 @@ include(":statistics")
 // dropdowns, settings fields, segmented buttons, the colour picker, tooltips and the rest. Generic
 // by construction: it knows the theme and the resources, and nothing else about the app.
 include(":ui-components")
+// The keyboard shortcuts: what actions there are, what they are currently bound to, and how a
+// binding is written out for a human to read. Its own module because every tab needs it — six of
+// them still in :composeApp, and each one that moves out would otherwise have to reach back in.
+// Not part of :ui-components, which is deliberately kept free of a production :settings dependency.
+include(":shortcuts")
 // The Dictionary tab, whole: the Strong's browser and its "In Scripture" panel, the view model
 // behind them, the settings tab that styles the output, and the presenter that draws it. The data
 // it reads is :dictionary; this is everything the operator and the audience see of it.

--- a/shortcuts/AGENT.md
+++ b/shortcuts/AGENT.md
@@ -1,0 +1,81 @@
+# `:shortcuts` — Agent Notes
+
+Rules, structure and commands for this module only. The repo-wide rules are in the root `AGENT.md`.
+
+## What it is
+
+**The keyboard shortcuts**: what actions there are, what each is currently bound to, and how a
+binding is written out for a human to read.
+
+`include(":shortcuts")`, `implementation(projects.shortcuts)`.
+
+Three files:
+
+| file | holds |
+|---|---|
+| `ShortcutAction.kt` | `ShortcutAction` — every action, its scope, its default chords and its description — and `ShortcutScope` |
+| `ShortcutMap.kt` | `ShortcutMap` (defaults with the user's overrides applied, plus matching and conflict detection) and the `LocalShortcuts` composition local |
+| `ShortcutLabels.kt` | rendering a `KeyChord` for a human: the label, the individual keycaps, and the searchable text |
+
+## Why it is its own module
+
+**Every tab needs it.** Six are still in `:composeApp` — Bible, Songs, Pictures, Presentation,
+Media and Canvas — and each one that moves out would otherwise have to reach back into the app for
+`LocalShortcuts`. It was extracted ahead of the Canvas tab for exactly that reason.
+
+**It is not part of `:ui-components`**, and must not be moved there. `ShortcutMap` reads
+`KeyboardShortcutSettings`, and the root `AGENT.md` records a deliberate decision that
+`:ui-components` does not gain a production `:settings` dependency — the same rule that keeps
+`assignedDisplayBounds` in `:composeApp`.
+
+## What moved with it, and what did not
+
+- **`Tabs` went to `:core-models`** (`org.churchpresenter.core.models.tabs`). `ShortcutAction` names
+  one as its `targetTab` — the F-keys that jump to a tab — and this module cannot depend on the app.
+  It is a plain enum with no dependencies, so `:core-models` is its natural home.
+- **The shortcuts *dialog* stayed in `:composeApp`.** `KeyboardShortcutsDialog`,
+  `ShortcutBindingRow` and `ShortcutCategoryRail` are options-dialog pages, peers of the other
+  settings screens. This module is the model and the rendering, not the editor.
+
+## A package that did not match its directory
+
+`:core-models`' `KeyEventFixture.kt` sits at `.../core/utils/` but declared
+`package org.churchpresenter.app.churchpresenter.utils`. That is why `ShortcutMapTest` used to
+resolve `keyDown()` with no import at all — it was in the same package by accident. Moving the test
+here broke it, and the fix was to make the package match the directory
+(`org.churchpresenter.core.utils`) and give all four callers an explicit import. If a shared fixture
+ever resolves without an import again, check for the same thing.
+
+## Testing
+
+Most of `ShortcutLabels.kt` is `@Composable` — it reads translated strings — so its tests go through
+`runComposeUiTest` and pull the result out of the composition. `ShortcutLabelRenderingTest.composed`
+is the helper; follow it rather than inventing another.
+
+**An empty override is how "unbound" is expressed.** `ShortcutMap.from` falls back to
+`action.defaults` when an action is absent from `overrides`, so a test that wants an unbound action
+must map its name to `emptyList()` — leaving the key out gives the shipped binding instead, which is
+the opposite.
+
+No `extra["coverageFloors"]` and no `extra["coverageExcludes"]` — the module clears the root build's
+0.85 default on all six counters:
+
+| counter | value |
+|---|---|
+| INSTRUCTION | 0.959 |
+| BRANCH | 0.925 |
+| LINE | 0.981 |
+| COMPLEXITY | 0.936 |
+| METHOD | 1.000 |
+| CLASS | 1.000 |
+
+There is no display, no network and no device anywhere in here — it is a table and some string
+formatting. **If a number here drops, something has been added that does not belong.**
+
+## Commands
+
+```bash
+./gradlew :shortcuts:test
+./gradlew :shortcuts:detekt
+./gradlew :shortcuts:jacocoTestCoverageVerification
+```

--- a/shortcuts/CLAUDE.md
+++ b/shortcuts/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENT.md

--- a/shortcuts/build.gradle.kts
+++ b/shortcuts/build.gradle.kts
@@ -1,0 +1,57 @@
+import org.jetbrains.compose.resources.ResourcesExtension
+
+plugins {
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.composeMultiplatform)
+    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.detekt)
+    jacoco
+}
+
+group = "org.churchpresenter"
+
+kotlin {
+    jvmToolchain(21)
+}
+
+compose.resources {
+    generateResClass = ResourcesExtension.ResourceClassGeneration.Never
+}
+
+dependencies {
+    // The bindings as saved, and the KeyChord they are saved as.
+    api(projects.settings)
+    api(projects.coreModels)
+    // Every action name, category and key alias is a translated string.
+    api(projects.resources)
+    implementation(compose.desktop.currentOs)
+    implementation(compose.components.resources)
+    testImplementation(kotlin("test"))
+    testImplementation(compose.desktop.uiTestJUnit4)
+    // keyDown(): the KeyEvent builder the shortcut tests match against. It lives with the
+    // KeyChord it produces events for, so there is one definition rather than one per module.
+    testImplementation(testFixtures(projects.coreModels))
+}
+
+tasks.withType<Test>().configureEach {
+    systemProperty("java.awt.headless", "true")
+}
+
+detekt {
+    buildUponDefaultConfig = true
+    config.setFrom(rootProject.file("config/detekt/detekt.yml"))
+    baseline = file("config/detekt/baseline.xml")
+    source.setFrom("src/main/kotlin", "src/test/kotlin")
+    parallel = true
+}
+
+tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
+    jvmTarget = "21"
+    reports {
+        html.required.set(true)
+        xml.required.set(false)
+        sarif.required.set(false)
+        txt.required.set(false)
+        md.required.set(false)
+    }
+}

--- a/shortcuts/config/detekt/baseline.xml
+++ b/shortcuts/config/detekt/baseline.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues/>
+</SmellBaseline>

--- a/shortcuts/src/main/kotlin/org/churchpresenter/shortcuts/ShortcutAction.kt
+++ b/shortcuts/src/main/kotlin/org/churchpresenter/shortcuts/ShortcutAction.kt
@@ -1,4 +1,4 @@
-package org.churchpresenter.app.churchpresenter.models
+package org.churchpresenter.shortcuts
 
 import androidx.compose.ui.input.key.Key
 import org.churchpresenter.resources.generated.resources.Res
@@ -59,7 +59,7 @@ import org.churchpresenter.resources.generated.resources.shortcut_description_sa
 import org.churchpresenter.resources.generated.resources.shortcut_description_save_schedule_as
 import org.churchpresenter.resources.generated.resources.shortcut_description_settings
 import org.churchpresenter.resources.generated.resources.shortcut_description_undo
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import org.churchpresenter.core.models.shortcuts.KeyChord
 import org.jetbrains.compose.resources.StringResource
 

--- a/shortcuts/src/main/kotlin/org/churchpresenter/shortcuts/ShortcutLabels.kt
+++ b/shortcuts/src/main/kotlin/org/churchpresenter/shortcuts/ShortcutLabels.kt
@@ -1,4 +1,4 @@
-package org.churchpresenter.app.churchpresenter.utils
+package org.churchpresenter.shortcuts
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.input.key.Key
@@ -24,7 +24,6 @@ import org.churchpresenter.resources.generated.resources.key_name_space
 import org.churchpresenter.resources.generated.resources.key_name_tab
 import org.churchpresenter.resources.generated.resources.shortcut_unbound
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
 import org.jetbrains.compose.resources.stringResource
 
 /** Chords of a multi-key binding are shown separated by this, e.g. `← / ↑`. */

--- a/shortcuts/src/main/kotlin/org/churchpresenter/shortcuts/ShortcutMap.kt
+++ b/shortcuts/src/main/kotlin/org/churchpresenter/shortcuts/ShortcutMap.kt
@@ -1,11 +1,9 @@
-package org.churchpresenter.app.churchpresenter.utils
+package org.churchpresenter.shortcuts
 
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.input.key.KeyEvent
 import org.churchpresenter.settings.KeyboardShortcutSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
 
 /**
  * The bindings actually in force — defaults with the user's overrides applied.

--- a/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/LocalShortcutsTest.kt
+++ b/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/LocalShortcutsTest.kt
@@ -1,0 +1,116 @@
+package org.churchpresenter.shortcuts
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.core.models.shortcuts.KeyChord
+import org.churchpresenter.settings.KeyboardShortcutSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * How a tab gets at the bindings in force.
+ *
+ * Every tab reads `LocalShortcuts.current` rather than being handed a map, so that a binding the
+ * operator changes in the settings dialog reaches all of them without threading a parameter through
+ * the whole tree. The default matters as much as the override: a composable rendered outside the
+ * app's provider — a preview, a screenshot harness, a settings page composed on its own — still has
+ * to get a working map rather than null.
+ */
+@OptIn(ExperimentalTestApi::class)
+class LocalShortcutsTest {
+
+    private fun <T> composed(body: @androidx.compose.runtime.Composable () -> T): T {
+        var out: T? = null
+        runComposeUiTest {
+            setContent { out = body() }
+            waitForIdle()
+        }
+        @Suppress("UNCHECKED_CAST")
+        return out as T
+    }
+
+    @Test
+    fun `with nothing provided the defaults are in force`() {
+        val map = composed { LocalShortcuts.current }
+
+        assertNotNull(map)
+        assertSame(ShortcutMap.DEFAULT, map, "a preview must get the shipped bindings, not null")
+    }
+
+    @Test
+    fun `the default map has the actions bound that ship bound`() {
+        val map = composed { LocalShortcuts.current }
+
+        assertTrue(map.chordsFor(ShortcutAction.UNDO).isNotEmpty(), "Undo ships with a binding")
+    }
+
+    @Test
+    fun `a provided map replaces the defaults for everything below it`() {
+        val custom = ShortcutMap.from(
+            KeyboardShortcutSettings(
+                overrides = mapOf(ShortcutAction.UNDO.name to listOf(KeyChord.of(Key.J))),
+            ),
+        )
+
+        val seen = composed<ShortcutMap> {
+            var inner: ShortcutMap? = null
+            CompositionLocalProvider(LocalShortcuts provides custom) { inner = LocalShortcuts.current }
+            inner!!
+        }
+
+        assertSame(custom, seen)
+        assertEquals(listOf(KeyChord.of(Key.J)), seen.chordsFor(ShortcutAction.UNDO))
+    }
+
+    @Test
+    fun `an action the provided map leaves alone keeps its shipped binding`() {
+        val custom = ShortcutMap.from(
+            KeyboardShortcutSettings(
+                overrides = mapOf(ShortcutAction.UNDO.name to listOf(KeyChord.of(Key.J))),
+            ),
+        )
+
+        val redo = composed<List<KeyChord>> {
+            var inner: List<KeyChord>? = null
+            CompositionLocalProvider(LocalShortcuts provides custom) {
+                inner = LocalShortcuts.current.chordsFor(ShortcutAction.REDO)
+            }
+            inner!!
+        }
+
+        // Overriding one action must not silently unbind every other one.
+        assertEquals(ShortcutAction.REDO.defaults, redo)
+    }
+
+    @Test
+    fun `an action with no chords at all reports an empty list rather than throwing`() {
+        val custom = ShortcutMap.from(
+            KeyboardShortcutSettings(overrides = mapOf(ShortcutAction.UNDO.name to emptyList())),
+        )
+
+        assertEquals(emptyList(), custom.chordsFor(ShortcutAction.UNDO))
+    }
+
+    // ── The string-resource accessors on the enums ──────────────────────────────
+
+    @Test
+    fun `every scope names a title and a hint`() {
+        ShortcutScope.entries.forEach {
+            assertNotNull(it.titleRes, "${it.name} has no title")
+            assertNotNull(it.hintRes, "${it.name} has no hint")
+        }
+    }
+
+    @Test
+    fun `every action names a description`() {
+        // The shortcuts dialog lists all of them; one without a description would render blank.
+        ShortcutAction.entries.forEach {
+            assertNotNull(it.descriptionRes, "${it.name} has no description")
+        }
+    }
+}

--- a/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/ShortcutActionDefaultsTest.kt
+++ b/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/ShortcutActionDefaultsTest.kt
@@ -1,7 +1,7 @@
-package org.churchpresenter.app.churchpresenter.models
+package org.churchpresenter.shortcuts
 
 import androidx.compose.ui.input.key.Key
-import org.churchpresenter.app.churchpresenter.tabs.Tabs
+import org.churchpresenter.core.models.tabs.Tabs
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue

--- a/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/ShortcutLabelRenderingTest.kt
+++ b/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/ShortcutLabelRenderingTest.kt
@@ -1,0 +1,261 @@
+package org.churchpresenter.shortcuts
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.core.models.shortcuts.KeyChord
+import org.churchpresenter.settings.KeyboardShortcutSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Rendering a binding for a human: the keycaps the dialog draws, the text the search box matches,
+ * and the joined labels the tabs show as hints.
+ *
+ * [ShortcutLabelsTest] covers `label(useSymbols)` — the single-string form. Everything built on top
+ * of it went untested, and each piece exists for a reason that would be invisible if it broke:
+ * `keyCaps` cannot be recovered by slicing the label (the macOS form has no separator at all),
+ * `searchText` has to match what a user types rather than what they see, and `pairLabel` has to
+ * collapse cleanly when one half of a pair is unbound.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ShortcutLabelRenderingTest {
+
+    private fun chord(
+        key: Key,
+        ctrl: Boolean = false,
+        shift: Boolean = false,
+        alt: Boolean = false,
+        meta: Boolean = false,
+    ) = KeyChord(keyCode = key.keyCode, ctrl = ctrl, shift = shift, alt = alt, meta = meta)
+
+    /** Runs [body] inside a composition and hands back what it produced. */
+    private fun <T> composed(body: @androidx.compose.runtime.Composable () -> T): T {
+        var out: T? = null
+        runComposeUiTest {
+            setContent { out = body() }
+            waitForIdle()
+        }
+        @Suppress("UNCHECKED_CAST")
+        return out as T
+    }
+
+    /**
+     * A map where [action] is bound to exactly [chords] — or unbound when none are given.
+     *
+     * An *empty* override is how "unbound" is expressed; leaving the key out entirely falls back to
+     * the action's own defaults, which is the opposite of what these tests want.
+     */
+    private fun mapWith(action: ShortcutAction, vararg chords: KeyChord): ShortcutMap =
+        ShortcutMap.from(KeyboardShortcutSettings(overrides = mapOf(action.name to chords.toList())))
+
+    // ── keyCaps ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an unmodified key is a single cap`() {
+        val caps = composed { chord(Key.F).keyCaps() }
+
+        assertEquals(1, caps.size)
+        assertTrue(caps.single().isNotBlank())
+    }
+
+    @Test
+    fun `each modifier held becomes its own cap, with the key last`() {
+        val caps = composed { chord(Key.Z, ctrl = true, shift = true).keyCaps() }
+
+        // Three caps: two modifiers and the key. The dialog draws each as its own rounded box, so
+        // this split is the whole reason the function exists rather than slicing `label()`.
+        assertEquals(3, caps.size)
+        assertTrue(caps.all { it.isNotBlank() })
+    }
+
+    @Test
+    fun `every modifier at once produces five caps`() {
+        val caps = composed { chord(Key.A, ctrl = true, shift = true, alt = true, meta = true).keyCaps() }
+
+        assertEquals(5, caps.size)
+    }
+
+    @Test
+    fun `the last cap is always the key itself`() {
+        val caps = composed { chord(Key.Spacebar, ctrl = true).keyCaps() }
+        val bare = composed { chord(Key.Spacebar).keyCaps() }
+
+        assertEquals(bare.single(), caps.last(), "the key reads the same with or without modifiers")
+    }
+
+    // ── searchText ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `search text is lower-cased`() {
+        val text = composed { chord(Key.Z, ctrl = true).searchText() }
+
+        assertEquals(text.lowercase(), text)
+    }
+
+    @Test
+    fun `search text carries both renderings, so either platform's spelling matches`() {
+        val text = composed { chord(Key.N, ctrl = true, shift = true).searchText() }
+
+        // A Mac user sees ⌃⇧N but will type "ctrl"; someone reading Windows docs on a Mac types the
+        // symbol. Both have to be in there or the search silently finds nothing on one platform.
+        assertTrue(text.contains("ctrl"), "the spelled-out modifier is missing: $text")
+        assertTrue(text.contains("⌃"), "the symbol form is missing: $text")
+        assertTrue(text.contains("shift") && text.contains("⇧"), text)
+    }
+
+    @Test
+    fun `every modifier contributes its common names`() {
+        val text = composed { chord(Key.A, ctrl = true, shift = true, alt = true, meta = true).searchText() }
+
+        listOf("ctrl", "control", "meta", "cmd", "command", "alt", "option", "shift")
+            .forEach { assertTrue(text.contains(it), "'$it' missing from: $text") }
+    }
+
+    @Test
+    fun `an unmodified chord contributes no modifier names`() {
+        val text = composed { chord(Key.F).searchText() }
+
+        listOf("ctrl", "cmd", "option", "shift").forEach {
+            assertFalse(text.contains(it), "'$it' should not appear for a bare key: $text")
+        }
+    }
+
+    @Test
+    fun `the arrow keys get a typeable alias`() {
+        val arrows = listOf(Key.DirectionUp, Key.DirectionDown, Key.DirectionLeft, Key.DirectionRight)
+
+        val texts = composed { arrows.map { chord(it).searchText() } }
+
+        // The arrows are the only bindings drawn as a glyph nobody can type, so without an alias
+        // they could not be found by key on any platform.
+        texts.forEachIndexed { i, t ->
+            assertTrue(t.trim().split(" ").any { it.length > 2 }, "${arrows[i]} has no typeable alias: $t")
+        }
+    }
+
+    @Test
+    fun `a key that needs no alias contributes none`() {
+        val text = composed { chord(Key.Period).searchText() }
+
+        // `.` is typeable as itself; only the arrows earn an alias.
+        assertTrue(text.isNotBlank())
+    }
+
+    // ── ShortcutMap label, labelOrUnbound, searchText, pairLabel ────────────────
+
+    @Test
+    fun `a bound action renders its chord`() {
+        val map = mapWith(ShortcutAction.UNDO, chord(Key.Z, ctrl = true))
+
+        val label = composed { map.label(ShortcutAction.UNDO) }
+
+        assertTrue(label.isNotBlank())
+    }
+
+    @Test
+    fun `an action bound to two chords renders both`() {
+        val map = mapWith(ShortcutAction.UNDO, chord(Key.Z, ctrl = true), chord(Key.U, ctrl = true))
+
+        val label = composed { map.label(ShortcutAction.UNDO) }
+        val single = composed { mapWith(ShortcutAction.UNDO, chord(Key.Z, ctrl = true)).label(ShortcutAction.UNDO) }
+
+        assertTrue(label.length > single.length, "both chords should be shown: $label")
+    }
+
+    @Test
+    fun `an unbound action renders empty, so a hint can hide itself`() {
+        val map = mapWith(ShortcutAction.UNDO)
+
+        val label = composed { map.label(ShortcutAction.UNDO) }
+
+        // Empty rather than a placeholder: an inline hint drops the phrase entirely rather than
+        // telling the operator about a key that does nothing.
+        assertEquals("", label)
+    }
+
+    @Test
+    fun `labelOrUnbound substitutes a placeholder where something must be drawn`() {
+        val map = mapWith(ShortcutAction.UNDO)
+
+        val label = composed { map.labelOrUnbound(ShortcutAction.UNDO) }
+
+        assertTrue(label.isNotBlank(), "the settings row has a cell to fill")
+    }
+
+    @Test
+    fun `labelOrUnbound leaves a bound action alone`() {
+        val map = mapWith(ShortcutAction.UNDO, chord(Key.Z, ctrl = true))
+
+        val bound = composed { map.labelOrUnbound(ShortcutAction.UNDO) }
+        val plain = composed { map.label(ShortcutAction.UNDO) }
+
+        assertEquals(plain, bound)
+    }
+
+    @Test
+    fun `a map's search text covers every chord bound to the action`() {
+        val map = mapWith(ShortcutAction.UNDO, chord(Key.Z, ctrl = true), chord(Key.U, alt = true))
+
+        val text = composed { map.searchText(ShortcutAction.UNDO) }
+
+        assertTrue(text.contains("ctrl"), text)
+        assertTrue(text.contains("alt"), text)
+    }
+
+    @Test
+    fun `an unbound action has no search text`() {
+        val map = mapWith(ShortcutAction.UNDO)
+
+        assertEquals("", composed { map.searchText(ShortcutAction.UNDO) })
+    }
+
+    @Test
+    fun `a pair of bound actions is joined into one phrase`() {
+        val map = ShortcutMap.from(
+            KeyboardShortcutSettings(
+                overrides = mapOf(
+                    ShortcutAction.UNDO.name to listOf(chord(Key.Z, ctrl = true)),
+                    ShortcutAction.REDO.name to listOf(chord(Key.Y, ctrl = true)),
+                ),
+            ),
+        )
+
+        val pair = composed { map.pairLabel(ShortcutAction.UNDO, ShortcutAction.REDO) }
+
+        assertTrue(pair.contains("  "), "the two labels sit side by side: $pair")
+    }
+
+    @Test
+    fun `a pair with one half unbound shows only the bound half`() {
+        val map = ShortcutMap.from(
+            KeyboardShortcutSettings(
+                overrides = mapOf(
+                    ShortcutAction.UNDO.name to listOf(chord(Key.Z, ctrl = true)),
+                    ShortcutAction.REDO.name to emptyList(),
+                ),
+            ),
+        )
+
+        val pair = composed { map.pairLabel(ShortcutAction.UNDO, ShortcutAction.REDO) }
+        val single = composed { map.label(ShortcutAction.UNDO) }
+
+        assertEquals(single, pair, "no stray separator where the missing half would have been")
+    }
+
+    @Test
+    fun `a pair with both halves unbound is empty, so the caller drops the phrase`() {
+        val map = ShortcutMap.from(
+            KeyboardShortcutSettings(
+                overrides = mapOf(
+                    ShortcutAction.UNDO.name to emptyList(),
+                    ShortcutAction.REDO.name to emptyList(),
+                ),
+            ),
+        )
+
+        assertEquals("", composed { map.pairLabel(ShortcutAction.UNDO, ShortcutAction.REDO) })
+    }
+}

--- a/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/ShortcutLabelsTest.kt
+++ b/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/ShortcutLabelsTest.kt
@@ -1,4 +1,4 @@
-package org.churchpresenter.app.churchpresenter.utils
+package org.churchpresenter.shortcuts
 
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ExperimentalTestApi

--- a/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/ShortcutMapTest.kt
+++ b/shortcuts/src/test/kotlin/org/churchpresenter/shortcuts/ShortcutMapTest.kt
@@ -1,10 +1,9 @@
-package org.churchpresenter.app.churchpresenter.utils
+package org.churchpresenter.shortcuts
 
 import androidx.compose.ui.input.key.Key
 import org.churchpresenter.settings.KeyboardShortcutSettings
 import org.churchpresenter.core.models.shortcuts.KeyChord
-import org.churchpresenter.app.churchpresenter.models.ShortcutAction
-import org.churchpresenter.app.churchpresenter.models.ShortcutScope
+import org.churchpresenter.core.utils.keyDown
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse

--- a/test-changed.sh
+++ b/test-changed.sh
@@ -33,7 +33,7 @@ cd "$ROOT"
 
 MAIN_SRC="composeApp/src/jvmMain/kotlin composeApp/src/commonMain/kotlin"
 # The other modules of this build, by directory — each maps to a `:<dir>:test` task.
-MODULE_DIRS="converter|companion-satellite|theme|core-models|bible-engine|lottieGenerator|crossword|presentation-engine|settings|diagnostics|atem|planning-center|bible-formats|songlibrary|song-chords|bible|dictionary|dictionary-tab|dictionary-settings-tab|announcements-tab|qa-tab|lower-third-tab|stt-tab|lower-third-settings-tab|web-tab|companion-server|statistics|ui-components"
+MODULE_DIRS="converter|companion-satellite|theme|core-models|bible-engine|lottieGenerator|crossword|presentation-engine|settings|diagnostics|atem|planning-center|bible-formats|songlibrary|song-chords|bible|dictionary|dictionary-tab|dictionary-settings-tab|announcements-tab|qa-tab|lower-third-tab|stt-tab|lower-third-settings-tab|web-tab|companion-server|statistics|ui-components|shortcuts"
 TEST_SRC="composeApp/src/jvmTest/kotlin"
 MAX_PATTERNS=120          # past this a full run is cheaper than a vast --tests filter
 BASE_REF="${BASE_REF:-origin/main}"


### PR DESCRIPTION
Moves shortcut actions, map, labels, and tests out of `:composeApp` into a new `:shortcuts` module, and wires that module into Gradle, CI, and `test-changed.sh`. To break app dependency cycles, `Tabs` is relocated to `:core-models` and all imports are updated across app and tests. Documentation is updated to describe the new module and ownership boundaries, and new shortcut-focused tests are added in `:shortcuts`.