### PR TITLE
Stop reporting an NDI runtime the operator has not installed

### DIFF
--- a/bible-formats/src/test/kotlin/org/churchpresenter/bibleformats/catalog/InstallHelpersTest.kt
+++ b/bible-formats/src/test/kotlin/org/churchpresenter/bibleformats/catalog/InstallHelpersTest.kt
@@ -1,5 +1,6 @@
 package org.churchpresenter.bibleformats.catalog
 
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import kotlinx.coroutines.CancellationException
 import java.io.File
 import java.nio.file.Files
@@ -217,6 +218,19 @@ class InstallHelpersTest {
         // bytes stop arriving. Reported once from a church whose network does that to
         // raw.githubusercontent.com; it is TruncatedBodyException's fact, one layer lower.
         assertTrue(isEnvironment(java.io.EOFException("the server prematurely closed the connection")))
+    }
+
+    @Test
+    fun `a request that timed out is the operator's line, not a defect`() {
+        // ktor raises this rather than SocketTimeoutException when its own request timeout fires,
+        // and it is a different type entirely — so the two have to be listed separately. A church
+        // in Jamaica on a slow line filed "Holy Bible XML catalogue fetch failed" against a
+        // 30-second timeout to raw.githubusercontent.com, which is a fact about the line.
+        assertTrue(isEnvironment(HttpRequestTimeoutException("https://example.invalid", 30_000)))
+        assertTrue(
+            isEnvironment(IOException("fetch failed", HttpRequestTimeoutException("https://example.invalid", 30_000))),
+            "ktor wraps, so the cause chain has to find it too",
+        )
     }
 
     @Test

--- a/ndi/src/main/kotlin/org/churchpresenter/ndi/JnaNdiLibrary.kt
+++ b/ndi/src/main/kotlin/org/churchpresenter/ndi/JnaNdiLibrary.kt
@@ -5,6 +5,8 @@ import com.sun.jna.Memory
 import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
+import io.sentry.SentryLevel
+import org.churchpresenter.diagnostics.CrashReporter
 import java.util.concurrent.ConcurrentHashMap
 
 private const val PROGRESSIVE = 1
@@ -97,13 +99,31 @@ class JnaNdiLibrary internal constructor(private val lib: NdiLibC) : NdiLibrary 
          * `UnsatisfiedLinkError` rather than an exception, which is why that is caught by name
          * rather than as `Throwable`.
          */
+        /**
+         * The runtime at [libraryPath], or null when it will not load.
+         *
+         * A load failure is not reported. The NDI Runtime is an optional download the operator
+         * installs themselves — the same standing as VLC and ffmpeg — and
+         * [NdiRuntimeStatus.LoadFailed] already carries the path to the settings card, which says
+         * it "may be for a different processor architecture, or too old" and links to the
+         * download. An event on top of that told us nothing the operator was not already being
+         * told, and it arrived once per attempt: the card's "look again" button made a single
+         * unusable install into eight reports from one church.
+         *
+         * The fact still rides along as a tag and a breadcrumb, so if something else in the
+         * session does report, the failed runtime is visible in it. Same shape as `jcef.blocked`.
+         */
         fun load(libraryPath: String): JnaNdiLibrary? = try {
             JnaNdiLibrary(Native.load(libraryPath, NdiLibC::class.java))
         } catch (e: UnsatisfiedLinkError) {
-            org.churchpresenter.diagnostics.CrashReporter.reportException(
-                RuntimeException("NDI runtime at $libraryPath could not be loaded", e),
-                "Loading the NDI runtime",
-            )
+            runCatching {
+                CrashReporter.setTag("ndi.load_failed", "true")
+                CrashReporter.breadcrumb(
+                    "NDI runtime at $libraryPath could not be loaded: ${e.message}",
+                    category = "ndi",
+                    level = SentryLevel.WARNING,
+                )
+            }
             null
         }
     }


### PR DESCRIPTION
Stacked on #443 (which is stacked on #442) — this targets `fix-sentry-backlog-2`, so the diff shown is only the new work.

### The NDI runtime is an optional download

`JnaNdiLibrary.load` filed a Sentry **exception** — error level, with a `crash-reports/` file — whenever the NDI library would not load. But the NDI Runtime is something the operator installs separately, the same standing as VLC and ffmpeg, and `NdiRuntimeStatus.LoadFailed` already carries the path to the settings card, which says the library "may be for a different processor architecture, or too old" and links to the download.

So the event told us nothing the operator was not already being told — and it arrived once per attempt. `start()` is deliberately safe to call again so the card can offer a "look again" after an install, which turned one unusable library into **8 reports from one church**.

The fact still rides along as a tag and a breadcrumb, so a failed runtime is visible on anything else that session reports — the same shape as `jcef.blocked`. This is the ffmpeg precedent from #421: a tool the user has not installed is not a defect.

Fixes CHURCH-PRESENTER-DESKTOP-51

### The catalogue timeout was already fixed — but nothing pinned it

I went in expecting to fix CHURCH-PRESENTER-DESKTOP-50 and found it already suppressed on `main`: `HttpRequestTimeoutException` joined `isOperatorEnvironment` in #421 on 2026-08-26, and the release that reported it (26.9.37) predates that — its events lack the `os.family` tag the same PR added. The Beblia catalogue fetch does route through `BibleInstallSupport.reported`.

What was missing is a test. It is the one entry in that list that cannot be inferred from the others: ktor raises **its own** exception type when the request timeout fires rather than `SocketTimeoutException`, so both have to be listed separately, and a refactor could quietly drop one without failing anything. The new test pins the bare type and the wrapped one, since ktor wraps.

No behaviour change for this issue — just the guard that keeps it fixed.

---

**Testing.** `:composeApp:check`, `:ndi:test` and `:bible-formats:test` pass, both modules' coverage gates included; `:composeApp:detekt` is clean.

One honest note on coverage: the removed report lives inside `JnaNdiLibrary.load`, which `NdiRuntimeHost`'s KDoc already designates as the single call left uncovered (it is the real JNA `Native.load`). The operator-facing contract either side of it — `start()` returning `LoadFailed` with the path it tried — is covered by `NdiRuntimeHostTest`. There is no seam that would let a test assert "and it did not report" without inventing one, so that part is documented rather than asserted.