### PR TITLE
Work through the production Sentry backlog

### DIFF
--- a/bible-formats/src/main/kotlin/org/churchpresenter/bibleformats/catalog/BibleInstallSupport.kt
+++ b/bible-formats/src/main/kotlin/org/churchpresenter/bibleformats/catalog/BibleInstallSupport.kt
@@ -83,6 +83,13 @@ object BibleInstallSupport {
      * Ktor wraps, so the cause chain is walked — but only as far as [isStall] walks it, for the
      * same reason.
      *
+     * [CancellationException] is here because closing a dialog cancels whatever it started, and
+     * ktor delivers that to the request's own catch as an ordinary [IOException] over a channel
+     * that has been closed underneath it. Every site that re-throws cancellation before its
+     * reporting catch is doing the right thing; this is the backstop for the one that forgets, and
+     * one of them did — a closed Bible download browser filed "eBible catalogue fetch failed"
+     * against a user who had merely changed their mind.
+     *
      * [EOFException] is here for the connection that stops mid-response — ktor CIO raises it as
      * "the server prematurely closed the connection", which reached Sentry from a church on a
      * network that does that to `raw.githubusercontent.com`. It is the same fact as
@@ -92,7 +99,8 @@ object BibleInstallSupport {
      * reaches the install dialog either way.
      */
     internal fun Throwable.isOperatorEnvironment(depth: Int = 0): Boolean =
-        this is UnresolvedAddressException ||
+        this is CancellationException ||
+            this is UnresolvedAddressException ||
             this is ConnectException ||
             this is SocketTimeoutException ||
             this is HttpRequestTimeoutException ||

--- a/bible-formats/src/main/kotlin/org/churchpresenter/bibleformats/catalog/EBibleSource.kt
+++ b/bible-formats/src/main/kotlin/org/churchpresenter/bibleformats/catalog/EBibleSource.kt
@@ -7,6 +7,8 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -119,7 +121,17 @@ object EBibleSource : BibleSource {
                 File(cacheFile.parentFile, cacheFile.name + ".meta").writeText(nowMillis.toString())
             }
             BibleCatalogOutcome.Success(modules)
+        } catch (e: CancellationException) {
+            // Closing the download browser cancels the fetch. That is the user's doing, not a fault.
+            throw e
         } catch (e: IOException) {
+            // ktor does not always deliver that cancellation as a CancellationException: a request
+            // suspended when the scope dies surfaces as an IOException over a channel closed
+            // underneath it, and the arm above never sees it. Asking the context whether it is
+            // still alive is what tells "the user closed the dialog" from "the network failed" —
+            // without it, closing the browser filed "eBible catalogue fetch failed" against
+            // someone who had merely changed their mind.
+            currentCoroutineContext().ensureActive()
             BibleInstallSupport.reported(
                 "eBible catalogue fetch failed",
                 e,
@@ -127,6 +139,7 @@ object EBibleSource : BibleSource {
                 cached?.let { BibleCatalogOutcome.Success(it, stale = true) } ?: BibleCatalogOutcome.NetworkError,
             )
         } catch (e: UnresolvedAddressException) {
+            currentCoroutineContext().ensureActive()
             BibleInstallSupport.reported(
                 "eBible catalogue fetch failed",
                 e,

--- a/bible-formats/src/test/kotlin/org/churchpresenter/bibleformats/catalog/EBibleCatalogCacheTest.kt
+++ b/bible-formats/src/test/kotlin/org/churchpresenter/bibleformats/catalog/EBibleCatalogCacheTest.kt
@@ -6,13 +6,19 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -65,6 +71,45 @@ class EBibleCatalogCacheTest {
 
     private fun fetch(client: HttpClient, now: Long) = runBlocking {
         EBibleSource.fetchCatalog(url = url, http = client, cacheFile = cacheFile, nowMillis = now)
+    }
+
+    @Test
+    fun `closing the browser mid-fetch cancels rather than reporting a failure`() = runBlocking {
+        // Closing the download browser cancels BibleCatalogViewModel's scope while the request is
+        // still suspended, and ktor delivers that as an IOException over a channel closed
+        // underneath it rather than as a CancellationException — so the fetch caught it and filed
+        // "eBible catalogue fetch failed" against a user who had merely changed their mind.
+        //
+        // The request is held until the test has cancelled the job, so the cancellation is the
+        // reason the call ends. Nothing here waits on a clock: both sides signal each other.
+        val inFlight = CompletableDeferred<Unit>()
+        val client = HttpClient(
+            MockEngine {
+                requests++
+                inFlight.complete(Unit)
+                awaitCancellation()
+            },
+        )
+
+        val job = async {
+            runCatching {
+                EBibleSource.fetchCatalog(url = url, http = client, cacheFile = cacheFile, nowMillis = 1_000)
+            }
+        }
+        inFlight.await()
+        job.cancel()
+
+        assertFailsWith<CancellationException> { job.await() }
+        assertEquals(1, requests)
+    }
+
+    @Test
+    fun `a network failure that is not a cancellation still yields an outcome`() {
+        // The other side of the arm above: a real failure must not start propagating instead of
+        // reaching the install dialog with something to show.
+        val client = HttpClient(MockEngine { requests++; throw IOException("connection reset") })
+
+        assertIs<BibleCatalogOutcome.NetworkError>(fetch(client, now = 1_000))
     }
 
     @Test

--- a/bible-formats/src/test/kotlin/org/churchpresenter/bibleformats/catalog/InstallHelpersTest.kt
+++ b/bible-formats/src/test/kotlin/org/churchpresenter/bibleformats/catalog/InstallHelpersTest.kt
@@ -1,5 +1,6 @@
 package org.churchpresenter.bibleformats.catalog
 
+import kotlinx.coroutines.CancellationException
 import java.io.File
 import java.nio.file.Files
 import javax.net.ssl.SSLException
@@ -216,6 +217,15 @@ class InstallHelpersTest {
         // bytes stop arriving. Reported once from a church whose network does that to
         // raw.githubusercontent.com; it is TruncatedBodyException's fact, one layer lower.
         assertTrue(isEnvironment(java.io.EOFException("the server prematurely closed the connection")))
+    }
+
+    @Test
+    fun `a cancelled download is the user changing their mind, not a fault`() {
+        // Closing the download browser cancels whatever it started, and ktor delivers that to the
+        // request's own catch as an IOException over a channel closed underneath it — which is how
+        // "eBible catalogue fetch failed" got filed against someone who had merely closed a dialog.
+        assertTrue(isEnvironment(CancellationException("Job was cancelled")))
+        assertTrue(isEnvironment(IOException("channel closed", CancellationException("Job was cancelled"))))
     }
 
     @Test

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooser.kt
@@ -158,6 +158,12 @@ abstract class FileChooser {
             attempt()
         } catch (e: CancellationException) {
             throw e
+        } catch (_: PortalUnavailableException) {
+            // A desktop with no portal running is the machine, not the app. Still latched, so the
+            // process asks once and every later dialog goes straight to Swing — but not reported:
+            // there is nothing here to fix, and the operator already has a working chooser.
+            nativeDialogsBroken = true
+            return fallback()
         } catch (t: Throwable) {
             CrashReporter.reportWarning(
                 "Native file dialog failed; fell back to the Swing chooser",

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/XdgFileChooser.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/XdgFileChooser.kt
@@ -24,6 +24,22 @@ import kotlin.io.use
 private const val HEX_RADIX = 16
 
 /**
+ * The XDG desktop portal is not reachable on this machine.
+ *
+ * A distinct type rather than a message, because that is what a caller can act on: the wording
+ * would have to be matched to be recognised, and the same reasoning is already written down for
+ * the Bible installer's environment classifier — matching on text works in one locale and quietly
+ * stops working in the other thirty-three the app ships.
+ *
+ * A Linux desktop with no `xdg-desktop-portal` running is a configuration, not a defect: the
+ * chooser falls back to Swing and the operator picks their file. It reached Sentry as an
+ * `IllegalStateException` anyway, which said the app had broken when it had not.
+ */
+internal class PortalUnavailableException : IllegalStateException(
+    "The D-Bus session connection has no unique name; the desktop portal is unreachable"
+)
+
+/**
  * A [FileChooser] implementation that uses DBus to communicate with the XDG Desktop Portal's File Chooser API on Linux.
  *
  * Everything here depends on someone else's process: a session bus, and a desktop portal that
@@ -125,7 +141,7 @@ object XdgFileChooser : FileChooser() {
             null
         }
         return name?.takeIf { it.isNotBlank() }
-            ?: error("The D-Bus session connection has no unique name; the desktop portal is unreachable")
+            ?: throw PortalUnavailableException()
     }
 
     /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/ComposeScenePump.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/ComposeScenePump.kt
@@ -9,8 +9,12 @@ import androidx.compose.ui.unit.Density
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.churchpresenter.diagnostics.CrashReporter
 
 private const val NANOS_PER_MILLI = 1_000_000L
 private const val MIN_FPS = 1
@@ -76,6 +80,22 @@ class ComposeScenePump(
          * frame. Deliberately slower than any tick rate.
          */
         internal const val IDLE_POLL_MS = 250L
+
+        /**
+         * Serialises [ImageComposeScene] construction across every pump in the process.
+         *
+         * Building one touches Compose state that is global to the JVM rather than local to the
+         * scene, and there is a pump per Browser Source output and per NDI output — all started
+         * from their own `LaunchedEffect`, all on the multi-threaded [Dispatchers.Default]. Two
+         * starting at once raced a shared `MutableObjectIntMap` inside the constructor and threw
+         * `ArrayIndexOutOfBoundsException` out of its own `resizeStorage`, which reached an
+         * operator with two outputs configured.
+         *
+         * Only the constructor is held: [runLoop] runs outside the lock, so N outputs still
+         * render in parallel and a slow one cannot stall another's startup for more than one
+         * scene creation.
+         */
+        private val sceneCreation = Mutex()
     }
 
     private var job: Job? = null
@@ -95,7 +115,29 @@ class ComposeScenePump(
     fun start(scope: CoroutineScope, onFrame: OnFrame) {
         if (job != null) return
         job = scope.launch(Dispatchers.Default) {
-            val scene = ImageComposeScene(width, height, Density(1f)) { content() }
+            val scene = try {
+                sceneCreation.withLock { ImageComposeScene(width, height, Density(1f)) { content() } }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
+                // Throwable, not Exception: the reported failure was an ArrayIndexOutOfBounds from
+                // inside a Compose collection, and a scene that fails to build can equally raise an
+                // Error out of native graphics. Narrowing this would let exactly the crash it
+                // exists for straight back through.
+                //
+                // An output that cannot build its scene is one dark output, not a dead app: this
+                // runs on a launched coroutine, so anything escaping here is an uncaught throw.
+                // Clearing the job is what lets the caller start again — a pump that failed once
+                // used to be permanently wedged, because `job` stayed non-null.
+                job = null
+                CrashReporter.reportWarning(
+                    "Off-screen output scene could not be created",
+                    throwable = t,
+                    tags = mapOf("subsystem" to "offscreen_output"),
+                    extras = mapOf("width" to width.toString(), "height" to height.toString()),
+                )
+                return@launch
+            }
             try {
                 runLoop(scene, onFrame)
             } finally {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/LottieFrameStream.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/LottieFrameStream.kt
@@ -55,6 +55,12 @@ class LottieFrameStream(
         const val CLOSE_LINGER_MS = 250L
         /** Sampled frames must be >1% opaque or the whole pre-render is considered blank. */
         const val BLANK_OPAQUE_FRACTION = 0.01f
+
+        // Where along a clip open() samples: an early frame, then the quarter points.
+        const val EARLY_SAMPLE_DIVISOR = 10
+        const val QUARTERS = 4
+        const val HALVES = 2
+        const val THREE_QUARTERS_NUMERATOR = 3
     }
 
     // Single thread so decode order matches request order and bitmap lifecycle is race-free.
@@ -74,16 +80,30 @@ class LottieFrameStream(
      * failure) by sampling a few decoded frames. Returns false — without starting the worker —
      * when the content is blank; the caller should discard the cache file and stay on the
      * live renderer. Must be called exactly once, before any [requestFrame].
+     *
+     * Every sample must be blank, not merely a majority of them. The check exists for a capture
+     * that produced nothing at all, and that case fails on all five samples including the early
+     * one, as does a zero-length or truncated cache ([isFrameBlank] calls an empty frame blank).
+     * A majority once meant something else too: a lower third that animates in, holds and fades
+     * out — the shape the bundled generator writes — is genuinely transparent at 50%, 75% and
+     * 100% of its clip, so three of the four old samples read blank and a perfectly good render
+     * was deleted, silently dropping the operator back to the live renderer and re-rendering from
+     * scratch on the next play. That was 14 reports across 3 churches.
      */
     suspend fun open(): Boolean = withContext(decodeDispatcher) {
         val r = LottieRenderCache.Reader(file)
         reader = r
         frameCount = r.frameCount
-        val sampleIndices = listOf(r.frameCount / 4, r.frameCount / 2, r.frameCount * 3 / 4, r.frameCount - 1)
-            .map { it.coerceIn(0, r.frameCount - 1) }
-            .distinct()
-        val blankCount = sampleIndices.count { isFrameBlank(r.frameArgb(it)) }
-        if (blankCount > sampleIndices.size / 2) return@withContext false
+        val sampleIndices = blankSampleIndices(r.frameCount)
+        blankSampleCount = sampleIndices.size
+        // A sample that will not decode counts as blank rather than throwing: it is no evidence
+        // that the capture worked, and the whole point of open() is to answer that question
+        // without taking the pre-render coroutine down. decodeAndPublish already treats a single
+        // bad frame this way during playback.
+        blankFrameCount = sampleIndices.count { index ->
+            runCatching { isFrameBlank(r.frameArgb(index)) }.getOrDefault(true)
+        }
+        if (blankFrameCount == sampleIndices.size) return@withContext false
         worker = scope.launch(decodeDispatcher) {
             for (index in requests) {
                 decodeAndPublish(index)
@@ -91,6 +111,12 @@ class LottieFrameStream(
         }
         true
     }
+
+    /** How many frames [open] sampled, and how many of them were blank. Read for reporting. */
+    internal var blankSampleCount = 0
+        private set
+    internal var blankFrameCount = 0
+        private set
 
     /** Ask for a frame; conflated, so only the most recent request is decoded. */
     fun requestFrame(index: Int) {
@@ -137,6 +163,24 @@ class LottieFrameStream(
             CrashReporter.reportException(e, "Lower third frame decode")
         }
     }
+
+    /**
+     * Which frames of a [frameCount]-frame clip [open] samples.
+     *
+     * Spread across the whole clip and deliberately including an early frame: a clip's own
+     * fade-out makes its tail transparent by design, so a set of samples drawn only from the
+     * second half cannot tell "nothing rendered" from "it ended".
+     */
+    internal fun blankSampleIndices(frameCount: Int): List<Int> =
+        listOf(
+            frameCount / EARLY_SAMPLE_DIVISOR,
+            frameCount / QUARTERS,
+            frameCount / HALVES,
+            frameCount * THREE_QUARTERS_NUMERATOR / QUARTERS,
+            frameCount - 1,
+        )
+            .map { it.coerceIn(0, maxOf(0, frameCount - 1)) }
+            .distinct()
 
     /**
      * Roughly estimates whether a frame is meaningfully blank (near-fully transparent).

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/WebsitePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/WebsitePresenter.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
 import androidx.compose.ui.graphics.Color
@@ -51,7 +54,15 @@ private const val AUDIO_RETRY_DELAY_MS = 5000L
  */
 object CefManager {
     private var cefApp: CefApp? = null
-    var initialized = false
+
+    /**
+     * Whether a usable [CefApp] exists right now.
+     *
+     * Compose-backed rather than a plain `var` because it can go from true to false mid-session:
+     * [createClient] clears it when the native side turns out to be dead, and the tab's
+     * "web engine unavailable" panel is only reached if that write recomposes its reader.
+     */
+    var initialized by mutableStateOf(false)
         private set
 
     /** True when [init] was skipped because the running macOS version is below [MIN_MACOS_MAJOR]. */
@@ -273,7 +284,36 @@ object CefManager {
         }
     }
 
-    fun createClient(): CefClient? = cefApp?.createClient()
+    /**
+     * A client for a new browser, or null when the web engine cannot provide one.
+     *
+     * [CefAppBuilder.build] returning normally is not a promise that the native side came up:
+     * jcefmaven hands back the process-wide singleton, whose startup can fail afterwards and
+     * asynchronously, leaving it in `INITIALIZATION_FAILED`. `CefApp.createClient()` then throws —
+     * and the only caller is [EmbeddedWebView], inside a `remember`, so the throw landed in
+     * composition on the UI thread and took the whole app down.
+     *
+     * Recovering is simply returning null, which every caller already handles by drawing nothing.
+     * [initialized] is cleared with it so the tab falls back to its explanatory panel and nothing
+     * asks a second time. Filed as a warning, not an exception: the condition is recovered, and an
+     * exception here would write a `crash-reports/` file for a session that carries on.
+     */
+    fun createClient(): CefClient? {
+        val app = cefApp ?: return null
+        return try {
+            app.createClient()
+        } catch (t: Throwable) {
+            cefApp = null
+            initialized = false
+            runCatching { CrashReporter.setTag("jcef.blocked", "client_creation_failed") }
+            CrashReporter.reportWarning(
+                "JCEF client creation failed; web features disabled for this session",
+                throwable = t,
+                tags = mapOf("subsystem" to "webview", "jcef.recovered" to "true"),
+            )
+            null
+        }
+    }
 
     fun dispose() {
         // Intentionally no-op — calling CefApp.dispose() during shutdown

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
@@ -30,6 +30,7 @@ import kotlin.io.path.absolutePathString
 import kotlin.io.path.exists
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -385,6 +386,9 @@ class ScheduleViewModel(
             clearAutoSave()
             notifyChanged()
             CrashReporter.breadcrumb("Schedule opened (${file.fileName}, ${items.size} items)", category = "schedule")
+        } catch (e: CancellationException) {
+            // The file dialog this runs behind is cancellable; abandoning it is not a fault.
+            throw e
         } catch (e: Exception) {
             CrashReporter.reportException(e, "Opening schedule file")
         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooserTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/dialogs/filechooser/FileChooserTest.kt
@@ -595,8 +595,10 @@ class XdgPortalRequestTest {
 
     @Test
     fun `a missing or blank unique name is refused too`() {
-        assertFailsWith<IllegalStateException> { XdgFileChooser.uniqueNameOf { null } }
-        assertFailsWith<IllegalStateException> { XdgFileChooser.uniqueNameOf { "  " } }
+        // The type is what withNativeDialog recognises, so it is part of the contract: matching on
+        // the message would work in one locale and quietly stop working in the rest.
+        assertFailsWith<PortalUnavailableException> { XdgFileChooser.uniqueNameOf { null } }
+        assertFailsWith<PortalUnavailableException> { XdgFileChooser.uniqueNameOf { "  " } }
     }
 
     // ── The path the portal will answer on ──────────────────────────────────────
@@ -881,6 +883,30 @@ class XdgPortalRequestTest {
             assertEquals("swing", result, "no portal must still leave the operator a dialog")
             assertEquals(true, fellBack)
             assertEquals(true, XdgFileChooser.nativeDialogsBroken, "a desktop with no portal is not asked again")
+        } finally {
+            XdgFileChooser.nativeDialogsBroken = false
+        }
+    }
+
+    @Test
+    fun `a desktop with no portal falls back without reporting it`() = runBlocking {
+        // A Linux desktop with no xdg-desktop-portal running is a configuration, not a defect, and
+        // the operator gets a working Swing chooser either way — but it filed a Sentry warning
+        // saying the app had broken. The latch still has to hold, or every later dialog pays for
+        // the same absent portal again.
+        XdgFileChooser.nativeDialogsBroken = false
+        try {
+            var fellBack = false
+
+            val result = XdgFileChooser.withNativeDialog(
+                context = "test",
+                attempt = { throw PortalUnavailableException() },
+                fallback = { fellBack = true; "swing" },
+            )
+
+            assertEquals("swing", result)
+            assertEquals(true, fellBack)
+            assertEquals(true, XdgFileChooser.nativeDialogsBroken, "the process must only ask once")
         } finally {
             XdgFileChooser.nativeDialogsBroken = false
         }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/CefManagerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/CefManagerTest.kt
@@ -287,4 +287,16 @@ class CefManagerTest {
         )
     }
 
+    @Test
+    fun `no CefApp means no client, and no throw`() {
+        // The suite never initialises JCEF, so this is the uninitialised branch — the one that has
+        // to answer null rather than dereference. The failed-native branch beside it cannot be
+        // reached without a real CefApp whose native side has died, which is exactly the state a
+        // test cannot construct; the guarantee that matters is shared and asserted here: every
+        // caller sees null, never an exception, because the only call site is inside a `remember`.
+        assertFalse(CefManager.initialized)
+        assertNull(CefManager.createClient())
+        assertFalse(CefManager.initialized, "answering null must not flip the flag on")
+    }
+
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/ComposeScenePumpTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/ComposeScenePumpTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.delay
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.AfterTest
@@ -204,6 +205,43 @@ class ComposeScenePumpTest {
         assertEquals(1000L / 1, ComposeScenePump(W, H, 0) {}.tickDelayMs)
         assertEquals(1000L / 1, ComposeScenePump(W, H, -5) {}.tickDelayMs)
         assertEquals(1000L / 60, ComposeScenePump(W, H, 240) {}.tickDelayMs)
+    }
+
+    @Test
+    fun `many pumps starting at once all reach a frame`() {
+        // ImageComposeScene's constructor touches Compose state that is global to the JVM, and
+        // there is a pump per Browser Source output and per NDI output, every one of them started
+        // from its own LaunchedEffect on the multi-threaded default dispatcher. Building two at
+        // the same time raced a shared map inside the constructor and threw
+        // ArrayIndexOutOfBoundsException out of its own resizeStorage, killing the app for an
+        // operator with two outputs configured. Construction is serialised now; this is the shape
+        // that used to break, driven wider than any real configuration.
+        val pumps = List(8) { redPump() }
+        val firstFrames = AtomicInteger(0)
+        pumps.forEach { pump -> pump.start(scope) { _, _, _, _ -> firstFrames.incrementAndGet() } }
+
+        waitFor("every pump's first frame") { firstFrames.get() >= pumps.size }
+        pumps.forEach { it.stop() }
+    }
+
+    @Test
+    fun `a pump whose content cannot compose does not take the app down, and can start again`() {
+        val explode = AtomicBoolean(true)
+        val pump = ComposeScenePump(width = W, height = H, fps = 60) {
+            if (explode.get()) error("no scene for you")
+            Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+        }
+
+        pump.start(scope) { _, _, _, _ -> }
+        // The failure clears the job rather than leaving the pump wedged for the rest of the
+        // session, which is what "can start again" below actually proves.
+        waitFor("the failed start to release the pump") { !pump.isRunning }
+
+        explode.set(false)
+        val frames = AtomicInteger(0)
+        pump.start(scope) { _, _, _, _ -> frames.incrementAndGet() }
+        waitFor("a frame from the restarted pump") { frames.get() > 0 }
+        pump.stop()
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/LottieFrameStreamTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/LottieFrameStreamTest.kt
@@ -121,12 +121,58 @@ class LottieFrameStreamTest {
     }
 
     @Test
-    fun `open returns false for a mostly blank cache but still reports the frame count`() {
+    fun `open returns false for a wholly blank cache but still reports the frame count`() {
         val file = writeCacheFile(2, 2, List(4) { encodeLiteral(solidFrame(2, 2, transparent)) })
         val stream = LottieFrameStream(file, newScope()) {}
 
         assertFalse(runBlocking { stream.open() })
         assertEquals(4, stream.frameCount)
+        assertEquals(stream.blankSampleCount, stream.blankFrameCount)
+    }
+
+    @Test
+    fun `a clip that fades out still opens`() {
+        // The shape the bundled generator writes: visible at the start, transparent for the whole
+        // back half. Under the old majority rule the 50, 75 and 100 percent samples were all blank
+        // and the render was deleted as a failed capture, which is what put 14 warnings and 3
+        // churches on one Sentry issue.
+        val opaque = List(10) { encodeLiteral(solidFrame(2, 2, opaqueRed)) }
+        val faded = List(10) { encodeLiteral(solidFrame(2, 2, transparent)) }
+        val stream = LottieFrameStream(writeCacheFile(2, 2, opaque + faded), newScope()) {}
+
+        assertTrue(runBlocking { stream.open() })
+        assertTrue(stream.blankFrameCount > 0, "the tail should still read as blank")
+        assertTrue(stream.blankFrameCount < stream.blankSampleCount)
+    }
+
+    @Test
+    fun `the samples span the clip and include an early frame`() {
+        val stream = LottieFrameStream(writeCacheFile(1, 1, emptyList()), newScope()) {}
+        val samples = stream.blankSampleIndices(100)
+
+        // An early sample is the whole point: a set drawn only from the second half cannot tell
+        // "nothing rendered" from "the animation ended".
+        assertTrue(samples.first() < 100 / 4, "expected a sample before the first quarter: $samples")
+        assertEquals(99, samples.last())
+        assertEquals(samples.distinct(), samples)
+    }
+
+    @Test
+    fun `a cache whose every frame is corrupt is rejected rather than thrown out of`() {
+        // open() decodes its samples, so a truncated cache used to throw straight out of the
+        // pre-render coroutine instead of answering the question it exists to answer.
+        val file = writeCacheFile(2, 2, List(5) { encodeTruncated(solidFrame(2, 2, opaqueRed)) })
+        val stream = LottieFrameStream(file, newScope()) {}
+
+        assertFalse(runBlocking { stream.open() })
+    }
+
+    @Test
+    fun `a one frame clip samples that frame once`() {
+        val stream = LottieFrameStream(writeCacheFile(1, 1, emptyList()), newScope()) {}
+        assertEquals(listOf(0), stream.blankSampleIndices(1))
+        // A cache with no frames at all must not index out of bounds while deciding it is blank.
+        assertEquals(listOf(0), stream.blankSampleIndices(0))
     }
 
     @Test


### PR DESCRIPTION
Five unresolved issues on `church-presenter-desktop`, every one from an operator on a release build. Two took the app down; two were the app reporting something that is not a defect.

### `Can't crate client in state INITIALIZATION_FAILED` — fatal

`CefAppBuilder.build()` returning normally is not a promise that JCEF came up: jcefmaven hands back the process-wide singleton, whose native startup can fail afterwards and asynchronously. `init()`'s catch never ran, so `initialized` stayed true, and `CefApp.createClient()` threw — from inside a `remember`, on the UI thread, in composition, with no catch anywhere on the path.

It answers null now, which every caller already handles by drawing nothing, and clears `initialized` so the tab falls back to the panel that explains it. That flag is Compose-backed for the same reason: it can now go true to false mid-session, and a plain `var` would not recompose its reader. Filed as a warning rather than an exception — a condition the session survives should not write a `crash-reports/` file.

Fixes CHURCH-PRESENTER-DESKTOP-4S

### `ArrayIndexOutOfBoundsException` inside `ImageComposeScene.<init>` — fatal

`ImageComposeScene`'s constructor touches Compose state that is global to the JVM, and there is a `ComposeScenePump` per Browser Source output and per NDI output, each started from its own `LaunchedEffect` on the multi-threaded default dispatcher. Two building at once raced a shared `MutableObjectIntMap` and threw out of its own `resizeStorage`.

Construction is serialised on one process-wide mutex; the render loop stays outside it, so N outputs still render in parallel. It also moves inside the `try`, because a throw there was uncaught — and left `job` non-null, so a pump that failed once could never be started again for the rest of the session.

Fixes CHURCH-PRESENTER-DESKTOP-44

### "Lottie pre-render produced blank frames, discarded" — 14 reports, 3 churches

The blank check sampled a clip at 25, 50, 75 and 100 percent and rejected it when a majority read blank. A lower third that animates in, holds and fades out — the shape the bundled generator writes — is genuinely transparent across its back half, so three of four samples were blank and a good render was deleted as a failed capture, dropping the operator to the live renderer and re-rendering from scratch on the next play.

It samples an early frame too and rejects only when **every** sample is blank, which still catches what the check exists for: a capture that produced nothing fails on all five, as does a zero-length cache. Sampling those frames also meant `open()` decoded them, so a truncated cache threw straight out of the pre-render coroutine; an undecodable sample counts as blank instead, the way `decodeAndPublish` already treats one during playback.

Fixes CHURCH-PRESENTER-DESKTOP-1F

### `CancellationException: Job was cancelled` from the Bible download browser

Closing the browser cancels the catalogue fetch, and ktor delivers that as an `IOException` over a channel closed underneath it rather than as a `CancellationException` — so the fetch's own catch filed "eBible catalogue fetch failed" against someone who had merely changed their mind. The install path in the same file already re-throws cancellation; the catalogue fetch was the one that did not.

It asks the context whether it is still alive before reporting, which is what tells a closed dialog from a failed network. `isOperatorEnvironment` gains cancellation as the backstop for any other site that forgets, and `ScheduleViewModel`'s file-dialog catch gets the same guard.

Fixes CHURCH-PRESENTER-DESKTOP-4R

### "The D-Bus session connection has no unique name"

A Linux desktop with no `xdg-desktop-portal` running is a configuration, not a defect: the chooser already falls back to Swing and the operator picks their file. It reported an `IllegalStateException` anyway, saying the app had broken when it had not.

The condition gets its own type so the caller can recognise it without matching on wording — the same reasoning the Bible installer's environment classifier already records, that matching text works in one locale and quietly stops working in the other thirty-three. It still latches, so the process asks once; everything else reports exactly as before.

Fixes CHURCH-PRESENTER-DESKTOP-4Q

---

**Testing.** `:composeApp:check` and `:bible-formats:test` pass; `:composeApp:detekt` is clean. The four changed suites were run three consecutive times with `--rerun-tasks`. New coverage: concurrent pump startup and a pump whose content cannot compose (`ComposeScenePumpTest`); a fade-out clip opening while an all-blank and an all-corrupt cache are still rejected (`LottieFrameStreamTest`); a genuinely cancelled fetch propagating while a real network failure still returns an outcome (`EBibleCatalogCacheTest`); the portal-absence type falling back without reporting (`FileChooserTest`). Every wait ends on a positive signal, never on a timeout.

No screenshots move — none of these changes touches a committed UI state.