### PR TITLE
Stop filing three production issues the app already survives

### DIFF
--- a/bible-formats/src/main/kotlin/org/churchpresenter/bibleformats/catalog/BibleInstallSupport.kt
+++ b/bible-formats/src/main/kotlin/org/churchpresenter/bibleformats/catalog/BibleInstallSupport.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import io.ktor.utils.io.ByteReadChannel
+import java.io.EOFException
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -81,6 +82,14 @@ object BibleInstallSupport {
      *
      * Ktor wraps, so the cause chain is walked — but only as far as [isStall] walks it, for the
      * same reason.
+     *
+     * [EOFException] is here for the connection that stops mid-response — ktor CIO raises it as
+     * "the server prematurely closed the connection", which reached Sentry from a church on a
+     * network that does that to `raw.githubusercontent.com`. It is the same fact as
+     * [TruncatedBodyException], arriving one layer lower: the bytes stopped coming. The cost of
+     * including it is that a genuinely truncated *archive* also stops being reported, which is
+     * accepted — a half-downloaded archive is the same failed download, and the outcome still
+     * reaches the install dialog either way.
      */
     internal fun Throwable.isOperatorEnvironment(depth: Int = 0): Boolean =
         this is UnresolvedAddressException ||
@@ -90,6 +99,7 @@ object BibleInstallSupport {
             this is TruncatedBodyException ||
             this is InsufficientDiskSpaceException ||
             this is SSLException ||
+            this is EOFException ||
             (depth < MAX_CAUSE_DEPTH && cause?.isOperatorEnvironment(depth + 1) == true)
 
     const val COPY_BUFFER_BYTES = 64 * 1024

--- a/bible-formats/src/test/kotlin/org/churchpresenter/bibleformats/catalog/InstallHelpersTest.kt
+++ b/bible-formats/src/test/kotlin/org/churchpresenter/bibleformats/catalog/InstallHelpersTest.kt
@@ -211,6 +211,14 @@ class InstallHelpersTest {
     }
 
     @Test
+    fun `a connection the server closed mid-response is the operator's`() {
+        // ktor CIO raises EOFException("...the server prematurely closed the connection") when the
+        // bytes stop arriving. Reported once from a church whose network does that to
+        // raw.githubusercontent.com; it is TruncatedBodyException's fact, one layer lower.
+        assertTrue(isEnvironment(java.io.EOFException("the server prematurely closed the connection")))
+    }
+
+    @Test
     fun `something this code got wrong is still reported`() {
         assertFalse(isEnvironment(IllegalStateException("a bug in the unpacker")))
         assertFalse(isEnvironment(IOException("a read that failed for no stated reason")))

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/SplashWindow.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/SplashWindow.kt
@@ -24,7 +24,7 @@ import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.app_name
 import churchpresenter.composeapp.generated.resources.ic_app_icon
 import churchpresenter.composeapp.generated.resources.loading
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.theme.ThemeMode
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -56,7 +56,7 @@ internal fun SplashWindow(theme: ThemeMode) {
 
 @Composable
 internal fun SplashContent(theme: ThemeMode) {
-    AppThemeWrapper(theme = theme) {
+    AppWindowRoot(theme = theme) {
         Box(
             modifier = Modifier
                 .fillMaxSize()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/AboutDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/AboutDialog.kt
@@ -56,7 +56,7 @@ import churchpresenter.composeapp.generated.resources.submit_feature_request
 import org.churchpresenter.app.churchpresenter.BuildConfig
 import org.churchpresenter.settings.AppSettings
 import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.app.churchpresenter.ui.theme.LocalLanguage
 import org.churchpresenter.theme.ThemeMode
 import org.churchpresenter.app.churchpresenter.utils.DeviceInfoReport
@@ -118,7 +118,7 @@ internal fun AboutDialogContent(
      */
     versionDisplay: String = BuildConfig.VERSION_DISPLAY,
 ) {
-    AppThemeWrapper(theme = theme) {
+    AppWindowRoot(theme = theme) {
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background
@@ -281,7 +281,7 @@ fun ConverterWindow(theme: ThemeMode, onClose: () -> Unit) {
         icon = painterResource(Res.drawable.ic_app_icon),
         state = rememberWindowState(width = 1100.dp, height = 800.dp)
     ) {
-        AppThemeWrapper(theme = theme) {
+        AppWindowRoot(theme = theme) {
             ConverterApp()
         }
     }
@@ -304,7 +304,7 @@ fun SongLibraryWindow(theme: ThemeMode, songStorageDirectory: String, onClose: (
         icon = painterResource(Res.drawable.ic_app_icon),
         state = rememberWindowState(width = 1420.dp, height = 880.dp)
     ) {
-        AppThemeWrapper(theme = theme) {
+        AppWindowRoot(theme = theme) {
             SongLibraryApp(
                 libraryFolder = File(songStorageDirectory),
                 onClose = onClose,
@@ -334,7 +334,7 @@ fun LottieGenWindow(theme: ThemeMode, outputDir: File?, onClose: () -> Unit, onF
         icon = painterResource(Res.drawable.ic_app_icon),
         state = rememberWindowState(width = 1200.dp, height = 800.dp)
     ) {
-        AppThemeWrapper(theme = theme) {
+        AppWindowRoot(theme = theme) {
             // embedded = true regardless of outputDir: opened from the Help menu there is no output
             // folder, but the generator is still inside the app's theme and must follow it.
             LottieGenApp(
@@ -356,7 +356,7 @@ fun StyleEditorWindow(theme: ThemeMode, onClose: () -> Unit) {
         icon = painterResource(Res.drawable.ic_app_icon),
         state = rememberWindowState(width = 1500.dp, height = 950.dp)
     ) {
-        AppThemeWrapper(theme = theme) {
+        AppWindowRoot(theme = theme) {
             StyleEditorApp(standalone = false)
         }
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/CCLIReportDialog.kt
@@ -168,7 +168,7 @@ import org.churchpresenter.app.churchpresenter.data.VerseKey
 import org.churchpresenter.app.churchpresenter.data.VerseSummary
 import org.churchpresenter.app.churchpresenter.data.availableYears
 import org.churchpresenter.app.churchpresenter.data.resolveDates
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.theme.ThemeMode
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -358,7 +358,7 @@ internal fun CCLIReportContent(
     val xlsChooserTitle = stringResource(Res.string.ccli_file_chooser_xls)
     val xlsFilterDesc = stringResource(Res.string.ccli_file_filter_xls)
 
-    AppThemeWrapper(theme = theme) {
+    AppWindowRoot(theme = theme) {
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
             Column(modifier = Modifier.fillMaxSize()) {
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/EditSongDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/EditSongDialog.kt
@@ -121,7 +121,7 @@ import org.churchpresenter.app.churchpresenter.composables.sectionKindOf
 import org.churchpresenter.app.churchpresenter.composables.songStatsOf
 import org.churchpresenter.core.models.songs.SongItem
 import org.churchpresenter.core.models.songs.SongTuning
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.theme.ThemeMode
 import org.churchpresenter.songchords.ChordSheetImporter
 import org.churchpresenter.songchords.ChordTransposer
@@ -299,7 +299,7 @@ internal fun EditSongContent(
         }
     }
 
-    AppThemeWrapper(theme = theme) {
+    AppWindowRoot(theme = theme) {
         Surface(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.background

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/MemoryMonitorWindow.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/MemoryMonitorWindow.kt
@@ -45,7 +45,7 @@ import churchpresenter.composeapp.generated.resources.memory_monitor_non_heap
 import churchpresenter.composeapp.generated.resources.memory_monitor_used
 import churchpresenter.composeapp.generated.resources.memory_monitor_window_title
 import kotlinx.coroutines.delay
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.theme.ThemeMode
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -112,7 +112,7 @@ fun MemoryMonitorWindow(isVisible: Boolean, theme: ThemeMode, onClose: () -> Uni
         // `DialogSizes.kt`, which records why it is 500dp and not the 440dp that shipped clipped.
         state = rememberWindowState(width = MEMORY_MONITOR_WINDOW_WIDTH, height = MEMORY_MONITOR_WINDOW_HEIGHT)
     ) {
-        AppThemeWrapper(theme = theme) {
+        AppWindowRoot(theme = theme) {
             MemoryMonitorContent()
         }
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/OptionsDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/OptionsDialog.kt
@@ -75,7 +75,7 @@ import org.churchpresenter.app.churchpresenter.dialogs.tabs.DictionarySettingsTa
 import org.churchpresenter.app.churchpresenter.dialogs.tabs.StageMonitorSettingsTab
 import org.churchpresenter.app.churchpresenter.composables.TabStripBackArrow
 import org.churchpresenter.app.churchpresenter.composables.TabStripForwardArrow
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.theme.ThemeMode
 import org.churchpresenter.app.churchpresenter.viewmodel.OBSWebSocketManager
 import org.churchpresenter.app.churchpresenter.viewmodel.PresenterManager
@@ -179,7 +179,7 @@ internal fun OptionsDialogContent(
     val safeTabIndex = selectedTabIndex.coerceIn(0, tabCount - 1)
     val tabScrollState = remember { ScrollState(0) }
 
-        AppThemeWrapper(theme = theme) {
+        AppWindowRoot(theme = theme) {
             Surface(
                 modifier = Modifier.fillMaxSize(),
                 color = MaterialTheme.colorScheme.background

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/PlanningCenterImportDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/PlanningCenterImportDialog.kt
@@ -100,7 +100,7 @@ import org.churchpresenter.core.models.songs.SongItem
 import org.churchpresenter.planningcenter.PlanningCenterAuthServer
 import org.churchpresenter.planningcenter.PlanningCenterClient
 import org.churchpresenter.settings.PlanningCenterSettings
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.theme.ThemeMode
 import org.churchpresenter.theme.semantic
 import org.jetbrains.compose.resources.stringResource
@@ -149,7 +149,7 @@ fun PlanningCenterImportDialog(
             ),
             title = stringResource(Res.string.planning_center_import_title)
         ) {
-            AppThemeWrapper(theme = theme) {
+            AppWindowRoot(theme = theme) {
                 PlanningCenterConnectDialogContent(
                     isConnecting = isConnecting,
                     connectionError = connectionError,
@@ -199,7 +199,7 @@ fun PlanningCenterImportDialog(
         title = stringResource(Res.string.planning_center_import_title),
         resizable = true
     ) {
-        AppThemeWrapper(theme = theme) {
+        AppWindowRoot(theme = theme) {
             PlanningCenterImportDialogContent(
                 viewModel = viewModel,
                 settings = settings,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/SetupWizardDialog.kt
@@ -166,7 +166,7 @@ import churchpresenter.composeapp.generated.resources.setup_wizard_skip
 import churchpresenter.composeapp.generated.resources.setup_wizard_step
 import churchpresenter.composeapp.generated.resources.setup_wizard_title
 import org.churchpresenter.app.churchpresenter.data.Language
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.app.churchpresenter.ui.theme.LanguageProvider
 import org.churchpresenter.theme.ThemeMode
 import org.jetbrains.compose.resources.painterResource
@@ -239,7 +239,7 @@ internal fun SetupWizardContent(
     var goingForward by remember { mutableStateOf(true) }
 
     LanguageProvider(language = selectedLanguage) {
-        AppThemeWrapper(theme = theme) {
+        AppWindowRoot(theme = theme) {
             Surface(
                 modifier = Modifier.fillMaxSize(),
                 color = MaterialTheme.colorScheme.background

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooser.kt
@@ -136,8 +136,17 @@ abstract class FileChooser {
      * desktop portal over D-Bus — and none of them failing is a reason for the app to die: without
      * this, a session with no portal takes the whole app down the first time an operator opens a
      * folder. A [CancellationException] is the operator dismissing the dialog, not a fault, so it
-     * is re-thrown untouched and must not latch the platform path off. [context] labels the crash
-     * report the fault path files.
+     * is re-thrown untouched and must not latch the platform path off. [context] labels the report
+     * the fault path files.
+     *
+     * That report is a **warning, not an exception**, because by the time it is written the app has
+     * already recovered: the operator gets the Swing dialog and the interaction completes. Filing it
+     * with [CrashReporter.reportException] said otherwise twice over — it wrote a file into
+     * `crash-reports/`, which is the folder users are told to attach to a bug report, and it reached
+     * Sentry at error level, where `RuntimeException: GetDisplayName failed` from inside FileKit's
+     * Windows shell call reads as a crash the app suffered rather than one it absorbed. Whose
+     * machine it was and that the fallback caught it are the two things a triager needs, so both are
+     * tags.
      */
     internal suspend fun <T> withNativeDialog(
         context: String,
@@ -150,7 +159,15 @@ abstract class FileChooser {
         } catch (e: CancellationException) {
             throw e
         } catch (t: Throwable) {
-            CrashReporter.reportException(t, context = context)
+            CrashReporter.reportWarning(
+                "Native file dialog failed; fell back to the Swing chooser",
+                throwable = t,
+                tags = mapOf(
+                    "subsystem" to "file_chooser",
+                    "chooser.context" to context,
+                    "chooser.recovered" to "true",
+                ),
+            )
             nativeDialogsBroken = true
             fallback()
         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/ServerSettingsTab.kt
@@ -50,7 +50,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.luminance
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.theme.ThemeMode
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.rememberDialogState
@@ -957,7 +957,7 @@ private fun ConnectionQrDialog(serverUrl: String, apiKey: String?, onDismiss: ()
         title = stringResource(Res.string.connection_qr_title),
         resizable = false
     ) {
-        AppThemeWrapper(theme = if (isDark) ThemeMode.DARK else ThemeMode.LIGHT) {
+        AppWindowRoot(theme = if (isDark) ThemeMode.DARK else ThemeMode.LIGHT) {
             ConnectionQrDialogContent(serverUrl = serverUrl, apiKey = apiKey, onDismiss = onDismiss)
         }
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -115,7 +115,7 @@ import org.churchpresenter.app.churchpresenter.viewmodel.OBSWebSocketManager
 import org.churchpresenter.app.churchpresenter.viewmodel.CompanionSatelliteViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.InstanceLinkViewModel
 import org.churchpresenter.app.churchpresenter.viewmodel.STTManager
-import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.app.churchpresenter.utils.AppWindowRoot
 import org.churchpresenter.settings.utils.AppDataDir
 import org.churchpresenter.settings.utils.Constants
 import org.churchpresenter.app.churchpresenter.utils.LocalShortcuts
@@ -849,7 +849,7 @@ private fun ApplicationScope.ChurchPresenterApp(coroutineExceptionHandler: Corou
             }
             MacMenuBarActivationFix()
             LanguageProvider(language = currentLanguage) {
-                AppThemeWrapper(theme = theme) {
+                AppWindowRoot(theme = theme) {
                     CompositionLocalProvider(
                         LocalMediaViewModel provides mediaViewModel,
                         LocalMainWindowState provides state,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/AppWindowRoot.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/AppWindowRoot.kt
@@ -1,0 +1,27 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import androidx.compose.runtime.Composable
+import org.churchpresenter.theme.AppThemeWrapper
+import org.churchpresenter.theme.ThemeMode
+
+/**
+ * What every one of the app's Compose windows is wrapped in: the theme, plus the app-wide
+ * composition locals that have to be installed once per window.
+ *
+ * Each Compose window is its own composition, so a `CompositionLocalProvider` in one window does
+ * not reach another — anything window-wide has to be installed at all fifteen roots or at none.
+ * Calling `AppThemeWrapper` directly is what those roots used to do, and adding a provider then
+ * meant editing fifteen call sites and remembering to edit the sixteenth. This exists so that is
+ * one edit in one place.
+ *
+ * `AppThemeWrapper` itself stays in `:theme` and stays about theming: that module owns the colour
+ * schemes and the type scale, and a clipboard has no business in it.
+ *
+ * **New windows should call this, not `AppThemeWrapper`.**
+ */
+@Composable
+fun AppWindowRoot(theme: ThemeMode = ThemeMode.SYSTEM, content: @Composable () -> Unit) {
+    AppThemeWrapper(theme = theme) {
+        ProvideSafeClipboard(content)
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SafeClipboard.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SafeClipboard.kt
@@ -1,0 +1,66 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.LocalClipboard
+
+/**
+ * A [Clipboard] that answers instead of throwing when the OS clipboard cannot be taken.
+ *
+ * The system clipboard is a single OS-wide lock any running application can be holding. Windows
+ * raises `IllegalStateException: cannot open system clipboard` from `WClipboard.openClipboard0`
+ * when it cannot take that lock, and Compose's own paste path does nothing about it: a reported
+ * crash went
+ *
+ *     TextFieldSelectionManager.paste -> AwtPlatformClipboard.getClipEntry -> WClipboard.openClipboard0
+ *
+ * and arrived in Sentry at **fatal** — an operator pressed Ctrl+V in a field and the app died, mid
+ * session, on the Songs tab.
+ *
+ * The app's own copy buttons were guarded separately (`SystemClipboard`); this covers the half of
+ * the problem that is not the app's code, by wrapping whatever [Clipboard] the platform installed
+ * and swallowing exactly the failure that is not ours to prevent. Everything else delegates
+ * untouched, so a working clipboard behaves precisely as it did.
+ *
+ * A copy or paste that could not happen is one the operator repeats. It is not worth ending what
+ * they were doing.
+ */
+internal class SafeClipboard(private val delegate: Clipboard) : Clipboard {
+
+    override suspend fun getClipEntry(): ClipEntry? = try {
+        delegate.getClipEntry()
+    } catch (_: IllegalStateException) {
+        null
+    }
+
+    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+        try {
+            delegate.setClipEntry(clipEntry)
+        } catch (_: IllegalStateException) {
+            // Nothing to report and nothing to do: the operator presses the key again.
+        }
+    }
+
+    /**
+     * Delegated as-is. This is the raw AWT clipboard, handed to callers that want to do their own
+     * thing with it — wrapping it would be a lie about what they were given, and the failure this
+     * class exists for happens on use rather than on access.
+     */
+    override val nativeClipboard: Any get() = delegate.nativeClipboard
+}
+
+/**
+ * Installs [SafeClipboard] over whatever the platform provided, for everything in [content].
+ *
+ * Belongs at a window root, which is what `AppWindowRoot` uses it for — every Compose window is its
+ * own composition, so a provider in one does not reach another.
+ */
+@Composable
+internal fun ProvideSafeClipboard(content: @Composable () -> Unit) {
+    val platform = LocalClipboard.current
+    val safe = remember(platform) { SafeClipboard(platform) }
+    CompositionLocalProvider(LocalClipboard provides safe, content = content)
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/SafeClipboardTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/SafeClipboardTest.kt
@@ -1,0 +1,94 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import kotlinx.coroutines.runBlocking
+import java.awt.datatransfer.StringSelection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [SafeClipboard]'s one contract: the failure Compose's own paste path does not survive becomes an
+ * answer instead of an exception, and nothing else changes.
+ *
+ * The reported crash was `TextFieldSelectionManager.paste` -> `AwtPlatformClipboard.getClipEntry`
+ * -> `WClipboard.openClipboard0`, at **fatal** — an operator pressed Ctrl+V and the app died. The
+ * delegate here throws exactly what Windows throws, so these exercise the real shape rather than a
+ * simulated one, on every platform.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class SafeClipboardTest {
+
+    private companion object {
+        const val WINDOWS_MESSAGE = "cannot open system clipboard"
+    }
+
+    private class Throwing : Clipboard {
+        // The exact exception `sun.awt.windows.WClipboard.openClipboard0` raises. `error()` is
+        // what detekt asks for and produces the same IllegalStateException.
+        override suspend fun getClipEntry(): ClipEntry = error(WINDOWS_MESSAGE)
+
+        override suspend fun setClipEntry(clipEntry: ClipEntry?): Unit = error(WINDOWS_MESSAGE)
+
+        override val nativeClipboard: Any get() = "native"
+    }
+
+    private class Recording(var entry: ClipEntry? = null) : Clipboard {
+        var setCalls = 0
+        override suspend fun getClipEntry(): ClipEntry? = entry
+        override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+            setCalls++
+            entry = clipEntry
+        }
+        override val nativeClipboard: Any get() = "native"
+    }
+
+    @Test
+    fun `a clipboard another application is holding yields null instead of killing the app`() =
+        runBlocking {
+            assertNull(SafeClipboard(Throwing()).getClipEntry())
+        }
+
+    @Test
+    fun `a copy onto a locked clipboard is dropped rather than thrown`() = runBlocking {
+        val outcome = runCatching {
+            SafeClipboard(Throwing()).setClipEntry(ClipEntry(StringSelection("a verse")))
+        }
+
+        assertTrue(outcome.isSuccess, "got ${outcome.exceptionOrNull()}")
+    }
+
+    @Test
+    fun `a working clipboard is delegated to untouched`() = runBlocking {
+        val real = Recording()
+        val safe = SafeClipboard(real)
+        val entry = ClipEntry(StringSelection("a verse"))
+
+        safe.setClipEntry(entry)
+
+        assertEquals(1, real.setCalls, "the write reached the real clipboard")
+        assertEquals(entry, safe.getClipEntry(), "and reading gives back what was written")
+    }
+
+    @Test
+    fun `clearing the clipboard is still passed through`() = runBlocking {
+        // Guarding must not turn into "skip the call when there is nothing to write" — clearing is
+        // a thing the platform asks for, and null is how it asks.
+        val real = Recording(entry = ClipEntry(StringSelection("stale")))
+
+        SafeClipboard(real).setClipEntry(null)
+
+        assertEquals(1, real.setCalls)
+        assertNull(real.entry)
+    }
+
+    @Test
+    fun `the native clipboard is handed over as-is`() {
+        // Wrapping it would misrepresent what the caller was given; the failure this class exists
+        // for happens on use, not on access.
+        assertEquals("native", SafeClipboard(Recording()).nativeClipboard)
+    }
+}


### PR DESCRIPTION
The rest of the unresolved production backlog after #421. Sentry has six
issues left; this takes three of them. The other three are accounted for below.

## What was left, and what happened to each

| Sentry | | |
|---|---|---|
| `-3E` `ConnectTimeoutException` on the Beblia catalogue | **already fixed by #421** | see below |
| `-4N` `EOFException: server prematurely closed the connection` | fixed here | |
| `-4G` `RuntimeException: GetDisplayName failed` | fixed here | |
| `-42` `IllegalStateException: cannot open system clipboard` | fixed here | |
| `-1F` blank Lottie pre-renders | deferred | shares a root cause with the CI hang in #423 |
| `-44` `ArrayIndexOutOfBoundsException` in `BrowserSourceVideoRenderer` | deferred | same |

**`-3E` needs no change.** `isOperatorEnvironment` already lists
`java.net.ConnectException`, and ktor's `ConnectTimeoutException` extends it —
verified against the jar rather than assumed:

```
public final class io.ktor.client.network.sockets.ConnectTimeoutException
        extends java.net.ConnectException
```

The events are all from release `26.9.37`, which predates the fix. It stops as
soon as #421 ships.

## The three fixed here

**`EOFException` is the operator's network.** ktor CIO raises it as "the server
prematurely closed the connection". The event is tagged `ebible_catalog` and
came from a church in Russia, on a network that does this to
`raw.githubusercontent.com`. It is `TruncatedBodyException`'s fact arriving one
layer lower — the bytes stopped coming — so it joins the same list, classified
by type rather than by message like everything else there. Accepted cost, stated
at the site: a genuinely truncated *archive* also stops being reported. That is
the same failed download, and the outcome still reaches the install dialog.

**The native file dialog now reports a warning, not an exception.** By the time
`withNativeDialog` writes anything, the app has already recovered — the operator
gets the Swing chooser and the interaction completes. `reportException` said
otherwise twice: it wrote a file into `crash-reports/`, which is the folder users
are told to attach to a bug report, and it reached Sentry at error level, where
`GetDisplayName failed` from inside FileKit's Windows shell call reads as a crash
the app suffered rather than one it absorbed. Now a warning tagged with the
context and with `chooser.recovered`.

**The clipboard crash is Compose's paste path, and `LocalClipboard` is the seam.**
#421 guarded the app's own six copy buttons and recorded the reported fatal as
not-ours. The stack says otherwise about the *remedy*:

```
TextFieldSelectionManager.paste$foundation
  -> AwtPlatformClipboard.getClipEntry(PlatformClipboard.desktop.kt:40)
    -> WClipboard.openClipboard0   IllegalStateException: cannot open system clipboard
```

`AwtPlatformClipboard` is the default `Clipboard` behind `LocalClipboard`, so
providing a guarded one intercepts exactly this. It arrived at **`level: fatal`**,
`active_tab: SONGS` — an operator pressed Ctrl+V in a field and the app died mid
session. `SafeClipboard` delegates everything and swallows only the failure that
is not ours to prevent, so a working clipboard behaves precisely as before.

Each Compose window is its own composition, so a provider installed in one does
not reach another: it has to be at all fifteen window roots or at none. Rather
than edit fifteen call sites and rely on remembering the sixteenth, the roots now
call `AppWindowRoot`, which is `AppThemeWrapper` plus the window-wide locals.
`AppThemeWrapper` stays in `:theme` and stays about theming.

## Verification

- `./gradlew :bible-formats:test :bible-formats:detekt :bible-formats:jacocoTestCoverageVerification` — green, coverage gate included.
- `./gradlew :composeApp:jvmTest --tests '*Clipboard*' --tests '*FileChooser*' --tests '*EditSongDialog*' --tests '*AboutDialog*' --tests '*OptionsDialog*'` — green.
- `./gradlew :composeApp:detekt` — clean.
- `SafeClipboardTest`'s delegate throws what `WClipboard.openClipboard0` throws, so the failure path is exercised on every platform rather than simulated.

## Note on `-44`

Seer attributes it to an off-by-one in `androidx.collection`'s
`ObjectIntMap.resizeStorage`. I would not act on that: an `ArrayIndexOutOfBounds`
inside a hash-map resize is the signature of unsynchronized concurrent mutation,
and the frame below it is `ComposeScenePump` constructing an `ImageComposeScene`
on `Dispatchers.Default`. That belongs with the threading work, not here.
