### PR TITLE
Report one InstanceLink failure as one issue, without the peer's address

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkClient.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkClient.kt
@@ -102,6 +102,16 @@ class InstanceLinkClient(
         const val MAX_RECONNECT_DELAY_MS = 30_000L
         /** How long a controller-mode command waits for its command_ack before soft-warning. */
         const val ACK_TIMEOUT_MS = 5_000L
+
+        /**
+         * The peer's address inside a connect failure's message, with the port kept.
+         *
+         * Group 1 is the scheme, group 2 the port and the rest of the URL, so the host between them
+         * is what [redactedConnectFailure] replaces. Deliberately narrow: it matches an address in a
+         * `ws://`/`wss://` URL and leaves every other word of ktor's message alone, because the rest
+         * of it is the diagnosis.
+         */
+        val PEER_URL = Regex("""(wss?://)[^/\s\]:]+(:\d+)?""")
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -207,12 +217,13 @@ class InstanceLinkClient(
                 val failureKind = classifyConnectFailure(e)
                 if (shouldReportConnectFailure(failureKind, consecutiveFailures)) {
                     CrashReporter.reportWarning(
-                        "InstanceLink: connection failed — ${e.message}",
+                        "InstanceLink: connection failed",
                         tags = mapOf(
                             "subsystem" to "instance_link",
                             "consecutive_failures" to consecutiveFailures.toString(),
                             "failure_kind" to failureKind
-                        )
+                        ),
+                        extras = mapOf("reason" to redactedConnectFailure(e.message))
                     )
                 }
                 InstanceLinkLogger.log(
@@ -262,6 +273,25 @@ class InstanceLinkClient(
      * "timeout"/"tls"/"other" are more likely to indicate an actual regression (e.g. a primary
      * that crashed mid-session, or a protocol/certificate bug).
      */
+    /**
+     * A connect failure's message with the peer's address taken out of it.
+     *
+     * The message used to be interpolated into the report's *title*, which did two things. It put
+     * the address of a church's own machine — `ws://192.168.1.100:8765/ws` — into an issue title,
+     * where nothing scrubs it: `CrashReporter` redacts home directories and the OS username, not
+     * private addresses. And because Sentry groups on the title, one failure arrived as **fourteen
+     * separate issues**, one per address and port, none of which looked related to the others.
+     *
+     * `PicturesViewModel.reportThumbnailFailures` fixed the same shape for file names and says why:
+     * a constant title so the class of failure is one issue, and what distinguishes an occurrence in
+     * the detail.
+     *
+     * The port is kept. It is not anyone's address, and a follower pointed at the wrong port is a
+     * real misconfiguration worth being able to see.
+     */
+    internal fun redactedConnectFailure(message: String?): String =
+        message?.replace(PEER_URL, "$1<peer>$2") ?: "none"
+
     internal fun classifyConnectFailure(e: Exception): String = when {
         // ktor's own pinger raises this when the primary misses the keepalive window, which is what
         // the heartbeat is for: the link drops, the backoff reconnects, and the operator sees the

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkMessageTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/server/InstanceLinkMessageTest.kt
@@ -228,6 +228,45 @@ class InstanceLinkMessageTest {
     }
 
     @Test
+    fun `a connect failure report carries the port but not the peer's address`() {
+        val c = clientWith(Recorder())
+
+        // The message ktor actually produces, from a report in the field.
+        val redacted = c.redactedConnectFailure(
+            "Connect timeout has expired [url=ws://192.168.1.100:8765/ws, connect_timeout=5000 ms]"
+        )
+
+        assertEquals(
+            "Connect timeout has expired [url=ws://<peer>:8765/ws, connect_timeout=5000 ms]",
+            redacted,
+            "the address of a church's own machine is not ours to keep, and nothing scrubs a report " +
+                "for private addresses — but the port is a real misconfiguration worth seeing",
+        )
+    }
+
+    @Test
+    fun `redacting a connect failure leaves the diagnosis intact`() {
+        val c = clientWith(Recorder())
+
+        assertEquals("No route to host", c.redactedConnectFailure("No route to host"))
+        assertEquals(
+            "none", c.redactedConnectFailure(null),
+            "a null message used to arrive as the literal title \"connection failed — null\"",
+        )
+    }
+
+    @Test
+    fun `a secure peer is redacted the same way`() {
+        val c = clientWith(Recorder())
+
+        assertEquals(
+            "failed [url=wss://<peer>:443/ws]",
+            c.redactedConnectFailure("failed [url=wss://studio.example.org:443/ws]"),
+            "a hostname names the church as surely as its address does",
+        )
+    }
+
+    @Test
     fun `a ping timeout is classified and rate-limited like a refused connection`() {
         val c = clientWith(Recorder())
 


### PR DESCRIPTION
The last of the reporting-hygiene items found while working on #462. Small and self-contained.

## What is wrong

```kotlin
CrashReporter.reportWarning("InstanceLink: connection failed — ${e.message}", …)
```

ktor's message names the peer — `Connect timeout has expired [url=ws://192.168.1.100:8765/ws, connect_timeout=5000 ms]` — so the message goes into the report's **title**. Two consequences, both live in production right now:

**A church's own machine address ends up in an issue title.** Nothing takes it out: `CrashReporter.scrubPii` redacts home directories and the OS username, not private network addresses.

**Sentry groups on the title, so one failure is fourteen issues.** Over 14 days, 57 events arrived as **14 separate issues**, one per address *and* port — none of them looking related to any other:

```
InstanceLink: connection failed — … [url=ws://192.168.8.101:8765/ws …]   13 events
InstanceLink: connection failed — … [url=ws://192.168.1.100:8765/ws …]   13 events
InstanceLink: connection failed — … [url=ws://192.168.1.100:8763/ws …]    4 events
… 11 more, one per address and port
```

## The fix

A constant title, with the reason in an extra and the host replaced. That is the shape `PicturesViewModel.reportThumbnailFailures` already settled on for file names, for the same two reasons, and its comment says why:

> One event per file made every file name its own Sentry issue — a folder of unreadable pictures arrived as a folder of unrelated-looking problems, each titled with a name belonging to the person who reported it.

**The port is kept.** It is nobody's address, and a follower pointed at the wrong port is a real misconfiguration worth being able to see. The redaction is deliberately narrow — it matches the host inside a `ws://`/`wss://` URL and leaves every other word of ktor's message alone, because the rest of it is the diagnosis.

A null message also stops arriving as the literal title `connection failed — null`, which is two of the current fourteen issues.

## What I deliberately did not change

Production shows `failure_kind=refused` on messages that plainly say *"Connect timeout has expired"*, which looks like a misclassification. **It is already fixed.** Those events are only from 26.9.37, 26.10.48 and 26.10.122; the newest release reporting these classifies the same failure as `timeout`. `classifyConnectFailure` already matches `ConnectTimeoutException` before `ConnectException` and documents why:

> Ktor's ConnectTimeoutException extends java.net.ConnectException, so it must be matched first or every connect timeout is filed as "refused" — the one bucket that says the operator simply has not started the primary yet.

The old events are older builds, not a live bug.

## Tests

Three cases in `InstanceLinkMessageTest`, driven by the message ktor actually produced in the field: the address goes and the port stays; a message with no URL is untouched, so the diagnosis survives; and a `wss://` hostname is redacted too, since a hostname names the church as surely as its address does.

Full suite green (10,362) and detekt clean.
