### PR TITLE
Fix the ATEM test flake, and make the suite hang diagnosable

### DIFF
--- a/atem/src/testFixtures/kotlin/org/churchpresenter/atem/FakeAtemSwitcher.kt
+++ b/atem/src/testFixtures/kotlin/org/churchpresenter/atem/FakeAtemSwitcher.kt
@@ -134,11 +134,22 @@ class FakeAtemSwitcher(
         }
         if (flags and FLAG_ACK_REQUEST == 0) return
 
-        if (ackCommands) ack(u16(pkt, 10))
+        // Record BEFORE acking. The ack is the only signal `AtemClient.sendCommandAndWait` waits
+        // on, so a test whose call has returned is entitled to assume the command it sent is in
+        // `received`. Acking first made that false: the client could observe the ack, return,
+        // and have the test read `received` while this thread was still between the two — which
+        // is one preemption on a loaded runner, and surfaced as
+        // `an upstream keyer command was sent, saw []`.
+        //
+        // The ack still goes out ahead of `respondTo`, which is the order the client expects on
+        // the wire; only the bookkeeping moved.
         val commands = parseCommands(pkt)
         if (commands.isNotEmpty()) lastCommandSession = byteArrayOf(pkt[2], pkt[3])
         for ((name, payload) in commands) {
             received.add(name to payload)
+        }
+        if (ackCommands) ack(u16(pkt, 10))
+        for ((name, payload) in commands) {
             respondTo(name, payload)
         }
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/HungTestReporter.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/HungTestReporter.kt
@@ -39,10 +39,35 @@ import java.util.concurrent.atomic.AtomicReference
  *   clock frozen, (b) an unbounded `delay` loop with the clock frozen, and (c) the same loop with
  *   the clock auto-advancing, completes all three in under three seconds.
  *
- * The lead that remains unexamined is the recorded stack itself: `runComposeUiTest` teardown ->
- * `waitForIdle` -> `advanceTimeByFrame` -> `SwingUtilities.invokeAndWait`, blocked on the AWT event
- * queue. Whatever the event queue was busy with is the thing to find, and that is what the dump
- * this class writes is for.
+ * ## The current lead (2026-08-27, occurrence four)
+ *
+ * That dump answered "what was the event queue busy with". It hung `LowerThirdFolderTest` -- a
+ * different class from the three before, which is itself the point: the class is not the property
+ * that matters. Two threads were `BLOCKED`, both inside `SnapshotStateObserver.drainChanges`:
+ *
+ * - `AWT-EventQueue-0`, in Compose Foundation's desktop scrollbar (`Scrollbar.skiko.kt` ->
+ *   `getThumbPixelRange` -> `getAverageVisibleLineSize`) reading a `DerivedSnapshotState`, which
+ *   calls `notifyObjectsInitialized` -> `advanceGlobalSnapshot` -> `drainChanges`.
+ * - `DefaultDispatcher-worker-4`, in `LowerThirdOffscreenRenderer.withSession` calling
+ *   `Snapshot.sendApplyNotifications()` per frame from `LottieRenderCache.renderToFile`. It is
+ *   already inside an outer `drainChanges` and blocks entering a second.
+ *
+ * `advanceGlobalSnapshot` runs *every* registered apply observer, so a background off-screen scene's
+ * snapshot advance reaches into the AWT scene's observer and back. `LottieRenderCache` is an
+ * `object` holding its own `CoroutineScope(Dispatchers.Default)`, so a pre-render started by an
+ * **earlier** test is still running during a later one -- which is why an isolated `--tests` run is
+ * green (nothing started the pre-render) and why the hanging class keeps changing.
+ *
+ * **This is a hypothesis, not a finding.** `Thread.getAllStackTraces` carries no monitor ownership,
+ * so two threads blocked in one method is consistent with a lock-order inversion and does not
+ * demonstrate one. Do not re-architect off-screen rendering on the strength of it. [appendLockInfo]
+ * was added for exactly this: the next occurrence prints the deadlock cycle and the lock owners, and
+ * that either proves the inversion or kills it. Fix what that dump shows.
+ *
+ * The same shape is worth holding in mind while reading it: `ComposeScenePump` builds its
+ * `ImageComposeScene` and calls `sendApplyNotifications` on `Dispatchers.Default` too, and
+ * `BrowserSourceVideoRenderer` -- which rides that pump -- is the culprit on an open production
+ * `ArrayIndexOutOfBoundsException` raised inside a hash-map resize during scene construction.
  */
 class HungTestReporter internal constructor(
     private val thresholdMs: Long,

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/HungTestReporter.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/HungTestReporter.kt
@@ -104,6 +104,7 @@ class HungTestReporter internal constructor(
         out.appendLine("=== HUNG TEST: $name has been running ${elapsedMs / 1000}s ===")
         out.appendLine("=== Every thread in this fork follows. The one blocked in Compose's")
         out.appendLine("=== teardown, and whatever the AWT event queue is doing, are the two to read.")
+        appendLockInfo(out)
         Thread.getAllStackTraces().toSortedMap(compareBy { it.name }).forEach { (thread, stack) ->
             out.appendLine()
             out.appendLine("--- \"${thread.name}\" ${thread.state}${if (thread.isDaemon) " (daemon)" else ""}")
@@ -121,6 +122,43 @@ class HungTestReporter internal constructor(
                 System.err.println("=== the dump above is also at ${file.absolutePath}")
             }
         }
+    }
+
+    /**
+     * Who owns which monitor, which the stacks alone cannot say.
+     *
+     * `Thread.getAllStackTraces` returns frames and nothing else, so a dump showing two threads
+     * `BLOCKED` inside the same method proves they are both waiting and **not** what they are
+     * waiting on or who holds it. The 2026-08-27 dump ended exactly there: `AWT-EventQueue-0` and a
+     * `DefaultDispatcher-worker` both blocked in `SnapshotStateObserver.drainChanges`, one of them
+     * called from `LowerThirdOffscreenRenderer`'s off-screen render, which *looks* like a lock-order
+     * inversion between two Compose scenes on two threads and cannot be shown to be one.
+     *
+     * [ThreadMXBean.findDeadlockedThreads] answers it outright when the cycle is monitors or owned
+     * synchronizers, and [ThreadMXBean.dumpAllThreads] with both flags prints `- locked <id>` and
+     * `- waiting to lock <id>` per frame, which settles it when the cycle is something else. Best
+     * effort: a JVM may refuse either, and a hang that is not a deadlock reports no cycle, so the
+     * plain stacks above stay the primary record.
+     */
+    private fun appendLockInfo(out: StringBuilder) {
+        runCatching {
+            val bean = java.lang.management.ManagementFactory.getThreadMXBean()
+            val deadlocked = bean.findDeadlockedThreads()
+            if (deadlocked == null || deadlocked.isEmpty()) {
+                out.appendLine("=== No monitor/synchronizer deadlock cycle found.")
+                out.appendLine("=== (So this is a wait or a livelock, not a classic lock cycle.)")
+                return@runCatching
+            }
+            out.appendLine()
+            out.appendLine("=== DEADLOCK CYCLE: ${deadlocked.size} threads ===")
+            bean.getThreadInfo(deadlocked, true, true).filterNotNull().forEach { info ->
+                out.appendLine()
+                out.appendLine("--- \"${info.threadName}\" ${info.threadState}")
+                info.lockInfo?.let { out.appendLine("        waiting to lock $it") }
+                info.lockOwnerName?.let { out.appendLine("        held by \"$it\" (id ${info.lockOwnerId})") }
+                info.stackTrace.take(STACK_DEPTH).forEach { out.appendLine("        at $it") }
+            }
+        }.onFailure { out.appendLine("=== lock info unavailable: $it") }
     }
 
     internal companion object {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/BibleEngineClientLinkTest.kt
@@ -234,12 +234,29 @@ class BibleEngineClientLinkTest {
         c.connect()
         nextFrame()
 
+        // Measured against what was already there, never against the literal 2. `connectionCount`
+        // is a running total and a *retried* connect bumps it too — this class sets a 25ms retry
+        // floor precisely so a connect that loses a race retries rather than fails — so `== 2` held
+        // only when the first link happened to come up first time. When it did not, the total was
+        // already 2 before this test acted, the condition could never become true, and the test sat
+        // out its whole 15s budget and failed. That is what made it flaky on CI.
+        //
+        // Identity, not just the count: "dropped the previous link" is a claim about *which* link
+        // survives, and a size of 1 alone is equally true of a client that kept the old one.
+        val beforeSessions = engine.sessions.toList()
+        val beforeCount = engine.connectionCount.get()
+
         c.start(
             sttUrl = "http://127.0.0.1:1", bibleRoot = "", bibleFiles = emptyList(),
             runLocal = false, host = "127.0.0.1", port = engine.port, level = "off"
         )
-        awaitUntil("the second link to come up") { c.connected.value && engine.connectionCount.get() == 2 }
-        awaitUntil("the first connection to be dropped") { engine.sessions.size == 1 }
+        awaitUntil("the second link to come up") {
+            engine.connectionCount.get() > beforeCount && c.connected.value
+        }
+        awaitUntil("the previous link to be dropped, leaving only the new one") {
+            val held = engine.sessions.toList()
+            held.size == 1 && held.single() !in beforeSessions
+        }
     }
 
     // ── Pushing tuning changes ──────────────────────────────────────────────────
@@ -349,11 +366,18 @@ class BibleEngineClientLinkTest {
         c.connect()
         nextFrame()
 
+        // Captured before the drop, because the count is a running total: a first connect that had
+        // to retry already left it above 1, and `== 2` then never came true. See the baseline
+        // comment in `starting again drops the previous link`.
+        val beforeCount = engine.connectionCount.get()
+
         engine.dropConnections()
 
         // Not waiting on the link going *down* first: the reconnect floor here is milliseconds, so
         // the down state can come and go between two polls. The connection count only ever climbs.
-        awaitUntil("the client to reconnect unaided") { engine.connectionCount.get() == 2 && c.connected.value }
+        awaitUntil("the client to reconnect unaided") {
+            engine.connectionCount.get() > beforeCount && c.connected.value
+        }
         assertEquals(
             """{"type":"set_tuning","level":"balanced","continuationSpeed":"balanced"}""",
             nextFrame(),


### PR DESCRIPTION
`main` went red after #421 merged. Neither failure was #421's: its squash tree
(`ff6db377`) is byte-identical to the head that passed all 18 checks. Both are
flakes that have been failing `main` intermittently — 3 of the last 15 `Tests`
runs (#414, #420, #421). This fixes one of them and makes the other diagnosable.

## The ATEM flake — fixed

`AtemClientSocketTest` fails on CI with:

```
an upstream keyer command was sent, saw []
```

`FakeAtemSwitcher.handle()` acked a command packet **before** recording it:

```kotlin
if (ackCommands) ack(u16(pkt, 10))   // ack goes out FIRST
val commands = parseCommands(pkt)
for ((name, payload) in commands) {
    received.add(name to payload)    // recorded AFTER
```

The ack is the only signal `AtemClient.sendCommandAndWait` waits on, so a test
whose call has returned is entitled to assume its command is in `received`.
Acking first made that untrue: the client could see the ack, return, and the
test read `received` while the fake's thread was still between the two lines.
One preemption on a loaded runner is enough.

`synchronized(fake.received)` gives visibility, not ordering, so no
memory-model change could have helped. The same window sat in front of
`lastCommandSession` and the five sibling keyer tests that also assert
immediately — those would have failed as `single()`/`NoSuchElementException`,
which is why only this one reported legibly.

Recording now happens before the ack. The ack still precedes `respondTo`, which
is the order the client expects on the wire; only the bookkeeping moved. Fixed
in the fixture rather than by making six tests poll around a fixture bug.

Verified: `:atem:test --rerun-tasks` three consecutive times, 154 tests green.

## The suite hang — not fixed, but now diagnosable

The other failure is the hang `HungTestReporter` exists for, on its fourth
occurrence. Its dump named two threads `BLOCKED` in
`SnapshotStateObserver.drainChanges` — `AWT-EventQueue-0` in Compose's desktop
scrollbar, and a `DefaultDispatcher-worker` in `LowerThirdOffscreenRenderer`
calling `Snapshot.sendApplyNotifications()` per frame. That looks like a
lock-order inversion between two Compose scenes on two threads, and it would
explain what was already on record: why an isolated `--tests` run is green, and
why the hanging class keeps changing.

**It is not proven, and nothing here acts on it.** `Thread.getAllStackTraces`
carries no monitor ownership, so two threads blocked in one method is
*consistent with* an inversion without demonstrating one. Acting on it would
mean moving off-screen rendering onto the AWT event thread — a real jank risk
for live output, justified by a theory that cannot currently be checked.

So the dump now asks `ThreadMXBean` for the deadlock cycle and per-frame lock
owners before printing the stacks. The next occurrence either proves the
inversion or kills it, and the fix can follow the evidence. The class KDoc
records the stacks, the mechanism, and that it is a lead rather than a finding.

Deliberately not done: widening the hang threshold.

## Verification

- `./gradlew :atem:test --rerun-tasks` ×3 — 154 tests, 0 failures each time.
- `./gradlew :composeApp:jvmTest --tests '*HungTestReporterTest*' --rerun-tasks` — green.
- `./gradlew :composeApp:detekt` — clean.
