### PR TITLE
Fix the Canvas CPU load and Windows camera detection, and make both self-diagnosing

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -1400,9 +1400,16 @@
     <string name="canvas_camera_device">Camera</string>
     <string name="canvas_camera_name">Device Name</string>
     <string name="canvas_camera_none_found">No cameras found</string>
+    <!-- Superseded by canvas_camera_ffmpeg_required, which does not frame ffmpeg as needed only for
+         virtual cameras. Kept defined because fourteen locales translate it: removing it here would
+         orphan every one of those, which LocaleStringsTest gates against. -->
     <string name="canvas_camera_ffmpeg_hint">Install ffmpeg to detect virtual cameras (OBS, NDI, etc.)</string>
+    <string name="canvas_camera_ffmpeg_required">ChurchPresenter opens cameras with ffmpeg. Until ffmpeg is installed, no camera can be shown — install it, then press Refresh Cameras.</string>
     <string name="canvas_camera_v4l2_hint">Install v4l2loopback for virtual cameras: sudo apt install v4l2loopback-dkms</string>
     <string name="canvas_camera_refresh">Refresh Cameras</string>
+    <string name="canvas_camera_error_ffmpeg_missing">This camera cannot be opened because ffmpeg is not installed. Install ffmpeg, then select the camera again.</string>
+    <string name="canvas_camera_error_permission_denied_windows">Windows is blocking camera access for ChurchPresenter. Open Settings → Privacy &amp; security → Camera, turn on camera access and "Let desktop apps access your camera", then select the camera again.</string>
+    <string name="canvas_camera_error_device_not_found_windows">Windows could not open a camera with this name. It may have been unplugged, or its driver may name it differently than Windows does — press Refresh Cameras and pick it again.</string>
     <string name="canvas_camera_error_permission_denied">macOS is blocking camera access for ChurchPresenter. Open System Settings → Privacy &amp; Security → Camera, switch ChurchPresenter on, then select the camera again.</string>
     <string name="canvas_camera_error_unsupported_format">This device does not accept the video format that was requested. Choose a specific one under Video Format.</string>
     <string name="canvas_camera_error_unsupported_framerate">This device does not accept the frame rate that was requested. Choose a specific format under Video Format.</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDeviceCatalog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDeviceCatalog.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
+import org.churchpresenter.diagnostics.CrashReporter
 import org.churchpresenter.core.models.camera.CameraDeviceRef
 
 /**
@@ -28,9 +29,54 @@ internal object CameraDeviceCatalog {
     /** Null until something has actually looked; an empty list means this machine has no camera. */
     val devices: StateFlow<List<CameraDevice>?> = _devices.asStateFlow()
 
+    /**
+     * What the last enumeration found, in shapes rather than names — null until one has run.
+     *
+     * Kept beside [devices] rather than in a singleton of its own so the two cannot disagree about
+     * the same enumeration. Read by camera failure reports, which need to say *how* a device was
+     * found in order to be answerable, and by the Save-diagnostic-info report.
+     *
+     * `@Volatile` because it is written on IO and read from capture coroutines on `Dispatchers.Default`.
+     */
+    @Volatile
+    private var _lastEnumeration: CameraEnumerationFacts? = null
+
+    internal val lastEnumeration: CameraEnumerationFacts? get() = _lastEnumeration
+
+    /** Bounds the blind-ffmpeg report to one per process — re-opening a picker re-enumerates. */
+    private val blindFfmpegReport = ReportOnce()
+
     /** Re-enumerates, on IO. Safe to call from a composition's `LaunchedEffect`. */
     suspend fun refresh(deckLinkDeviceFormat: String) {
-        _devices.value = withContext(Dispatchers.IO) { listCameraDevicesWithDeckLink(deckLinkDeviceFormat) }
+        val listing = withContext(Dispatchers.IO) { listCameraDevicesWithDeckLinkListing(deckLinkDeviceFormat) }
+        _lastEnumeration = listing.facts
+        _devices.value = listing.devices
+        reportBlindFfmpeg(listing.facts)
+    }
+
+    /**
+     * Says once that ffmpeg is installed and working, and still listed no DirectShow device, on a
+     * machine where Windows itself can see one.
+     *
+     * Today that state is only learnable if the operator goes on to pick one of those unopenable
+     * names and waits out five capture attempts. It is worth knowing on its own, because the picker
+     * is offering devices that cannot work.
+     *
+     * [shouldReportBlindFfmpeg] carries the conditions and the reasons for each; keeping the
+     * decision there rather than here is what lets it be tested without Sentry.
+     */
+    private fun reportBlindFfmpeg(facts: CameraEnumerationFacts) {
+        if (!shouldReportBlindFfmpeg(facts)) return
+        if (!blindFfmpegReport.claim()) return
+        CrashReporter.reportWarning(
+            "Camera: ffmpeg listed no DirectShow devices while Windows lists cameras",
+            tags = mapOf("subsystem" to "camera") +
+                cameraEnumerationTags(facts, deviceName = "", ffmpegAvailable = true),
+            extras = mapOf(
+                "camera_enumeration" to
+                    cameraEnumerationExtra(facts, deviceName = "", ffmpegAvailable = true)
+            )
+        )
     }
 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDiagnostics.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDiagnostics.kt
@@ -34,6 +34,16 @@ internal enum class CameraFailure {
     /** A DeckLink card whose input cannot be opened because the app is using it for output. */
     DECKLINK_INPUT_IN_USE,
 
+    /**
+     * ffmpeg is not installed, so no camera can be opened at all.
+     *
+     * Decided before ffmpeg runs rather than classified from its stderr, which is why
+     * [classifyCameraFfmpegStderr] has no marker for it: there is no stderr, because there is no
+     * process. Not a defect in the app — but the operator has to be told, or the canvas is simply
+     * black with no reason given.
+     */
+    FFMPEG_MISSING,
+
     /** ffmpeg failed for a reason not recognised here. The stderr tail is reported as-is. */
     UNKNOWN,
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
@@ -59,7 +59,13 @@ internal data class CameraDevice(
     val deckLinkIndex: Int = -1
 )
 
-internal fun listCameraDevicesWithDeckLink(deckLinkDeviceFormat: String = "DeckLink: %1\$s"): List<CameraDevice> {
+internal fun listCameraDevicesWithDeckLink(deckLinkDeviceFormat: String = "DeckLink: %1\$s"): List<CameraDevice> =
+    listCameraDevicesWithDeckLinkListing(deckLinkDeviceFormat).devices
+
+/** [listCameraDevicesWithDeckLink], keeping what enumeration found — see [CameraEnumerationFacts]. */
+internal fun listCameraDevicesWithDeckLinkListing(
+    deckLinkDeviceFormat: String = "DeckLink: %1\$s",
+): CameraListing {
     val devices = mutableListOf<CameraDevice>()
 
     if (DeckLinkManager.isAvailable()) {
@@ -75,13 +81,15 @@ internal fun listCameraDevicesWithDeckLink(deckLinkDeviceFormat: String = "DeckL
         }
     }
 
+    val deckLinkCount = devices.size
     val hasDeckLink = devices.any { it.isDeckLink }
-    listCameraDevices().filterNot { cam ->
+    val listing = listCameraDevices()
+    listing.devices.filterNot { cam ->
         hasDeckLink && cam.name.lowercase().contains("decklink")
     }.let { devices.addAll(it) }
 
-    System.err.println("[Camera] Found ${devices.size} total device(s) (${devices.count { it.isDeckLink }} DeckLink)")
-    return devices
+    System.err.println("[Camera] Found ${devices.size} total device(s) ($deckLinkCount DeckLink)")
+    return CameraListing(devices, listing.facts.copy(deckLinkCount = deckLinkCount))
 }
 
 internal data class CameraFormat(
@@ -262,18 +270,69 @@ internal fun parseAvfoundationFormats(output: String): List<CameraFormat> {
 
 internal fun isFfmpegAvailable(): Boolean = FfmpegBinary.isAvailable
 
-private fun listCameraDevices(): List<CameraDevice> {
-    val devices = cameraDevicesFor(System.getProperty("os.name", "").lowercase(), ::readCommandOutput)
+/**
+ * The impure edge of enumeration: the real OS, the real commands, the real clock.
+ *
+ * [enumerateCameras] stays pure over its runner, so everything about *which* tool answers is driven
+ * from a fake in tests. The two facts that cannot be known there — whether ffmpeg resolved on this
+ * machine, and when this ran — are filled in here.
+ */
+private fun listCameraDevices(): CameraListing {
+    val listing = enumerateCameras(System.getProperty("os.name", "").lowercase(), ::readCommandOutput)
+    val devices = listing.devices
     System.err.println("[Camera] Found ${devices.size} camera device(s):")
     devices.forEach { System.err.println("[Camera]   ${it.displayName} -> ${it.path}") }
-    return devices
+    return listing.copy(
+        facts = listing.facts.copy(
+            ffmpegAvailable = isFfmpegAvailable(),
+            enumeratedAtMs = System.currentTimeMillis(),
+        )
+    )
 }
 
-internal fun cameraDevicesFor(osName: String, run: CommandRunner): List<CameraDevice> = when {
-    osName.contains("linux") -> listLinuxCameras()
-    osName.contains("win") -> windowsCamerasFrom(run)
-    osName.contains("mac") -> macCamerasFrom(run)
-    else -> emptyList()
+internal fun cameraDevicesFor(osName: String, run: CommandRunner): List<CameraDevice> =
+    enumerateCameras(osName, run).devices
+
+/**
+ * The cameras this machine has, and how they were found.
+ *
+ * [cameraDevicesFor] is this without the second half, and remains the entry point for everything
+ * that only wants the list. The facts exist so a camera that fails to open can be reported with the
+ * context that explains why — see [CameraEnumerationFacts].
+ *
+ * `ffmpegAvailable` and the timestamp are filled by the impure caller ([listCameraDevices]), not
+ * here: keeping this function a pure fold over the runner's output is what lets the whole
+ * enumeration be driven from a `FakeCommandRunner`.
+ */
+internal fun enumerateCameras(osName: String, run: CommandRunner): CameraListing = when {
+    osName.contains("linux") -> listLinuxCameras().asListing(CameraEnumerator.V4L2_SYSFS)
+    osName.contains("win") -> windowsListing(run)
+    osName.contains("mac") -> macListing(run)
+    else -> emptyList<CameraDevice>().asListing(CameraEnumerator.UNSUPPORTED_OS)
+}
+
+/**
+ * A listing from devices that came from one tool, with the counts filled in from which tool it was.
+ *
+ * A fallback enumerator's devices are counted as [CameraEnumerationFacts.fallbackListedCount] and
+ * ffmpeg's as [CameraEnumerationFacts.ffmpegListedCount], because the question a report has to
+ * answer is which of the two produced the name that failed.
+ */
+private fun List<CameraDevice>.asListing(enumerator: CameraEnumerator): CameraListing {
+    val fromFallback = enumerator == CameraEnumerator.PNP_FALLBACK ||
+        enumerator == CameraEnumerator.SYSTEM_PROFILER_FALLBACK
+    return CameraListing(
+        devices = this,
+        facts = CameraEnumerationFacts(
+            enumerator = enumerator,
+            ffmpegListedCount = if (fromFallback) 0 else size,
+            fallbackListedCount = if (fromFallback) size else 0,
+            deckLinkCount = 0,
+            ffmpegAvailable = false,
+            enumeratedAtMs = 0L,
+            names = mapTo(mutableSetOf()) { it.name.lowercase() },
+        ),
+    )
 }
 
 internal fun listLinuxCameras(
@@ -348,7 +407,10 @@ private const val PNP_QUERY_TIMEOUT_S = 15L
  * This mirrors [parseMacCameras], which resolved the same conflict between ffmpeg and
  * `system_profiler` the same way and for the same reason.
  */
-internal fun windowsCamerasFrom(run: CommandRunner): List<CameraDevice> {
+internal fun windowsCamerasFrom(run: CommandRunner): List<CameraDevice> = windowsListing(run).devices
+
+/** [windowsCamerasFrom], keeping which tool answered. */
+internal fun windowsListing(run: CommandRunner): CameraListing {
     val dshowOutput = run(
         listOf(FfmpegBinary.path, "-list_devices", "true", "-f", "dshow", "-i", "dummy"),
         DSHOW_LIST_TIMEOUT_S,
@@ -356,18 +418,25 @@ internal fun windowsCamerasFrom(run: CommandRunner): List<CameraDevice> {
     val fromDshow = dshowCameras(dshowOutput)
     // Not merely discarded when ffmpeg answered — not run at all. It is the slowest call on this
     // path and the common case has no use for it.
-    if (fromDshow.isNotEmpty()) return fromDshow
+    if (fromDshow.isNotEmpty()) return fromDshow.asListing(CameraEnumerator.DSHOW)
 
     val pnpOutput = run(
         listOf("powershell", "-NoProfile", "-Command", PNP_CAMERA_QUERY),
         PNP_QUERY_TIMEOUT_S,
     ).output
-    return pnpFallbackCameras(pnpOutput)
+    return pnpFallbackCameras(pnpOutput).asListing(CameraEnumerator.PNP_FALLBACK)
 }
 
 /** The pure form of [windowsCamerasFrom]'s decision, which is what the tests drive. */
 internal fun parseWindowsCameras(dshowOutput: String, pnpOutput: String): List<CameraDevice> =
-    dshowCameras(dshowOutput).ifEmpty { pnpFallbackCameras(pnpOutput) }
+    windowsListingOf(dshowOutput, pnpOutput).devices
+
+/** [parseWindowsCameras], keeping which tool answered. */
+internal fun windowsListingOf(dshowOutput: String, pnpOutput: String): CameraListing {
+    val fromDshow = dshowCameras(dshowOutput)
+    return if (fromDshow.isNotEmpty()) fromDshow.asListing(CameraEnumerator.DSHOW)
+    else pnpFallbackCameras(pnpOutput).asListing(CameraEnumerator.PNP_FALLBACK)
+}
 
 /**
  * The devices in ffmpeg's `-list_devices` output, in both shapes it has printed them.
@@ -415,11 +484,14 @@ private fun pnpFallbackCameras(pnpOutput: String): List<CameraDevice> {
 private fun windowsCameraDevice(name: String) =
     CameraDevice(name = name, path = "dshow://:dshow-vdev=$name", displayName = name)
 
-internal fun macCamerasFrom(run: CommandRunner): List<CameraDevice> {
+internal fun macCamerasFrom(run: CommandRunner): List<CameraDevice> = macListing(run).devices
+
+/** [macCamerasFrom], keeping which tool answered. */
+internal fun macListing(run: CommandRunner): CameraListing {
     val profilerOutput = run(listOf("system_profiler", "SPCameraDataType", "-detailLevel", "mini"), 0L).output
     val listDevices = listOf(FfmpegBinary.path, "-f", "avfoundation", "-list_devices", "true", "-i", "")
     val ffmpegOutput = run(listDevices, 0L).output
-    return parseMacCameras(profilerOutput, ffmpegOutput)
+    return macListingOf(profilerOutput, ffmpegOutput)
 }
 
 /** Adds an `[0] Camera name` line from ffmpeg's AVFoundation listing, if it names a new device. */
@@ -495,11 +567,15 @@ private fun systemProfilerCameraNames(systemProfilerOutput: String): List<String
  * they exist so the operator still sees their camera named beside the `canvas_camera_ffmpeg_hint`
  * telling them what to install, rather than an empty list.
  */
-internal fun parseMacCameras(systemProfilerOutput: String, ffmpegOutput: String): List<CameraDevice> {
-    val fromFfmpeg = avfoundationCamerasFrom(ffmpegOutput)
-    if (fromFfmpeg.isNotEmpty()) return fromFfmpeg
+internal fun parseMacCameras(systemProfilerOutput: String, ffmpegOutput: String): List<CameraDevice> =
+    macListingOf(systemProfilerOutput, ffmpegOutput).devices
 
-    return systemProfilerCameraNames(systemProfilerOutput).mapIndexed { index, name ->
-        CameraDevice(name = name, path = "avfoundation://$index", displayName = name)
-    }
+/** [parseMacCameras], keeping which tool answered. */
+internal fun macListingOf(systemProfilerOutput: String, ffmpegOutput: String): CameraListing {
+    val fromFfmpeg = avfoundationCamerasFrom(ffmpegOutput)
+    if (fromFfmpeg.isNotEmpty()) return fromFfmpeg.asListing(CameraEnumerator.AVFOUNDATION)
+
+    return systemProfilerCameraNames(systemProfilerOutput)
+        .mapIndexed { index, name -> CameraDevice(name = name, path = "avfoundation://$index", displayName = name) }
+        .asListing(CameraEnumerator.SYSTEM_PROFILER_FALLBACK)
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
@@ -297,23 +297,90 @@ internal fun listLinuxCameras(
     } catch (_: Exception) { emptyList() }
 }
 
+/**
+ * Camera-class PnP devices, by their friendly name.
+ *
+ * `PNPClass = 'Image'` is deliberately **not** included. It covers flatbed scanners and other
+ * still-image devices, which were being offered to the operator as cameras. What it also covers is
+ * a handful of pre-UVC webcams that register under `Image` rather than `Camera`; losing those is
+ * acceptable because this query is only the fallback below, and on that path nothing is openable
+ * anyway.
+ */
 private const val PNP_CAMERA_QUERY =
-    "Get-CimInstance Win32_PnPEntity | Where-Object { \$_.PNPClass -eq 'Camera' -or " +
-        "\$_.PNPClass -eq 'Image' } | Select-Object -ExpandProperty Name"
+    "Get-CimInstance Win32_PnPEntity | Where-Object { \$_.PNPClass -eq 'Camera' } | " +
+        "Select-Object -ExpandProperty Name"
 
+/**
+ * How long to wait for ffmpeg's DirectShow listing.
+ *
+ * It instantiates and queries every registered DirectShow video filter, so a box carrying an OBS
+ * virtual camera, an NDI filter and a vendor capture driver genuinely takes a couple of seconds.
+ * This is a ceiling for a pathological machine, not a budget.
+ */
+private const val DSHOW_LIST_TIMEOUT_S = 10L
+
+/**
+ * How long to wait for the PnP query.
+ *
+ * More generous than the ffmpeg one because `powershell.exe` costs a second or three to start even
+ * with `-NoProfile`, and `Get-CimInstance Win32_PnPEntity` walks the whole device tree through WMI.
+ * Only ever paid on the fallback path.
+ */
+private const val PNP_QUERY_TIMEOUT_S = 15L
+
+/**
+ * The machine's cameras, preferring ffmpeg's DirectShow listing outright over the PnP one.
+ *
+ * **These two tools do not name devices in the same space, so their results must never be merged.**
+ * ffmpeg enumerates the DirectShow video filters it can open and prints the `FriendlyName` needed to
+ * open one; `Get-CimInstance Win32_PnPEntity` enumerates hardware Windows knows about and prints a
+ * PnP friendly name, which is a label rather than an address. [buildFfmpegCommand] turns whatever is
+ * stored here into `-f dshow -i video=<name>`, so a name ffmpeg never listed produces
+ * "Could not find video device" — which [classifyCameraFfmpegStderr] reads as
+ * `DEVICE_NOT_FOUND`, telling the operator their camera "is no longer connected" about a device that
+ * was never openable in the first place.
+ *
+ * The PnP query is therefore only a fallback for when ffmpeg listed nothing, which in practice means
+ * ffmpeg is not installed. Capture needs ffmpeg too, so those entries can never be opened; they
+ * exist so the operator still sees their camera named beside the `canvas_camera_ffmpeg_required`
+ * hint telling them what to install, rather than an empty list.
+ *
+ * This mirrors [parseMacCameras], which resolved the same conflict between ffmpeg and
+ * `system_profiler` the same way and for the same reason.
+ */
 internal fun windowsCamerasFrom(run: CommandRunner): List<CameraDevice> {
-    val dshowOutput = run(listOf(FfmpegBinary.path, "-list_devices", "true", "-f", "dshow", "-i", "dummy"), 0L).output
-    val pnpOutput = run(listOf("powershell", "-NoProfile", "-Command", PNP_CAMERA_QUERY), 0L).output
-    return parseWindowsCameras(dshowOutput, pnpOutput)
+    val dshowOutput = run(
+        listOf(FfmpegBinary.path, "-list_devices", "true", "-f", "dshow", "-i", "dummy"),
+        DSHOW_LIST_TIMEOUT_S,
+    ).output
+    val fromDshow = dshowCameras(dshowOutput)
+    // Not merely discarded when ffmpeg answered — not run at all. It is the slowest call on this
+    // path and the common case has no use for it.
+    if (fromDshow.isNotEmpty()) return fromDshow
+
+    val pnpOutput = run(
+        listOf("powershell", "-NoProfile", "-Command", PNP_CAMERA_QUERY),
+        PNP_QUERY_TIMEOUT_S,
+    ).output
+    return pnpFallbackCameras(pnpOutput)
 }
 
-internal fun parseWindowsCameras(dshowOutput: String, pnpOutput: String): List<CameraDevice> {
+/** The pure form of [windowsCamerasFrom]'s decision, which is what the tests drive. */
+internal fun parseWindowsCameras(dshowOutput: String, pnpOutput: String): List<CameraDevice> =
+    dshowCameras(dshowOutput).ifEmpty { pnpFallbackCameras(pnpOutput) }
+
+/**
+ * The devices in ffmpeg's `-list_devices` output, in both shapes it has printed them.
+ *
+ * `(none)` counts alongside `(video)`: an untyped capture card is still a camera to us.
+ */
+private fun dshowCameras(dshowOutput: String): List<CameraDevice> {
     val devices = mutableListOf<CameraDevice>()
     val seenNames = mutableSetOf<String>()
 
     fun add(name: String) {
         if (name.lowercase() !in seenNames) {
-            devices.add(CameraDevice(name = name, path = "dshow://:dshow-vdev=$name", displayName = name))
+            devices.add(windowsCameraDevice(name))
             seenNames.add(name.lowercase())
         }
     }
@@ -321,7 +388,6 @@ internal fun parseWindowsCameras(dshowOutput: String, pnpOutput: String): List<C
     val namePattern = Regex("\"(.+?)\"\\s+\\((video|none)\\)")
     var isVideo = false
     for (line in dshowOutput.lines()) {
-
         val newMatch = namePattern.find(line)
         if (newMatch != null) {
             add(newMatch.groupValues[1])
@@ -334,14 +400,20 @@ internal fun parseWindowsCameras(dshowOutput: String, pnpOutput: String): List<C
             Regex("\"(.+?)\"").find(line)?.let { add(it.groupValues[1]) }
         }
     }
-
-    pnpOutput.lines()
-        .map { it.trim() }
-        .filter { it.isNotBlank() }
-        .forEach { add(it) }
-
     return devices
 }
+
+/** The PnP names, when ffmpeg named nothing. Unopenable by construction — see [windowsCamerasFrom]. */
+private fun pnpFallbackCameras(pnpOutput: String): List<CameraDevice> {
+    val seenNames = mutableSetOf<String>()
+    return pnpOutput.lines()
+        .map { it.trim() }
+        .filter { it.isNotBlank() && seenNames.add(it.lowercase()) }
+        .map { windowsCameraDevice(it) }
+}
+
+private fun windowsCameraDevice(name: String) =
+    CameraDevice(name = name, path = "dshow://:dshow-vdev=$name", displayName = name)
 
 internal fun macCamerasFrom(run: CommandRunner): List<CameraDevice> {
     val profilerOutput = run(listOf("system_profiler", "SPCameraDataType", "-detailLevel", "mini"), 0L).output

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumerationFacts.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumerationFacts.kt
@@ -1,0 +1,81 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+/**
+ * Which tool named the cameras a listing is made of.
+ *
+ * The distinction is the whole point: a device ffmpeg named can be opened by that name, and a device
+ * only the platform's own inventory named cannot — see `windowsCamerasFrom` and [parseMacCameras].
+ * When a camera fails, knowing which of those produced it separates "the hardware went away" from
+ * "we offered a name nothing answers to", and those have opposite remedies.
+ */
+internal enum class CameraEnumerator {
+    /** ffmpeg's DirectShow listing, on Windows. Openable. */
+    DSHOW,
+
+    /** The PowerShell PnP inventory, on Windows. Only reached when ffmpeg listed nothing. */
+    PNP_FALLBACK,
+
+    /** ffmpeg's AVFoundation listing, on macOS. Openable. */
+    AVFOUNDATION,
+
+    /** `system_profiler`, on macOS. Only reached when ffmpeg listed nothing. */
+    SYSTEM_PROFILER_FALLBACK,
+
+    /** `/dev/video*` and sysfs, on Linux. Needs no ffmpeg to enumerate. */
+    V4L2_SYSFS,
+
+    /** An OS none of the enumerators has a branch for. */
+    UNSUPPORTED_OS,
+
+    /** Nothing has enumerated in this process yet — a real state on the presenter restore path. */
+    NOT_RUN,
+}
+
+/**
+ * What one enumeration found, in shapes rather than names.
+ *
+ * Exists so a camera that fails to open can be reported with the context that explains *why* — which
+ * tool named it, whether ffmpeg was there at all, how many devices each tool saw. Without this a
+ * report says only "could not open", and the two causes behind issue #462 (ffmpeg absent; ffmpeg
+ * present but the device came from the platform inventory) are indistinguishable, which is what
+ * forced us to ask a reporter to run `ffmpeg -list_devices` by hand.
+ *
+ * Every field except [names] is a count or an enum, and those are what reports carry.
+ */
+internal data class CameraEnumerationFacts(
+    val enumerator: CameraEnumerator,
+    /** How many devices ffmpeg named — DirectShow or AVFoundation. */
+    val ffmpegListedCount: Int,
+    /** How many the fallback inventory named. Non-zero only when ffmpeg named none. */
+    val fallbackListedCount: Int,
+    val deckLinkCount: Int,
+    val ffmpegAvailable: Boolean,
+    val enumeratedAtMs: Long,
+    /**
+     * The device names of this listing, lower-cased.
+     *
+     * **Local only. This never leaves the process, and must never be put in a tag, an extra, or a
+     * message.** It is here for exactly one question — was the device we are failing on in the last
+     * listing at all — whose *answer* is a boolean and is what gets reported. A camera is often
+     * named after the person or room it belongs to, and the reporting stance for this subsystem is
+     * shapes and counts only.
+     */
+    val names: Set<String>,
+)
+
+/** A listing and the facts about how it was produced, returned together so neither can drift. */
+internal data class CameraListing(
+    val devices: List<CameraDevice>,
+    val facts: CameraEnumerationFacts,
+)
+
+/** Facts for a process where enumeration has not run — honest, and itself diagnostic. */
+internal fun notEnumeratedFacts() = CameraEnumerationFacts(
+    enumerator = CameraEnumerator.NOT_RUN,
+    ffmpegListedCount = 0,
+    fallbackListedCount = 0,
+    deckLinkCount = 0,
+    ffmpegAvailable = false,
+    enumeratedAtMs = 0L,
+    names = emptySet(),
+)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraFailureText.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraFailureText.kt
@@ -4,15 +4,18 @@ import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.canvas_camera_error_decklink_in_use
 import churchpresenter.composeapp.generated.resources.canvas_camera_error_device_busy
 import churchpresenter.composeapp.generated.resources.canvas_camera_error_device_not_found
+import churchpresenter.composeapp.generated.resources.canvas_camera_error_device_not_found_windows
+import churchpresenter.composeapp.generated.resources.canvas_camera_error_ffmpeg_missing
 import churchpresenter.composeapp.generated.resources.canvas_camera_error_no_frames
 import churchpresenter.composeapp.generated.resources.canvas_camera_error_permission_denied
+import churchpresenter.composeapp.generated.resources.canvas_camera_error_permission_denied_windows
 import churchpresenter.composeapp.generated.resources.canvas_camera_error_unknown
 import churchpresenter.composeapp.generated.resources.canvas_camera_error_unsupported_format
 import churchpresenter.composeapp.generated.resources.canvas_camera_error_unsupported_framerate
 import org.jetbrains.compose.resources.StringResource
 
 /**
- * What the operator is told about [failure].
+ * What the operator is told about [failure] on [osName].
  *
  * This lives apart from [CameraFailure] itself so the classifier stays free of generated
  * resources — it is a function over ffmpeg's stderr and is tested as one — and apart from the
@@ -20,14 +23,31 @@ import org.jetbrains.compose.resources.StringResource
  *
  * The `when` is exhaustive with no `else` on purpose: a new [CameraFailure] constant should fail
  * to compile here rather than quietly reach the screen as "could not be opened".
+ *
+ * Two failures read differently per platform, because their remedy is a place in that platform's
+ * settings and naming the wrong one is worse than saying nothing. [osName] defaults to the real OS;
+ * tests pass one explicitly rather than faking the system property, which skiko latches.
  */
-internal fun cameraFailureStringRes(failure: CameraFailure): StringResource = when (failure) {
-    CameraFailure.PERMISSION_DENIED -> Res.string.canvas_camera_error_permission_denied
-    CameraFailure.UNSUPPORTED_PIXEL_FORMAT -> Res.string.canvas_camera_error_unsupported_format
-    CameraFailure.UNSUPPORTED_FRAMERATE -> Res.string.canvas_camera_error_unsupported_framerate
-    CameraFailure.DEVICE_BUSY -> Res.string.canvas_camera_error_device_busy
-    CameraFailure.DEVICE_NOT_FOUND -> Res.string.canvas_camera_error_device_not_found
-    CameraFailure.NO_FRAMES -> Res.string.canvas_camera_error_no_frames
-    CameraFailure.DECKLINK_INPUT_IN_USE -> Res.string.canvas_camera_error_decklink_in_use
-    CameraFailure.UNKNOWN -> Res.string.canvas_camera_error_unknown
+internal fun cameraFailureStringRes(
+    failure: CameraFailure,
+    osName: String = System.getProperty("os.name", ""),
+): StringResource {
+    val windows = osName.lowercase().contains("win")
+    return when (failure) {
+        CameraFailure.PERMISSION_DENIED ->
+            if (windows) Res.string.canvas_camera_error_permission_denied_windows
+            else Res.string.canvas_camera_error_permission_denied
+        CameraFailure.UNSUPPORTED_PIXEL_FORMAT -> Res.string.canvas_camera_error_unsupported_format
+        CameraFailure.UNSUPPORTED_FRAMERATE -> Res.string.canvas_camera_error_unsupported_framerate
+        CameraFailure.DEVICE_BUSY -> Res.string.canvas_camera_error_device_busy
+        CameraFailure.DEVICE_NOT_FOUND ->
+            // Windows gets its own sentence because there the likeliest cause is not an unplugged
+            // camera but a name that DirectShow does not answer to — see `windowsCamerasFrom`.
+            if (windows) Res.string.canvas_camera_error_device_not_found_windows
+            else Res.string.canvas_camera_error_device_not_found
+        CameraFailure.NO_FRAMES -> Res.string.canvas_camera_error_no_frames
+        CameraFailure.DECKLINK_INPUT_IN_USE -> Res.string.canvas_camera_error_decklink_in_use
+        CameraFailure.FFMPEG_MISSING -> Res.string.canvas_camera_error_ffmpeg_missing
+        CameraFailure.UNKNOWN -> Res.string.canvas_camera_error_unknown
+    }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFacts.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFacts.kt
@@ -1,0 +1,155 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import org.churchpresenter.core.models.scene.SceneSource
+import org.churchpresenter.diagnostics.CrashReporter
+import java.util.concurrent.atomic.AtomicBoolean
+
+/*
+ * What a camera failure report says about the enumeration behind it.
+ *
+ * Apart from `CameraDiagnostics.kt`, which is about reading ffmpeg's own output, and apart from the
+ * capture cache, which is about opening devices — these are pure functions over what enumeration
+ * found, so the tag vocabulary can be asserted whole in a test without a camera, a process or Sentry.
+ */
+
+
+/** Tag names, in one place so the report and its test cannot drift apart. */
+internal object CameraReportTag {
+    const val FFMPEG = "camera.ffmpeg"
+    const val ENUMERATOR = "camera.enumerator"
+    const val LISTED = "camera.listed"
+    const val DEVICE_LISTED = "camera.device_listed"
+}
+
+/**
+ * What a camera report says about the enumeration behind it, as tags.
+ *
+ * **Tag values are not scrubbed.** `CrashReporter.scrubPii` reaches messages, string extras,
+ * breadcrumbs and contexts — not tags — so every value here is an enum name or a count, and none of
+ * it is derived from what the operator's hardware is called. `CameraReportFactsTest` asserts that.
+ *
+ * Together these settle, from the event alone, which of the two causes behind issue #462 is in play:
+ * `camera.ffmpeg=absent` is one, and `camera.enumerator=pnp_fallback` is the other — the fallback
+ * runs only when ffmpeg listed nothing, so the enumerator name alone proves the DirectShow count was
+ * zero.
+ *
+ * [ffmpegAvailable] is passed rather than read from [facts] because the capture path knows it even
+ * when nothing has enumerated: it has just tested it.
+ */
+internal fun cameraEnumerationTags(
+    facts: CameraEnumerationFacts?,
+    deviceName: String,
+    ffmpegAvailable: Boolean,
+): Map<String, String> {
+    val enumerator = facts?.enumerator ?: CameraEnumerator.NOT_RUN
+    val listed = when (enumerator) {
+        CameraEnumerator.PNP_FALLBACK, CameraEnumerator.SYSTEM_PROFILER_FALLBACK ->
+            facts?.fallbackListedCount ?: 0
+        else -> facts?.ffmpegListedCount ?: 0
+    }
+    return mapOf(
+        CameraReportTag.FFMPEG to if (ffmpegAvailable) "present" else "absent",
+        CameraReportTag.ENUMERATOR to enumerator.name.lowercase(),
+        CameraReportTag.LISTED to listed.toString(),
+        CameraReportTag.DEVICE_LISTED to deviceListedValue(facts, deviceName),
+    )
+}
+
+/**
+ * Whether the device being captured was in the last listing.
+ *
+ * "no" is the interesting answer: a settings file carried from another machine, a camera unplugged
+ * since the picker was opened, or a name nothing answers to. Distinct from "not_enumerated", which
+ * says only that we never looked in this process.
+ */
+private fun deviceListedValue(facts: CameraEnumerationFacts?, deviceName: String): String = when {
+    facts == null || facts.enumerator == CameraEnumerator.NOT_RUN -> "not_enumerated"
+    deviceName.lowercase() in facts.names -> "yes"
+    else -> "no"
+}
+
+/**
+ * The same facts as a readable block, for the report's one extra.
+ *
+ * Counts and enum names only, for the reason given on [cameraEnumerationTags]. An extra *is*
+ * scrubbed, but relying on that for data we chose not to send would be the wrong way round.
+ */
+internal fun cameraEnumerationExtra(
+    facts: CameraEnumerationFacts?,
+    deviceName: String,
+    ffmpegAvailable: Boolean,
+    nowMs: Long = System.currentTimeMillis(),
+): String {
+    val enumerator = facts?.enumerator ?: CameraEnumerator.NOT_RUN
+    val ageSeconds = if (facts == null || facts.enumeratedAtMs <= 0L) "never"
+    else ((nowMs - facts.enumeratedAtMs) / MILLIS_PER_SECOND).toString()
+    return listOf(
+        "enumerator=${enumerator.name.lowercase()}",
+        "ffmpeg=${if (ffmpegAvailable) "present" else "absent"}",
+        "ffmpeg_listed=${facts?.ffmpegListedCount ?: 0}",
+        "fallback_listed=${facts?.fallbackListedCount ?: 0}",
+        "decklink=${facts?.deckLinkCount ?: 0}",
+        "device_listed=${deviceListedValue(facts, deviceName)}",
+        "enumerated_age_s=$ageSeconds",
+    ).joinToString("\n")
+}
+
+private const val MILLIS_PER_SECOND = 1000L
+
+/**
+ * Whether a listing is the "ffmpeg works, Windows sees a camera, ffmpeg does not" state.
+ *
+ * A pure predicate rather than a report call so the decision is testable without standing up Sentry.
+ * All three clauses matter: ffmpeg resolved (so this is not simply a machine without it), the
+ * fallback won (so ffmpeg listed no DirectShow device), and the fallback found something (so this is
+ * not a machine with no camera at all — reporting that would make the operator's own hardware
+ * inventory look like a defect).
+ */
+internal fun shouldReportBlindFfmpeg(facts: CameraEnumerationFacts?): Boolean =
+    facts != null &&
+        facts.ffmpegAvailable &&
+        facts.enumerator == CameraEnumerator.PNP_FALLBACK &&
+        facts.fallbackListedCount > 0
+
+/**
+ * A gate that lets exactly one report through per process.
+ *
+ * For facts that cannot change while the app runs — whether ffmpeg resolved is a `by lazy` — so a
+ * second event would carry nothing the first did not. Atomic because captures start on
+ * `Dispatchers.Default` and two canvas tiles can reach the same gate at once; a plain `var` would
+ * let both through.
+ */
+internal class ReportOnce {
+    private val fired = AtomicBoolean(false)
+
+    /** True the first time only. */
+    fun claim(): Boolean = fired.compareAndSet(false, true)
+}
+
+/**
+ * Says once that a chosen camera cannot open because ffmpeg is not installed.
+ *
+ * Top-level rather than a member of the capture cache so that object stays under its function
+ * threshold, and because it is pure apart from the one report call.
+ *
+ * The title is constant so every affected operator lands in one issue rather than one per machine;
+ * what differs between them is in the tags.
+ */
+internal fun reportCameraFfmpegMissing(
+    source: SceneSource.CameraSource,
+    facts: CameraEnumerationFacts?,
+    gate: ReportOnce,
+) {
+    if (!gate.claim()) return
+    CrashReporter.reportWarning(
+        "Camera: ffmpeg is not installed, so the selected camera cannot be opened",
+        tags = mapOf(
+            "subsystem" to "camera",
+            "device_scheme" to deviceScheme(source.devicePath),
+            "failure_cause" to CameraFailure.FFMPEG_MISSING.name.lowercase(),
+        ) + cameraEnumerationTags(facts, source.deviceName, ffmpegAvailable = false),
+        extras = mapOf(
+            "camera_enumeration" to cameraEnumerationExtra(facts, source.deviceName, ffmpegAvailable = false)
+        )
+    )
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraToolHints.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraToolHints.kt
@@ -1,0 +1,51 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import churchpresenter.composeapp.generated.resources.Res
+import churchpresenter.composeapp.generated.resources.canvas_camera_ffmpeg_required
+import churchpresenter.composeapp.generated.resources.canvas_camera_none_found
+import churchpresenter.composeapp.generated.resources.canvas_camera_v4l2_hint
+import org.jetbrains.compose.resources.StringResource
+
+/**
+ * What to tell the operator about the tools a camera needs, given what enumeration found.
+ *
+ * One function rather than a block of conditions at each picker, because the two pickers disagreed
+ * and one of them was wrong. `CameraPickerRow` only ever mentioned ffmpeg when the device list came
+ * back *empty* — but on Windows without ffmpeg the list is not empty. The PnP fallback fills it with
+ * names that cannot be opened, so the operator saw an ordinary dropdown, picked their camera, and
+ * got a black rectangle with nothing on screen explaining why. That is the shape of the
+ * "USB camera is not detecting" report.
+ *
+ * So the ffmpeg sentence is **not** conditioned on emptiness: on any platform that opens cameras
+ * through ffmpeg, not having it is worth saying whether or not a name happens to be listed.
+ *
+ * [devices] null is "nothing has enumerated yet" and is deliberately distinct from "there are none"
+ * — saying "No cameras found" before anything has looked is a wrong answer that the operator acts
+ * on, and enumeration takes a noticeable moment.
+ *
+ * [ffmpegAvailable] is a parameter rather than a call to [isFfmpegAvailable] so this is a pure
+ * decision a test can drive. `FfmpegBinary` resolves its path in a `by lazy` and must not grow a
+ * mutable seam for testing.
+ */
+internal fun cameraHintStringRes(
+    osName: String,
+    devices: List<CameraDevice>?,
+    ffmpegAvailable: Boolean,
+): List<StringResource> {
+    if (devices == null) return emptyList()
+
+    val os = osName.lowercase()
+    val hints = mutableListOf<StringResource>()
+
+    if (devices.isEmpty()) hints += Res.string.canvas_camera_none_found
+
+    // Linux opens cameras through v4l2 and needs ffmpeg only for virtual devices, so it keeps its
+    // own hint and is never told to install ffmpeg.
+    if (os.contains("linux")) {
+        if (devices.isEmpty()) hints += Res.string.canvas_camera_v4l2_hint
+    } else if (!ffmpegAvailable) {
+        hints += Res.string.canvas_camera_ffmpeg_required
+    }
+
+    return hints
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LivePreviewPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LivePreviewPanel.kt
@@ -43,6 +43,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.layout.ContentScale
@@ -103,6 +105,9 @@ private const val PREVIEW_BACKGROUND = 0xFF121212
 private const val LIVE_BADGE_COLOR = 0xFF2196F3
 private const val LOCK_BADGE_COLOR = 0xFFFFC107
 private const val AUDIO_LEVEL_COLOR = 0xFF4CAF50
+
+/** Half a pulse of the LIVE badge, in milliseconds; it reverses, so a full cycle is twice this. */
+private const val LIVE_PULSE_MS = 550
 
 /**
  * A scaled-down preview of whatever is currently live on the presenter windows.
@@ -295,16 +300,6 @@ private fun SingleDisplayPreview(
     }
 
     val isLive = effectiveMode != Presenting.NONE && showsContent
-    val liveTransition = rememberInfiniteTransition(label = "live")
-    val livePulse by liveTransition.animateFloat(
-        initialValue = 0.70f,
-        targetValue = 1.0f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(550, easing = LinearEasing),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "live_pulse"
-    )
     val borderColor by animateColorAsState(
         targetValue = if (isLive) Color.Red.copy(alpha = 0.85f)
                       else MaterialTheme.colorScheme.outlineVariant,
@@ -522,16 +517,7 @@ private fun SingleDisplayPreview(
 
         // "LIVE" badge — only when this screen is showing content
         if (isLive) {
-            Text(
-                text = stringResource(Res.string.live_preview_title),
-                color = Color.White,
-                fontSize = 10.sp,
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .padding(4.dp)
-                    .background(Color.Red.copy(alpha = livePulse), RoundedCornerShape(3.dp))
-                    .padding(horizontal = 6.dp, vertical = 2.dp)
-            )
+            LiveBadge(Modifier.align(Alignment.TopStart))
         }
 
         // FILL badge when key output is configured
@@ -617,6 +603,46 @@ private fun SingleDisplayPreview(
         }
         }
     }
+}
+
+/**
+ * The pulsing LIVE badge.
+ *
+ * Its own composable, and its own animation, on purpose. The pulse used to be read at the top of
+ * [SingleDisplayPreview]'s scope, which invalidated that whole scope — the nested `PresenterScreen`
+ * and every source under it — on every animation frame, for every output, whether or not the output
+ * was live. With one preview per display, per Browser Source and per NDI output, that was the app
+ * re-rendering all of its outputs twice over at 60fps while sitting idle.
+ *
+ * The alpha is read inside `drawBehind`, so a pulse now costs a redraw of this one badge and no
+ * recomposition at all.
+ */
+@Composable
+private fun LiveBadge(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "live")
+    val pulse = transition.animateFloat(
+        initialValue = 0.70f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(LIVE_PULSE_MS, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "live_pulse"
+    )
+    Text(
+        text = stringResource(Res.string.live_preview_title),
+        color = Color.White,
+        fontSize = 10.sp,
+        modifier = modifier
+            .padding(4.dp)
+            .drawBehind {
+                drawRoundRect(
+                    color = Color.Red.copy(alpha = pulse.value),
+                    cornerRadius = CornerRadius(3.dp.toPx()),
+                )
+            }
+            .padding(horizontal = 6.dp, vertical = 2.dp)
+    )
 }
 
 @Composable

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LoopingVideoBackground.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/LoopingVideoBackground.kt
@@ -1,36 +1,35 @@
 package org.churchpresenter.app.churchpresenter.composables
 
 import androidx.compose.foundation.Image
-import org.churchpresenter.diagnostics.CrashReporter
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.layout.ContentScale
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
-import uk.co.caprica.vlcj.factory.MediaPlayerFactory
-import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormatCallback
-import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormat
-import uk.co.caprica.vlcj.player.embedded.videosurface.callback.RenderCallback
-import uk.co.caprica.vlcj.player.embedded.videosurface.callback.format.RV32BufferFormat
-import java.awt.image.BufferedImage
-import java.awt.image.DataBufferInt
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.churchpresenter.diagnostics.CrashReporter
 import java.io.File
-import java.nio.ByteBuffer
 
-private const val FRAME_INTERVAL_MS = 16L
-private const val SURFACE_ATTACH_MS = 100L
+/** A background is silent; the file may still carry an audio track. */
+private const val SILENT = 0f
 
 /**
- * A self-contained looping video background with no audio.
- * Plays the video at [videoPath] in an infinite loop, filling the available space.
- * Uses VLCJ with software rendering (CallbackVideoSurface) so video frames are
- * rendered as a Compose Image — respecting normal z-order (text draws on top).
+ * A looping video background with no audio, filling the available space.
+ *
+ * Drawn as a Compose `Image` rather than into a native surface so it respects normal z-order —
+ * lyrics and verses draw on top of it.
+ *
+ * The decode itself is [SharedSceneVideoCache]'s, not this composable's. One background is composed
+ * once per presenter output *and* once per sidebar live preview, and every instance used to build
+ * its own `MediaPlayerFactory` and its own player: the same file decoded at full source resolution
+ * once for each place it appeared, and converted to an `ImageBitmap` per instance at 60fps. Two
+ * outputs meant four decodes of one loop. Per-song backgrounds multiply the instance count again.
  */
 @Composable
 fun LoopingVideoBackground(
@@ -40,93 +39,25 @@ fun LoopingVideoBackground(
     val file = remember(videoPath) { File(videoPath) }
     val playable = videoPath.isNotBlank() && file.exists() &&
         isVlcAvailable && !CrashReporter.videoBackgroundsDisabled
-    if (!playable) return
 
-    val currentFrame = remember { mutableStateOf<ImageBitmap?>(null) }
-    val frameVersion = remember { mutableStateOf(0L) }
-    val bufferedImageHolder = remember { mutableStateOf<BufferedImage?>(null) }
-
-    val factory = remember {
-        try { MediaPlayerFactory("--no-video-title-show") } catch (t: Throwable) {
-            CrashReporter.reportException(t, "LoopingVideoBackground: VLC MediaPlayerFactory init failed"); null
-        }
-    } ?: return
-
-    val mediaPlayer = remember(factory) {
-        try { factory.mediaPlayers().newEmbeddedMediaPlayer() } catch (_: Throwable) { null }
-    } ?: return
-
-    // Convert frames off VLC's render thread to avoid blocking its internal pipeline
-    LaunchedEffect(Unit) {
-        var lastVersion = 0L
-        while (isActive) {
-            val v = frameVersion.value
-            if (v != lastVersion) {
-                lastVersion = v
-                val img = bufferedImageHolder.value
-                if (img != null) {
-                    currentFrame.value = img.toComposeImageBitmap()
-                }
-            }
-            delay(FRAME_INTERVAL_MS)
-        }
-    }
-
-    // Set up callback video surface for software rendering
-    DisposableEffect(Unit) {
-        val bufferFormatCallback = object : BufferFormatCallback {
-            override fun getBufferFormat(sourceWidth: Int, sourceHeight: Int): BufferFormat {
-                bufferedImageHolder.value = BufferedImage(sourceWidth, sourceHeight, BufferedImage.TYPE_INT_ARGB)
-                return RV32BufferFormat(sourceWidth, sourceHeight)
-            }
-            override fun allocatedBuffers(buffers: Array<out ByteBuffer>) = Unit
-        }
-
-        // Use RenderCallback directly (not RenderCallbackAdapter) to avoid
-        // the adapter's null dst crash when VLC fires display before buffer allocation.
-        val renderCallback = RenderCallback { player, nativeBuffers, bufferFormat ->
-            val img = bufferedImageHolder.value ?: return@RenderCallback
-            if (nativeBuffers == null || nativeBuffers.isEmpty()) return@RenderCallback
-            val pixelData = (img.raster.dataBuffer as? DataBufferInt)?.data ?: return@RenderCallback
-            try {
-                val buf = nativeBuffers[0] ?: return@RenderCallback
-                buf.rewind()
-                buf.asIntBuffer().get(pixelData, 0, pixelData.size.coerceAtMost(buf.remaining() / 4))
-                frameVersion.value++
-            } catch (_: Throwable) { }
-        }
-
-        mediaPlayer.videoSurface().set(
-            factory.videoSurfaces().newVideoSurface(bufferFormatCallback, renderCallback, true)
-        )
-
+    val spec = remember(videoPath) { SceneVideoSpec(videoPath, loop = true) }
+    var frames by remember { mutableStateOf<StateFlow<ImageBitmap?>?>(null) }
+    DisposableEffect(spec, playable) {
+        if (playable) frames = SharedSceneVideoCache.acquire(spec, SILENT)
         onDispose {
-            try {
-                mediaPlayer.controls().stop()
-                mediaPlayer.release()
-                factory.release()
-            } catch (_: Throwable) { }
+            if (playable) {
+                frames = null
+                SharedSceneVideoCache.release(spec)
+            }
         }
     }
 
-    // Start playback with VLC input-level repeat (loops at demuxer level, no gap)
-    LaunchedEffect(videoPath) {
-        delay(SURFACE_ATTACH_MS) // let video surface attach
-        try {
-            mediaPlayer.audio().setVolume(0)
-            mediaPlayer.media().play(
-                file.absolutePath,
-                ":file-caching=10000",
-                ":network-caching=10000",
-                ":input-repeat=65535"
-            )
-        } catch (_: Throwable) { }
-    }
+    val noFrame = remember { MutableStateFlow<ImageBitmap?>(null) }
+    val frame by (frames ?: noFrame).collectAsState()
 
-    // Render current frame as a regular Compose Image (respects z-order)
-    currentFrame.value?.let { frame ->
+    frame?.let {
         Image(
-            bitmap = frame,
+            bitmap = it,
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = modifier

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/NdiFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/NdiFrameCache.kt
@@ -106,6 +106,7 @@ open class NdiFrameCache(
     @Synchronized
     fun acquire(source: SceneSource.NdiSource): NdiFlows {
         val entry = entries.getOrPut(keyFor(source)) { CacheEntry() }
+        ResourceCensus.record(SharedResource.NDI_RECEIVER, entries.size)
         entry.refCount++
         if (entry.refCount == 1) {
             entry.captureJob = scope.launch { capture(source, entry) }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/NdiFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/NdiFrameCache.kt
@@ -137,7 +137,11 @@ open class NdiFrameCache(
     // same throw uncaught takes down the coroutine that would have closed the receiver, mid-service.
     @Suppress("TooGenericExceptionCaught")
     private suspend fun capture(source: SceneSource.NdiSource, entry: CacheEntry) {
-        val receiver = withContext(Dispatchers.IO) {
+        // NonCancellable around the open for the same reason the close below has it: the last layer
+        // can let go while the receiver is still being opened, and a cancellable open throws out of
+        // here with the native receiver already alive and nothing holding it — the sender goes on
+        // encoding for a subscriber that no longer exists.
+        val receiver = withContext(NonCancellable + Dispatchers.IO) {
             openReceiver(infoFor(source), NdiBandwidth.of(source.lowBandwidth))?.takeIf { it.open() }
         }
         if (receiver == null) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ResourceCensus.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ResourceCensus.kt
@@ -1,0 +1,103 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import org.churchpresenter.diagnostics.CrashReporter
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A native resource the app holds open on someone else's behalf, and shares between the places that
+ * draw it.
+ *
+ * Every one of these is a refcounted cache entry that owns something outside the JVM — an ffmpeg
+ * process, a libvlc decoder, a Chromium process, an NDI receiver, a screen-grab loop. That is the
+ * point of the list: **a JVM heap chart cannot see any of them**, so the ordinary memory telemetry
+ * that would be reached for first is blind to exactly the leaks this app is prone to.
+ */
+internal enum class SharedResource {
+    CAMERA_CAPTURE,
+    VIDEO_DECODE,
+    SCREEN_GRAB,
+    NDI_RECEIVER,
+    BROWSER_SOURCE,
+}
+
+/**
+ * The high-water mark of each shared native resource, and whether it looks like a leak.
+ *
+ * **Why a census of counts rather than CPU or memory.** Three leaks were found in this area in one
+ * week — a leaked ffmpeg process holding a camera, a leaked libvlc decoder, and a leaked headless
+ * browser on every viewport resize. All three leak a *process or a native handle*, so a heap gauge
+ * stays flat through all of them, and CPU is no better: a busy canvas legitimately costs a lot, and
+ * without a per-machine baseline "expensive" and "three times more expensive than it should be" look
+ * identical.
+ *
+ * What all three have in common is a count that goes up and does not come down. That is cheap to
+ * watch, carries nothing about the operator, and is specific to the failure this app actually has.
+ *
+ * The peak is recorded rather than the live value because the moment of shutdown is not when a leak
+ * is visible — a leak is visible in how high the count climbed while the service ran.
+ */
+internal object ResourceCensus {
+
+    private val peaks = ConcurrentHashMap<SharedResource, Int>()
+
+    /**
+     * Notes that [liveCount] entries of [resource] were open at once.
+     *
+     * Called from each cache's `acquire` after the entry is added, which is the only moment the
+     * count can rise.
+     */
+    fun record(resource: SharedResource, liveCount: Int) {
+        peaks.merge(resource, liveCount, ::maxOf)
+    }
+
+    internal fun peak(resource: SharedResource): Int = peaks[resource] ?: 0
+
+    internal fun snapshot(): Map<SharedResource, Int> =
+        SharedResource.entries.associateWith { peak(it) }
+
+    /** Tests share one JVM, and this is process-global state. */
+    internal fun reset() = peaks.clear()
+
+    private val reported = ReportOnce()
+
+    /**
+     * Reports the census once, at shutdown, and only when it looks like a leak.
+     *
+     * Not a metric on every run: a report that arrives from every install is a number nobody reads,
+     * and the shape worth knowing is the tail. [looksLikeLeak] carries the judgement.
+     */
+    fun reportIfLeaky() {
+        val counts = snapshot()
+        if (!looksLikeLeak(counts)) return
+        if (!reported.claim()) return
+        CrashReporter.reportWarning(
+            "Shared native resources climbed higher than a scene can explain",
+            tags = mapOf("subsystem" to "resource_census") +
+                counts.mapKeys { (resource, _) -> "census.${resource.name.lowercase()}" }
+                    .mapValues { (_, peak) -> peak.toString() },
+            extras = mapOf("census" to renderCensus(counts)),
+        )
+    }
+}
+
+/**
+ * The most of one shared resource a real setup can be holding at once.
+ *
+ * Not a tuning knob and not a performance threshold — those are the ones that fire on a merely busy
+ * machine and get muted. This is a bound on *distinct native handles*, and the entries are keyed by
+ * what they open: one per camera device, one per video file, one per capture region, one per NDI
+ * source, one per browser viewport. A schedule reaching eight simultaneous distinct video decodes is
+ * not a booth that is working hard; it is a count that stopped coming down.
+ *
+ * Deliberately generous. A false negative costs one undetected leak, which is where we already were;
+ * a false positive costs a report that trains everyone to ignore the next one.
+ */
+private const val IMPLAUSIBLE_LIVE_COUNT = 8
+
+/** Whether any resource climbed past what a scene can account for. Pure, so it can be tested. */
+internal fun looksLikeLeak(peaks: Map<SharedResource, Int>): Boolean =
+    peaks.values.any { it >= IMPLAUSIBLE_LIVE_COUNT }
+
+/** The census as a readable block. Counts only — there is nothing here to redact. */
+internal fun renderCensus(peaks: Map<SharedResource, Int>): String =
+    SharedResource.entries.joinToString("\n") { "${it.name.lowercase()}=${peaks[it] ?: 0}" }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneDeviceEditors.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneDeviceEditors.kt
@@ -20,10 +20,7 @@ import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.canvas_source_camera
 import churchpresenter.composeapp.generated.resources.canvas_source_screen_capture
 import churchpresenter.composeapp.generated.resources.canvas_camera_device
-import churchpresenter.composeapp.generated.resources.canvas_camera_ffmpeg_hint
 import churchpresenter.composeapp.generated.resources.canvas_camera_open_privacy_settings
-import churchpresenter.composeapp.generated.resources.canvas_camera_v4l2_hint
-import churchpresenter.composeapp.generated.resources.canvas_camera_none_found
 import churchpresenter.composeapp.generated.resources.canvas_camera_refresh
 import churchpresenter.composeapp.generated.resources.canvas_camera_format
 import churchpresenter.composeapp.generated.resources.canvas_camera_format_auto
@@ -199,7 +196,6 @@ internal fun CameraProperties(source: SceneSource.CameraSource, onUpdate: (Scene
 
     val deckLinkDeviceFormat = stringResource(Res.string.canvas_decklink_device)
     var devices by remember { mutableStateOf(listCameraDevicesWithDeckLink(deckLinkDeviceFormat)) }
-    val noCamerasLabel = stringResource(Res.string.canvas_camera_none_found)
 
     Button(
         onClick = { devices = listCameraDevicesWithDeckLink(deckLinkDeviceFormat) },
@@ -313,34 +309,54 @@ internal fun CameraProperties(source: SceneSource.CameraSource, onUpdate: (Scene
                 modifier = Modifier.fillMaxWidth()
             )
         }
-    } else {
-        Text(
-            noCamerasLabel,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
-        )
     }
 
     val osName = System.getProperty("os.name", "").lowercase()
-    if (osName.contains("linux") && devices.isEmpty()) {
+    // Probed off the composition thread: `isFfmpegAvailable()` runs `ffmpeg -version` against each
+    // candidate install path in turn, with a five-second timeout each. It starts `true` so the
+    // "install ffmpeg" sentence never flashes up on a machine that has it.
+    var ffmpegAvailable by remember { mutableStateOf(true) }
+    LaunchedEffect(Unit) { ffmpegAvailable = withContext(Dispatchers.IO) { isFfmpegAvailable() } }
+
+    CameraToolHints(osName, devices, ffmpegAvailable)
+
+    if (osName.contains("mac") || osName.contains("darwin")) {
+        MacCameraPrivacyHint()
+    }
+    if (osName.contains("win")) {
+        WindowsCameraPrivacyHint()
+    }
+}
+
+/** Whatever [cameraHintStringRes] decides is worth saying about this machine's camera tooling. */
+@Composable
+private fun CameraToolHints(osName: String, devices: List<CameraDevice>?, ffmpegAvailable: Boolean) {
+    cameraHintStringRes(osName, devices, ffmpegAvailable).forEach { hint ->
         Text(
-            stringResource(Res.string.canvas_camera_v4l2_hint),
+            stringResource(hint),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
-    if (!osName.contains("linux")) {
-        val ffmpegAvailable by remember { mutableStateOf(isFfmpegAvailable()) }
-        if (!ffmpegAvailable) {
-            Text(
-                stringResource(Res.string.canvas_camera_ffmpeg_hint),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        }
-    }
-    if (osName.contains("mac") || osName.contains("darwin")) {
-        MacCameraPrivacyHint()
+}
+
+/** The Windows Camera privacy page, opened for the same reason as [MAC_CAMERA_PRIVACY_URI]. */
+internal const val WINDOWS_CAMERA_PRIVACY_URI = "ms-settings:privacy-webcam"
+
+/**
+ * The way out of a privacy refusal on Windows — the twin of [MacCameraPrivacyHint], and there for
+ * the same reasons, which are written out at that one.
+ *
+ * Windows has two separate switches on that page (camera access at all, and desktop apps in
+ * particular) and blocks with either off, which is why the button leads there rather than the text
+ * trying to describe the sequence.
+ */
+@Composable
+private fun WindowsCameraPrivacyHint(
+    onOpenPrivacySettings: () -> Unit = { UrlOpener.open(WINDOWS_CAMERA_PRIVACY_URI) },
+) {
+    Button(onClick = onOpenPrivacySettings, modifier = Modifier.fillMaxWidth()) {
+        Text(stringResource(Res.string.canvas_camera_open_privacy_settings), fontSize = 12.sp)
     }
 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneDeviceEditors.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneDeviceEditors.kt
@@ -8,9 +8,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -198,11 +200,21 @@ internal fun CameraProperties(source: SceneSource.CameraSource, onUpdate: (Scene
     )
 
     val deckLinkDeviceFormat = stringResource(Res.string.canvas_decklink_device)
-    var devices by remember { mutableStateOf(listCameraDevicesWithDeckLink(deckLinkDeviceFormat)) }
     val noCamerasLabel = stringResource(Res.string.canvas_camera_none_found)
 
+    // Through the catalog, never `listCameraDevicesWithDeckLink` directly: that shells out to
+    // ffmpeg, and on Windows to a PowerShell `Get-CimInstance` as well, so calling it from
+    // composition — or from a click handler — blocked the UI thread for as long as those took. A
+    // panel that hangs the app for seconds every time a camera source is selected is the reported
+    // "Canvas tab is very hanging"; the catalog does the same work on IO and caches it.
+    val known by CameraDeviceCatalog.devices.collectAsState()
+    val devices = known.orEmpty()
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(deckLinkDeviceFormat) { CameraDeviceCatalog.refresh(deckLinkDeviceFormat) }
+
     Button(
-        onClick = { devices = listCameraDevicesWithDeckLink(deckLinkDeviceFormat) },
+        onClick = { scope.launch { CameraDeviceCatalog.refresh(deckLinkDeviceFormat) } },
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(8.dp)
     ) {
@@ -313,7 +325,9 @@ internal fun CameraProperties(source: SceneSource.CameraSource, onUpdate: (Scene
                 modifier = Modifier.fillMaxWidth()
             )
         }
-    } else {
+    } else if (known != null) {
+        // `known` null means the first enumeration has not answered yet, which is not the same as
+        // "this machine has no camera" and must not be shown as it.
         Text(
             noCamerasLabel,
             style = MaterialTheme.typography.bodySmall,
@@ -322,7 +336,7 @@ internal fun CameraProperties(source: SceneSource.CameraSource, onUpdate: (Scene
     }
 
     val osName = System.getProperty("os.name", "").lowercase()
-    if (osName.contains("linux") && devices.isEmpty()) {
+    if (osName.contains("linux") && known != null && devices.isEmpty()) {
         Text(
             stringResource(Res.string.canvas_camera_v4l2_hint),
             style = MaterialTheme.typography.bodySmall,
@@ -330,8 +344,11 @@ internal fun CameraProperties(source: SceneSource.CameraSource, onUpdate: (Scene
         )
     }
     if (!osName.contains("linux")) {
-        val ffmpegAvailable by remember { mutableStateOf(isFfmpegAvailable()) }
-        if (!ffmpegAvailable) {
+        // Also off the composition thread: the probe runs `ffmpeg -version`, with a five-second
+        // timeout, against each candidate install path in turn.
+        var ffmpegMissing by remember { mutableStateOf(false) }
+        LaunchedEffect(Unit) { ffmpegMissing = !withContext(Dispatchers.IO) { isFfmpegAvailable() } }
+        if (ffmpegMissing) {
             Text(
                 stringResource(Res.string.canvas_camera_ffmpeg_hint),
                 style = MaterialTheme.typography.bodySmall,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneSourceRenderer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneSourceRenderer.kt
@@ -2,7 +2,6 @@ package org.churchpresenter.app.churchpresenter.composables
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import org.churchpresenter.diagnostics.CrashReporter
 import org.churchpresenter.app.churchpresenter.utils.PictureDecoder
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -59,7 +58,6 @@ import org.churchpresenter.core.models.scene.ClockModes
 import org.churchpresenter.core.models.scene.SceneSource
 import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
 import org.churchpresenter.app.churchpresenter.utils.WindowsWindowCapture
-import org.churchpresenter.app.churchpresenter.utils.X11WindowCapture
 import org.churchpresenter.app.churchpresenter.utils.Utils.systemFontFamilyOrDefault
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -72,21 +70,12 @@ import com.google.zxing.BarcodeFormat
 import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
 import com.google.zxing.qrcode.decoder.ErrorCorrectionLevel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import java.awt.Rectangle
-import java.awt.Robot
 import java.awt.image.BufferedImage
-import java.awt.image.DataBufferInt
-import java.nio.ByteBuffer
-import uk.co.caprica.vlcj.factory.MediaPlayerFactory
-import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormatCallback
-import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormat
-import uk.co.caprica.vlcj.player.embedded.videosurface.callback.RenderCallback
-import uk.co.caprica.vlcj.player.embedded.videosurface.callback.format.RV32BufferFormat
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 import java.time.LocalTime
@@ -104,9 +93,6 @@ import androidx.compose.ui.graphics.StrokeJoin
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.drawscope.Stroke
 
-private const val FRAME_INTERVAL_MS = 16L
-private const val PLAYER_SETTLE_MS = 100L
-private const val VOLUME_PERCENT_SCALE = 100
 private const val URL_DEBOUNCE_MS = 800L
 private const val ERROR_TEXT_COLOR = 0xFFFF8888
 private const val POLL_INTERVAL_MS = 1000L
@@ -118,16 +104,10 @@ private const val PERCENT_SCALE = 100f
 private const val MAX_CURVE_TURNS = 2f
 /** How much room a bent reference line gets: its own height, plus the room the bend needs. */
 private const val REFERENCE_ROWS = 3f
-private const val MIN_CAPTURE_INTERVAL_MS = 33L
 private const val WINDOW_BOUNDS_FIELDS = 4
 private const val BOUNDS_WIDTH_INDEX = 2
 private const val BOUNDS_HEIGHT_INDEX = 3
 
-// libvlc media options. Written out per branch rather than collected into a list and spread: play()
-// is a Java vararg, so a spread copies the array on every call, and building the list allocated one
-// more object again for what is at most two constant strings.
-private const val VLC_OPT_TIGHT_CLOCK = ":clock-jitter=0"
-private const val VLC_OPT_LOOP = ":input-repeat=65535"
 
 /**
  * Draws one scene source.
@@ -355,83 +335,29 @@ private fun VideoSourceContent(
         return
     }
 
-    val currentFrame = remember { mutableStateOf<ImageBitmap?>(null) }
-    val frameVersion = remember { mutableStateOf(0L) }
-    val bufferedImageHolder = remember { mutableStateOf<BufferedImage?>(null) }
-
-    val factory = remember {
-        try { MediaPlayerFactory("--no-video-title-show") } catch (t: Throwable) {
-            CrashReporter.reportException(t, "SceneSourceRenderer: VLC MediaPlayerFactory init failed"); null
-        }
-    } ?: return
-
-    val mediaPlayer = remember(factory) {
-        try { factory.mediaPlayers().newEmbeddedMediaPlayer() } catch (_: Throwable) { null }
-    } ?: return
-
-    // Convert frames off VLC's render thread to avoid blocking audio pipeline
-    LaunchedEffect(Unit) {
-        var lastVersion = 0L
-        while (isActive) {
-            val v = frameVersion.value
-            if (v != lastVersion) {
-                lastVersion = v
-                val img = bufferedImageHolder.value
-                if (img != null) {
-                    currentFrame.value = img.toComposeImageBitmap()
-                }
-            }
-            delay(FRAME_INTERVAL_MS)
-        }
-    }
-
-    DisposableEffect(source.filePath) {
-        val bufferFormatCallback = object : BufferFormatCallback {
-            override fun getBufferFormat(sourceWidth: Int, sourceHeight: Int): BufferFormat {
-                bufferedImageHolder.value = BufferedImage(sourceWidth, sourceHeight, BufferedImage.TYPE_INT_ARGB)
-                return RV32BufferFormat(sourceWidth, sourceHeight)
-            }
-            override fun allocatedBuffers(buffers: Array<out ByteBuffer>) = Unit
-        }
-
-        val renderCallback = RenderCallback { _, nativeBuffers, _ ->
-            val img = bufferedImageHolder.value ?: return@RenderCallback
-            if (nativeBuffers == null || nativeBuffers.isEmpty()) return@RenderCallback
-            val pixelData = (img.raster.dataBuffer as? DataBufferInt)?.data ?: return@RenderCallback
-            try {
-                val buf = nativeBuffers[0] ?: return@RenderCallback
-                buf.rewind()
-                buf.asIntBuffer().get(pixelData, 0, pixelData.size.coerceAtMost(buf.remaining() / 4))
-                frameVersion.value++
-            } catch (_: Throwable) { }
-        }
-
-        mediaPlayer.videoSurface().set(
-            factory.videoSurfaces().newVideoSurface(bufferFormatCallback, renderCallback, true)
-        )
-
+    // Through the shared cache: this composable is mounted once in the canvas editor, once in each
+    // sidebar live preview and once on each presenter output, and each instance used to build its
+    // own VLC factory, its own player and its own conversion loop — decoding the same file that
+    // many times, and playing its audio that many times over itself.
+    val spec = remember(source.filePath, source.loop) { SceneVideoSpec(source.filePath, source.loop) }
+    var frames by remember { mutableStateOf<StateFlow<ImageBitmap?>?>(null) }
+    DisposableEffect(spec) {
+        frames = SharedSceneVideoCache.acquire(spec, source.volume)
         onDispose {
-            try {
-                mediaPlayer.controls().stop()
-                mediaPlayer.release()
-                factory.release()
-            } catch (_: Throwable) { }
+            frames = null
+            SharedSceneVideoCache.release(spec)
         }
     }
+    // Volume is not part of the key, so a change reaches the running decode without restarting it.
+    LaunchedEffect(spec, source.volume) { SharedSceneVideoCache.setVolume(spec, source.volume) }
 
-    LaunchedEffect(source.filePath, source.loop, source.volume) {
-        delay(PLAYER_SETTLE_MS)
-        try {
-            mediaPlayer.audio().setVolume((source.volume * VOLUME_PERCENT_SCALE).toInt())
-            if (source.loop) mediaPlayer.media().play(file.absolutePath, VLC_OPT_TIGHT_CLOCK, VLC_OPT_LOOP)
-            else mediaPlayer.media().play(file.absolutePath, VLC_OPT_TIGHT_CLOCK)
-        } catch (_: Throwable) { }
-    }
+    val noFrame = remember { MutableStateFlow<ImageBitmap?>(null) }
+    val frame by (frames ?: noFrame).collectAsState()
 
-    val frame = currentFrame.value
-    if (frame != null) {
+    val shown = frame
+    if (shown != null) {
         Image(
-            bitmap = frame,
+            bitmap = shown,
             contentDescription = source.name,
             contentScale = ContentScale.Fit,
             modifier = modifier.fillMaxSize()
@@ -1022,39 +948,19 @@ private fun NdiPlaceholder(text: String, modifier: Modifier) {
 
 @Composable
 private fun ScreenCaptureSourceContent(source: SceneSource.ScreenCaptureSource, modifier: Modifier) {
-    var frame by remember { mutableStateOf<ImageBitmap?>(null) }
-
-    LaunchedEffect(source.captureMode, source.captureX, source.captureY, source.captureWidth, source.captureHeight, source.captureInterval, source.windowTitle, source.windowId) {
-        try {
-            val robot = Robot()
-            while (isActive) {
-                val capture: BufferedImage? = if (source.captureMode == "window" && source.windowId.isNotBlank()) {
-                    withContext(Dispatchers.IO) {
-                        val wid = source.windowId.removePrefix("0x").toLongOrNull(16) ?: 0L
-                        // Try platform-specific occluded capture, fall back to Robot + bounds
-                        WindowsWindowCapture.captureWindow(wid)
-                            ?: X11WindowCapture.captureWindow(wid)
-                            ?: run {
-                                val rect = findWindowBounds(source.windowTitle)
-                                if (rect != null && rect.width > 0 && rect.height > 0) robot.createScreenCapture(rect) else null
-                            }
-                    }
-                } else if (source.captureMode == "window" && source.windowTitle.isNotBlank()) {
-                    val rect = withContext(Dispatchers.IO) { findWindowBounds(source.windowTitle) }
-                    if (rect != null && rect.width > 0 && rect.height > 0) robot.createScreenCapture(rect) else null
-                } else {
-                    val rect = Rectangle(source.captureX, source.captureY, source.captureWidth, source.captureHeight)
-                    if (rect.width > 0 && rect.height > 0) robot.createScreenCapture(rect) else null
-                }
-                if (capture != null) {
-                    frame = capture.toComposeImageBitmap()
-                }
-                delay(source.captureInterval.toLong().coerceAtLeast(MIN_CAPTURE_INTERVAL_MS))
-            }
-        } catch (_: Exception) {
-            // Robot may fail in headless/restricted environments
+    // Through the shared cache: this composable is mounted once in the canvas editor, once in each
+    // sidebar live preview and once on each presenter output, and each instance used to run its own
+    // `Robot.createScreenCapture` loop over the same pixels at up to 30fps.
+    var frames by remember { mutableStateOf<StateFlow<ImageBitmap?>?>(null) }
+    DisposableEffect(ScreenCaptureSpec.of(source)) {
+        frames = SharedScreenCaptureCache.acquire(source)
+        onDispose {
+            frames = null
+            SharedScreenCaptureCache.release(source)
         }
     }
+    val noFrame = remember { MutableStateFlow<ImageBitmap?>(null) }
+    val frame by (frames ?: noFrame).collectAsState()
 
     Box(
         modifier = modifier.fillMaxSize().background(Color.Black),
@@ -1074,7 +980,7 @@ private fun ScreenCaptureSourceContent(source: SceneSource.ScreenCaptureSource, 
     }
 }
 
-private fun findWindowBounds(windowTitle: String): Rectangle? =
+internal fun findWindowBounds(windowTitle: String): Rectangle? =
     windowBoundsFor(System.getProperty("os.name", "").lowercase(), windowTitle, ::readCommandOutput)
 
 /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneSourceRenderer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneSourceRenderer.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.MutableStateFlow
 import java.awt.Rectangle
 import java.awt.Robot
 import java.awt.image.BufferedImage
@@ -460,15 +461,19 @@ private fun BrowserSourceContent(
         return
     }
 
-    // Only re-create browser when id or viewport size changes
-    val browserFlows = remember(source.id, source.renderWidth, source.renderHeight) {
-        SharedBrowserFrameCache.acquire(
+    // Only re-create browser when id or viewport size changes.
+    //
+    // Acquired in the effect, for the reason spelled out in [CameraSourceContent] — and here the
+    // dispose keys used to be narrower than the acquire keys, so a resize acquired a second time
+    // and released neither. That leaked a whole headless browser per resize.
+    var browserFlows by remember { mutableStateOf<SharedBrowserFrameCache.BrowserFlows?>(null) }
+    DisposableEffect(source.id, source.renderWidth, source.renderHeight) {
+        browserFlows = SharedBrowserFrameCache.acquire(
             source.id, source.url, source.renderWidth, source.renderHeight,
             source.customCss, source.fps, source.forceTransparent
         )
-    }
-    DisposableEffect(source.id) {
         onDispose {
+            browserFlows = null
             SharedBrowserFrameCache.release(source.id)
         }
     }
@@ -491,8 +496,10 @@ private fun BrowserSourceContent(
         SharedBrowserFrameCache.setFps(source.id, source.fps)
     }
 
-    val frame by browserFlows.frame.collectAsState()
-    val error by browserFlows.error.collectAsState()
+    val noFrame = remember { MutableStateFlow<ImageBitmap?>(null) }
+    val noError = remember { MutableStateFlow<String?>(null) }
+    val frame by (browserFlows?.frame ?: noFrame).collectAsState()
+    val error by (browserFlows?.error ?: noError).collectAsState()
 
     if (frame != null) {
         Image(
@@ -906,18 +913,28 @@ private fun CameraSourceContent(
         return
     }
 
-    // Use shared cache so canvas preview and presenter output share one capture process
-    val cameraFlows = remember(source.devicePath, source.videoFormat, source.videoConnection, source.deckLinkIndex) {
-        SharedCameraFrameCache.acquire(source)
-    }
+    // Use shared cache so canvas preview and presenter output share one capture process.
+    //
+    // Acquired in the effect rather than in `remember`: a composition that is abandoned before its
+    // effects run still discards what `remember` produced, and it does so without calling any
+    // `onDispose`. Acquiring there leaked the refcount — and with it the ffmpeg process holding the
+    // device open, which the *next* acquire then found busy. That is the reported
+    // "Error opening input: Input/output error" on a camera nothing else is using.
+    var cameraFlows by remember { mutableStateOf<SharedCameraFrameCache.CameraFlows?>(null) }
     DisposableEffect(source.devicePath, source.videoFormat, source.videoConnection, source.deckLinkIndex) {
+        cameraFlows = SharedCameraFrameCache.acquire(source)
         onDispose {
+            cameraFlows = null
             SharedCameraFrameCache.release(source)
         }
     }
 
-    val frame by cameraFlows.frame.collectAsState()
-    val error by cameraFlows.error.collectAsState()
+    // Stand-ins for the one composition pass before the effect has acquired: collecting needs a
+    // flow, and a conditional `collectAsState` would move with the acquire.
+    val noFrame = remember { MutableStateFlow<ImageBitmap?>(null) }
+    val noFailure = remember { MutableStateFlow<CameraFailure?>(null) }
+    val frame by (cameraFlows?.frame ?: noFrame).collectAsState()
+    val error by (cameraFlows?.error ?: noFailure).collectAsState()
 
     if (frame != null) {
         Image(
@@ -958,15 +975,20 @@ private fun NdiSourceContent(source: SceneSource.NdiSource, modifier: Modifier) 
         return
     }
 
-    val flows = remember(source.sourceName, source.sourceAddress, source.lowBandwidth) {
-        SharedNdiFrameCache.acquire(source)
-    }
+    // Acquired in the effect, for the reason spelled out in [CameraSourceContent].
+    var flows by remember { mutableStateOf<NdiFrameCache.NdiFlows?>(null) }
     DisposableEffect(source.sourceName, source.sourceAddress, source.lowBandwidth) {
-        onDispose { SharedNdiFrameCache.release(source) }
+        flows = SharedNdiFrameCache.acquire(source)
+        onDispose {
+            flows = null
+            SharedNdiFrameCache.release(source)
+        }
     }
 
-    val frame by flows.frame.collectAsState()
-    val connected by flows.connected.collectAsState()
+    val noFrame = remember { MutableStateFlow<ImageBitmap?>(null) }
+    val notConnected = remember { MutableStateFlow(false) }
+    val frame by (flows?.frame ?: noFrame).collectAsState()
+    val connected by (flows?.connected ?: notConnected).collectAsState()
     val label = source.sourceName.ifBlank { source.sourceAddress }
 
     val shown = frame

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneVideoCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneVideoCache.kt
@@ -1,0 +1,285 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.churchpresenter.diagnostics.CrashReporter
+import uk.co.caprica.vlcj.factory.MediaPlayerFactory
+import uk.co.caprica.vlcj.player.embedded.EmbeddedMediaPlayer
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormat
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormatCallback
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.RenderCallback
+import uk.co.caprica.vlcj.player.embedded.videosurface.callback.format.RV32BufferFormat
+import java.awt.image.BufferedImage
+import java.awt.image.DataBufferInt
+import java.io.File
+import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/** How often the shared conversion loop looks for a new decoded frame — about 60fps. */
+private const val VIDEO_POLL_MS = 16L
+
+/** Let the video surface attach before asking the player to play. */
+private const val PLAYER_SETTLE_MS = 100L
+
+private const val VOLUME_PERCENT_SCALE = 100
+private const val BYTES_PER_PIXEL = 4
+
+// libvlc media options, written out per branch rather than spread from a list: play() is a Java
+// vararg, so a spread copies the array on every call.
+private const val VLC_OPT_TIGHT_CLOCK = ":clock-jitter=0"
+private const val VLC_OPT_LOOP = ":input-repeat=65535"
+
+/**
+ * Which decode two layers must agree on to share one.
+ *
+ * Volume is deliberately **not** part of it. Two layers of one file at different volumes are still
+ * one decode — the picture is identical and only the audio differs — and keying on it would both
+ * decode the file twice and restart playback on every drag of a volume slider.
+ */
+internal data class SceneVideoSpec(val filePath: String, val loop: Boolean)
+
+/**
+ * One decoded video, however many layers are drawing it.
+ *
+ * [frameVersion] is bumped by the decoder each time it writes a new picture into [frame]; the cache
+ * polls it rather than being pushed, so conversion happens on the cache's own coroutine and never
+ * on the decoder's render thread — blocking that stalls the audio pipeline.
+ */
+internal interface SceneVideoHandle {
+    val frameVersion: Long
+    val frame: BufferedImage?
+    fun setVolume(percent: Int)
+    fun close()
+}
+
+/**
+ * One decode per video file, however many layers draw it.
+ *
+ * The third of the canvas's shared caches, and the one that costs the most. A video layer is
+ * composed once in the canvas editor, once in each sidebar live preview and once on each presenter
+ * output, and every one of those instances used to build **its own** `MediaPlayerFactory`, its own
+ * player and its own conversion loop — decoding the same file at full source resolution that many
+ * times over, and converting every frame to an `ImageBitmap` per instance at 60fps.
+ *
+ * It also played the audio that many times. Nothing mixed those streams; they simply overlapped.
+ *
+ * Reference counted like [SharedCameraFrameCache] and [NdiFrameCache]: the first layer to want a
+ * file starts the decode, the last one to let go stops it.
+ *
+ * [openPlayer] is the seam — a test supplies one that hands back frames without libvlc, which is
+ * not present in the test JVM. A constructor parameter, not the ad-hoc mutable `internal var` on a
+ * singleton that AGENT.md rules out.
+ */
+internal open class SceneVideoCache(
+    private val openPlayer: (SceneVideoSpec) -> SceneVideoHandle?,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val entries = mutableMapOf<SceneVideoSpec, CacheEntry>()
+
+    private class CacheEntry {
+        val frame = MutableStateFlow<ImageBitmap?>(null)
+        var refCount = 0
+        var job: Job? = null
+        var handle: SceneVideoHandle? = null
+
+        /**
+         * The volume the layers want, held whether or not a player exists yet.
+         *
+         * Opening is asynchronous, so the first `acquire` almost always names its volume before
+         * there is anything to set it on. Without somewhere to keep it that setting was simply
+         * dropped and the file played at the decoder's default — the source's own volume never
+         * reached it.
+         */
+        var volumePercent = VOLUME_PERCENT_SCALE
+    }
+
+    /**
+     * Frames for [spec], starting the decode on the first caller and sharing it afterwards.
+     *
+     * Every acquire must be matched by a [release], from the same `DisposableEffect` that made it.
+     */
+    @Synchronized
+    fun acquire(spec: SceneVideoSpec, volume: Float): StateFlow<ImageBitmap?> {
+        val entry = entries.getOrPut(spec) { CacheEntry() }
+        entry.refCount++
+        if (entry.refCount == 1) {
+            entry.job = scope.launch { play(spec, entry) }
+        }
+        setVolume(spec, volume)
+        return entry.frame
+    }
+
+    /**
+     * Sets the volume of an already-playing file.
+     *
+     * Separate from [acquire] because volume is not part of the key: a slider drag changes this
+     * without disturbing the decode. Last writer wins, which is what two layers of one file at
+     * different volumes get — they share the one audio stream, as they share the one picture.
+     */
+    @Synchronized
+    fun setVolume(spec: SceneVideoSpec, volume: Float) {
+        val entry = entries[spec] ?: return
+        entry.volumePercent = (volume * VOLUME_PERCENT_SCALE).toInt()
+        entry.handle?.setVolume(entry.volumePercent)
+    }
+
+    /** Lets go of [spec]. The decode stops when the last layer does. */
+    @Synchronized
+    fun release(spec: SceneVideoSpec) {
+        val entry = entries[spec] ?: return
+        entry.refCount--
+        if (entry.refCount > 0) return
+        entry.job?.cancel()
+        entry.job = null
+        entry.frame.value = null
+        entries.remove(spec)
+    }
+
+    /** How many decodes are running — how a test sees the sharing, and the release. */
+    @get:Synchronized
+    internal val liveDecodeCount: Int get() = entries.size
+
+    private suspend fun play(spec: SceneVideoSpec, entry: CacheEntry) {
+        // NonCancellable around the *open*, not just the close. The last layer can let go while the
+        // player is still being built — a scene switched quickly, a composition mounted and
+        // unmounted — and a cancellable open throws out of here with the player already alive and
+        // nothing holding it, leaking the native decoder for the life of the app. Opening
+        // uninterruptibly means cancellation lands on the line below instead, where the `finally`
+        // can close what was built.
+        val handle = withContext(NonCancellable + Dispatchers.IO) { openPlayer(spec) } ?: return
+        synchronized(this) {
+            entry.handle = handle
+            // Whatever the layers asked for while this was opening.
+            handle.setVolume(entry.volumePercent)
+        }
+        try {
+            convertFrames(handle, entry)
+        } catch (_: CancellationException) {
+            // Ordinary teardown — the last layer let go.
+        } finally {
+            synchronized(this) { entry.handle = null }
+            // NonCancellable: the ordinary way out of here is cancellation, and a plain
+            // `withContext` in a cancelled coroutine throws instead of running — which would leak
+            // the player and its native decoder for the life of the app.
+            withContext(NonCancellable + Dispatchers.IO) { handle.close() }
+        }
+    }
+
+    /** Publishes each newly decoded picture, converting on this coroutine and not the decoder's. */
+    private suspend fun convertFrames(handle: SceneVideoHandle, entry: CacheEntry) {
+        var lastVersion = -1L
+        while (currentCoroutineContext().isActive) {
+            val version = handle.frameVersion
+            if (version != lastVersion) {
+                lastVersion = version
+                handle.frame?.let { entry.frame.value = it.toComposeImageBitmap() }
+            }
+            delay(VIDEO_POLL_MS)
+        }
+    }
+}
+
+/**
+ * A factory and a player from it, or null when either could not be built.
+ *
+ * Its own function so [openVlcSceneVideo] has one failure path rather than three: a factory that
+ * cannot be created is reported, and a player that cannot be created releases the factory it came
+ * from rather than leaking it.
+ */
+@Suppress("TooGenericExceptionCaught")
+private fun newVlcPlayer(): Pair<MediaPlayerFactory, EmbeddedMediaPlayer>? {
+    val factory = try {
+        MediaPlayerFactory("--no-video-title-show")
+    } catch (t: Throwable) {
+        CrashReporter.reportException(t, "SceneVideoCache: VLC MediaPlayerFactory init failed")
+        null
+    } ?: return null
+
+    val player = try {
+        factory.mediaPlayers().newEmbeddedMediaPlayer()
+    } catch (_: Throwable) {
+        try { factory.release() } catch (_: Throwable) { }
+        null
+    } ?: return null
+
+    return factory to player
+}
+
+/**
+ * A libvlc player behind [SceneVideoHandle], or null when one could not be built.
+ *
+ * The render callback writes straight into the `BufferedImage`'s own int array and bumps the
+ * version — no allocation, no conversion, nothing that can block the decoder.
+ */
+@Suppress("TooGenericExceptionCaught")
+internal fun openVlcSceneVideo(spec: SceneVideoSpec): SceneVideoHandle? {
+    val file = File(spec.filePath)
+    if (!file.exists() || !isVlcAvailable) return null
+    val (factory, player) = newVlcPlayer() ?: return null
+
+    val holder = AtomicReference<BufferedImage?>(null)
+    val version = AtomicLong(0)
+
+    val bufferFormatCallback = object : BufferFormatCallback {
+        override fun getBufferFormat(sourceWidth: Int, sourceHeight: Int): BufferFormat {
+            holder.set(BufferedImage(sourceWidth, sourceHeight, BufferedImage.TYPE_INT_ARGB))
+            return RV32BufferFormat(sourceWidth, sourceHeight)
+        }
+        override fun allocatedBuffers(buffers: Array<out ByteBuffer>) = Unit
+    }
+    val renderCallback = RenderCallback { _, nativeBuffers, _ ->
+        val img = holder.get() ?: return@RenderCallback
+        if (nativeBuffers.isNullOrEmpty()) return@RenderCallback
+        val pixels = (img.raster.dataBuffer as? DataBufferInt)?.data ?: return@RenderCallback
+        try {
+            val buf = nativeBuffers[0] ?: return@RenderCallback
+            buf.rewind()
+            buf.asIntBuffer().get(pixels, 0, pixels.size.coerceAtMost(buf.remaining() / BYTES_PER_PIXEL))
+            version.incrementAndGet()
+        } catch (_: Throwable) { }
+    }
+    player.videoSurface().set(factory.videoSurfaces().newVideoSurface(bufferFormatCallback, renderCallback, true))
+
+    Thread.sleep(PLAYER_SETTLE_MS)
+    try {
+        if (spec.loop) player.media().play(file.absolutePath, VLC_OPT_TIGHT_CLOCK, VLC_OPT_LOOP)
+        else player.media().play(file.absolutePath, VLC_OPT_TIGHT_CLOCK)
+    } catch (_: Throwable) { }
+
+    return object : SceneVideoHandle {
+        override val frameVersion: Long get() = version.get()
+        override val frame: BufferedImage? get() = holder.get()
+        override fun setVolume(percent: Int) {
+            try { player.audio().setVolume(percent) } catch (_: Throwable) { }
+        }
+        override fun close() {
+            try {
+                player.controls().stop()
+                player.release()
+                factory.release()
+            } catch (_: Throwable) { }
+        }
+    }
+}
+
+/**
+ * The one cache the app decodes canvas video layers and looping backgrounds from.
+ *
+ * Holds no logic of its own — everything it does is [SceneVideoCache]'s, which is an ordinary class
+ * a test builds over a stand-in player.
+ */
+internal object SharedSceneVideoCache : SceneVideoCache(openPlayer = ::openVlcSceneVideo)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneVideoCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneVideoCache.kt
@@ -115,6 +115,7 @@ internal open class SceneVideoCache(
     @Synchronized
     fun acquire(spec: SceneVideoSpec, volume: Float): StateFlow<ImageBitmap?> {
         val entry = entries.getOrPut(spec) { CacheEntry() }
+        ResourceCensus.record(SharedResource.VIDEO_DECODE, entries.size)
         entry.refCount++
         if (entry.refCount == 1) {
             entry.job = scope.launch { play(spec, entry) }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ScreenCaptureCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ScreenCaptureCache.kt
@@ -99,6 +99,7 @@ internal open class ScreenCaptureCache(
     fun acquire(source: SceneSource.ScreenCaptureSource): StateFlow<ImageBitmap?> {
         val spec = ScreenCaptureSpec.of(source)
         val entry = entries.getOrPut(spec) { CacheEntry() }
+        ResourceCensus.record(SharedResource.SCREEN_GRAB, entries.size)
         entry.refCount++
         if (entry.refCount == 1) {
             entry.captureJob = scope.launch { capture(spec, entry) }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ScreenCaptureCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/ScreenCaptureCache.kt
@@ -1,0 +1,194 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.churchpresenter.app.churchpresenter.utils.WindowsWindowCapture
+import org.churchpresenter.app.churchpresenter.utils.X11WindowCapture
+import org.churchpresenter.core.models.scene.SceneSource
+import java.awt.Rectangle
+import java.awt.Robot
+import java.awt.image.BufferedImage
+
+/** The floor on how often a capture repeats, whatever the source asks for. */
+private const val MIN_CAPTURE_INTERVAL_MS = 33L
+
+/** Capture mode naming a window rather than a region of the screen. */
+internal const val CAPTURE_MODE_WINDOW = "window"
+
+/**
+ * One screen-capture configuration: everything that decides what a grab returns.
+ *
+ * A data class because it is the cache key. Two layers capturing the same region at the same rate
+ * are one capture; two layers capturing different regions are two, and folding those together
+ * would put one layer's picture on the other.
+ */
+internal data class ScreenCaptureSpec(
+    val mode: String,
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val intervalMs: Long,
+    val windowTitle: String,
+    val windowId: String,
+) {
+    companion object {
+        fun of(source: SceneSource.ScreenCaptureSource) = ScreenCaptureSpec(
+            mode = source.captureMode,
+            x = source.captureX,
+            y = source.captureY,
+            width = source.captureWidth,
+            height = source.captureHeight,
+            intervalMs = source.captureInterval.toLong().coerceAtLeast(MIN_CAPTURE_INTERVAL_MS),
+            windowTitle = source.windowTitle,
+            windowId = source.windowId,
+        )
+    }
+}
+
+/**
+ * One screen grab loop per distinct capture configuration, however many layers are drawing it.
+ *
+ * The same shape and the same reason as [SharedCameraFrameCache] and [NdiFrameCache], and it was
+ * the last canvas source type without one. A screen-capture layer is composed once in the canvas
+ * editor, once in each sidebar live preview, and once on each presenter output — and each of those
+ * ran **its own** `Robot.createScreenCapture` loop at up to 30fps over the same pixels. Grabbing
+ * the framebuffer is work the window server does, not the app, which is why an operator sees it as
+ * the *compositor* pegged rather than ChurchPresenter: the reported machine had WindowServer at
+ * 91-95% alongside the app's own 160%.
+ *
+ * Reference counted: the first layer to want a configuration starts the loop, the last one to let
+ * go stops it.
+ *
+ * A class rather than the object it is reached through, so the whole of it is testable: [grab] is
+ * the seam, and a test supplies one that returns a constructed image without ever touching
+ * `java.awt.Robot` — which throws in the headless test JVM. That is a constructor parameter, not
+ * the ad-hoc mutable `internal var` on a singleton that AGENT.md rules out.
+ */
+internal open class ScreenCaptureCache(
+    private val grab: (ScreenCaptureSpec) -> BufferedImage?,
+) {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val entries = mutableMapOf<ScreenCaptureSpec, CacheEntry>()
+
+    private class CacheEntry {
+        val frame = MutableStateFlow<ImageBitmap?>(null)
+        var refCount = 0
+        var captureJob: Job? = null
+    }
+
+    /**
+     * Frames for [source], starting the loop on the first caller and sharing it afterwards.
+     *
+     * Every acquire must be matched by a [release], from the same `DisposableEffect` that made it —
+     * acquiring from a `remember` block leaks the entry when a composition is abandoned.
+     */
+    @Synchronized
+    fun acquire(source: SceneSource.ScreenCaptureSource): StateFlow<ImageBitmap?> {
+        val spec = ScreenCaptureSpec.of(source)
+        val entry = entries.getOrPut(spec) { CacheEntry() }
+        entry.refCount++
+        if (entry.refCount == 1) {
+            entry.captureJob = scope.launch { capture(spec, entry) }
+        }
+        return entry.frame
+    }
+
+    /** Lets go of [source]. The grab loop stops when the last layer does. */
+    @Synchronized
+    fun release(source: SceneSource.ScreenCaptureSource) {
+        val spec = ScreenCaptureSpec.of(source)
+        val entry = entries[spec] ?: return
+        entry.refCount--
+        if (entry.refCount > 0) return
+        entry.captureJob?.cancel()
+        entry.captureJob = null
+        entry.frame.value = null
+        entries.remove(spec)
+    }
+
+    /** How many grab loops are running — how a test sees the sharing, and the release. */
+    @get:Synchronized
+    internal val liveCaptureCount: Int get() = entries.size
+
+    // TooGenericExceptionCaught, narrowly: `Robot` and the two native window-capture helpers throw
+    // across a range this code cannot enumerate — headless, a display that went away, a window
+    // closed mid-grab. A layer that stops capturing is a black rectangle; the same throw uncaught
+    // takes down the coroutine and leaves the entry live but frozen.
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun capture(spec: ScreenCaptureSpec, entry: CacheEntry) {
+        try {
+            while (currentCoroutineContext().isActive) {
+                val image = withContext(Dispatchers.IO) { grab(spec) }
+                if (image != null) entry.frame.value = image.toComposeImageBitmap()
+                delay(spec.intervalMs)
+            }
+        } catch (_: CancellationException) {
+            // Ordinary teardown — the last layer let go.
+        } catch (e: Exception) {
+            System.err.println("[Screen Capture] ${spec.mode}: ${e.message}")
+        }
+    }
+}
+
+/**
+ * The robot the real grabs go through, built once.
+ *
+ * Constructing one reaches `GraphicsEnvironment`, which throws in a headless JVM — so it is
+ * resolved lazily and to null rather than at class-init, and a machine that cannot provide one
+ * captures nothing instead of failing to load the class.
+ */
+private val screenRobot: Robot? by lazy {
+    try {
+        Robot()
+    } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+        System.err.println("[Screen Capture] no Robot available: ${e.message}")
+        null
+    }
+}
+
+/**
+ * One grab of what [spec] names, or null when there is nothing to grab.
+ *
+ * Window mode prefers the platform's own occluded-window capture — which can read a window that is
+ * behind another one — and falls back to grabbing the screen rectangle the window currently
+ * occupies, which cannot. Region mode is the rectangle as given.
+ */
+internal fun grabScreen(spec: ScreenCaptureSpec): BufferedImage? {
+    val robot = screenRobot ?: return null
+    return when {
+        spec.mode == CAPTURE_MODE_WINDOW && spec.windowId.isNotBlank() -> {
+            val wid = spec.windowId.removePrefix("0x").toLongOrNull(16) ?: 0L
+            WindowsWindowCapture.captureWindow(wid)
+                ?: X11WindowCapture.captureWindow(wid)
+                ?: robot.grabOrNull(findWindowBounds(spec.windowTitle))
+        }
+        spec.mode == CAPTURE_MODE_WINDOW && spec.windowTitle.isNotBlank() ->
+            robot.grabOrNull(findWindowBounds(spec.windowTitle))
+        else -> robot.grabOrNull(Rectangle(spec.x, spec.y, spec.width, spec.height))
+    }
+}
+
+/** Grabs [rect], or null when it names no area — `createScreenCapture` throws on an empty one. */
+private fun Robot.grabOrNull(rect: Rectangle?): BufferedImage? =
+    rect?.takeIf { it.width > 0 && it.height > 0 }?.let { createScreenCapture(it) }
+
+/**
+ * The one cache the app draws screen-capture layers from.
+ *
+ * Holds no logic of its own — everything it does is [ScreenCaptureCache]'s, which is an ordinary
+ * class a test builds over a stand-in grab.
+ */
+internal object SharedScreenCaptureCache : ScreenCaptureCache(grab = ::grabScreen)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
@@ -108,6 +108,7 @@ object SharedBrowserFrameCache {
         forceTransparent: Boolean
     ): BrowserFlows {
         val entry = entries.getOrPut(sourceId) { CacheEntry() }
+        ResourceCensus.record(SharedResource.BROWSER_SOURCE, entries.size)
         entry.refCount++
         if (entry.refCount == 1) {
             entry.captureJob = scope.launch {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -318,11 +318,17 @@ object SharedCameraFrameCache {
 
         // ffmpeg is an optional external tool, not something shipped with the app, and a machine
         // without it fails every attempt for the same knowable reason. Discovering that five times
-        // over ten seconds tells the operator nothing the canvas has not already told them
-        // (canvas_camera_ffmpeg_hint), so the loop does not run and nothing is reported: a tool the
-        // user has not installed is not a fault in the app.
+        // over ten seconds tells the operator nothing, so the loop does not run and nothing is
+        // reported to Sentry: a tool the user has not installed is not a fault in the app.
+        //
+        // The failure is still put on `entry.error`, which is new. It used to return silently, so
+        // the canvas drew the ordinary grey placeholder with the device's name on it and the
+        // operator was told nothing at all — on Windows, where the PnP fallback fills the picker
+        // with names even when ffmpeg is absent, that is a camera that looks selectable, selects
+        // fine, and then shows nothing for no stated reason.
         if (!withContext(Dispatchers.IO) { isFfmpegAvailable() }) {
             System.err.println("[Camera] ffmpeg is not on PATH — cannot capture $path")
+            entry.error.value = CameraFailure.FFMPEG_MISSING
             return
         }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -44,6 +44,17 @@ object SharedCameraFrameCache {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val entries = mutableMapOf<String, CacheEntry>()
 
+    /**
+     * How many devices are being captured right now — read-only, and the one thing a test can ask
+     * that distinguishes a released capture from a leaked one.
+     *
+     * A leak here is not a wasted object: the entry owns a live ffmpeg process holding the device
+     * open, so the next acquire of that camera fails with `device_busy` and the operator's canvas
+     * goes black on hardware nothing else is using.
+     */
+    @get:Synchronized
+    internal val liveCaptureCount: Int get() = entries.size
+
     /** Build a unique key for a camera source. */
     internal fun keyFor(source: SceneSource.CameraSource): String {
         return if (source.isDeckLink && source.deckLinkIndex >= 0) {
@@ -102,9 +113,18 @@ object SharedCameraFrameCache {
             entry.frame.value = null
             entries.remove(key)
 
-            // Only close the device if no other cache entry is using the same device.
-            // When switching connections, the new acquire's openInput() already closed
-            // the old input — calling closeInput here would kill the new one.
+            // Only close the device if no other cache entry is using the same device — two scene
+            // sources on one camera are one capture, and the first of them to go must not take the
+            // picture away from the second.
+            //
+            // A *switch* — another format, another connection — no longer reaches that guard. It
+            // used to: acquire ran from a `remember` block, so the incoming entry existed before
+            // the outgoing one was released, and this skipped the close on the strength of the new
+            // `openInput` having displaced the old one. Acquire now runs from the same
+            // `DisposableEffect` that releases, and Compose disposes the old effect before running
+            // the new one, so a switch closes the device and then reopens it. That is the order
+            // this cache wants: an ffmpeg process still holding a device when the next one asks for
+            // it is exactly the `device_busy` failure the release path exists to prevent.
             if (source.isDeckLink && source.deckLinkIndex >= 0 && DeckLinkManager.isAvailable()) {
                 val deviceStillActive = entries.keys.any {
                     it.startsWith("decklink:${source.deckLinkIndex}:")

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -77,6 +77,7 @@ object SharedCameraFrameCache {
     internal fun acquire(source: SceneSource.CameraSource): CameraFlows {
         val key = keyFor(source)
         val entry = entries.getOrPut(key) { CacheEntry() }
+        ResourceCensus.record(SharedResource.CAMERA_CAPTURE, entries.size)
         entry.refCount++
         if (entry.refCount == 1) {
             entry.error.value = null
@@ -148,6 +149,9 @@ object SharedCameraFrameCache {
             }
         }
     }
+
+    /** Bounds the ffmpeg-missing report to one per process — see [runFfmpegCapture]. */
+    private val ffmpegMissingReport = ReportOnce()
 
     // ── DeckLink capture ────────────────────────────────────────────
 
@@ -336,19 +340,24 @@ object SharedCameraFrameCache {
             return
         }
 
-        // ffmpeg is an optional external tool, not something shipped with the app, and a machine
-        // without it fails every attempt for the same knowable reason. Discovering that five times
-        // over ten seconds tells the operator nothing, so the loop does not run and nothing is
-        // reported to Sentry: a tool the user has not installed is not a fault in the app.
+        // ffmpeg is an optional external tool, and a machine without it fails every attempt for the
+        // same knowable reason. Discovering that five times over ten seconds tells the operator
+        // nothing, so the retry loop does not run.
         //
-        // The failure is still put on `entry.error`, which is new. It used to return silently, so
-        // the canvas drew the ordinary grey placeholder with the device's name on it and the
-        // operator was told nothing at all — on Windows, where the PnP fallback fills the picker
-        // with names even when ffmpeg is absent, that is a camera that looks selectable, selects
-        // fine, and then shows nothing for no stated reason.
+        // It is reported, though, which it did not used to be. The old reasoning — a tool the user
+        // has not installed is not a fault in the app — is right about a *tool* and wrong about this
+        // state: the app listed this device in its own picker, the operator chose it, and the app
+        // then produced nothing. On Windows the picker deliberately offers unopenable names beside a
+        // hint saying what to install, so whether that hint is doing its job is a question about our
+        // own UI. Issue #462 is the evidence that it was not, and the reason we could not see it is
+        // that this path was silent.
+        //
+        // Bounded hard: `FfmpegBinary.isAvailable` is a `by lazy`, so a second report in the same
+        // process would carry nothing the first did not.
         if (!withContext(Dispatchers.IO) { isFfmpegAvailable() }) {
             System.err.println("[Camera] ffmpeg is not on PATH — cannot capture $path")
             entry.error.value = CameraFailure.FFMPEG_MISSING
+            reportCameraFfmpegMissing(source, CameraDeviceCatalog.lastEnumeration, ffmpegMissingReport)
             return
         }
 
@@ -443,6 +452,11 @@ object SharedCameraFrameCache {
             if (consecutiveFailures < MAX_CONSECUTIVE_FAILURES && !stoppedEarly) return
             val reason = cameraGiveUpReason(everStarted, sawImmediateExit)
             System.err.println("[Camera] Giving up after $consecutiveFailures failures ($reason/$lastFailure)")
+            // What enumeration found is carried alongside what capture saw, because on its own
+            // "could not open" does not say whether the name we tried was one ffmpeg had offered.
+            // That distinction is the whole of issue #462, and asking a reporter to run
+            // `ffmpeg -list_devices` by hand was the only way to learn it.
+            val facts = CameraDeviceCatalog.lastEnumeration
             CrashReporter.reportWarning(
                 "Camera: Giving up on device after repeated ffmpeg failures",
                 tags = mapOf(
@@ -451,11 +465,13 @@ object SharedCameraFrameCache {
                     "device_scheme" to deviceScheme(source.devicePath),
                     "failure_cause" to lastFailure.name.lowercase(),
                     "attempts" to consecutiveFailures.toString()
-                ),
+                ) + cameraEnumerationTags(facts, source.deviceName, ffmpegAvailable = true),
                 extras = mapOf(
                     "ffmpeg_stderr_tail" to redactedFfmpegStderr(lastStderr, source.deviceName),
                     "ffmpeg_command" to redactedFfmpegCommand(lastCommand),
-                    "exit_code" to lastExitCode.toString()
+                    "exit_code" to lastExitCode.toString(),
+                    "camera_enumeration" to
+                        cameraEnumerationExtra(facts, source.deviceName, ffmpegAvailable = true)
                 )
             )
         }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundCameraPicker.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundCameraPicker.kt
@@ -26,12 +26,11 @@ import churchpresenter.composeapp.generated.resources.background_camera_auto
 import churchpresenter.composeapp.generated.resources.background_camera_connection
 import churchpresenter.composeapp.generated.resources.background_camera_device
 import churchpresenter.composeapp.generated.resources.background_camera_format
-import churchpresenter.composeapp.generated.resources.canvas_camera_ffmpeg_hint
-import churchpresenter.composeapp.generated.resources.canvas_camera_none_found
 import churchpresenter.composeapp.generated.resources.canvas_decklink_device
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.churchpresenter.app.churchpresenter.dialogs.PanelCaption
+import org.churchpresenter.app.churchpresenter.composables.cameraHintStringRes
 import org.churchpresenter.app.churchpresenter.composables.CameraDevice
 import org.churchpresenter.app.churchpresenter.composables.CameraDeviceCatalog
 import org.churchpresenter.app.churchpresenter.composables.CameraFormat
@@ -65,20 +64,30 @@ internal fun CameraPickerRow(config: BackgroundConfig, onConfigChange: (Backgrou
     val devices by CameraDeviceCatalog.devices.collectAsState()
     LaunchedEffect(Unit) { CameraDeviceCatalog.refresh(deckLinkLabel) }
 
+    // Probed off the composition thread. This file's own note above says it deliberately does not
+    // copy the Canvas panel's habit of shelling out from composition — but this call did exactly
+    // that, and `isFfmpegAvailable()` runs `ffmpeg -version` against each candidate install path in
+    // turn with a five-second timeout each. Starts `true` so no hint flashes on a machine that has
+    // ffmpeg.
+    var ffmpegAvailable by remember { mutableStateOf(true) }
+    LaunchedEffect(Unit) { ffmpegAvailable = withContext(Dispatchers.IO) { isFfmpegAvailable() } }
+
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         PanelCaption(stringResource(Res.string.background_camera_device))
         val found = devices.orEmpty()
-        if (found.isEmpty()) {
+
+        // Above the dropdown rather than instead of it: on Windows without ffmpeg the PnP fallback
+        // fills the list with names that cannot be opened, so a hint shown only when the list is
+        // empty is a hint the operator who needs it never sees.
+        cameraHintStringRes(System.getProperty("os.name", ""), devices, ffmpegAvailable).forEach { hint ->
             Text(
-                text = stringResource(
-                    if (isFfmpegAvailable()) Res.string.canvas_camera_none_found
-                    else Res.string.canvas_camera_ffmpeg_hint
-                ),
+                text = stringResource(hint),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            return@Column
         }
+        if (found.isEmpty()) return@Column
+
         DropdownSelector(
             label = stringResource(Res.string.background_camera_device),
             items = found.map { it.displayName },

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -164,6 +164,7 @@ import org.churchpresenter.app.churchpresenter.server.shouldMirrorRemoteBackgrou
 import org.churchpresenter.app.churchpresenter.server.shouldMirrorRemoteOutput
 import org.churchpresenter.app.churchpresenter.server.shouldUseRemoteContent
 import org.churchpresenter.app.churchpresenter.server.withAnnouncement
+import org.churchpresenter.app.churchpresenter.composables.ResourceCensus
 import org.churchpresenter.app.churchpresenter.utils.UrlOpener
 
 private const val MILLIS_PER_MINUTE = 60_000L
@@ -291,6 +292,9 @@ fun main() {
     val sessionStartedAt = System.currentTimeMillis()
     Runtime.getRuntime().addShutdownHook(Thread {
         UsageEvents.recordSessionMinutes(((System.currentTimeMillis() - sessionStartedAt) / MILLIS_PER_MINUTE).toInt())
+        // Shutdown is when the high-water marks are final. Reports only when they are higher than a
+        // scene can account for — see ResourceCensus, and why counts rather than CPU or heap.
+        ResourceCensus.reportIfLeaky()
     })
 
     val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PresenterBackground.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PresenterBackground.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.churchpresenter.app.churchpresenter.composables.CameraBackground
+import org.churchpresenter.app.churchpresenter.composables.CameraDevice
+import org.churchpresenter.app.churchpresenter.composables.CameraDeviceCatalog
 import org.churchpresenter.app.churchpresenter.composables.LoopingVideoBackground
 import org.churchpresenter.app.churchpresenter.utils.PictureDecoder
 import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
@@ -134,11 +136,17 @@ internal fun resolveBackground(
     transparentWhenBlank: Boolean,
     /** The background this content carries itself, if any. Bible verses carry none. */
     ownBackground: SongBackground = SongBackground(),
+    /** The cameras this machine has; see [songBackgroundResolves]. Passed explicitly only by tests. */
+    knownCameras: List<CameraDevice>? = CameraDeviceCatalog.devices.value,
 ): ResolvedBackground {
     val override = if (isLowerThird) settings.quickLowerThirdBackground else settings.quickBackground
     // Both remembered unconditionally: a `&&` short-circuit here would be a conditional remember.
-    val overrideDraws = remember(override) { override != null && songBackgroundResolves(override) }
-    val ownDraws = remember(ownBackground) { ownBackground.isCustom && songBackgroundResolves(ownBackground) }
+    val overrideDraws = remember(override, knownCameras) {
+        override != null && songBackgroundResolves(override, knownCameras)
+    }
+    val ownDraws = remember(ownBackground, knownCameras) {
+        ownBackground.isCustom && songBackgroundResolves(ownBackground, knownCameras)
+    }
 
     val live = when {
         !showBackground -> null

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/SongPresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/SongPresenter.kt
@@ -57,6 +57,7 @@ import org.churchpresenter.app.churchpresenter.composables.ChordChart
 import org.churchpresenter.songchords.ChordTransposer
 import org.churchpresenter.app.churchpresenter.utils.calculateAutoFitForAllSections
 import org.churchpresenter.app.churchpresenter.utils.calculateChordChartFontSize
+import org.churchpresenter.app.churchpresenter.composables.CameraDevice
 import org.churchpresenter.app.churchpresenter.composables.CameraDeviceCatalog
 import org.churchpresenter.app.churchpresenter.composables.cameraResolves
 import org.churchpresenter.app.churchpresenter.utils.Utils.parseHexColor
@@ -91,12 +92,21 @@ internal fun songBackgroundTypeConstant(type: String): String = when (type) {
  * enumerating: this runs inside a `remember` on the composition thread of every presenter output,
  * and enumerating shells out to ffmpeg. Before anything has enumerated the answer is yes — see
  * [cameraResolves] for why accepting is the safe direction there.
+ *
+ * [knownCameras] defaults to that catalog and is passed explicitly only by tests. It is a parameter
+ * rather than a read of the singleton because the catalog is process-global and a *composition*
+ * fills it: opening a camera property panel enumerates, so a suite that renders one leaves every
+ * later test in that fork looking at a populated catalog. Taking it as an argument is what makes
+ * this decision testable without either faking a singleton or depending on what ran first.
  */
-internal fun songBackgroundResolves(background: SongBackground): Boolean = when (background.type) {
+internal fun songBackgroundResolves(
+    background: SongBackground,
+    knownCameras: List<CameraDevice>? = CameraDeviceCatalog.devices.value,
+): Boolean = when (background.type) {
     SongBackgroundType.COLOR, SongBackgroundType.GRADIENT -> true
     SongBackgroundType.IMAGE, SongBackgroundType.VIDEO ->
         background.mediaPath.isNotBlank() && File(background.mediaPath).exists()
-    SongBackgroundType.CAMERA -> cameraResolves(background.camera, CameraDeviceCatalog.devices.value)
+    SongBackgroundType.CAMERA -> cameraResolves(background.camera, knownCameras)
     else -> false
 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/DeviceInfoReport.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/DeviceInfoReport.kt
@@ -1,6 +1,7 @@
 package org.churchpresenter.app.churchpresenter.utils
 
 import org.churchpresenter.app.churchpresenter.BuildConfig
+import org.churchpresenter.app.churchpresenter.composables.CameraDeviceCatalog
 import org.churchpresenter.app.churchpresenter.composables.DeckLinkManager
 import org.churchpresenter.app.churchpresenter.composables.isVlcAvailable
 import org.churchpresenter.app.churchpresenter.composables.vlcUnavailableReason
@@ -123,6 +124,21 @@ object DeviceInfoReport {
         if (facts.deckLinkAvailable) {
             if (facts.deckLinkDevices.isEmpty()) appendLine("  (no devices detected)")
             else facts.deckLinkDevices.forEach { appendLine(it) }
+        }
+        appendLine()
+
+        appendLine("-- Cameras --")
+        // From the last enumeration this run, not a fresh one: enumerating costs up to ten seconds
+        // for ffmpeg's DirectShow listing plus fifteen for the PnP query, and this report is
+        // generated from a button the operator is waiting on.
+        val cameras = CameraDeviceCatalog.lastEnumeration
+        if (cameras == null) {
+            appendLine("Not enumerated this run (no camera picker has been opened)")
+        } else {
+            appendLine("ffmpeg: ${if (cameras.ffmpegAvailable) "available" else "not installed"}")
+            appendLine("Enumerated by: ${cameras.enumerator.name.lowercase()}")
+            appendLine("Listed by ffmpeg: ${cameras.ffmpegListedCount}")
+            appendLine("Listed by the platform inventory: ${cameras.fallbackListedCount}")
         }
         appendLine()
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDiagnosticsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDiagnosticsTest.kt
@@ -2,6 +2,7 @@ package org.churchpresenter.app.churchpresenter.composables
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -219,7 +220,36 @@ class CameraDiagnosticsTest {
 
     @Test
     fun `every failure the app can reach has its own sentence for the operator`() {
-        val resources = CameraFailure.entries.map { cameraFailureStringRes(it) }
-        assertEquals(CameraFailure.entries.size, resources.toSet().size, resources.toString())
+        listOf("Mac OS X", "Windows 11", "Linux").forEach { os ->
+            val resources = CameraFailure.entries.map { cameraFailureStringRes(it, os) }
+            assertEquals(CameraFailure.entries.size, resources.toSet().size, "$os: $resources")
+        }
+    }
+
+    @Test
+    fun `windows is sent to the windows camera settings, not the mac ones`() {
+        assertNotEquals(
+            cameraFailureStringRes(CameraFailure.PERMISSION_DENIED, "Mac OS X"),
+            cameraFailureStringRes(CameraFailure.PERMISSION_DENIED, "Windows 11"),
+            "naming the wrong platform's settings pane is worse than saying nothing",
+        )
+    }
+
+    @Test
+    fun `windows is told a name may not match rather than that the camera was unplugged`() {
+        assertNotEquals(
+            cameraFailureStringRes(CameraFailure.DEVICE_NOT_FOUND, "Mac OS X"),
+            cameraFailureStringRes(CameraFailure.DEVICE_NOT_FOUND, "Windows 11"),
+            "on windows the likelier cause is a name DirectShow does not answer to",
+        )
+    }
+
+    @Test
+    fun `a failure with no platform remedy reads the same everywhere`() {
+        assertEquals(
+            cameraFailureStringRes(CameraFailure.DEVICE_BUSY, "Mac OS X"),
+            cameraFailureStringRes(CameraFailure.DEVICE_BUSY, "Windows 11"),
+            "only the two whose remedy is a place in the platform's settings diverge",
+        )
     }
 }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFactsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFactsTest.kt
@@ -1,0 +1,215 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What a camera failure report says about the enumeration behind it.
+ *
+ * These tags are the reason we can stop asking a reporter to run `ffmpeg -list_devices` by hand.
+ * Issue #462 had two possible causes — ffmpeg absent, and ffmpeg present but the device coming from
+ * the platform inventory whose names DirectShow does not answer to — and an event carrying only
+ * "could not open" cannot tell them apart. Each test below is one of the states we have to be able
+ * to read straight off the issue.
+ *
+ * Whole maps are asserted rather than individual keys on purpose: a later edit that drops a tag
+ * should fail here rather than quietly make a class of report unanswerable again.
+ */
+class CameraReportFactsTest {
+
+    private fun facts(
+        enumerator: CameraEnumerator,
+        ffmpegListed: Int = 0,
+        fallbackListed: Int = 0,
+        deckLink: Int = 0,
+        ffmpegAvailable: Boolean = true,
+        names: Set<String> = emptySet(),
+        enumeratedAtMs: Long = 1_000L,
+    ) = CameraEnumerationFacts(
+        enumerator = enumerator,
+        ffmpegListedCount = ffmpegListed,
+        fallbackListedCount = fallbackListed,
+        deckLinkCount = deckLink,
+        ffmpegAvailable = ffmpegAvailable,
+        enumeratedAtMs = enumeratedAtMs,
+        names = names,
+    )
+
+    // ── The four states a report has to distinguish ───────────────────────────────────────────
+
+    @Test
+    fun `ffmpeg absent is readable from the tags alone`() {
+        val tags = cameraEnumerationTags(
+            facts(CameraEnumerator.PNP_FALLBACK, fallbackListed = 2, ffmpegAvailable = false, names = setOf("webcam")),
+            deviceName = "Webcam",
+            ffmpegAvailable = false,
+        )
+
+        assertEquals(
+            mapOf(
+                "camera.ffmpeg" to "absent",
+                "camera.enumerator" to "pnp_fallback",
+                "camera.listed" to "2",
+                "camera.device_listed" to "yes",
+            ),
+            tags,
+        )
+    }
+
+    @Test
+    fun `ffmpeg present but listing nothing is the fallback enumerator`() {
+        val tags = cameraEnumerationTags(
+            facts(CameraEnumerator.PNP_FALLBACK, fallbackListed = 1, names = setOf("webcam")),
+            deviceName = "Webcam",
+            ffmpegAvailable = true,
+        )
+
+        assertEquals("present", tags["camera.ffmpeg"])
+        assertEquals(
+            "pnp_fallback", tags["camera.enumerator"],
+            "the fallback runs only when ffmpeg listed nothing, so this alone proves the dshow count was zero",
+        )
+    }
+
+    @Test
+    fun `a device ffmpeg listed and then failed on reads as an ordinary capture failure`() {
+        val tags = cameraEnumerationTags(
+            facts(CameraEnumerator.DSHOW, ffmpegListed = 3, names = setOf("logitech brio")),
+            deviceName = "Logitech BRIO",
+            ffmpegAvailable = true,
+        )
+
+        assertEquals(
+            mapOf(
+                "camera.ffmpeg" to "present",
+                "camera.enumerator" to "dshow",
+                "camera.listed" to "3",
+                "camera.device_listed" to "yes",
+            ),
+            tags,
+        )
+    }
+
+    @Test
+    fun `a device missing from the last listing says so`() {
+        val tags = cameraEnumerationTags(
+            facts(CameraEnumerator.DSHOW, ffmpegListed = 1, names = setOf("integrated webcam")),
+            deviceName = "Some Other Camera",
+            ffmpegAvailable = true,
+        )
+
+        assertEquals(
+            "no", tags["camera.device_listed"],
+            "a settings file carried from another machine, or a camera unplugged since the picker was opened",
+        )
+    }
+
+    @Test
+    fun `nothing having enumerated is distinct from nothing having been found`() {
+        val tags = cameraEnumerationTags(facts = null, deviceName = "Webcam", ffmpegAvailable = true)
+
+        assertEquals("not_run", tags["camera.enumerator"])
+        assertEquals(
+            "not_enumerated", tags["camera.device_listed"],
+            "the presenter restore path can capture without any picker having been opened",
+        )
+    }
+
+    // ── Privacy ───────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `no tag and no extra carries what the camera is called`() {
+        val deviceName = "Bob's Logitech"
+        val withName = facts(CameraEnumerator.DSHOW, ffmpegListed = 1, names = setOf(deviceName.lowercase()))
+
+        val tags = cameraEnumerationTags(withName, deviceName, ffmpegAvailable = true)
+        val extra = cameraEnumerationExtra(withName, deviceName, ffmpegAvailable = true, nowMs = 2_000L)
+
+        // Tag values are NOT scrubbed by CrashReporter — this is the only thing standing between a
+        // camera named after its owner and a Sentry tag, so it is asserted rather than assumed.
+        tags.forEach { (key, value) ->
+            assertFalse(value.contains("Logitech", ignoreCase = true), "tag $key leaked the device name")
+            assertFalse(value.contains("Bob", ignoreCase = true), "tag $key leaked the device name")
+        }
+        assertFalse(extra.contains("Logitech", ignoreCase = true), extra)
+        assertFalse(extra.contains("Bob", ignoreCase = true), extra)
+    }
+
+    @Test
+    fun `the extra carries the counts a triager needs and nothing else`() {
+        val extra = cameraEnumerationExtra(
+            facts(CameraEnumerator.PNP_FALLBACK, fallbackListed = 2, deckLink = 1, names = setOf("webcam")),
+            deviceName = "Webcam",
+            ffmpegAvailable = true,
+            nowMs = 6_000L,
+        )
+
+        assertEquals(
+            """
+            enumerator=pnp_fallback
+            ffmpeg=present
+            ffmpeg_listed=0
+            fallback_listed=2
+            decklink=1
+            device_listed=yes
+            enumerated_age_s=5
+            """.trimIndent(),
+            extra,
+        )
+    }
+
+    @Test
+    fun `an age is never invented for an enumeration that did not happen`() {
+        val extra = cameraEnumerationExtra(facts = null, deviceName = "Webcam", ffmpegAvailable = false)
+
+        assertTrue("enumerated_age_s=never" in extra, extra)
+    }
+
+    // ── The blind-ffmpeg predicate ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ffmpeg working but listing nothing while windows lists cameras is worth reporting`() {
+        assertTrue(shouldReportBlindFfmpeg(facts(CameraEnumerator.PNP_FALLBACK, fallbackListed = 1)))
+    }
+
+    @Test
+    fun `a machine with no camera at all is not a defect and is not reported`() {
+        assertFalse(
+            shouldReportBlindFfmpeg(facts(CameraEnumerator.PNP_FALLBACK, fallbackListed = 0)),
+            "the operator's own hardware inventory must not be made to look like a fault in the app",
+        )
+    }
+
+    @Test
+    fun `a machine without ffmpeg is not reported here`() {
+        assertFalse(
+            shouldReportBlindFfmpeg(
+                facts(CameraEnumerator.PNP_FALLBACK, fallbackListed = 2, ffmpegAvailable = false)
+            ),
+            "that is the ffmpeg-missing report's business, and reporting both would double-count it",
+        )
+    }
+
+    @Test
+    fun `a machine where ffmpeg answered is not reported`() {
+        assertFalse(shouldReportBlindFfmpeg(facts(CameraEnumerator.DSHOW, ffmpegListed = 2)))
+    }
+
+    @Test
+    fun `nothing having enumerated is not reported`() {
+        assertFalse(shouldReportBlindFfmpeg(null))
+    }
+
+    // ── The once-per-process gate ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a gate lets exactly one report through`() {
+        val gate = ReportOnce()
+
+        assertTrue(gate.claim(), "the first caller reports")
+        assertFalse(gate.claim(), "and no one else does")
+        assertFalse(gate.claim())
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraToolHintsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraToolHintsTest.kt
@@ -1,0 +1,89 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import churchpresenter.composeapp.generated.resources.Res
+import churchpresenter.composeapp.generated.resources.canvas_camera_ffmpeg_required
+import churchpresenter.composeapp.generated.resources.canvas_camera_none_found
+import churchpresenter.composeapp.generated.resources.canvas_camera_v4l2_hint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What the operator is told about the tools their cameras need.
+ *
+ * Both camera pickers used to decide this inline, and they disagreed — which is the bug this covers.
+ * The decision is a pure function now, so the platform and the presence of ffmpeg are parameters
+ * rather than properties of the machine running the suite: `FfmpegBinary` resolves its path in a
+ * `by lazy` and must not grow a mutable seam, and `os.name` cannot be faked in a JVM that has
+ * composed anything (skiko latches it).
+ */
+class CameraToolHintsTest {
+
+    private fun camera(name: String = "Integrated Webcam") =
+        CameraDevice(name = name, path = "dshow://:dshow-vdev=$name", displayName = name)
+
+    @Test
+    fun `nothing is said before the first enumeration answers`() {
+        assertEquals(
+            emptyList(), cameraHintStringRes("Windows 11", devices = null, ffmpegAvailable = false),
+            "\"No cameras found\" before anything has looked is a wrong answer the operator acts on",
+        )
+    }
+
+    @Test
+    fun `a windows machine without ffmpeg is told so even though the list is not empty`() {
+        val hints = cameraHintStringRes("Windows 11", listOf(camera()), ffmpegAvailable = false)
+
+        assertTrue(
+            Res.string.canvas_camera_ffmpeg_required in hints,
+            "this is the whole bug: the PnP fallback fills the picker with names that cannot be " +
+                "opened, so a hint shown only on an empty list is one the operator never sees",
+        )
+        assertTrue(Res.string.canvas_camera_none_found !in hints, "there is a name in the list")
+    }
+
+    @Test
+    fun `a windows machine without ffmpeg and no cameras is told both`() {
+        val hints = cameraHintStringRes("Windows 11", emptyList(), ffmpegAvailable = false)
+
+        assertEquals(
+            listOf(Res.string.canvas_camera_none_found, Res.string.canvas_camera_ffmpeg_required),
+            hints,
+            "what was found, then what to do about it",
+        )
+    }
+
+    @Test
+    fun `a mac without ffmpeg is told the same thing as windows`() {
+        assertEquals(
+            cameraHintStringRes("Windows 11", listOf(camera()), ffmpegAvailable = false),
+            cameraHintStringRes("Mac OS X", listOf(camera()), ffmpegAvailable = false),
+            "both open every camera through ffmpeg, and the remedy is the same sentence",
+        )
+    }
+
+    @Test
+    fun `linux is never told to install ffmpeg`() {
+        val hints = cameraHintStringRes("Linux", listOf(camera()), ffmpegAvailable = false)
+
+        assertEquals(
+            emptyList(), hints,
+            "linux opens cameras through v4l2 and wants ffmpeg only for virtual ones",
+        )
+    }
+
+    @Test
+    fun `linux with no cameras is pointed at v4l2loopback`() {
+        val hints = cameraHintStringRes("Linux", emptyList(), ffmpegAvailable = true)
+
+        assertEquals(listOf(Res.string.canvas_camera_none_found, Res.string.canvas_camera_v4l2_hint), hints)
+    }
+
+    @Test
+    fun `a machine with ffmpeg and a camera is told nothing`() {
+        assertEquals(
+            emptyList(), cameraHintStringRes("Windows 11", listOf(camera()), ffmpegAvailable = true),
+            "a working picker needs no explanation, and one that always explains is read past",
+        )
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/DeviceEnumerationTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/DeviceEnumerationTest.kt
@@ -28,7 +28,67 @@ class DeviceEnumerationTest {
 
         cameraDevicesFor("windows 11", runner::run)
 
+        assertEquals(
+            listOf("ffmpeg", "powershell"), runner.programs,
+            "the PnP query is the fallback, and an empty ffmpeg listing is what calls for it",
+        )
+    }
+
+    @Test
+    fun `PowerShell is not run when ffmpeg already listed the cameras`() {
+        // Exit code 1 on purpose: `-i dummy` always exits non-zero, and the listing is read off
+        // stderr regardless — the code must go on ignoring the exit code.
+        val runner = FakeCommandRunner { command ->
+            if (command.first() == "ffmpeg") CommandResult(1, "[dshow @ 0x1] \"Integrated Webcam\" (video)")
+            else null
+        }
+
+        val devices = cameraDevicesFor("windows 11", runner::run)
+
+        assertEquals(listOf("ffmpeg"), runner.programs, "the slowest call on this path is skipped outright")
+        assertEquals(listOf("Integrated Webcam"), devices.map { it.name })
+    }
+
+    @Test
+    fun `an absent ffmpeg leaves the PowerShell fallback to name the cameras`() {
+        // Exactly what an unstartable process yields, which is how a machine without ffmpeg reads.
+        val runner = FakeCommandRunner { command ->
+            if (command.first() == "ffmpeg") CommandResult(-1, "") else CommandResult(0, "Surface Camera Front")
+        }
+
+        val devices = cameraDevicesFor("windows 11", runner::run)
+
         assertEquals(listOf("ffmpeg", "powershell"), runner.programs)
+        assertEquals(
+            listOf("Surface Camera Front"), devices.map { it.name },
+            "the operator still sees their camera named, beside the hint saying to install ffmpeg",
+        )
+    }
+
+    @Test
+    fun `the windows enumeration commands are bounded`() {
+        val runner = FakeCommandRunner.alwaysReturning("")
+
+        cameraDevicesFor("windows 11", runner::run)
+
+        assertEquals(
+            listOf(10L, 15L), runner.timeouts,
+            "both used to wait forever, so a DirectShow filter or a slow WMI query hung the caller",
+        )
+    }
+
+    @Test
+    fun `the PowerShell query asks only for camera-class devices`() {
+        val runner = FakeCommandRunner.alwaysReturning("")
+
+        cameraDevicesFor("windows 11", runner::run)
+
+        val query = runner.calls.first { it.first() == "powershell" }.last()
+        assertTrue(query.contains("PNPClass -eq 'Camera'"), "cameras are what the picker offers")
+        assertTrue(
+            !query.contains("'Image'"),
+            "the Image class is scanners and other still-image devices, offered as cameras until now",
+        )
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/DeviceEnumerationTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/DeviceEnumerationTest.kt
@@ -77,6 +77,100 @@ class DeviceEnumerationTest {
         )
     }
 
+    // ── What the enumeration reports about itself ─────────────────────────────────────────────
+
+    @Test
+    fun `a listing ffmpeg produced is attributed to ffmpeg`() {
+        val runner = FakeCommandRunner { command ->
+            if (command.first() == "ffmpeg") {
+                CommandResult(1, "[dshow @ 0x1] \"Integrated Webcam\" (video)\n[dshow @ 0x1] \"Capture Card\" (video)")
+            } else {
+                null
+            }
+        }
+
+        val facts = enumerateCameras("windows 11", runner::run).facts
+
+        assertEquals(CameraEnumerator.DSHOW, facts.enumerator)
+        assertEquals(2, facts.ffmpegListedCount)
+        assertEquals(0, facts.fallbackListedCount, "the fallback was never consulted, let alone counted")
+    }
+
+    @Test
+    fun `a listing the PnP inventory produced is attributed to the fallback`() {
+        val runner = FakeCommandRunner { command ->
+            if (command.first() == "ffmpeg") CommandResult(-1, "") else CommandResult(0, "Surface Camera Front")
+        }
+
+        val facts = enumerateCameras("windows 11", runner::run).facts
+
+        assertEquals(CameraEnumerator.PNP_FALLBACK, facts.enumerator)
+        assertEquals(0, facts.ffmpegListedCount)
+        assertEquals(1, facts.fallbackListedCount)
+    }
+
+    @Test
+    fun `a machine neither tool found a camera on counts nothing`() {
+        val runner = FakeCommandRunner.alwaysReturning("")
+
+        val facts = enumerateCameras("windows 11", runner::run).facts
+
+        assertEquals(0, facts.ffmpegListedCount)
+        assertEquals(
+            0, facts.fallbackListedCount,
+            "a machine with no camera must be distinguishable from one whose cameras cannot be opened",
+        )
+    }
+
+    @Test
+    fun `a mac listing ffmpeg produced is attributed to avfoundation`() {
+        val runner = FakeCommandRunner { command ->
+            if (command.first() == "ffmpeg") {
+                CommandResult(
+                    1,
+                    """
+                    [AVFoundation indev @ 0x1] AVFoundation video devices:
+                    [AVFoundation indev @ 0x1] [0] FaceTime HD Camera
+                    """.trimIndent(),
+                )
+            } else {
+                CommandResult(0, "")
+            }
+        }
+
+        assertEquals(CameraEnumerator.AVFOUNDATION, enumerateCameras("mac os x", runner::run).facts.enumerator)
+    }
+
+    @Test
+    fun `a mac listing only system_profiler produced is attributed to the fallback`() {
+        val runner = FakeCommandRunner { command ->
+            if (command.first() == "system_profiler") CommandResult(0, "    FaceTime HD Camera:\n")
+            else CommandResult(-1, "")
+        }
+
+        assertEquals(
+            CameraEnumerator.SYSTEM_PROFILER_FALLBACK,
+            enumerateCameras("mac os x", runner::run).facts.enumerator,
+        )
+    }
+
+    @Test
+    fun `an OS with no enumerator says so rather than looking like a machine with no camera`() {
+        val runner = FakeCommandRunner.alwaysReturning("")
+
+        assertEquals(CameraEnumerator.UNSUPPORTED_OS, enumerateCameras("TestOS", runner::run).facts.enumerator)
+    }
+
+    @Test
+    fun `the pure enumeration never decides whether ffmpeg is installed`() {
+        val runner = FakeCommandRunner.alwaysReturning("")
+
+        assertEquals(
+            false, enumerateCameras("windows 11", runner::run).facts.ffmpegAvailable,
+            "that is the impure caller's to fill in, which is what keeps this function drivable from a fake",
+        )
+    }
+
     @Test
     fun `the PowerShell query asks only for camera-class devices`() {
         val runner = FakeCommandRunner.alwaysReturning("")

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/ResourceCensusTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/ResourceCensusTest.kt
@@ -1,0 +1,115 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The high-water marks of the native resources the app holds on someone else's behalf.
+ *
+ * Three leaks were found in this area in one week — an ffmpeg process holding a camera, a libvlc
+ * decoder, and a headless browser leaked on every viewport resize — and every one of them leaks a
+ * process or a native handle rather than heap. That is why the signal watched here is a count and
+ * not memory: a JVM heap chart was flat through all three.
+ *
+ * [ResourceCensus] is process-global and the suite shares a JVM, so every test resets it.
+ */
+class ResourceCensusTest {
+
+    @BeforeTest fun clear() = ResourceCensus.reset()
+
+    @AfterTest fun clearAfter() = ResourceCensus.reset()
+
+    @Test
+    fun `the census remembers the highest count, not the last one`() {
+        ResourceCensus.record(SharedResource.VIDEO_DECODE, 1)
+        ResourceCensus.record(SharedResource.VIDEO_DECODE, 5)
+        ResourceCensus.record(SharedResource.VIDEO_DECODE, 2)
+
+        assertEquals(
+            5, ResourceCensus.peak(SharedResource.VIDEO_DECODE),
+            "a leak is visible in how high the count climbed, not in what it happens to be at shutdown",
+        )
+    }
+
+    @Test
+    fun `resources are counted apart from each other`() {
+        ResourceCensus.record(SharedResource.CAMERA_CAPTURE, 2)
+        ResourceCensus.record(SharedResource.BROWSER_SOURCE, 9)
+
+        assertEquals(2, ResourceCensus.peak(SharedResource.CAMERA_CAPTURE))
+        assertEquals(9, ResourceCensus.peak(SharedResource.BROWSER_SOURCE))
+        assertEquals(0, ResourceCensus.peak(SharedResource.NDI_RECEIVER), "one never opened is zero, not absent")
+    }
+
+    @Test
+    fun `a snapshot names every resource, including the ones never opened`() {
+        ResourceCensus.record(SharedResource.SCREEN_GRAB, 1)
+
+        assertEquals(
+            SharedResource.entries.toSet(), ResourceCensus.snapshot().keys,
+            "a missing key in a report reads as a resource that does not exist rather than one at zero",
+        )
+    }
+
+    // ── What counts as a leak ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `an ordinary booth is not reported`() {
+        val ordinary = mapOf(
+            SharedResource.CAMERA_CAPTURE to 2,
+            SharedResource.VIDEO_DECODE to 3,
+            SharedResource.SCREEN_GRAB to 1,
+            SharedResource.NDI_RECEIVER to 2,
+            SharedResource.BROWSER_SOURCE to 1,
+        )
+
+        assertFalse(
+            looksLikeLeak(ordinary),
+            "a report that arrives from every install is one nobody reads by the second week",
+        )
+    }
+
+    @Test
+    fun `a count a scene cannot account for is reported`() {
+        assertTrue(looksLikeLeak(mapOf(SharedResource.VIDEO_DECODE to 8)))
+    }
+
+    @Test
+    fun `one leaking resource is enough, whatever the others are doing`() {
+        val onlyBrowsersLeaked = mapOf(
+            SharedResource.CAMERA_CAPTURE to 1,
+            SharedResource.BROWSER_SOURCE to 40,
+        )
+
+        assertTrue(
+            looksLikeLeak(onlyBrowsersLeaked),
+            "the browser leak fired on every resize, so its count outran everything else",
+        )
+    }
+
+    @Test
+    fun `an app that opened nothing is not a leak`() {
+        assertFalse(looksLikeLeak(emptyMap()))
+        assertFalse(looksLikeLeak(SharedResource.entries.associateWith { 0 }))
+    }
+
+    @Test
+    fun `the rendered census names every resource and carries only counts`() {
+        val rendered = renderCensus(mapOf(SharedResource.VIDEO_DECODE to 12))
+
+        assertEquals(
+            """
+            camera_capture=0
+            video_decode=12
+            screen_grab=0
+            ndi_receiver=0
+            browser_source=0
+            """.trimIndent(),
+            rendered,
+        )
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneSourceCameraLifecycleTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneSourceCameraLifecycleTest.kt
@@ -1,0 +1,102 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import org.churchpresenter.core.models.scene.SceneSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * What a camera source costs the capture cache as it comes and goes from a composition.
+ *
+ * **Why this can be tested at all**, when `SceneSourceRendererTest` says the camera branch needs
+ * real hardware: the device path here names a scheme `buildFfmpegCommand` has no branch for, so
+ * `runFfmpegCapture` returns at its first line and no process is ever started. The cache entry is
+ * still created and still has to be released, which is the whole of what these tests are about.
+ *
+ * They exist because the release path had drifted from the acquire path. `acquire` was called from
+ * a `remember` block and released from a `DisposableEffect`, and those are not the same lifecycle:
+ * a composition that is abandoned before its effects run discards what `remember` produced without
+ * calling any `onDispose`. The leaked entry owns an ffmpeg process holding the device open, so the
+ * next acquire of that camera fails with `device_busy` — reported from the field as a canvas gone
+ * black on a camera nothing else was using.
+ *
+ * Not covered: the abandonment itself, which needs a composition to be started and thrown away
+ * mid-frame and has no hook in `runComposeUiTest`. What is pinned here is the invariant that made
+ * it a leak — acquire and release keyed and scoped alike, balanced over an ordinary mount and
+ * unmount.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SceneSourceCameraLifecycleTest {
+
+    /** A scheme `buildFfmpegCommand` returns null for, so the capture coroutine starts nothing. */
+    private fun camera(id: String, devicePath: String = "unsupported://test-device") =
+        SceneSource.CameraSource(
+            id = id,
+            name = "Camera",
+            devicePath = devicePath,
+            videoFormat = "",
+            videoConnection = 0,
+            isDeckLink = false,
+            deckLinkIndex = -1,
+        )
+
+    @Test
+    fun `a camera leaving the composition releases its capture`() = runComposeUiTest {
+        val before = SharedCameraFrameCache.liveCaptureCount
+        var shown by mutableStateOf(true)
+
+        setContent {
+            if (shown) SceneSourceRenderer(camera("cam"), Modifier.size(64.dp))
+        }
+        waitForIdle()
+        assertEquals(before + 1, SharedCameraFrameCache.liveCaptureCount, "mounting acquires one capture")
+
+        shown = false
+        waitForIdle()
+        assertEquals(before, SharedCameraFrameCache.liveCaptureCount, "unmounting must release it")
+    }
+
+    @Test
+    fun `the canvas preview and the presenter output share one capture of the same device`() =
+        runComposeUiTest {
+            val before = SharedCameraFrameCache.liveCaptureCount
+
+            setContent {
+                SceneSourceRenderer(camera("editor"), Modifier.size(64.dp))
+                SceneSourceRenderer(camera("output"), Modifier.size(64.dp))
+            }
+            waitForIdle()
+
+            assertEquals(
+                before + 1,
+                SharedCameraFrameCache.liveCaptureCount,
+                "two renderers of one device are one capture, not two",
+            )
+        }
+
+    @Test
+    fun `re-pointing a source at another device leaves only the new one capturing`() =
+        runComposeUiTest {
+            val before = SharedCameraFrameCache.liveCaptureCount
+            var path by mutableStateOf("unsupported://first")
+
+            setContent { SceneSourceRenderer(camera("cam", path), Modifier.size(64.dp)) }
+            waitForIdle()
+            assertEquals(before + 1, SharedCameraFrameCache.liveCaptureCount)
+
+            path = "unsupported://second"
+            waitForIdle()
+            assertEquals(
+                before + 1,
+                SharedCameraFrameCache.liveCaptureCount,
+                "the old device's capture must be released, not left beside the new one",
+            )
+        }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneVideoCacheTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneVideoCacheTest.kt
@@ -1,0 +1,153 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.awt.image.BufferedImage
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * That one video file costs one decode, however many layers draw it.
+ *
+ * The most expensive of the three shared caches. A video layer is composed in the canvas editor, in
+ * every sidebar live preview and on every presenter output, and each instance used to build its own
+ * VLC factory, its own player and its own conversion loop — the same file decoded at full source
+ * resolution that many times, its audio played that many times over itself, and every frame
+ * converted to an `ImageBitmap` per instance at 60fps.
+ *
+ * libvlc is never loaded here: the cache takes its player as a constructor parameter and these
+ * tests supply a stand-in that hands back frames on demand. So this measures the sharing, the
+ * release and the volume path, not the decoder.
+ */
+class SceneVideoCacheTest {
+
+    /** Ends on the condition itself; the deadline only fails the test. */
+    private fun waitFor(what: String, condition: () -> Boolean) = runBlocking {
+        val deadline = System.nanoTime() + VIDEO_WAIT_MS * VIDEO_NANOS_PER_MS
+        while (!condition()) {
+            if (System.nanoTime() > deadline) throw AssertionError("timed out waiting for $what")
+            delay(VIDEO_POLL_MS)
+        }
+    }
+
+    /** A player that produces one frame and records what was asked of it. */
+    private class FakePlayer : SceneVideoHandle {
+        val volumes = mutableListOf<Int>()
+        var closed = false
+        override var frameVersion = 1L
+        override val frame: BufferedImage? = BufferedImage(4, 4, BufferedImage.TYPE_INT_ARGB)
+        override fun setVolume(percent: Int) { volumes += percent }
+        override fun close() { closed = true }
+    }
+
+    private fun spec(path: String = "/videos/loop.mp4", loop: Boolean = true) = SceneVideoSpec(path, loop)
+
+    @Test
+    fun `two layers of one file share a single decode`() {
+        val opened = AtomicInteger()
+        val cache = SceneVideoCache { opened.incrementAndGet(); FakePlayer() }
+
+        val editor = cache.acquire(spec(), volume = 1f)
+        val output = cache.acquire(spec(), volume = 1f)
+
+        assertEquals(1, cache.liveDecodeCount, "one file is one decode")
+        assertSame(editor, output, "and both layers draw from the same flow")
+        waitFor("the decode to open") { opened.get() == 1 }
+        assertEquals(1, opened.get(), "the player must be built once, not once per layer")
+    }
+
+    @Test
+    fun `the same file looped and unlooped are separate decodes`() {
+        val cache = SceneVideoCache { FakePlayer() }
+
+        cache.acquire(spec(loop = true), volume = 1f)
+        cache.acquire(spec(loop = false), volume = 1f)
+
+        assertEquals(2, cache.liveDecodeCount, "looping changes what is played, so it cannot be shared")
+    }
+
+    @Test
+    fun `volume is not part of the key, so two volumes are still one decode`() {
+        val opened = AtomicInteger()
+        val cache = SceneVideoCache { opened.incrementAndGet(); FakePlayer() }
+
+        cache.acquire(spec(), volume = 1f)
+        cache.acquire(spec(), volume = 0.2f)
+
+        assertEquals(1, cache.liveDecodeCount, "the picture is identical; only the audio differs")
+    }
+
+    @Test
+    fun `the volume asked for while the player was opening is applied when it arrives`() {
+        val player = FakePlayer()
+        val cache = SceneVideoCache { player }
+
+        // Opening is asynchronous, so this names a volume before there is anything to set it on.
+        cache.acquire(spec(), volume = 0.4f)
+
+        waitFor("the opening volume to be applied") { player.volumes.contains(40) }
+        assertTrue(
+            player.volumes.contains(40),
+            "the source's own volume must reach the decoder, not be dropped for its default",
+        )
+    }
+
+    @Test
+    fun `a volume change reaches the running player without restarting it`() {
+        val opened = AtomicInteger()
+        val player = FakePlayer()
+        val cache = SceneVideoCache { opened.incrementAndGet(); player }
+
+        cache.acquire(spec(), volume = 1f)
+        waitFor("the decode to open") { player.volumes.isNotEmpty() }
+        cache.setVolume(spec(), 0.5f)
+
+        waitFor("the volume change to be applied") { player.volumes.contains(50) }
+        assertEquals(1, opened.get(), "a slider drag must not rebuild the decoder")
+    }
+
+    @Test
+    fun `the decode stops only when the last layer lets go`() {
+        val player = FakePlayer()
+        val cache = SceneVideoCache { player }
+
+        cache.acquire(spec(), volume = 1f)
+        cache.acquire(spec(), volume = 1f)
+        // Wait for the player to exist before letting go of it: releasing before the decode has
+        // opened is a real case, but it is the *no player was ever built* one, and it is not what
+        // this test is about.
+        waitFor("the decode to open") { player.volumes.isNotEmpty() }
+
+        cache.release(spec())
+        assertEquals(1, cache.liveDecodeCount, "one layer leaving must not blank the other")
+
+        cache.release(spec())
+        assertEquals(0, cache.liveDecodeCount, "the last one out stops the decode")
+        waitFor("the player to be closed") { player.closed }
+        assertTrue(player.closed, "the native decoder must be released, not left running")
+    }
+
+    @Test
+    fun `a decoded frame reaches the flow`() {
+        val cache = SceneVideoCache { FakePlayer() }
+        val frames = cache.acquire(spec(), volume = 1f)
+        waitFor("a frame") { frames.value != null }
+        assertNotNull(frames.value, "the layer must be given the decoded picture")
+    }
+
+    @Test
+    fun `a file whose player cannot be built holds an entry but no frames`() {
+        val cache = SceneVideoCache { null }
+        val frames = cache.acquire(spec(), volume = 1f)
+        assertEquals(1, cache.liveDecodeCount, "a video that will not open is still one subscriber")
+        assertEquals(null, frames.value)
+    }
+}
+
+private const val VIDEO_WAIT_MS = 2_000L
+private const val VIDEO_POLL_MS = 5L
+private const val VIDEO_NANOS_PER_MS = 1_000_000L

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/ScreenCaptureCacheTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/ScreenCaptureCacheTest.kt
@@ -1,0 +1,119 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.churchpresenter.core.models.scene.SceneSource
+import java.awt.image.BufferedImage
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+private const val WAIT_MS = 2_000L
+private const val POLL_MS = 5L
+private const val NANOS_PER_MS = 1_000_000L
+
+/**
+ * That one screen-capture configuration costs one grab loop, however many layers draw it.
+ *
+ * The point of the cache: a screen-capture layer is composed in the canvas editor, in every sidebar
+ * live preview and on every presenter output, and each of those used to run its own
+ * `Robot.createScreenCapture` at up to 30fps over the same pixels — work the window server does, so
+ * it lands on the compositor rather than on the app.
+ *
+ * `Robot` itself is never constructed here. The cache takes its grab as a constructor parameter and
+ * these tests supply one that counts calls and returns a constructed image, so the suite measures
+ * the sharing rather than the platform — and runs headless, where a real `Robot` throws.
+ */
+class ScreenCaptureCacheTest {
+
+    /** Ends on the condition itself; the deadline only fails the test. */
+    private fun waitFor(what: String, condition: () -> Boolean) = runBlocking {
+        val deadline = System.nanoTime() + WAIT_MS * NANOS_PER_MS
+        while (!condition()) {
+            if (System.nanoTime() > deadline) throw AssertionError("timed out waiting for $what")
+            delay(POLL_MS)
+        }
+    }
+
+    private fun source(
+        id: String = "cap",
+        mode: String = "region",
+        x: Int = 0,
+        y: Int = 0,
+        width: Int = 320,
+        height: Int = 240,
+        interval: Int = 33,
+    ) = SceneSource.ScreenCaptureSource(
+        id = id,
+        name = "Screen Capture",
+        captureMode = mode,
+        captureX = x,
+        captureY = y,
+        captureWidth = width,
+        captureHeight = height,
+        captureInterval = interval,
+    )
+
+    private fun image() = BufferedImage(4, 4, BufferedImage.TYPE_INT_ARGB)
+
+    @Test
+    fun `two layers of one configuration share a single grab loop`() {
+        val opened = AtomicInteger()
+        val cache = ScreenCaptureCache { opened.incrementAndGet(); image() }
+
+        val editor = cache.acquire(source(id = "editor"))
+        val output = cache.acquire(source(id = "output"))
+
+        assertEquals(1, cache.liveCaptureCount, "one configuration is one grab loop")
+        assertSame(editor, output, "and both layers draw from the same flow")
+    }
+
+    @Test
+    fun `different regions are different captures`() {
+        val cache = ScreenCaptureCache { image() }
+
+        cache.acquire(source(id = "a", x = 0))
+        cache.acquire(source(id = "b", x = 400))
+
+        assertEquals(2, cache.liveCaptureCount, "folding these together would show one the other's pixels")
+    }
+
+    @Test
+    fun `the loop stops only when the last layer lets go`() {
+        val cache = ScreenCaptureCache { image() }
+        val first = source(id = "editor")
+        val second = source(id = "output")
+
+        cache.acquire(first)
+        cache.acquire(second)
+        cache.release(first)
+        assertEquals(1, cache.liveCaptureCount, "one layer leaving must not blank the other")
+
+        cache.release(second)
+        assertEquals(0, cache.liveCaptureCount, "the last one out stops the grab")
+    }
+
+    @Test
+    fun `releasing something never acquired changes nothing`() {
+        val cache = ScreenCaptureCache { image() }
+        cache.release(source())
+        assertEquals(0, cache.liveCaptureCount)
+    }
+
+    @Test
+    fun `a grab that returns a frame reaches the flow`() {
+        val cache = ScreenCaptureCache { image() }
+        val frames = cache.acquire(source())
+        waitFor("a frame") { frames.value != null }
+        assertNotNull(frames.value, "the layer must be given the picture the grab produced")
+    }
+
+    @Test
+    fun `a configuration whose grab yields nothing still holds one entry`() {
+        val cache = ScreenCaptureCache { null }
+        cache.acquire(source())
+        assertEquals(1, cache.liveCaptureCount, "a screen that cannot be grabbed is still one subscriber")
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCacheTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCacheTest.kt
@@ -18,6 +18,12 @@ import kotlin.test.assertTrue
  * Also not covered here: the retry loop that consumes [CaptureOverride], the stderr drain feeding
  * it, and the `CrashReporter` report at the end — each needs a real process and a real device. The
  * decisions they make live in `CameraDiagnostics.kt` and are tested in `CameraDiagnosticsTest`.
+ *
+ * The same goes for the ffmpeg-missing report added for issue #462: reaching the call needs
+ * `FfmpegBinary.isAvailable` to be false, and that is a `by lazy` which must not grow a mutable seam
+ * (`CameraToolHints.kt` says why). What the report *says* is a pure function and is asserted whole in
+ * `CameraReportFactsTest`; that it fires at most once is `ReportOnce`'s test in the same file. Only
+ * the three lines wiring the two together are unexercised.
  */
 class SharedCameraFrameCacheTest {
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesCameraTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesCameraTest.kt
@@ -33,8 +33,10 @@ import kotlin.test.assertEquals
  *    and the mode dropdown — all of which need `DeckLinkManager.isAvailable()` to be true, and that
  *    needs the native `decklink_jni` library the suite does not ship.
  *  * **The ffmpeg format dropdown**, which needs a non-DeckLink device path to enumerate against.
- *  * **The two "install the tools" hints**: whether they render depends on whether the machine has
- *    `ffmpeg` on its PATH, so neither their presence nor their absence can be asserted.
+ *  * **The rendering of the "install the tools" hints**, which still depends on whether the machine
+ *    running the suite has `ffmpeg` on its PATH. *Which* hint each platform should get no longer
+ *    depends on the host and is pinned in `CameraToolHintsTest`; only the act of drawing the list
+ *    is uncovered here.
  */
 class SourcePropertiesCameraTest {
 
@@ -68,6 +70,13 @@ class SourcePropertiesCameraTest {
     fun `the refresh button is the panel's only button`() = cameraPanel { _ ->
         roleButtons().assertCountEquals(1)
         onNodeWithText("Refresh Cameras").assertHasClickAction()
+    }
+
+    @Test
+    fun `an unknown platform is offered no privacy settings button`() = cameraPanel { _ ->
+        // Neither the macOS nor the Windows privacy button belongs on an OS that is neither, and
+        // the count above is what would catch one appearing — this says why that number is 1.
+        onNodeWithText("Open Camera Privacy Settings").assertDoesNotExist()
     }
 
     // ── Refresh ───────────────────────────────────────────────────────────────

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesDeviceListingTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/SourcePropertiesDeviceListingTest.kt
@@ -276,15 +276,41 @@ class SourcePropertiesDeviceListingTest {
     }
 
     @Test
-    fun `PowerShell fills in cameras ffmpeg did not report`() {
+    fun `PowerShell names are ignored when ffmpeg listed any DirectShow device`() {
         val devices = parseWindowsCameras(
             dshowOutput = "\"Integrated Webcam\" (video)",
             pnpOutput = "Integrated Webcam\nSurface Camera Front\n",
         )
 
         assertEquals(
+            listOf("Integrated Webcam"), devices.map { it.name },
+            "a PnP friendly name is not a DirectShow filter name — ffmpeg enumerates every filter " +
+                "it can open, so a device missing from its listing cannot be opened by name, and " +
+                "offering it produces \"could not find video device\" reported as an unplugged camera",
+        )
+    }
+
+    @Test
+    fun `PowerShell names the cameras when ffmpeg listed none`() {
+        val devices = parseWindowsCameras(
+            dshowOutput = "",
+            pnpOutput = "Integrated Webcam\nSurface Camera Front\n",
+        )
+
+        assertEquals(
             listOf("Integrated Webcam", "Surface Camera Front"), devices.map { it.name },
-            "the one both listings know is offered once, under ffmpeg's name for it",
+            "which in practice means ffmpeg is not installed: the names are unopenable either way, " +
+                "and exist so the operator sees their camera beside the hint saying what to install",
+        )
+    }
+
+    @Test
+    fun `a PnP-only name is still addressed as a dshow device`() {
+        val devices = parseWindowsCameras(dshowOutput = "", pnpOutput = "Surface Camera Front")
+
+        assertEquals(
+            listOf("dshow://:dshow-vdev=Surface Camera Front"), devices.map { it.path },
+            "the fallback changes which names are offered, not the shape of the path they carry",
         )
     }
 
@@ -294,7 +320,18 @@ class SourcePropertiesDeviceListingTest {
 
         assertEquals(
             listOf("Integrated Webcam"), devices.map { it.name },
-            "matching is case-insensitive, and ffmpeg's spelling is the one that must be kept",
+            "ffmpeg's spelling is the one that must be kept, and here it wins by being the only " +
+                "listing consulted at all",
+        )
+    }
+
+    @Test
+    fun `the PnP fallback does not offer one camera twice`() {
+        val devices = parseWindowsCameras("", "Surface Camera Front\nSURFACE CAMERA FRONT")
+
+        assertEquals(
+            listOf("Surface Camera Front"), devices.map { it.name },
+            "dedupe is case-insensitive on the fallback path too",
         )
     }
 

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/PresenterCameraBackgroundTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/PresenterCameraBackgroundTest.kt
@@ -3,6 +3,7 @@
 package org.churchpresenter.app.churchpresenter.presenter
 
 import androidx.compose.ui.test.runComposeUiTest
+import org.churchpresenter.app.churchpresenter.composables.CameraDevice
 import org.churchpresenter.core.models.camera.CameraDeviceRef
 import org.churchpresenter.core.models.songs.SongBackground
 import org.churchpresenter.core.models.songs.SongBackgroundType
@@ -37,7 +38,14 @@ class PresenterCameraBackgroundTest {
     private fun cameraSong(camera: CameraDeviceRef = card) =
         SongBackground(type = SongBackgroundType.CAMERA, camera = camera)
 
-    /** Runs the resolver in a composition and hands back what it decided. */
+    /**
+     * Runs the resolver in a composition and hands back what it decided.
+     *
+     * [knownCameras] is passed explicitly on every call, and defaults to null — "nothing has
+     * enumerated". It must never be left to `CameraDeviceCatalog`: that is process-global and a
+     * composition fills it, so a camera property panel rendered by any earlier suite in this fork
+     * would decide these assertions instead of the arguments below.
+     */
     private fun resolve(
         settings: BackgroundSettings = BackgroundSettings(),
         config: BackgroundConfig = BackgroundConfig(),
@@ -45,6 +53,7 @@ class PresenterCameraBackgroundTest {
         showBackground: Boolean = true,
         transparentWhenBlank: Boolean = false,
         ownBackground: SongBackground = SongBackground(),
+        knownCameras: List<CameraDevice>? = null,
     ): ResolvedBackground {
         lateinit var resolved: ResolvedBackground
         runComposeUiTest {
@@ -56,6 +65,7 @@ class PresenterCameraBackgroundTest {
                     showBackground = showBackground,
                     transparentWhenBlank = transparentWhenBlank,
                     ownBackground = ownBackground,
+                    knownCameras = knownCameras,
                 )
             }
         }
@@ -151,9 +161,25 @@ class PresenterCameraBackgroundTest {
 
     @Test
     fun `a song's camera is dropped when this machine does not have the device`() {
-        // Nothing has enumerated in this test JVM, so the catalog is null and accepts — the
-        // rejecting case is CameraDeviceCatalogTest's, which drives the predicate directly.
-        val resolved = resolve(config = BackgroundConfig(), ownBackground = cameraSong())
+        val resolved = resolve(
+            config = BackgroundConfig(),
+            ownBackground = cameraSong(),
+            knownCameras = listOf(
+                CameraDevice(name = "Logitech BRIO", path = "avfoundation://1", displayName = "Logitech BRIO")
+            ),
+        )
+
+        assertFalse(resolved.usesCamera, "the song names a card this machine has not got")
+    }
+
+    /**
+     * Accepting before the first enumeration answers is deliberate — see `cameraResolves`. A cold
+     * start would otherwise drop a perfectly good camera to the settings background for as long as
+     * shelling out to ffmpeg takes.
+     */
+    @Test
+    fun `a song's camera is kept while this machine has not been asked`() {
+        val resolved = resolve(config = BackgroundConfig(), ownBackground = cameraSong(), knownCameras = null)
 
         assertTrue(resolved.usesCamera, "accepted while this machine has not been asked")
     }


### PR DESCRIPTION
Fixes #462, both halves.

The Canvas tab pegs the CPU and the app "hangs"; a camera nothing else is using refuses to open; and on Windows a USB camera is "not detecting". All three reproduce on a Mac mini except the Windows half, which is reasoned from the code and covered by tests.

---

# Part 1 — the CPU load

**Shared sources were not shared.** The canvas has four source types a scene can draw more than once — a layer is composed in the canvas editor, in every sidebar live preview, and on every presenter output. Camera and NDI had a refcounted cache; **video and screen capture did not**, so every instance did the whole job again:

- Screen capture ran its own `Robot.createScreenCapture` loop per instance at up to 30fps over the same pixels. Grabbing the framebuffer is the window server's work, which is why it reads as the compositor being pegged — the reported machine had WindowServer at 91-95% beside the app's 160%.
- Video built its own `MediaPlayerFactory`, player and conversion loop per instance: the same file decoded at full source resolution once per place it appeared, and its audio played that many times over itself with nothing mixing the streams. `LoopingVideoBackground` carried a second copy of the same per-instance decode.

**Acquire and release were on different lifecycles.** Camera, NDI and Browser Source all called `acquire` from a `remember` block and `release` from a `DisposableEffect`. A composition abandoned before its effects run discards what `remember` produced without calling any `onDispose`, so the entry leaked — and it owns an ffmpeg process holding the camera open, which is why the *next* acquire finds it busy. Browser Source also disposed on `source.id` while acquiring on id plus viewport size, so every resize acquired a second headless browser and released neither.

**The idle app never idled.** `SingleDisplayPreview` read an infinite transition's value at the top of its own scope, invalidating that scope — and the `PresenterScreen` nested in it — every animation frame, for every output, whether or not the output was live. The badge it animates is only drawn when live.

### Two bugs the new tests found

Both predate the caches and were carried in the per-instance code:

- **Releasing while a player was still opening leaked it.** The open ran in a cancellable `withContext`, so a scene switched quickly cancelled it mid-open and the handle the `finally` would have closed was never assigned — the native decoder then ran for the life of the app. `NdiFrameCache` opened its receiver the same way and is fixed with it.
- **A canvas video's volume never reached the decoder.** It was applied at acquire, while the player was still opening and there was nothing to set it on, so it was dropped and the file played at libvlc's default.

### Measured

Mac mini, 1 display + 1 Browser Source + 1 NDI output configured. Each figure is the mean of thirty `ps %cpu` reads over 60s, display confirmed on for the whole window (a sleeping display pauses compositing and reads as ~2% whatever the build).

| | `v26.10.224` | this branch |
|---|---|---|
| idle, nothing live | 22.9 / 22.2 / 23.8 → **23.0%** | 1.1 / 2.9 / 1.2 → **1.7%** |
| canvas live, video + screen capture | 159.6 / 159.2 → **159.4%** | 64.8 / 65.4 → **65.1%** |

The reporter's screenshots show 160.5% and 162.7% on the same scenario, so the baseline is their bug rather than an approximation of it. Worth being precise about what each fix bought: the idle saving is the recomposition fix and it does **nothing** for the live case (measured: 158.3% with only that fix). The live saving is entirely the shared caches.

---

# Part 2 — Windows camera detection

`windowsCamerasFrom` ran two enumerations and **merged** them — ffmpeg's DirectShow listing and a PowerShell `Win32_PnPEntity` query — turning both into the same `dshow://:dshow-vdev=<name>` path. They do not name devices in the same space: ffmpeg prints the `FriendlyName` needed to open a filter, PnP prints a label for hardware Windows knows about. A PnP-only name becomes `-i video=<label>`, ffmpeg answers "Could not find video device", and the classifier reports `DEVICE_NOT_FOUND` — telling the operator their camera "is no longer connected" about a device that was never openable.

**Worse with no ffmpeg installed**: the DirectShow listing comes back empty, PowerShell fills the picker anyway, and every entry is unopenable because capture needs ffmpeg however the device was found. `runFfmpegCapture` returned without setting an error, so the canvas drew its ordinary placeholder and nothing said why. That is a camera that looks present, selects fine, and shows nothing — which matches the report better than a name mismatch does.

ffmpeg's listing is authoritative now; the PnP query is a fallback for when it named nothing. Those entries still cannot be opened — they exist so the operator sees their camera named beside the hint saying what to install, rather than an empty list. **This is what `parseMacCameras` already does with `system_profiler`, for the same reason and with the reasoning already written down there.** Also: PowerShell is not run at all when ffmpeg answered, `PNPClass = 'Image'` is dropped (scanners were offered as cameras), and both commands are bounded — they waited forever.

**The hint the operator needed was the one they could not see.** Both pickers decided it inline and disagreed: `CameraPickerRow` mentioned ffmpeg only when the list was empty, which on Windows without ffmpeg it is not. `cameraHintStringRes` decides once for both, and the ffmpeg sentence no longer depends on emptiness or frames ffmpeg as needed only for *virtual* cameras. `CameraFailure.FFMPEG_MISSING` gives the canvas something to say on the silent path, and Windows gets its own wording for the two failures whose remedy is a page in the platform's settings.

`CameraPickerRow` also probed `isFfmpegAvailable()` straight from composition — running `ffmpeg -version` against each candidate install path with a 5s timeout each — in a file whose own comment says it deliberately does not do that. Moved to an IO-dispatched effect.

---

## Behaviour changes worth knowing

- One decode means **one audio stream**. A scene drawing the same video in several places used to play its audio once per instance, unmixed and overlapping.
- Switching a camera's format or connection is now release-then-acquire rather than acquire-then-release, so it closes and reopens the device instead of relying on the incoming open to displace the outgoing one. `SharedCameraFrameCache.release` documents why.
- A Windows machine may be offered **fewer** cameras than before — specifically the ones ffmpeg never listed, which could not be opened.
- `canvas_camera_ffmpeg_hint` is superseded but stays defined: fourteen locales translate it, and removing it would orphan every one, which `LocaleStringsTest` gates against. Its 37-key allowance is tracked debt, not permission to add more.

## Tests

New: `ScreenCaptureCacheTest`, `SceneVideoCacheTest`, `SceneSourceCameraLifecycleTest`, `CameraToolHintsTest`. Each takes its platform call as a constructor seam, so none touches `Robot`, libvlc, PowerShell or a real camera. Full suite green (10,137) and detekt clean; the new suites were run three consecutive times with `--rerun-tasks`.

`SourcePropertiesDeviceListingTest`'s `PowerShell fills in cameras ffmpeg did not report` **asserted the defect** and is rewritten rather than deleted.

Not covered, and said so in the test classes: composition abandonment itself, which has no hook in `runComposeUiTest`.

## What cannot be verified here

CI is Linux and nobody on the project has Windows, so the Windows half splits by confidence:

| Part | Confidence |
|---|---|
| Enumeration precedence, dedupe, fallback, command sequencing, timeouts, query text, hint selection | **High** — pure functions over strings, covered by `FakeCommandRunner` |
| That every modern webcam registers under `PNPClass = 'Camera'` | **Medium** — the query string is tested; real-world class coverage is not. Fallback-only placement bounds the downside |
| That ffmpeg's dshow list is a superset of openable devices | **Medium-high** — architecturally sound; mitigated by keeping the PnP fallback rather than an empty list |
| The 10s/15s timeouts | **Medium** — reasoned from `powershell.exe` cold start and WMI enumeration cost, not measured. They are ceilings |
| `ms-settings:privacy-webcam` and the Windows Settings labels | **Low-medium** — Windows 11 wording; Windows 10 differs |

**A limitation these timeouts do not fix:** `readCommandOutput` reads stdout to EOF *before* `waitFor` (deliberate — it prevents a pipe-buffer deadlock). They therefore bound the wait, not the read, so a DirectShow filter that hangs holding the pipe open still blocks forever. Fixing that needs a drained-with-budget read affecting every caller, with no deterministic test under the no-sleep rule. Out of scope; future "camera detection hangs" reports may bottom out here.

## Still open

- The camera frame path does four full passes per frame — read, per-pixel BGRA→ARGB, `setRGB`, `toComposeImageBitmap`. `ComposeScenePump.FrameBuffer` is the worked example of removing exactly that, and the camera path never got it.
- Worth asking the reporter for `ffmpeg -list_devices true -f dshow -i dummy` to confirm which Windows cause it was. After this change the two are distinguishable from the UI alone.

---

# Part 3 — making the next one self-diagnosing

Triaging this issue we could not tell the two Windows causes apart from the report, and the
ffmpeg-missing path reported nothing at all. The only way to learn which it was would have been to
ask the reporter to run `ffmpeg -list_devices` — which most church operators cannot do.

Enumeration now returns what it found alongside the devices, and camera reports carry four tags that
settle it from the issue page alone:

| tag | values |
|---|---|
| `camera.ffmpeg` | `present` / `absent` — one cause on its own |
| `camera.enumerator` | `dshow`, `pnp_fallback`, `avfoundation`, `system_profiler_fallback`, `v4l2_sysfs`, `unsupported_os`, `not_run` — `pnp_fallback` **is** the other cause |
| `camera.listed` | how many the winning enumerator named |
| `camera.device_listed` | `yes` / `no` / `not_enumerated` |

**Everything sent is a count or an enum name.** Device names stay in the process, and
`CameraReportFactsTest` asserts that a camera called "Bob's Logitech" leaves no trace of itself in
any tag or in the extra — `CrashReporter.scrubPii` covers messages, string extras, breadcrumbs and
contexts but **not tags**, so that test is the only thing standing between the two.

Three reports, all bounded:
- the **existing give-up warning** gains the tags — no new volume;
- the **ffmpeg-missing path** now reports once per process instead of silently. The old comment is
  right about a *tool* and wrong about this state: the app listed the device in its own picker, the
  operator chose it, and the app produced nothing. That is our UI's contract, not the user's machine;
- one **new report** when ffmpeg works, Windows lists a camera and ffmpeg lists none — otherwise only
  learnable if someone picks a doomed device and waits out five attempts.

`DeviceInfoReport` gains a **Cameras** section, reading the cached enumeration rather than running a
fresh one (which would cost ~25s under the new timeouts with the operator waiting on a button). That
changes the triage ask from a terminal command to *Save diagnostic info*, and covers the installs
with analytics switched off.

## Part 4 — a resource census, and why not CPU or memory

Three leaks were found in this area in one week — an ffmpeg process holding a camera, a libvlc
decoder, and a headless browser leaked on every viewport resize. **All three leak a process or a
native handle, so a JVM heap chart was flat through every one of them.** CPU is no better: a busy
canvas legitimately costs a lot, and without a per-machine baseline "expensive" and "three times more
expensive than it should be" look identical — we only knew because we had a before/after on identical
hardware.

What the three have in common is a count that goes up and does not come down, so that is what is
watched. `ResourceCensus` records the high-water mark of the five refcounted native resources where
it can rise, and reports **once at shutdown, only when a peak is higher than a scene can account
for**. Nothing is sent on a normal run.

There is a threshold, and it is worth pushing on: it bounds **distinct native handles**, not CPU or
memory. Entries are keyed by what they open — one per camera device, one per video file, one per
capture region — so eight simultaneous distinct video decodes is not a booth working hard, it is a
count that stopped coming down. That is hardware-independent in the way a CPU threshold is not. Set
generously on purpose: a false negative costs one missed leak, which is where we already were; a
false positive trains everyone to ignore the next report.

Deliberately **not** added: general CPU or memory telemetry. It would have missed all three leaks
above, and broad profiling sends far more about what users are doing than the shapes-and-counts
stance the rest of this PR commits to.
