### PR TITLE
Stop a saved camera index from quietly becoming a screen recording

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.churchpresenter.core.models.scene.SceneSource
 import java.io.File
 
@@ -586,4 +588,153 @@ internal fun macListingOf(systemProfilerOutput: String, ffmpegOutput: String): C
     return systemProfilerCameraNames(systemProfilerOutput)
         .mapIndexed { index, name -> CameraDevice(name = name, path = "avfoundation://$index", displayName = name) }
         .asListing(CameraEnumerator.SYSTEM_PROFILER_FALLBACK)
+}
+
+/** The scheme prefix every AVFoundation device path carries. */
+private const val AVFOUNDATION_PREFIX = "avfoundation://"
+
+/** How AVFoundation names the displays it offers alongside the real cameras. */
+private const val SCREEN_CAPTURE_PREFIX = "capture screen"
+
+/**
+ * True for AVFoundation's screen-grab pseudo-devices, which share one index space with the cameras.
+ *
+ * `ffmpeg -f avfoundation -list_devices true` prints the attached displays as ordinary numbered
+ * video devices at the end of the same list — `[4] Capture screen 0` — and opening one is a screen
+ * recording, which is what macOS raises its Screen Recording prompt for. Nothing distinguishes them
+ * but the name.
+ */
+internal fun isScreenCaptureDevice(name: String): Boolean =
+    name.trim().lowercase().startsWith(SCREEN_CAPTURE_PREFIX)
+
+/** Where a saved AVFoundation device is *now*, or why it must not be opened. */
+internal sealed interface AvfResolution {
+
+    /** The saved name is at this path — either the stored index, confirmed, or a corrected one. */
+    data class At(val devicePath: String) : AvfResolution
+
+    /** The saved name is not in the current listing. Whatever is at that index, it is not this. */
+    data object Gone : AvfResolution
+
+    /** Nothing to resolve: not an AVFoundation device, no saved name, or nothing has enumerated. */
+    data object NotApplicable : AvfResolution
+}
+
+/**
+ * Re-finds [source]'s device by **name** in [known], because its stored index may no longer be it.
+ *
+ * AVFoundation has no name-based addressing: a device is opened by its position in the listing, and
+ * that listing is not stable across launches. Virtual cameras (OBS, NDI, Meld) register when their
+ * host app starts, and displays come and go, so a position that named a capture card yesterday can
+ * name a different camera today — or `Capture screen 0`, which turns a camera layer into a screen
+ * recording and makes macOS ask for Screen Recording permission at launch. That is issue #478, and
+ * a real machine was observed listing 5 devices one minute and 6 the next.
+ *
+ * Issue #431 fixed *enumeration* to use the index ffmpeg itself prints. This is the other half:
+ * a stored index is a snapshot of one enumeration, and it has to be re-checked against the current
+ * one before anything is opened.
+ *
+ * [known] null means nothing has enumerated yet, which is [AvfResolution.NotApplicable] rather than
+ * a refusal — the caller enumerates first and asks again. **Empty is the same answer**, and for the
+ * more important reason: an enumeration that listed nothing has told us we do not know what this
+ * machine has, not that the operator's camera is gone, and turning "we could not look" into a
+ * refusal would black out a working camera to fix a rare one. A blank
+ * [SceneSource.CameraSource.deviceName] — a settings file written before names were stored — is
+ * unresolvable on the same principle.
+ *
+ * A refusal therefore needs a positive fact: a listing that has entries, and none of them this one.
+ */
+internal fun resolveAvfoundationDevice(
+    source: SceneSource.CameraSource,
+    known: List<CameraDevice>?,
+): AvfResolution {
+    if (!needsAvfResolution(source) || known.isNullOrEmpty()) return AvfResolution.NotApplicable
+
+    val match = known.firstOrNull { !it.isDeckLink && it.name == source.deviceName }
+    return if (match != null) AvfResolution.At(match.path) else AvfResolution.Gone
+}
+
+/**
+ * Whether [source] is the kind of device [resolveAvfoundationDevice] can say anything about, asked
+ * without an enumeration in hand.
+ *
+ * Separate because the capture path has to decide **whether to enumerate at all** before it has
+ * anything to resolve against, and enumerating shells out to `ffmpeg` and `system_profiler` — far
+ * too much to spend on a Windows camera or a DeckLink card that was never in this index space.
+ */
+internal fun needsAvfResolution(source: SceneSource.CameraSource): Boolean =
+    source.devicePath.startsWith(AVFOUNDATION_PREFIX) && source.deviceName.isNotBlank()
+
+/**
+ * The name currently sitting at [source]'s stored index, for a report that has to say what we
+ * refused to open. Blank when the index is past the end of the listing.
+ *
+ * Only ever used to describe a [AvfResolution.Gone] — the decision itself is the name match above,
+ * so that a stored index landing on another *camera* is refused just as firmly as one landing on a
+ * display. But which of the two happened is the difference between "your camera is unplugged" and
+ * "we just stopped the app from recording your screen", and only the report can tell us that.
+ */
+internal fun avfDeviceNameAt(source: SceneSource.CameraSource, known: List<CameraDevice>?): String {
+    val index = source.devicePath.removePrefix(AVFOUNDATION_PREFIX).toIntOrNull() ?: return ""
+    return known?.getOrNull(index)?.name.orEmpty()
+}
+
+/**
+ * [source] with its AVFoundation index re-checked against the current listing, or null when the
+ * device it names is not there any more and nothing may be opened.
+ *
+ * **This is the first thing on the startup path that enumerates**, and that is the point of it. A
+ * camera background renders as soon as the presenter window opens, long before any picker has run,
+ * so [CameraDeviceCatalog] is empty and [cameraResolves] — which accepts a null catalog on
+ * purpose — has let the stored index through unchecked. One `ffmpeg -list_devices` on the first
+ * camera of the run is the only moment at which the check can be made at all.
+ *
+ * Top-level rather than a member of [SharedCameraFrameCache] so that object stays under its
+ * function threshold, which is why the failure arrives by [onRefused] rather than by touching the
+ * cache entry directly.
+ *
+ * @param onRefused run with what to show the operator when the device may not be opened.
+ * [CameraFailure.DEVICE_NOT_FOUND] and not a constant of its own: its sentence — the camera is no
+ * longer connected — is exactly true of a name that has left the listing, whether it left because
+ * the card was unplugged or because something else now sits at its index.
+ */
+internal suspend fun avfSourceToOpen(
+    source: SceneSource.CameraSource,
+    gate: ReportOnce,
+    onRefused: (CameraFailure) -> Unit,
+): SceneSource.CameraSource? {
+    if (!needsAvfResolution(source)) return source
+
+    val catalogDevices = CameraDeviceCatalog.devices.value
+    val listing = if (catalogDevices == null) {
+        withContext(Dispatchers.IO) { macListing(::readCommandOutput) }
+    } else null
+    val known = catalogDevices ?: listing?.devices
+
+    return when (val resolution = resolveAvfoundationDevice(source, known)) {
+        is AvfResolution.At -> {
+            if (resolution.devicePath != source.devicePath) {
+                System.err.println(
+                    "[Camera] '${source.deviceName}' has moved to ${resolution.devicePath} " +
+                        "(saved as ${source.devicePath}) — opening it where it is now"
+                )
+            }
+            // The cache key is built from the *stored* path (see `keyFor`), and `release` looks its
+            // entry up by that same key. Only the command line follows the device.
+            source.copy(devicePath = resolution.devicePath)
+        }
+
+        AvfResolution.Gone -> {
+            val refused = avfDeviceNameAt(source, known)
+            System.err.println(
+                "[Camera] Refusing ${source.devicePath}: it holds " +
+                    "'${refused.ifBlank { "nothing" }}' now, not '${source.deviceName}'"
+            )
+            onRefused(CameraFailure.DEVICE_NOT_FOUND)
+            reportAvfIndexDrift(source, refused, CameraDeviceCatalog.lastEnumeration ?: listing?.facts, gate)
+            null
+        }
+
+        AvfResolution.NotApplicable -> source
+    }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFacts.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFacts.kt
@@ -153,3 +153,41 @@ internal fun reportCameraFfmpegMissing(
         )
     )
 }
+
+/**
+ * Says once that a saved AVFoundation index was refused because the name it was stored under is no
+ * longer at it.
+ *
+ * The tag worth having is [refusedName]: an index that now holds `Capture screen 0` means the app
+ * was one call away from recording the operator's display and asking macOS for permission to do it
+ * on every launch — issue #478 — while an index holding another camera, or nothing, is the ordinary
+ * "that device is gone". They are one decision (see `resolveAvfoundationDevice`) and two very
+ * different reports.
+ *
+ * Once per process, like [reportCameraFfmpegMissing], because a canvas layer and a background on
+ * the same stale device would otherwise each send one.
+ */
+internal fun reportAvfIndexDrift(
+    source: SceneSource.CameraSource,
+    refusedName: String,
+    facts: CameraEnumerationFacts?,
+    gate: ReportOnce,
+) {
+    if (!gate.claim()) return
+    CrashReporter.reportWarning(
+        "Camera: saved AVFoundation index no longer holds the saved device",
+        tags = mapOf(
+            "subsystem" to "camera",
+            "device_scheme" to deviceScheme(source.devicePath),
+            "failure_cause" to CameraFailure.DEVICE_NOT_FOUND.name.lowercase(),
+            "avf_index_now" to when {
+                refusedName.isBlank() -> "out_of_range"
+                isScreenCaptureDevice(refusedName) -> "screen_capture"
+                else -> "other_camera"
+            },
+        ) + cameraEnumerationTags(facts, source.deviceName, ffmpegAvailable = true),
+        extras = mapOf(
+            "camera_enumeration" to cameraEnumerationExtra(facts, source.deviceName, ffmpegAvailable = true)
+        )
+    )
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -153,6 +153,9 @@ object SharedCameraFrameCache {
     /** Bounds the ffmpeg-missing report to one per process — see [runFfmpegCapture]. */
     private val ffmpegMissingReport = ReportOnce()
 
+    /** The same, for a stored AVFoundation index that has drifted — see [avfSourceToOpen]. */
+    private val avfIndexDriftReport = ReportOnce()
+
     // ── DeckLink capture ────────────────────────────────────────────
 
     /** Puts one polled DeckLink frame on screen; false when the poll returned no usable frame. */
@@ -361,7 +364,9 @@ object SharedCameraFrameCache {
             return
         }
 
-        val loop = CaptureLoop(source, entry)
+        val opening = avfSourceToOpen(source, avfIndexDriftReport) { entry.error.value = it } ?: return
+
+        val loop = CaptureLoop(opening, entry)
         loop.run()
         loop.reportIfGaveUp()
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/AvfoundationIndexDriftTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/AvfoundationIndexDriftTest.kt
@@ -1,0 +1,155 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import org.churchpresenter.core.models.scene.SceneSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Re-finding a saved AVFoundation camera when the index it was saved at no longer holds it.
+ *
+ * AVFoundation addresses a device by its position in one listing that also contains virtual
+ * cameras and the machine's own displays. Virtual cameras register when their host app starts, so
+ * that listing is a different length at different moments — a real reporter's Mac was seen
+ * alternating between five and six entries minutes apart. A stored index is therefore a snapshot,
+ * and the device at it can become a *different camera* or `Capture screen 0`, whose picture is the
+ * operator's display: opening that is a screen recording, which is why macOS asked that reporter
+ * for Screen Recording permission on every launch (issue #478).
+ *
+ * The fixtures below are that machine's real listing, from the reporter's own terminal output in
+ * issue #431, and are driven through the production parser rather than hand-built device lists.
+ */
+class AvfoundationIndexDriftTest {
+
+    /** The reporter's Mac with everything running: four video devices, then the display. */
+    private val fullListing = """
+        [AVFoundation indev @ 0x7f8b1bf052c0] AVFoundation video devices:
+        [AVFoundation indev @ 0x7f8b1bf052c0] [0] Meld Studio Virtual Camera
+        [AVFoundation indev @ 0x7f8b1bf052c0] [1] OBS Virtual Camera
+        [AVFoundation indev @ 0x7f8b1bf052c0] [2] USB3 Video
+        [AVFoundation indev @ 0x7f8b1bf052c0] [3] NDI Virtual Camera
+        [AVFoundation indev @ 0x7f8b1bf052c0] [4] Capture screen 0
+        [AVFoundation indev @ 0x7f8b1bf052c0] AVFoundation audio devices:
+        [AVFoundation indev @ 0x7f8b1bf052c0] [0] MacBook Pro Microphone
+    """.trimIndent()
+
+    /**
+     * The same Mac at login, before OBS and Meld have started. The capture card is at 0 now, and
+     * index 2 — where it used to be — is the display.
+     */
+    private val coldListing = """
+        [AVFoundation indev @ 0x7f8b1bf052c0] AVFoundation video devices:
+        [AVFoundation indev @ 0x7f8b1bf052c0] [0] USB3 Video
+        [AVFoundation indev @ 0x7f8b1bf052c0] [1] NDI Virtual Camera
+        [AVFoundation indev @ 0x7f8b1bf052c0] [2] Capture screen 0
+        [AVFoundation indev @ 0x7f8b1bf052c0] AVFoundation audio devices:
+        [AVFoundation indev @ 0x7f8b1bf052c0] [0] MacBook Pro Microphone
+    """.trimIndent()
+
+    /** The card unplugged, so nothing but the virtual cameras and the display are left. */
+    private val unpluggedListing = """
+        [AVFoundation indev @ 0x7f8b1bf052c0] AVFoundation video devices:
+        [AVFoundation indev @ 0x7f8b1bf052c0] [0] Meld Studio Virtual Camera
+        [AVFoundation indev @ 0x7f8b1bf052c0] [1] OBS Virtual Camera
+        [AVFoundation indev @ 0x7f8b1bf052c0] [2] Capture screen 0
+    """.trimIndent()
+
+    private fun devices(ffmpegOutput: String) = parseMacCameras("", ffmpegOutput)
+
+    /** The capture card as the operator saved it, back when it was at index 2. */
+    private fun savedCard(path: String = "avfoundation://2") = SceneSource.CameraSource(
+        id = "layer-1", name = "Camera", devicePath = path, deviceName = "USB3 Video",
+    )
+
+    @Test
+    fun `the listing puts the display in the same index space as the cameras`() {
+        val parsed = devices(fullListing)
+        assertEquals(5, parsed.size, "the display is a video device to AVFoundation, so it is listed")
+        assertEquals("avfoundation://4", parsed.last().path)
+        assertTrue(isScreenCaptureDevice(parsed.last().name))
+        assertFalse(isScreenCaptureDevice(parsed[2].name))
+    }
+
+    @Test
+    fun `an index that still holds the saved device is confirmed`() {
+        assertEquals(
+            AvfResolution.At("avfoundation://2"),
+            resolveAvfoundationDevice(savedCard(), devices(fullListing)),
+        )
+    }
+
+    @Test
+    fun `an index that has drifted is corrected to where the device is now`() {
+        assertEquals(
+            AvfResolution.At("avfoundation://0"),
+            resolveAvfoundationDevice(savedCard(), devices(coldListing)),
+            "the card is at 0 before the virtual cameras register; opening 2 would grab the screen",
+        )
+    }
+
+    @Test
+    fun `an index now holding the display is refused rather than opened`() {
+        assertEquals(AvfResolution.Gone, resolveAvfoundationDevice(savedCard(), devices(unpluggedListing)))
+        assertEquals("Capture screen 0", avfDeviceNameAt(savedCard(), devices(unpluggedListing)))
+    }
+
+    @Test
+    fun `an index now holding a different camera is refused just as firmly`() {
+        val saved = savedCard(path = "avfoundation://1")
+        assertEquals(AvfResolution.Gone, resolveAvfoundationDevice(saved, devices(unpluggedListing)))
+        assertEquals(
+            "OBS Virtual Camera",
+            avfDeviceNameAt(saved, devices(unpluggedListing)),
+            "the wrong picture behind the lyrics is a worse failure than a black screen",
+        )
+    }
+
+    @Test
+    fun `an index past the end of the listing names nothing`() {
+        val saved = savedCard(path = "avfoundation://9")
+        assertEquals(AvfResolution.Gone, resolveAvfoundationDevice(saved, devices(unpluggedListing)))
+        assertEquals("", avfDeviceNameAt(saved, devices(unpluggedListing)))
+    }
+
+    @Test
+    fun `nothing is resolved before an enumeration has run`() {
+        assertEquals(AvfResolution.NotApplicable, resolveAvfoundationDevice(savedCard(), null))
+        assertTrue(needsAvfResolution(savedCard()), "but the caller is told to go and enumerate")
+    }
+
+    @Test
+    fun `an enumeration that listed nothing is not evidence the device is gone`() {
+        assertEquals(
+            AvfResolution.NotApplicable,
+            resolveAvfoundationDevice(savedCard(), emptyList()),
+            "a listing we could not read means we do not know, and blacking out a working camera " +
+                "on no evidence is a worse trade than the rare stale index this guards against",
+        )
+    }
+
+    @Test
+    fun `a device saved without a name has nothing to match on`() {
+        val nameless = SceneSource.CameraSource(
+            id = "layer-1", name = "Camera", devicePath = "avfoundation://2", deviceName = "",
+        )
+        assertFalse(needsAvfResolution(nameless))
+        assertEquals(AvfResolution.NotApplicable, resolveAvfoundationDevice(nameless, devices(fullListing)))
+    }
+
+    @Test
+    fun `devices in other index spaces are left alone`() {
+        val windows = SceneSource.CameraSource(
+            id = "layer-1", name = "Camera",
+            devicePath = "dshow://:dshow-vdev=USB3 Video", deviceName = "USB3 Video",
+        )
+        val card = SceneSource.CameraSource(
+            id = "layer-1", name = "Camera", devicePath = "decklink://1",
+            deviceName = "DeckLink Mini Recorder", isDeckLink = true, deckLinkIndex = 1,
+        )
+        assertFalse(needsAvfResolution(windows))
+        assertFalse(needsAvfResolution(card))
+        assertEquals(AvfResolution.NotApplicable, resolveAvfoundationDevice(windows, devices(fullListing)))
+        assertEquals(AvfResolution.NotApplicable, resolveAvfoundationDevice(card, devices(fullListing)))
+    }
+}


### PR DESCRIPTION
Towards #478, and the other half of #431.

## The problem

AVFoundation has no name-based addressing — a camera is opened by its **position** in a listing that also contains virtual cameras and the machine's own displays:

```
[0] Meld Studio Virtual Camera
[1] OBS Virtual Camera
[2] USB3 Video          ← saved as avfoundation://2
[3] NDI Virtual Camera
[4] Capture screen 0
```

That listing changes shape between launches: OBS, NDI and Meld register their virtual cameras when their host app starts. At login, before any of them are up, the same Mac lists `[0] USB3 Video, [1] NDI Virtual Camera, [2] Capture screen 0` — and index 2, the saved one, is now the **display**.

Opening that is a screen recording, which is what macOS raises its Screen Recording prompt for. A camera background renders as soon as the presenter window opens, long before any picker has enumerated, so `cameraResolves` — which accepts a null catalog on purpose — let the stale index straight through. On every launch.

The reporter's crash-reporter data shows their device list alternating between **5 and 6 entries** minutes apart, while their own `-list_devices` output in #431 showed four real cameras. The extras are the displays.

## The change

Enumerate before the first camera of the run is opened, and re-find the device by the name already stored beside the index (`CameraDeviceRef.deviceName`):

- index still holds the saved device → confirmed, opened as before;
- index has drifted → corrected to where the device is now, so the camera keeps working instead of going black;
- index holds anything else → refused, shown as `DEVICE_NOT_FOUND`.

`DEVICE_NOT_FOUND` is reused rather than given a new constant: its existing sentence — the camera is no longer connected — is exactly true of a name that has left the listing, so no new string resource and no translation surface.

**A refusal needs a positive fact:** a listing with entries, none of them this device. An empty or absent listing means we could not look, and blacking out a working camera on no evidence is the worse trade — so that stays `NotApplicable`.

The cache key still hashes the *stored* path (`keyFor`), since `release` looks its entry up by the same key. Only the command line follows the device.

## Reporting

The warning distinguishes an index now holding a display (`avf_index_now=screen_capture`) from one holding another camera or nothing. They are one decision and two very different events — the first is the app one call away from recording someone's screen — and that tag is what will confirm whether #478 was this.

## Notes

- Nothing changes off macOS: `needsAvfResolution` is false for dshow, v4l2 and DeckLink, so there is no enumeration cost on those paths.
- The extra enumeration is one `ffmpeg -list_devices` on the first camera of the run, and only when the picker has not already populated the catalogue.
- I could not reproduce #478 directly, so this is not confirmed as its cause. It is a real defect either way, and it adds the signal that would tell us.

## Tests

`AvfoundationIndexDriftTest` — nine cases driven through the production parser on the reporter's real listing: index confirmed, index corrected, index now a display, index now another camera, index out of range, no enumeration yet, empty enumeration, no saved name, and the other index spaces left alone. All pure, 0.0s.

`test-changed.sh` green; `:composeApp:detekt` clean.