### PR TITLE
Say why a camera cannot open when ffmpeg is present and blind

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -1167,7 +1167,7 @@
     <string name="audio_output_device">Output device</string>
     <string name="audio_output_default">System Default</string>
     <string name="media_vlc_required">VLC media player is required for media playback</string>
-    <string name="background_camera_required">A camera or capture device is required. Install ffmpeg, or connect a Blackmagic DeckLink card.</string>
+    <string name="background_camera_required">A camera or capture device is required. Connect a camera or a Blackmagic DeckLink card, or check Settings → Projection if ffmpeg could not be found.</string>
     <string name="media_vlc_install">Please install VLC from videolan.org and restart the application</string>
     <string name="media_vlc_arch_mismatch">Wrong VLC architecture. Your Mac uses Apple Silicon (arm64) but the installed VLC is Intel-only (x86_64). Download the Apple Silicon build of VLC from videolan.org and restart.</string>
     <string name="media_vlc_load_failed">VLC was found but could not be loaded. Try reinstalling VLC from videolan.org (on Windows, also install the Microsoft Visual C++ Redistributable), then restart the application.</string>
@@ -1493,10 +1493,11 @@
          virtual cameras. Kept defined because fourteen locales translate it: removing it here would
          orphan every one of those, which LocaleStringsTest gates against. -->
     <string name="canvas_camera_ffmpeg_hint">Install ffmpeg to detect virtual cameras (OBS, NDI, etc.)</string>
+    <string name="canvas_camera_unopenable_listing">ffmpeg could not list any camera on this machine. The cameras below were found by the system instead, and none of them will show a picture.</string>
     <string name="canvas_camera_ffmpeg_required">ChurchPresenter opens cameras with ffmpeg, and this build could not find its copy. Open Settings → Projection to point at an ffmpeg, then check again.</string>
     <string name="canvas_camera_v4l2_hint">Install v4l2loopback for virtual cameras: sudo apt install v4l2loopback-dkms</string>
     <string name="canvas_camera_refresh">Refresh Cameras</string>
-    <string name="canvas_camera_error_ffmpeg_missing">This camera cannot be opened because ffmpeg is not installed. Install ffmpeg, then select the camera again.</string>
+    <string name="canvas_camera_error_ffmpeg_missing">This camera cannot be opened because ChurchPresenter could not find its copy of ffmpeg. Open Settings → Projection to point at an ffmpeg, then select the camera again.</string>
     <string name="canvas_camera_error_permission_denied_windows">Windows is blocking camera access for ChurchPresenter. Open Settings → Privacy &amp; security → Camera, turn on camera access and "Let desktop apps access your camera", then select the camera again.</string>
     <string name="canvas_camera_error_device_not_found_windows">Windows could not open a camera with this name. It may have been unplugged, or its driver may name it differently than Windows does — press Refresh Cameras and pick it again.</string>
     <string name="canvas_camera_error_permission_denied">macOS is blocking camera access for ChurchPresenter. Open System Settings → Privacy &amp; Security → Camera, switch ChurchPresenter on, then select the camera again.</string>

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDeviceCatalog.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDeviceCatalog.kt
@@ -46,8 +46,14 @@ internal object CameraDeviceCatalog {
     /** Bounds the blind-ffmpeg report to one per process — re-opening a picker re-enumerates. */
     private val blindFfmpegReport = ReportOnce()
 
-    /** Re-enumerates, on IO. Safe to call from a composition's `LaunchedEffect`. */
-    suspend fun refresh(deckLinkDeviceFormat: String) {
+    /**
+     * Re-enumerates, on IO. Safe to call from a composition's `LaunchedEffect`.
+     *
+     * The default matches [listCameraDevicesWithDeckLink]'s, for the startup call that has no
+     * composition to read a string resource from — it only labels DeckLink devices, and a label is
+     * not what the startup enumeration is for.
+     */
+    suspend fun refresh(deckLinkDeviceFormat: String = "DeckLink: %1\$s") {
         val listing = withContext(Dispatchers.IO) { listCameraDevicesWithDeckLinkListing(deckLinkDeviceFormat) }
         _lastEnumeration = listing.facts
         _devices.value = listing.devices

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDiagnostics.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraDiagnostics.kt
@@ -61,8 +61,12 @@ internal enum class CameraFailure {
      *
      * Decided before ffmpeg runs rather than classified from its stderr, which is why
      * [classifyCameraFfmpegStderr] has no marker for it: there is no stderr, because there is no
-     * process. Not a defect in the app — but the operator has to be told, or the canvas is simply
-     * black with no reason given.
+     * process.
+     *
+     * It stopped meaning "the operator has not installed ffmpeg" when the app started shipping one.
+     * On a build that carries a binary this **is** a defect — the app could not find or execute its
+     * own — and the remaining innocent causes are an architecture we publish nothing for, a package
+     * that stripped it, or an override pointing at something that will not run.
      */
     FFMPEG_MISSING,
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumeration.kt
@@ -407,10 +407,15 @@ private const val PNP_QUERY_TIMEOUT_S = 15L
  * `DEVICE_NOT_FOUND`, telling the operator their camera "is no longer connected" about a device that
  * was never openable in the first place.
  *
- * The PnP query is therefore only a fallback for when ffmpeg listed nothing, which in practice means
- * ffmpeg is not installed. Capture needs ffmpeg too, so those entries can never be opened; they
- * exist so the operator still sees their camera named beside the `canvas_camera_ffmpeg_required`
- * hint telling them what to install, rather than an empty list.
+ * The PnP query is therefore only a fallback for when ffmpeg listed nothing. Capture needs ffmpeg
+ * whatever named the device, so those entries can never be opened; they exist so the operator sees
+ * their camera named beside a hint explaining that, rather than an empty list.
+ *
+ * What that hint has to say changed when the app started shipping ffmpeg. "Install ffmpeg" was the
+ * answer while the fallback meant a machine without it; now ffmpeg is present and listed nothing
+ * anyway, which is a different problem — a driver that exposes no DirectShow filter, or a device the
+ * frame server has claimed. `canvas_camera_unopenable_listing` is the sentence for that state, and
+ * `CameraEnumerator.listsUnopenableDevices` is what selects it.
  *
  * This mirrors [parseMacCameras], which resolved the same conflict between ffmpeg and
  * `system_profiler` the same way and for the same reason.
@@ -570,10 +575,15 @@ private fun systemProfilerCameraNames(systemProfilerOutput: String): List<String
  * by position invents an address, and an invented address opens the wrong device rather than
  * failing — see [avfoundationCamerasFrom].
  *
- * `system_profiler` is therefore only a fallback for when ffmpeg listed nothing, which in practice
- * means ffmpeg is not installed. Capture needs ffmpeg too, so those entries can never be opened;
- * they exist so the operator still sees their camera named beside the `canvas_camera_ffmpeg_hint`
- * telling them what to install, rather than an empty list.
+ * `system_profiler` is therefore only a fallback for when ffmpeg listed nothing. Capture needs ffmpeg
+ * whatever named the device, so those entries can never be opened; they exist so the operator sees
+ * their camera named beside a hint explaining that, rather than an empty list.
+ *
+ * Since the app ships ffmpeg, reaching this on a Mac most often means AVFoundation enumerated
+ * nothing — and the usual cause of that is a privacy refusal, which is what makes the camera
+ * privacy button beside this picker the useful thing on screen. The accompanying sentence is
+ * `canvas_camera_unopenable_listing`; this doc used to name `canvas_camera_ffmpeg_hint`, which was
+ * superseded and is kept defined only so fourteen locales' translations are not orphaned.
  */
 internal fun parseMacCameras(systemProfilerOutput: String, ffmpegOutput: String): List<CameraDevice> =
     macListingOf(systemProfilerOutput, ffmpegOutput).devices

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumerationFacts.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraEnumerationFacts.kt
@@ -29,6 +29,23 @@ internal enum class CameraEnumerator {
 
     /** Nothing has enumerated in this process yet — a real state on the presenter restore path. */
     NOT_RUN,
+
+    ;
+
+    /**
+     * Whether devices this enumerator named can be opened at all.
+     *
+     * The fallbacks name hardware the platform knows about, in a namespace ffmpeg does not accept —
+     * a PnP friendly name is not a DirectShow filter name, and a `system_profiler` position is not
+     * an AVFoundation index. Capture goes through ffmpeg either way, so those entries are decoration
+     * whatever else is true of the machine.
+     *
+     * One property rather than the same `== PNP_FALLBACK || == SYSTEM_PROFILER_FALLBACK` in two
+     * places: the hint and the blind-ffmpeg report ask the identical question, and they disagreed
+     * once already — the report was Windows-only while the hint keyed on something else entirely.
+     */
+    val listsUnopenableDevices: Boolean
+        get() = this == PNP_FALLBACK || this == SYSTEM_PROFILER_FALLBACK
 }
 
 /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFacts.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFacts.kt
@@ -97,27 +97,38 @@ internal fun cameraEnumerationExtra(
 private const val MILLIS_PER_SECOND = 1000L
 
 /**
- * Whether a listing is the "ffmpeg works, Windows sees a camera, ffmpeg does not" state.
+ * Whether a listing is the "ffmpeg works, the platform sees a camera, ffmpeg does not" state.
  *
  * A pure predicate rather than a report call so the decision is testable without standing up Sentry.
- * All three clauses matter: ffmpeg resolved (so this is not simply a machine without it), the
- * fallback won (so ffmpeg listed no DirectShow device), and the fallback found something (so this is
- * not a machine with no camera at all — reporting that would make the operator's own hardware
- * inventory look like a defect).
+ * All three clauses matter: ffmpeg resolved, the fallback won (so ffmpeg listed nothing), and the
+ * fallback found something — that last one is what keeps a machine with no camera at all from being
+ * reported, which would make the operator's own hardware inventory look like a defect.
+ *
+ * Not Windows-only. It was, and macOS reaches the identical state through `system_profiler` — where
+ * the likeliest cause is a privacy refusal, since a TCC denial makes AVFoundation enumerate nothing.
+ * macOS carries almost all of this app's camera traffic, so the Windows-only form was silent exactly
+ * where the users are.
+ *
+ * The first clause no longer discriminates on a build that bundles ffmpeg, where it is always true.
+ * It is kept for the builds that ship no binary — an unpinned architecture, or a package that
+ * stripped it — where "no ffmpeg" and "ffmpeg that sees nothing" are still different problems.
  */
 internal fun shouldReportBlindFfmpeg(facts: CameraEnumerationFacts?): Boolean =
     facts != null &&
         facts.ffmpegAvailable &&
-        facts.enumerator == CameraEnumerator.PNP_FALLBACK &&
+        facts.enumerator.listsUnopenableDevices &&
         facts.fallbackListedCount > 0
 
 /**
  * A gate that lets exactly one report through per process.
  *
- * For facts that cannot change while the app runs — whether ffmpeg resolved is a `by lazy` — so a
- * second event would carry nothing the first did not. Atomic because captures start on
- * `Dispatchers.Default` and two canvas tiles can reach the same gate at once; a plain `var` would
- * let both through.
+ * For facts that are worth saying once and no more, so a second event would carry nothing the first
+ * did not. Atomic because captures start on `Dispatchers.Default` and two canvas tiles can reach the
+ * same gate at once; a plain `var` would let both through.
+ *
+ * This used to lean on ffmpeg availability being a `by lazy` that could not change within a process.
+ * It can now — the settings card re-resolves it — so the gate is the whole of the bound rather than
+ * a belt beside a brace.
  */
 internal class ReportOnce {
     private val fired = AtomicBoolean(false)
@@ -139,17 +150,18 @@ internal fun reportCameraFfmpegMissing(
     source: SceneSource.CameraSource,
     facts: CameraEnumerationFacts?,
     gate: ReportOnce,
+    ffmpegAvailable: Boolean = false,
 ) {
     if (!gate.claim()) return
     CrashReporter.reportWarning(
-        "Camera: ffmpeg is not installed, so the selected camera cannot be opened",
+        "Camera: ChurchPresenter could not find an ffmpeg to open the selected camera with",
         tags = mapOf(
             "subsystem" to "camera",
             "device_scheme" to deviceScheme(source.devicePath),
             "failure_cause" to CameraFailure.FFMPEG_MISSING.name.lowercase(),
-        ) + cameraEnumerationTags(facts, source.deviceName, ffmpegAvailable = false),
+        ) + cameraEnumerationTags(facts, source.deviceName, ffmpegAvailable),
         extras = mapOf(
-            "camera_enumeration" to cameraEnumerationExtra(facts, source.deviceName, ffmpegAvailable = false)
+            "camera_enumeration" to cameraEnumerationExtra(facts, source.deviceName, ffmpegAvailable)
         )
     )
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraToolHints.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraToolHints.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.composables
 import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.canvas_camera_ffmpeg_required
 import churchpresenter.composeapp.generated.resources.canvas_camera_none_found
+import churchpresenter.composeapp.generated.resources.canvas_camera_unopenable_listing
 import churchpresenter.composeapp.generated.resources.canvas_camera_v4l2_hint
 import org.jetbrains.compose.resources.StringResource
 
@@ -19,6 +20,14 @@ import org.jetbrains.compose.resources.StringResource
  * So the ffmpeg sentence is **not** conditioned on emptiness: on any platform that opens cameras
  * through ffmpeg, not having it is worth saying whether or not a name happens to be listed.
  *
+ * Since ffmpeg is bundled with the app, "not having it" stopped being the interesting case and a
+ * second one took its place. A fallback enumerator only runs when ffmpeg listed nothing, and its
+ * devices are named by the platform's own inventory rather than by ffmpeg — so they cannot be opened
+ * whether or not ffmpeg is present. With a bundled binary [ffmpegAvailable] is true, which used to
+ * suppress the hint entirely and left the operator with a dropdown of cameras that silently show
+ * nothing. What matters is therefore **whether the listing is openable**, which [enumerator] says,
+ * not whether the tool is installed.
+ *
  * [devices] null is "nothing has enumerated yet" and is deliberately distinct from "there are none"
  * — saying "No cameras found" before anything has looked is a wrong answer that the operator acts
  * on, and enumeration takes a noticeable moment.
@@ -31,6 +40,7 @@ internal fun cameraHintStringRes(
     osName: String,
     devices: List<CameraDevice>?,
     ffmpegAvailable: Boolean,
+    enumerator: CameraEnumerator? = null,
 ): List<StringResource> {
     if (devices == null) return emptyList()
 
@@ -45,6 +55,11 @@ internal fun cameraHintStringRes(
         if (devices.isEmpty()) hints += Res.string.canvas_camera_v4l2_hint
     } else if (!ffmpegAvailable) {
         hints += Res.string.canvas_camera_ffmpeg_required
+    } else if (devices.isNotEmpty() && enumerator != null && enumerator.listsUnopenableDevices) {
+        // ffmpeg is here and still listed nothing, so what is in the dropdown came from the
+        // platform's inventory and none of it will open. Saying so is the whole point: the picker
+        // looks completely ordinary otherwise.
+        hints += Res.string.canvas_camera_unopenable_listing
     }
 
     return hints

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneDeviceEditors.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneDeviceEditors.kt
@@ -345,7 +345,12 @@ internal fun CameraProperties(source: SceneSource.CameraSource, onUpdate: (Scene
 /** Whatever [cameraHintStringRes] decides is worth saying about this machine's camera tooling. */
 @Composable
 private fun CameraToolHints(osName: String, devices: List<CameraDevice>?, ffmpegAvailable: Boolean) {
-    cameraHintStringRes(osName, devices, ffmpegAvailable).forEach { hint ->
+    cameraHintStringRes(
+        osName,
+        devices,
+        ffmpegAvailable,
+        CameraDeviceCatalog.lastEnumeration?.enumerator,
+    ).forEach { hint ->
         Text(
             stringResource(hint),
             style = MaterialTheme.typography.bodySmall,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -340,24 +340,28 @@ object SharedCameraFrameCache {
             return
         }
 
-        // ffmpeg is an optional external tool, and a machine without it fails every attempt for the
-        // same knowable reason. Discovering that five times over ten seconds tells the operator
-        // nothing, so the retry loop does not run.
+        // ffmpeg ships with the app now, so reaching this is no longer an operator who has not
+        // installed something — it is a build that could not carry or execute its own binary, an
+        // architecture we publish no binary for, or an override pointing at something that will not
+        // run. Retrying five times over ten seconds answers none of those, so the loop does not run.
         //
-        // It is reported, though, which it did not used to be. The old reasoning — a tool the user
-        // has not installed is not a fault in the app — is right about a *tool* and wrong about this
-        // state: the app listed this device in its own picker, the operator chose it, and the app
-        // then produced nothing. On Windows the picker deliberately offers unopenable names beside a
-        // hint saying what to install, so whether that hint is doing its job is a question about our
-        // own UI. Issue #462 is the evidence that it was not, and the reason we could not see it is
-        // that this path was silent.
+        // It is reported, which it did not used to be. The old reasoning — a tool the user has not
+        // installed is not a fault in the app — was right about a *tool* and wrong about this state
+        // even then: the app listed the device in its own picker, the operator chose it, and the app
+        // produced nothing. It reads more plainly now that we ship the tool.
         //
-        // Bounded hard: `FfmpegBinary.isAvailable` is a `by lazy`, so a second report in the same
-        // process would carry nothing the first did not.
+        // The `ReportOnce` gate is what bounds this, and it has to be: `FfmpegBinary.isAvailable`
+        // used to be a `by lazy` that could not change in a process, and is now a cached value the
+        // settings card's Check again clears.
         if (!withContext(Dispatchers.IO) { isFfmpegAvailable() }) {
-            System.err.println("[Camera] ffmpeg is not on PATH — cannot capture $path")
+            System.err.println("[Camera] no usable ffmpeg found — cannot capture $path")
             entry.error.value = CameraFailure.FFMPEG_MISSING
-            reportCameraFfmpegMissing(source, CameraDeviceCatalog.lastEnumeration, ffmpegMissingReport)
+            reportCameraFfmpegMissing(
+                source,
+                CameraDeviceCatalog.lastEnumeration,
+                ffmpegMissingReport,
+                ffmpegAvailable = false,
+            )
             return
         }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundCameraPicker.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundCameraPicker.kt
@@ -79,7 +79,12 @@ internal fun CameraPickerRow(config: BackgroundConfig, onConfigChange: (Backgrou
         // Above the dropdown rather than instead of it: on Windows without ffmpeg the PnP fallback
         // fills the list with names that cannot be opened, so a hint shown only when the list is
         // empty is a hint the operator who needs it never sees.
-        cameraHintStringRes(System.getProperty("os.name", ""), devices, ffmpegAvailable).forEach { hint ->
+        cameraHintStringRes(
+            System.getProperty("os.name", ""),
+            devices,
+            ffmpegAvailable,
+            CameraDeviceCatalog.lastEnumeration?.enumerator,
+        ).forEach { hint ->
             Text(
                 text = stringResource(hint),
                 style = MaterialTheme.typography.bodySmall,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -166,6 +166,7 @@ import org.churchpresenter.app.churchpresenter.server.shouldMirrorRemoteBackgrou
 import org.churchpresenter.app.churchpresenter.server.shouldMirrorRemoteOutput
 import org.churchpresenter.app.churchpresenter.server.shouldUseRemoteContent
 import org.churchpresenter.app.churchpresenter.server.withAnnouncement
+import org.churchpresenter.app.churchpresenter.composables.CameraDeviceCatalog
 import org.churchpresenter.app.churchpresenter.composables.ResourceCensus
 import org.churchpresenter.app.churchpresenter.utils.UrlOpener
 
@@ -290,6 +291,17 @@ fun main() {
             if (previousSessionMinutes > 0) UsageEvents.clearSessionMinutes()
         }
     )
+
+    // One camera enumeration at startup, so a capture that fails before any picker has been opened
+    // can still report what the machine had. A fifth of camera reports arrived carrying
+    // `camera.enumerator=not_run` — nothing had looked, because only a picker enumerates and the
+    // presenter restores a scene without one.
+    //
+    // Its own daemon thread, like the font warm-up above: this shells out to ffmpeg, and on Windows
+    // to PowerShell as well, so it must not be on the path that opens the window.
+    Thread {
+        runCatching { runBlocking { CameraDeviceCatalog.refresh() } }
+    }.apply { isDaemon = true }.start()
 
     val sessionStartedAt = System.currentTimeMillis()
     Runtime.getRuntime().addShutdownHook(Thread {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFactsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraReportFactsTest.kt
@@ -193,6 +193,15 @@ class CameraReportFactsTest {
     }
 
     @Test
+    fun `the mac fallback is reported too, not just the windows one`() {
+        assertTrue(
+            shouldReportBlindFfmpeg(facts(CameraEnumerator.SYSTEM_PROFILER_FALLBACK, fallbackListed = 1)),
+            "macOS reaches the identical state through system_profiler, and carries almost all of " +
+                "this app's camera traffic — the Windows-only form was silent where the users are",
+        )
+    }
+
+    @Test
     fun `a machine where ffmpeg answered is not reported`() {
         assertFalse(shouldReportBlindFfmpeg(facts(CameraEnumerator.DSHOW, ffmpegListed = 2)))
     }

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraToolHintsTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/CameraToolHintsTest.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.composables
 import churchpresenter.composeapp.generated.resources.Res
 import churchpresenter.composeapp.generated.resources.canvas_camera_ffmpeg_required
 import churchpresenter.composeapp.generated.resources.canvas_camera_none_found
+import churchpresenter.composeapp.generated.resources.canvas_camera_unopenable_listing
 import churchpresenter.composeapp.generated.resources.canvas_camera_v4l2_hint
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -77,6 +78,87 @@ class CameraToolHintsTest {
         val hints = cameraHintStringRes("Linux", emptyList(), ffmpegAvailable = true)
 
         assertEquals(listOf(Res.string.canvas_camera_none_found, Res.string.canvas_camera_v4l2_hint), hints)
+    }
+
+    // ── A listing nothing can open ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `a fallback listing is explained even though ffmpeg is present`() {
+        val hints = cameraHintStringRes(
+            "Windows 11",
+            listOf(camera()),
+            ffmpegAvailable = true,
+            enumerator = CameraEnumerator.PNP_FALLBACK,
+        )
+
+        assertEquals(
+            listOf(Res.string.canvas_camera_unopenable_listing), hints,
+            "bundling ffmpeg made the old condition always false, which left a dropdown of cameras " +
+                "that cannot open with nothing on screen saying so",
+        )
+    }
+
+    @Test
+    fun `the mac fallback is explained the same way`() {
+        val hints = cameraHintStringRes(
+            "Mac OS X",
+            listOf(camera()),
+            ffmpegAvailable = true,
+            enumerator = CameraEnumerator.SYSTEM_PROFILER_FALLBACK,
+        )
+
+        assertEquals(listOf(Res.string.canvas_camera_unopenable_listing), hints)
+    }
+
+    @Test
+    fun `a listing ffmpeg itself produced is not explained away`() {
+        val hints = cameraHintStringRes(
+            "Windows 11",
+            listOf(camera()),
+            ffmpegAvailable = true,
+            enumerator = CameraEnumerator.DSHOW,
+        )
+
+        assertEquals(emptyList(), hints, "these open perfectly well and need no sentence")
+    }
+
+    @Test
+    fun `a missing ffmpeg still outranks the unopenable-listing sentence`() {
+        val hints = cameraHintStringRes(
+            "Windows 11",
+            listOf(camera()),
+            ffmpegAvailable = false,
+            enumerator = CameraEnumerator.PNP_FALLBACK,
+        )
+
+        assertEquals(
+            listOf(Res.string.canvas_camera_ffmpeg_required), hints,
+            "with no ffmpeg at all, finding one is the first thing to do and the more specific " +
+                "sentence would only be noise beside it",
+        )
+    }
+
+    @Test
+    fun `an unopenable listing with nothing in it says only that nothing was found`() {
+        val hints = cameraHintStringRes(
+            "Windows 11",
+            emptyList(),
+            ffmpegAvailable = true,
+            enumerator = CameraEnumerator.PNP_FALLBACK,
+        )
+
+        assertEquals(
+            listOf(Res.string.canvas_camera_none_found), hints,
+            "there is no listing to explain, and a machine with no camera is not a fault",
+        )
+    }
+
+    @Test
+    fun `an unknown enumerator adds no sentence`() {
+        assertEquals(
+            emptyList(),
+            cameraHintStringRes("Windows 11", listOf(camera()), ffmpegAvailable = true, enumerator = null),
+        )
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #462 / #463, prompted by two things that landed after it: `afb7f58ed` (ship ffmpeg with the app) and a week of the camera telemetry #463 added.

## What production said

The instrumentation from #463 worked. `Camera: ffmpeg is not installed…` fired **7 times for 4 distinct operators**, which is almost certainly what prompted bundling ffmpeg in the first place.

It also overturned the theory that PR was built around. Over 7 days:

| failure | platform | events | users |
|---|---|---|---|
| `permission_or_unavailable` | macOS | 60 | 3 |
| `no_frames` | macOS | 35 | 5 |
| `device_busy` | macOS | 24 | 3 |
| `unsupported_framerate` | macOS | 20 | 3 |
| `ffmpeg_missing` | macOS | 7 | 4 |
| `device_busy` | **Windows** | **1** | **1** |

`camera.enumerator=pnp_fallback` has **zero events**. The Windows enumeration work was correct and is still worth having, but macOS is where the users are.

Nothing here touches the macOS failures themselves — `359bcd575` already fixed their misdiagnosis and added the device-defaults retry, and it is deployed. Whether those counts fall is next week's question.

## Bundling ffmpeg left one state with nothing on screen

`cameraHintStringRes` showed its sentence when ffmpeg was unavailable. With a bundled binary that is false on a normal install, so the hint disappeared — including where it was most needed.

A fallback enumerator runs only when ffmpeg listed nothing, and names devices out of the platform's own inventory, in a namespace ffmpeg does not accept: a PnP friendly name is not a DirectShow filter name, and a `system_profiler` position is not an AVFoundation index. Those entries cannot be opened whether or not ffmpeg is present. The result was an ordinary-looking dropdown of cameras that silently show nothing.

The hint now keys on **whether the listing is openable** rather than on whether the tool is installed — which `CameraEnumerator` already records. One property, `listsUnopenableDevices`, because the hint and the blind-ffmpeg report ask the identical question and had already drifted apart once.

## The blind-ffmpeg report was silent where the users are

```kotlin
facts.enumerator == CameraEnumerator.PNP_FALLBACK   // before
facts.enumerator.listsUnopenableDevices             // after
```

macOS reaches the same state through `system_profiler`, where the likeliest cause is a privacy refusal — a TCC denial makes AVFoundation enumerate nothing.

## A fifth of reports had no context

`camera.enumerator=not_run`: **33 events from 4 users** where nothing had enumerated, because only opening a picker enumerates and the presenter restores a scene without one. I flagged this exact risk when planning the instrumentation; the data confirmed it. One enumeration at startup, on its own daemon thread since it shells out to ffmpeg and to PowerShell.

## Text that had quietly become false

- Two **user-facing** strings still said to install ffmpeg, which now ships and whose absence is answered in Settings → Projection.
- `parseMacCameras` cited `canvas_camera_ffmpeg_hint`, superseded a release ago (its Windows twin was updated; this one was missed).
- The capture path called ffmpeg an "optional external tool" and claimed a `by lazy` bound that no longer exists — the settings card can re-resolve it, so the `ReportOnce` gate is the whole of that bound now.
- `FFMPEG_MISSING` documented itself as "not a defect in the app". That stopped being true when the app took on carrying the binary: on a pinned target, reaching it means we failed to ship or execute our own.

## Two things a reviewer should weigh

**The ffmpeg-missing report's title changes, so it opens a new Sentry issue rather than continuing the existing one (7 events / 4 users).** Intended — the event means something different now: not an operator who has not installed a tool, but a build that could not find the one it carries. Overrule me if continuity matters more.

**The central fix is reasoned, not observed.** The fallback-with-ffmpeg-present state has **zero events** so far; the fallbacks have only ever fired with `ffmpeg=absent` (2 events). This is a hazard bundling introduces as it rolls out. If it turns out bundling makes the fallbacks unreachable entirely, then this hint and that report are both dead code and should be **deleted** rather than kept — another week of data settles it.

## Tests

Extends `CameraToolHintsTest` (6 cases, including that a missing ffmpeg still outranks the new sentence, and that an empty fallback listing says only "none found" — a machine with no camera is not a fault) and `CameraReportFactsTest`. Both were already pure functions with whole-map assertions, so no new harness. Full suite green (10,349) and detekt clean.

Windows remains unverified: CI is Linux, nobody on the project has a Windows machine, and production has produced exactly one Windows camera event.
