### PR TITLE
Persist a song background's opacity in the .song file

### DIFF
--- a/core-models/src/main/kotlin/org/churchpresenter/core/models/songs/SongBackground.kt
+++ b/core-models/src/main/kotlin/org/churchpresenter/core/models/songs/SongBackground.kt
@@ -72,7 +72,8 @@ private const val SONG_BACKGROUND_PERCENT_MAX = 100
  * than two, so a background reads the same wherever it is stored.
  */
 fun songBackgroundKeys(prefix: String): List<String> =
-    listOf(prefix) + listOf("color", "color-end", "image", "video", "dim", "blur").map { "$prefix-$it" }
+    listOf(prefix) +
+        listOf("color", "color-end", "image", "video", "dim", "blur", "opacity").map { "$prefix-$it" }
 
 /**
  * The [SongBackground] held under [prefix] in [fields], or an inheriting one when nothing there
@@ -89,6 +90,8 @@ fun songBackgroundFrom(fields: Map<String, String>, prefix: String): SongBackgro
         video = fields["$prefix-video"].orEmpty(),
         dim = fields["$prefix-dim"]?.toIntOrNull()?.coerceIn(0, SONG_BACKGROUND_PERCENT_MAX) ?: 0,
         blur = fields["$prefix-blur"]?.toIntOrNull()?.coerceIn(0, SONG_BACKGROUND_MAX_BLUR) ?: 0,
+        opacity = fields["$prefix-opacity"]?.toIntOrNull()?.coerceIn(0, SONG_BACKGROUND_PERCENT_MAX)
+            ?: SONG_BACKGROUND_FULL_OPACITY,
     )
 }
 
@@ -97,7 +100,7 @@ fun songBackgroundFrom(fields: Map<String, String>, prefix: String): SongBackgro
  * it inherits, since an inherited background is stored by writing nothing at all.
  *
  * Only what the type actually reads is written: a colour background records no gradient end, and
- * dim and blur appear only when they are set to something.
+ * dim, blur and opacity appear only when they are set to something other than their default.
  */
 fun songBackgroundFields(background: SongBackground, prefix: String): List<Pair<String, String>> {
     if (!background.isCustom) return emptyList()
@@ -114,5 +117,8 @@ fun songBackgroundFields(background: SongBackground, prefix: String): List<Pair<
         }
         if (background.dim > 0) add("$prefix-dim" to background.dim.toString())
         if (background.blur > 0) add("$prefix-blur" to background.blur.toString())
+        if (background.opacity < SONG_BACKGROUND_FULL_OPACITY) {
+            add("$prefix-opacity" to background.opacity.toString())
+        }
     }
 }

--- a/core-models/src/test/kotlin/org/churchpresenter/core/models/songs/SongBackgroundFormatTest.kt
+++ b/core-models/src/test/kotlin/org/churchpresenter/core/models/songs/SongBackgroundFormatTest.kt
@@ -217,6 +217,35 @@ class SongBackgroundFormatTest {
         assertFalse(text.contains("background-blur"))
     }
 
+    /**
+     * Opacity was in [SongBackground] but in neither [songBackgroundKeys] nor
+     * [songBackgroundFields], so a song's background opacity silently reverted to full on every
+     * reload. It is written like dim and blur — only when it is set to something.
+     */
+    @Test
+    fun `a full opacity is not written, and anything less is`() {
+        val full = written(blank().copy(background = SongBackground(type = SongBackgroundType.COLOR)))
+        val faded = written(
+            blank().copy(background = SongBackground(type = SongBackgroundType.COLOR, opacity = 55))
+        )
+
+        assertFalse(full.contains("background-opacity"))
+        assertTrue(faded.contains("background-opacity: 55"))
+    }
+
+    @Test
+    fun `an opacity out of range is clamped, and a non-numeric one falls back to full`() {
+        val over = songBackgroundFrom(
+            mapOf("background" to "color", "background-opacity" to "180"), SONG_BACKGROUND_PREFIX
+        )
+        val junk = songBackgroundFrom(
+            mapOf("background" to "color", "background-opacity" to "half"), SONG_BACKGROUND_PREFIX
+        )
+
+        assertEquals(SONG_BACKGROUND_FULL_OPACITY, over.opacity)
+        assertEquals(SONG_BACKGROUND_FULL_OPACITY, junk.opacity)
+    }
+
     @Test
     fun `every field of both backgrounds survives the round trip`() {
         val original = blank().copy(
@@ -227,12 +256,14 @@ class SongBackgroundFormatTest {
                 colorEnd = "#3a2352",
                 dim = 25,
                 blur = 3,
+                opacity = 70,
             ),
             lowerThirdBackground = SongBackground(
                 type = SongBackgroundType.VIDEO,
                 video = "/media/loop.mp4",
                 dim = 65,
                 blur = 12,
+                opacity = 40,
             ),
         )
 
@@ -301,6 +332,7 @@ class SongBackgroundFormatTest {
     fun `the header and a section directive are written in one vocabulary`() {
         val background = SongBackground(
             type = SongBackgroundType.GRADIENT, color = "#131a3a", colorEnd = "#3a2352", dim = 25, blur = 3,
+            opacity = 80,
         )
 
         val fields = songBackgroundFields(background, SONG_BACKGROUND_PREFIX)
@@ -313,6 +345,7 @@ class SongBackgroundFormatTest {
                 "background-color-end" to "#3a2352",
                 "background-dim" to "25",
                 "background-blur" to "3",
+                "background-opacity" to "80",
             ),
             fields,
         )


### PR DESCRIPTION
`SongBackground.opacity` was in the data class but in neither `songBackgroundKeys` nor `songBackgroundFields`, so it was never written and never read back: a song whose background was faded reverted to fully opaque on every reload, and a per-section background could not express an opacity at all.

Written like dim and blur — only when it is set to something other than the default — so no existing file changes and an inheriting background still records nothing. Read back clamped to 0–100, falling back to full opacity for a value that is missing or not a number.

Found while planning #439 (camera backgrounds), which appends further keys under the same rule; kept separate so it is not folded into a feature review.

```
./gradlew :core-models:test :core-models:detekt :core-models:jacocoTestCoverageVerification
./gradlew :composeApp:jvmTest --tests '*SectionBackgroundSlot*' --tests '*SongBackground*' --tests '*QuickBackground*' --tests '*LyricSections*'
```
all green.