### PR TITLE
Fix six Sentry issues: a slide-killing picture, a dead-handle crash, and four reports

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -354,8 +354,12 @@ kotlin {
             // Logging backend + Sentry log forwarding (WARN/ERROR → breadcrumbs/events)
             implementation(libs.logback.classic)
             implementation(libs.sentry.logback)
-            implementation("com.twelvemonkeys.imageio:imageio-core:3.10.1")
-            implementation("com.twelvemonkeys.imageio:imageio-jpeg:3.10.1")
+            // ImageIO readers for what Skia refuses — see PictureDecoder. jpeg covers CMYK/YCCK
+            // JPEGs out of print workflows; psd covers Photoshop files, which reach picture
+            // folders under a .jpg name often enough to have been reported from the field.
+            implementation(libs.twelvemonkeys.imageio.core)
+            implementation(libs.twelvemonkeys.imageio.jpeg)
+            implementation(libs.twelvemonkeys.imageio.psd)
             // Apache PDFBox for PDF slide extraction
             implementation(libs.pdfbox)
             // Apache POI for PowerPoint slide extraction.

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/DeckLinkManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/DeckLinkManager.kt
@@ -2,6 +2,7 @@ package org.churchpresenter.app.churchpresenter.composables
 
 import org.churchpresenter.core.models.scene.Scene
 import org.churchpresenter.core.models.scene.SceneSource
+import org.churchpresenter.app.churchpresenter.utils.addGuardedShutdownHook
 import org.churchpresenter.app.churchpresenter.utils.UsageEvent
 import org.churchpresenter.app.churchpresenter.utils.UsageEvents
 
@@ -141,9 +142,9 @@ object DeckLinkManager {
     private fun registerShutdownHook() {
         if (shutdownHookRegistered) return
         shutdownHookRegistered = true
-        Runtime.getRuntime().addShutdownHook(Thread {
+        addGuardedShutdownHook("decklink") {
             closeAllOutputs()
-        })
+        }
     }
 
     /** Send black frames and close all open DeckLink outputs. */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/PlayerReleaseGate.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/PlayerReleaseGate.kt
@@ -1,0 +1,46 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+/**
+ * Guards deferred native calls against a vlcj player that has already been released.
+ *
+ * A `MediaPlayer` handle is native memory owned by libvlc. Once `releasePlayer()` has run, calling
+ * anything on it — `controls().pause()` is the one that reached production — dereferences freed
+ * memory, and libvlc answers with `java.lang.Error: Invalid memory access`, which kills the app
+ * rather than the playback. Anything deferred can land in that window: a `javax.swing.Timer` firing
+ * 200 ms later, or a block queued with `SwingUtilities.invokeLater`.
+ *
+ * So every deferred native call goes through [ifLive]. [release] must be called **before**
+ * `releasePlayer()`, so the flag is already set for anything the release itself races.
+ *
+ * The catch is `Throwable`, not `Exception`: the failure this exists for is an `Error`, and a
+ * `catch (_: Exception)` would let it straight through.
+ */
+internal class PlayerReleaseGate {
+
+    @Volatile
+    private var released = false
+
+    /** Whether [release] has been called. */
+    val isReleased: Boolean get() = released
+
+    /** Marks the player released. Call before `releasePlayer()`; safe to call more than once. */
+    fun release() {
+        released = true
+    }
+
+    /**
+     * Runs [block] only while the player is still alive, swallowing anything it throws.
+     *
+     * Returns whether it ran — for tests and for callers that want to know they were too late; the
+     * production call sites ignore it.
+     */
+    fun ifLive(block: () -> Unit): Boolean {
+        if (released) return false
+        return try {
+            block()
+            true
+        } catch (_: Throwable) {
+            false
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedBrowserFrameCache.kt
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletionStage
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import javax.imageio.ImageIO
+import org.churchpresenter.app.churchpresenter.utils.addGuardedShutdownHook
 
 private const val HTTP_OK = 200
 private const val MILLIS_PER_SECOND = 1000L
@@ -70,12 +71,12 @@ object SharedBrowserFrameCache {
 
     init {
         // Kill all browser processes on JVM shutdown to prevent orphaned Chrome/Edge windows
-        Runtime.getRuntime().addShutdownHook(Thread {
+        addGuardedShutdownHook("browser-source") {
             synchronized(this@SharedBrowserFrameCache) {
                 entries.values.forEach { stopBrowser(it) }
                 entries.clear()
             }
-        })
+        }
     }
 
     private class CacheEntry(

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/VideoPlayer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/VideoPlayer.kt
@@ -411,6 +411,10 @@ fun VideoPlayer(
     // their first frame before the player is paused.
     val firstFrameCaptured = remember { mutableStateOf(false) }
 
+    // Native-handle lifetime guard and the deferred pause it protects — see PlayerReleaseGate.
+    val gate = remember { PlayerReleaseGate() }
+    val pauseTimer = remember { mutableStateOf<javax.swing.Timer?>(null) }
+
     DisposableEffect(Unit) {
         mp.events().addMediaPlayerEventListener(object : MediaPlayerEventAdapter() {
             override fun lengthChanged(mediaPlayer: MediaPlayer, newLength: Long) {
@@ -421,11 +425,15 @@ fun VideoPlayer(
                     if (!firstFrameCaptured.value) {
                         // Delay pause by 200 ms so VLC can decode and render the first frame
                         // before being paused. Without this, portrait/MOV videos stay black.
-                        javax.swing.Timer(POSITION_POLL_MS) {
-                            if (!viewModel.isPlaying) mediaPlayer.controls().pause()
+                        // The timer is held so onDispose can stop it: switching media disposes
+                        // this composable well inside those 200 ms, and the callback would
+                        // otherwise pause a player that has already been released.
+                        pauseTimer.value?.stop()
+                        pauseTimer.value = javax.swing.Timer(POSITION_POLL_MS) {
+                            gate.ifLive { if (!viewModel.isPlaying) mediaPlayer.controls().pause() }
                         }.also { it.isRepeats = false; it.start() }
                     } else {
-                        SwingUtilities.invokeLater { mediaPlayer.controls().pause() }
+                        SwingUtilities.invokeLater { gate.ifLive { mediaPlayer.controls().pause() } }
                     }
                 }
             }
@@ -443,8 +451,13 @@ fun VideoPlayer(
             }
         })
         onDispose {
-            mp.controls().stop()
-            component.releasePlayer()
+            // Before releasePlayer(), so anything already queued sees the player as gone.
+            gate.release()
+            pauseTimer.value?.stop()
+            try {
+                mp.controls().stop()
+                component.releasePlayer()
+            } catch (_: Throwable) { }
         }
     }
 
@@ -591,6 +604,10 @@ fun SoftwareVideoPlayer(
         }
     }
 
+    // Native-handle lifetime guard and the deferred pause it protects — see PlayerReleaseGate.
+    val gate = remember { PlayerReleaseGate() }
+    val pauseTimer = remember { mutableStateOf<javax.swing.Timer?>(null) }
+
     // Set up callback video surface for software rendering
     DisposableEffect(Unit) {
         val bufferFormatCallback = object : uk.co.caprica.vlcj.player.embedded.videosurface.callback.BufferFormatCallback {
@@ -632,11 +649,13 @@ fun SoftwareVideoPlayer(
                         // Give VLC up to 200 ms to decode and deliver the first frame to the
                         // render callback before pausing. This is critical for portrait/rotated
                         // videos (e.g. iPhone MOV) where the decoder may take longer to start.
-                        javax.swing.Timer(POSITION_POLL_MS) {
-                            if (!viewModel.isPlaying) mediaPlayer.controls().pause()
+                        // Held so onDispose can stop it — see the embedded player above.
+                        pauseTimer.value?.stop()
+                        pauseTimer.value = javax.swing.Timer(POSITION_POLL_MS) {
+                            gate.ifLive { if (!viewModel.isPlaying) mediaPlayer.controls().pause() }
                         }.also { it.isRepeats = false; it.start() }
                     } else {
-                        SwingUtilities.invokeLater { mediaPlayer.controls().pause() }
+                        SwingUtilities.invokeLater { gate.ifLive { mediaPlayer.controls().pause() } }
                     }
                 }
             }
@@ -650,6 +669,9 @@ fun SoftwareVideoPlayer(
         })
 
         onDispose {
+            // Before releasePlayer(), so anything already queued sees the player as gone.
+            gate.release()
+            pauseTimer.value?.stop()
             try {
                 mp.controls().stop()
                 component.releasePlayer()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import org.churchpresenter.app.churchpresenter.composables.DeckLinkManager
+import org.churchpresenter.app.churchpresenter.utils.addGuardedShutdownHook
 import org.churchpresenter.app.churchpresenter.utils.DevFlags
 import org.churchpresenter.app.churchpresenter.utils.LottieFonts
 import org.churchpresenter.app.churchpresenter.utils.SystemFonts
@@ -304,12 +305,12 @@ fun main() {
     }.apply { isDaemon = true }.start()
 
     val sessionStartedAt = System.currentTimeMillis()
-    Runtime.getRuntime().addShutdownHook(Thread {
+    addGuardedShutdownHook("session") {
         UsageEvents.recordSessionMinutes(((System.currentTimeMillis() - sessionStartedAt) / MILLIS_PER_MINUTE).toInt())
         // Shutdown is when the high-water marks are final. Reports only when they are higher than a
         // scene can account for — see ResourceCensus, and why counts rather than CPU or heap.
         ResourceCensus.reportIfLeaky()
-    })
+    }
 
     val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
         CrashReporter.reportException(throwable, context = "CoroutineExceptionHandler")

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/NdiManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/NdiManager.kt
@@ -8,6 +8,7 @@ import org.churchpresenter.ndi.NdiReceiver
 import org.churchpresenter.ndi.NdiRuntimeStatus
 import org.churchpresenter.ndi.NdiSourceInfo
 import org.churchpresenter.settings.ScreenAssignment
+import org.churchpresenter.app.churchpresenter.utils.addGuardedShutdownHook
 
 /**
  * The app's single NDI runtime: the senders opened over it, and the receivers taking sources back
@@ -63,6 +64,6 @@ object NdiManager {
     private fun registerShutdownHook() {
         if (shutdownHookRegistered) return
         shutdownHookRegistered = true
-        Runtime.getRuntime().addShutdownHook(Thread { registry.stopAll() })
+        addGuardedShutdownHook("ndi") { registry.stopAll() }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PresentationPlayer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/PresentationPlayer.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import org.churchpresenter.app.churchpresenter.utils.reportDegradedSlide
 import org.churchpresenter.diagnostics.CrashReporter
 import org.churchpresenter.presentationengine.DeckRasterizer
 import org.churchpresenter.presentationengine.model.Deck
@@ -88,7 +89,7 @@ class PresentationPlayer(
     )
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-    private val rasterizer = DeckRasterizer(deck, renderWidthPx)
+    private val rasterizer = DeckRasterizer(deck, renderWidthPx, onDegraded = ::reportDegradedSlide)
     private val rasterLock = Any()
 
     private val slideCache = ConcurrentHashMap<Int, SlideLayers>()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/WebsitePresenter.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/WebsitePresenter.kt
@@ -49,6 +49,186 @@ private const val AUDIO_INIT_DELAY_MS = 2000L
 private const val AUDIO_RETRY_DELAY_MS = 5000L
 
 /**
+ * Choosing where JCEF's native install goes, and getting it there.
+ *
+ * Its own object rather than more members on [CefManager]: picking a directory, probing it, and
+ * moving on to the next one when an install fails is one job with one reason to change — and it is
+ * the half of the engine's startup that can be exercised without a browser.
+ */
+internal object JcefInstall {
+
+    /**
+     * Root directories for JCEF's native install + web cache, best first.
+     *
+     * On Windows, prefer an ASCII-safe, username-free path under %ProgramData%
+     * (e.g. C:\ProgramData\ChurchPresenter) — a home directory containing non-ASCII characters is
+     * a suspected trigger for native-load failures, and a fresh extraction here also clears any
+     * partially-corrupted install. ~/.churchpresenter follows it, because ProgramData is shared
+     * between accounts: a directory this user can create is not necessarily one this user can
+     * extract into when another account got there first, and that is only knowable by trying.
+     *
+     * On macOS/Linux the home directory is the only candidate — no accent problem, no ProgramData.
+     *
+     * A list rather than one chosen path because the choice cannot be made up front. The old form
+     * probed `canWrite()` and committed to whatever passed; the failure reported from the field
+     * passed that probe and then hit `Access is denied` extracting `chrome_elf.dll`, which left the
+     * browser engine down for the session with a usable directory sitting unused beside it.
+     */
+    internal fun rootCandidates(
+        osName: String = System.getProperty("os.name", ""),
+        programData: String? = System.getenv("ProgramData"),
+        homeDir: String = System.getProperty("user.home")
+    ): List<File> {
+        val home = File(homeDir, ".churchpresenter")
+        if (!osName.lowercase().contains("win")) return listOf(home)
+        return listOf(File(programData ?: "C:\\ProgramData", "ChurchPresenter"), home)
+            .distinctBy { it.absolutePath }
+    }
+
+    /**
+     * Whether [dir] can actually be written to, established by creating it and putting a file in it.
+     *
+     * `File.canWrite()` does not answer this on Windows: it reports the read-only attribute and not
+     * the ACL, so a directory the account cannot write to can still come back true. The only
+     * reliable probe is the write itself, and it is trivially cheap beside the ~100 MB extraction
+     * it is deciding whether to start.
+     */
+    internal fun directoryIsWritable(dir: File): Boolean = runCatching {
+        dir.mkdirs()
+        if (!dir.isDirectory) return@runCatching false
+        val probe = File(dir, ".write-probe-" + System.nanoTime())
+        probe.createNewFile().also { probe.delete() }
+    }.getOrDefault(false)
+
+    /**
+     * Why a JCEF install cannot be attempted into a directory in this state, or null to go ahead.
+     *
+     * Both answers are the machine: a directory the user cannot write to (ProgramData ACLs vary,
+     * and a locked-down install is a normal corporate build), and a disk without room for a
+     * bundled Chromium. Neither is a defect and neither becomes an event; what they do is stop the
+     * app spending a download to discover it, and leave a tag saying which one it was.
+     *
+     * Zero is not "full": `File.usableSpace` answers 0 when it cannot determine the figure at all,
+     * so treating it as no space would block the install on every machine whose filesystem does not
+     * report one. An unknown figure goes ahead and lets the real attempt decide.
+     */
+    internal fun installBlocker(writable: Boolean, usableSpaceBytes: Long): String? = when {
+        !writable -> "permission_denied"
+        usableSpaceBytes in 1 until JCEF_REQUIRED_BYTES -> "disk_space"
+        else -> null
+    }
+
+    /**
+     * "policy" when [message] is a machine refusing to load the library, or null for a real failure.
+     *
+     * Matched on the message because it is only knowable after the load has been attempted — unlike
+     * [installBlocker], whose two causes can be asked about beforehand. Matching English wording is
+     * a real limitation and the reason this only ever *suppresses* an event: a localised Windows
+     * falls through and is reported as before, which is the safe direction to be wrong in.
+     */
+    internal fun policyBlock(message: String?): String? {
+        val text = message?.lowercase() ?: return null
+        val blocked = listOf("application control policy", "blocked by group policy", "blocked this file")
+        return if (blocked.any { it in text }) "policy" else null
+    }
+
+    /** How an attempt to install JCEF into the candidate roots ended. */
+    internal sealed interface Outcome {
+        /** It installed into [root]. */
+        data class Installed(val root: File) : Outcome
+        /** Nothing was attempted; [reason] is the last candidate's blocker. */
+        data class Blocked(val reason: String) : Outcome
+        /** An attempt ran and threw; [cause] came from [root]. */
+        data class Failed(val root: File, val cause: Throwable) : Outcome
+    }
+
+    /**
+     * Builds the CEF app against [root], throwing whatever the install or the native load throws.
+     *
+     * The throw is the point: it is what tells [installIntoFirstUsableRoot] this root did not work.
+     */
+    fun buildCefApp(root: File): CefApp {
+        val installDir = File(root, "jcef")
+        installDir.mkdirs()
+        val cacheDir = File(root, "webview-cache")
+        cacheDir.mkdirs()
+
+        val builder = CefAppBuilder()
+        builder.setInstallDir(installDir)
+        builder.setProgressHandler(ConsoleProgressHandler())
+        builder.setAppHandler(object : MavenCefAppHandlerAdapter() {})
+        builder.cefSettings.windowless_rendering_enabled = false
+        builder.cefSettings.cache_path = cacheDir.absolutePath
+        // Fallback to software rendering on VMs / systems without proper GPU drivers
+        val dmiTexts = listOf("product_name", "sys_vendor").mapNotNull { file ->
+            runCatching { File("/sys/class/dmi/id/$file").readText().trim() }.getOrNull()
+        }
+        if (isVirtualizedEnvironment(dmiTexts)) {
+            builder.addJcefArgs("--disable-gpu")
+            builder.addJcefArgs("--disable-gpu-compositing")
+            builder.addJcefArgs("--enable-unsafe-swiftshader")
+        }
+        return builder.build()
+    }
+
+    /** Installs into the first usable root, with the real candidates and the real probes. */
+    fun install(attempt: (File) -> Unit): Outcome = installIntoFirstUsableRoot(
+        roots = rootCandidates(),
+        // Two of the ways this fails are the machine rather than the app, and both are knowable
+        // before the download starts. Asking beforehand keeps them out of the crash reports and is
+        // locale-independent — the exceptions they raise say "Access is denied" and "There is not
+        // enough space on the disk" only on an English Windows, so classifying them after the fact
+        // would work in one language.
+        blockerFor = { root ->
+            val installDir = File(root, "jcef")
+            installBlocker(directoryIsWritable(installDir), installDir.usableSpace)
+        },
+        stopRetrying = { policyBlock(it.message) != null },
+        attempt = attempt,
+    )
+
+    /**
+     * Tries [attempt] against each of [roots] in turn and reports how it ended.
+     *
+     * A root that [blockerFor] rules out is skipped without an attempt; one whose attempt throws is
+     * followed by the next root, unless [stopRetrying] says the failure is about the machine rather
+     * than the directory — a software-policy block applies everywhere, so trying a second path only
+     * spends another download to be refused identically.
+     *
+     * The attempt is a parameter because it is the one step that cannot run in a test: it downloads
+     * and extracts a Chromium build. Everything around it — the order, the skipping, the stop
+     * condition, and which outcome is reported — is the part that was wrong in production, and this
+     * way it is the part under test.
+     */
+    // Throwable is deliberate: a JCEF install fails with UnsatisfiedLinkError as readily as with an
+    // IOException, and both mean "this directory did not work, try the next one".
+    @Suppress("TooGenericExceptionCaught")
+    internal fun installIntoFirstUsableRoot(
+        roots: List<File>,
+        blockerFor: (File) -> String?,
+        stopRetrying: (Throwable) -> Boolean,
+        attempt: (File) -> Unit,
+    ): Outcome {
+        var lastOutcome: Outcome = Outcome.Blocked("no_install_dir")
+        for (root in roots) {
+            val blocker = blockerFor(root)
+            if (blocker != null) {
+                lastOutcome = Outcome.Blocked(blocker)
+                continue
+            }
+            try {
+                attempt(root)
+                return Outcome.Installed(root)
+            } catch (t: Throwable) {
+                lastOutcome = Outcome.Failed(root, t)
+                if (stopRetrying(t)) return lastOutcome
+            }
+        }
+        return lastOutcome
+    }
+}
+
+/**
  * Manages a single CefApp instance for the entire application.
  * Must call [init] once at startup before any WebView is used.
  */
@@ -157,33 +337,6 @@ object CefManager {
     }
 
     /**
-     * Root directory for JCEF's native install + web cache.
-     *
-     * On Windows, prefer an ASCII-safe, username-free path under %ProgramData%
-     * (e.g. C:\ProgramData\ChurchPresenter) — a home directory containing non-ASCII
-     * characters is a suspected trigger for native-load failures, and a fresh
-     * extraction here also clears any partially-corrupted install. Fall back to
-     * ~/.churchpresenter when ProgramData is missing or not writable.
-     *
-     * On macOS/Linux the home directory is used unchanged — no accent problem, no ProgramData.
-     */
-    internal fun jcefRootDir(
-        osName: String = System.getProperty("os.name", ""),
-        programData: String? = System.getenv("ProgramData"),
-        homeDir: String = System.getProperty("user.home")
-    ): File {
-        val isWindows = osName.lowercase().contains("win")
-        if (isWindows) {
-            val candidate = File(programData ?: "C:\\ProgramData", "ChurchPresenter")
-            // Only use it if we can actually create and write to it (ProgramData ACLs vary).
-            val usable = runCatching { candidate.mkdirs(); candidate.isDirectory && candidate.canWrite() }
-                .getOrDefault(false)
-            if (usable) return candidate
-        }
-        return File(homeDir, ".churchpresenter")
-    }
-
-    /**
      * One-time cleanup of the legacy JCEF footprint left under ~/.churchpresenter after a
      * Windows user is relocated to %ProgramData%. Only runs when [activeRoot] is NOT the home
      * directory — i.e. we actually moved. If ProgramData was unwritable and we fell back to the
@@ -204,38 +357,6 @@ object CefManager {
         }.apply { isDaemon = true; name = "jcef-legacy-cleanup" }.start()
     }
 
-    /**
-     * Why a JCEF install cannot be attempted into a directory in this state, or null to go ahead.
-     *
-     * Both answers are the machine: a directory the user cannot write to (ProgramData ACLs vary,
-     * and a locked-down install is a normal corporate build), and a disk without room for a
-     * bundled Chromium. Neither is a defect and neither becomes an event; what they do is stop the
-     * app spending a download to discover it, and leave a tag saying which one it was.
-     *
-     * Zero is not "full": `File.usableSpace` answers 0 when it cannot determine the figure at all,
-     * so treating it as no space would block the install on every machine whose filesystem does not
-     * report one. An unknown figure goes ahead and lets the real attempt decide.
-     */
-    internal fun jcefInstallBlocker(writable: Boolean, usableSpaceBytes: Long): String? = when {
-        !writable -> "permission_denied"
-        usableSpaceBytes in 1 until JCEF_REQUIRED_BYTES -> "disk_space"
-        else -> null
-    }
-
-    /**
-     * "policy" when [message] is a machine refusing to load the library, or null for a real failure.
-     *
-     * Matched on the message because it is only knowable after the load has been attempted — unlike
-     * [jcefInstallBlocker], whose two causes can be asked about beforehand. Matching English
-     * wording is a real limitation and the reason this only ever *suppresses* an event: a localised
-     * Windows falls through and is reported as before, which is the safe direction to be wrong in.
-     */
-    internal fun jcefPolicyBlock(message: String?): String? {
-        val text = message?.lowercase() ?: return null
-        val blocked = listOf("application control policy", "blocked by group policy", "blocked this file")
-        return if (blocked.any { it in text }) "policy" else null
-    }
-
     fun init() {
         if (initialized) return
         if (isUnsupportedMacOS()) {
@@ -245,79 +366,70 @@ object CefManager {
         // Must run before any JCEF class is loaded — CefBrowserWindowMac.getWindowHandle()
         // directly references sun.awt.AWTAccessor which the JVM module system blocks by default.
         patchJcefModuleAccess()
-        val root = jcefRootDir()
-        val installDir = File(root, "jcef")
-        try {
-            installDir.mkdirs()
+        applyInstallOutcome(JcefInstall.install { root -> cefApp = JcefInstall.buildCefApp(root) })
+    }
 
-            // Two of the ways this fails are the machine rather than the app, and both are knowable
-            // before the download starts. Asking beforehand keeps them out of the crash reports and
-            // is locale-independent — the exceptions they raise say "Access is denied" and "There is
-            // not enough space on the disk" only on an English Windows, so classifying them after
-            // the fact would work in one language.
-            val blocker = jcefInstallBlocker(installDir.canWrite(), installDir.usableSpace)
-            if (blocker != null) {
-                System.err.println("[JCEF] Not installing to ${installDir.path}: $blocker")
-                cefApp = null
-                initialized = false
-                // No event: web features simply stay unavailable, which jcef.available already
-                // says. The tag rides along on anything else this session reports.
-                runCatching { CrashReporter.setTag("jcef.blocked", blocker) }
-                return
-            }
-
-            val cacheDir = File(root, "webview-cache")
-            cacheDir.mkdirs()
-
-            val builder = CefAppBuilder()
-            builder.setInstallDir(installDir)
-            builder.setProgressHandler(ConsoleProgressHandler())
-            builder.setAppHandler(object : MavenCefAppHandlerAdapter() {})
-            builder.cefSettings.windowless_rendering_enabled = false
-            builder.cefSettings.cache_path = cacheDir.absolutePath
-            // Fallback to software rendering on VMs / systems without proper GPU drivers
-            val dmiTexts = listOf("product_name", "sys_vendor").mapNotNull { file ->
-                runCatching { File("/sys/class/dmi/id/$file").readText().trim() }.getOrNull()
-            }
-            if (isVirtualizedEnvironment(dmiTexts)) {
-                builder.addJcefArgs("--disable-gpu")
-                builder.addJcefArgs("--disable-gpu-compositing")
-                builder.addJcefArgs("--enable-unsafe-swiftshader")
-            }
-
-            cefApp = builder.build()
+    /** Sets the engine's state from [outcome], reporting only a failure that is ours. */
+    private fun applyInstallOutcome(outcome: JcefInstall.Outcome) = when (outcome) {
+        is JcefInstall.Outcome.Installed -> {
             initialized = true
+            runCatching { CrashReporter.setTag("jcef.install_root", outcome.root.name) }
             // Now that the relocated install works, reclaim the orphaned old footprint.
-            cleanupLegacyJcef(root)
-        } catch (t: Throwable) {
-            // JCEF native load can fail with UnsatisfiedLinkError (an Error, not an
-            // Exception) — e.g. a broken/partial chrome_elf.dll install, a missing VC++
-            // runtime, or a non-ASCII install path. Catch Throwable so the whole app
-            // does not crash at startup; embedded web features simply stay unavailable.
-            cefApp = null
-            initialized = false
-            // Best-effort telemetry: distinguish the accented-path theory from the
-            // VC++-runtime theory at a glance in Sentry. Never let telemetry throw.
-            runCatching {
-                CrashReporter.setTag("jcef.path_ascii", installDir.path.all { it.code < ASCII_MAX }.toString())
-                CrashReporter.setContext("jcef", mapOf(
-                    "installDir" to installDir.path,
-                    "os" to (System.getProperty("os.name") ?: ""),
-                    "arch" to (System.getProperty("os.arch") ?: "")
-                ))
-            }
-            // A policy block is the machine, not a defect, and it recurs on every launch of every
-            // affected install — so it is tagged and told to the operator rather than reported,
-            // exactly as the two blockers checked before the download are.
-            val policy = jcefPolicyBlock(t.message)
-            if (policy != null) {
-                blockedByPolicy = true
-                System.err.println("[JCEF] Blocked by this machine's software policy: ${t.message}")
-                runCatching { CrashReporter.setTag("jcef.blocked", policy) }
-                return
-            }
-            CrashReporter.reportException(t, context = "CefManager.init")
+            cleanupLegacyJcef(outcome.root)
         }
+        is JcefInstall.Outcome.Blocked -> {
+            engineUnavailable()
+            System.err.println("[JCEF] Not installing: ${outcome.reason}")
+            // No event: web features simply stay unavailable, which jcef.available already
+            // says. The tag rides along on anything else this session reports.
+            runCatching { CrashReporter.setTag("jcef.blocked", outcome.reason) }
+            Unit
+        }
+        is JcefInstall.Outcome.Failed -> {
+            engineUnavailable()
+            reportInstallFailure(outcome)
+        }
+    }
+
+    /** Leaves the web engine off for this session. */
+    private fun engineUnavailable() {
+        cefApp = null
+        initialized = false
+    }
+
+    /**
+     * Reports an install that ran and threw, after every candidate root had its turn — so this is
+     * the engine being genuinely unavailable, not one directory being unusable.
+     *
+     * JCEF native load can fail with UnsatisfiedLinkError (an Error, not an Exception) — e.g. a
+     * broken/partial chrome_elf.dll install, a missing VC++ runtime, or a non-ASCII install path.
+     * All of it is caught so the app does not crash at startup; embedded web features simply stay
+     * unavailable.
+     */
+    private fun reportInstallFailure(outcome: JcefInstall.Outcome.Failed) {
+        val installDir = File(outcome.root, "jcef")
+        // Best-effort telemetry: distinguish the accented-path theory from the
+        // VC++-runtime theory at a glance in Sentry. Never let telemetry throw.
+        runCatching {
+            CrashReporter.setTag("jcef.path_ascii", installDir.path.all { it.code < ASCII_MAX }.toString())
+            CrashReporter.setTag("jcef.install_root", outcome.root.name)
+            CrashReporter.setContext("jcef", mapOf(
+                "installDir" to installDir.path,
+                "os" to (System.getProperty("os.name") ?: ""),
+                "arch" to (System.getProperty("os.arch") ?: "")
+            ))
+        }
+        // A policy block is the machine, not a defect, and it recurs on every launch of every
+        // affected install — so it is tagged and told to the operator rather than reported,
+        // exactly as the two blockers checked before the download are.
+        val policy = JcefInstall.policyBlock(outcome.cause.message)
+        if (policy != null) {
+            blockedByPolicy = true
+            System.err.println("[JCEF] Blocked by this machine's software policy: ${outcome.cause.message}")
+            runCatching { CrashReporter.setTag("jcef.blocked", policy) }
+            return
+        }
+        CrashReporter.reportException(outcome.cause, context = "CefManager.init")
     }
 
     /**

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationStore.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/PresentationStore.kt
@@ -16,6 +16,7 @@ import org.churchpresenter.presentationengine.LoadResult
 import org.churchpresenter.presentationengine.PresentationLoader
 import org.churchpresenter.presentationengine.cache.SlideCacheSupersededException
 import org.churchpresenter.presentationengine.cache.SlideDiskCache
+import org.churchpresenter.app.churchpresenter.utils.reportDegradedSlide
 import org.churchpresenter.settings.utils.Constants
 
 /**
@@ -136,12 +137,20 @@ internal class PresentationStore(
         if (slideDiskCache.isWriting(file)) return null
         val deck = when (val result = PresentationLoader.load(file)) {
             is LoadResult.Failure -> {
+                // The detail is the message the loader caught, and without it every distinct
+                // cause files as the same unactionable "parse_failed". It goes in extras and not
+                // in the context sentence: the sentence is what Sentry groups on, and an
+                // exception message can carry a file path.
                 CrashReporter.reportWarning(
                     "Presentation: No slides extracted from ${file.extension.lowercase()} file (server)",
                     tags = mapOf(
                         "subsystem" to "presentation",
                         "file.type" to file.extension.lowercase(),
                         "failure.reason" to result.error.name.lowercase()
+                    ),
+                    extras = mapOf(
+                        "detail" to (result.detail ?: "none"),
+                        "file.size" to file.length().toString(),
                     )
                 )
                 return null
@@ -152,7 +161,7 @@ internal class PresentationStore(
         var committed = false
         return try {
             val jpegSlides = CrashReporter.trace("server.render", "Server render presentation") {
-                DeckRasterizer(deck).use { rasterizer ->
+                DeckRasterizer(deck, onDegraded = ::reportDegradedSlide).use { rasterizer ->
                     deck.slides.map { slide ->
                         val slideFile = writer.putSlide(
                             index = slide.index,

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/TunnelManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/server/TunnelManager.kt
@@ -20,6 +20,7 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
+import org.churchpresenter.app.churchpresenter.utils.addGuardedShutdownHook
 
 private const val HTTP_OK = 200
 private const val TUNNEL_READY_TIMEOUT_MS = 30_000L
@@ -94,9 +95,9 @@ class TunnelManager {
     private val downloadUrl = cloudflaredDownloadUrl(isWin, isMac, isArm)
 
     init {
-        Runtime.getRuntime().addShutdownHook(Thread {
+        addGuardedShutdownHook("tunnel") {
             process?.destroyForcibly()
-        })
+        }
     }
 
     fun start(localPort: Int) {

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/PictureDecoder.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/PictureDecoder.kt
@@ -20,6 +20,8 @@ import javax.imageio.ImageIO
  *   TwelveMonkeys `imageio-jpeg` reader on the classpath reads them.
  * - **A HEIC/HEIF carrying a `.jpg`/`.jpeg` name.** Phone exports and chat apps rename freely, so
  *   the HEIC path is chosen by sniffing the `ftyp` box rather than by extension.
+ * - **A Photoshop file carrying a `.jpg` name.** Reported from the field as an undecodable
+ *   thumbnail whose leading bytes were `8BPS`; the `imageio-psd` reader on the classpath reads it.
  * - **A format only ImageIO knows**, TIFF being the one that turns up in picture folders.
  *
  * The fallbacks re-encode, so they cost a full extra decode — they run only after Skia has already

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ShutdownHooks.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/ShutdownHooks.kt
@@ -1,0 +1,32 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+/**
+ * Registers a JVM shutdown hook whose body cannot turn a clean exit into a reported crash.
+ *
+ * A shutdown hook runs on its own thread, so anything it throws goes to the default uncaught
+ * handler — which is `CrashReporter`. The app has already closed successfully by then, and the
+ * user sees nothing, but a `fatal` event is filed as though it had crashed. That is what happened
+ * to the resource census hook: it was the first thing to ask for a class, the class could not be
+ * loaded during exit, and a clean shutdown was reported as a crash.
+ *
+ * `Throwable` and not `Exception`: the observed failure was a `NoClassDefFoundError`, and the
+ * shutdown path is exactly where `Error`s of that shape appear. Failing to release something while
+ * the process is ending is not worth a report — the OS reclaims it either way.
+ *
+ * [name] names the thread, so a hang during shutdown is identifiable in a thread dump.
+ */
+internal fun addGuardedShutdownHook(name: String, body: () -> Unit) {
+    Runtime.getRuntime().addShutdownHook(Thread(guardedShutdownBody(body), "shutdown-$name"))
+}
+
+/**
+ * [body] wrapped so nothing escapes it — the part of [addGuardedShutdownHook] that can be run in a
+ * test, since registering a real hook only pays off when the JVM ends.
+ */
+internal fun guardedShutdownBody(body: () -> Unit): Runnable = Runnable {
+    try {
+        body()
+    } catch (_: Throwable) {
+        // Shutting down already; there is nowhere useful for this to go.
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SlideRenderReporting.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/SlideRenderReporting.kt
@@ -1,0 +1,30 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import org.churchpresenter.diagnostics.CrashReporter
+import org.churchpresenter.presentationengine.SlideRenderDegradation
+
+/**
+ * Reports a slide the engine could only render by leaving elements out.
+ *
+ * The engine cannot report this itself — `:presentation-engine` has no dependency on the crash
+ * reporter — so every `DeckRasterizer` the app builds passes this in. One function rather than one
+ * per call site so all three renders (the tab, the companion API and live playback) group as a
+ * single issue.
+ *
+ * The context sentence is constant, per `CrashReporter.reportWarning`'s contract: the slide index
+ * and the counts vary per occurrence and belong in tags and extras.
+ */
+fun reportDegradedSlide(degradation: SlideRenderDegradation) {
+    CrashReporter.reportWarning(
+        "Presentation: a slide rendered with shapes left out",
+        tags = mapOf(
+            "subsystem" to "presentation",
+            "degraded.cause" to degradation.cause,
+        ),
+        extras = mapOf(
+            "slide.index" to degradation.slideIndex.toString(),
+            "shapes.total" to degradation.shapesTotal.toString(),
+            "shapes.skipped" to degradation.shapesSkipped.toString(),
+        ),
+    )
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.churchpresenter.core.models.presentation.AnimationType
 import org.churchpresenter.core.models.presentation.PresentationLoadError
+import org.churchpresenter.app.churchpresenter.utils.reportDegradedSlide
 import org.churchpresenter.diagnostics.CrashReporter
 import org.churchpresenter.presentationengine.DeckRasterizer
 import org.churchpresenter.presentationengine.LoadResult
@@ -398,7 +399,7 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
             val cacheWriter = diskCache.beginWrite(file, deck.format, renderWidth)
             writer = cacheWriter
             var reportedSlideFailure = false
-            DeckRasterizer(deck, renderWidth).use { rasterizer ->
+            DeckRasterizer(deck, renderWidth, onDegraded = ::reportDegradedSlide).use { rasterizer ->
                 for (slide in deck.slides) {
                     try {
                         val frame = renderSlideFrame(rasterizer, slide.index)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/ScheduleViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import org.churchpresenter.app.churchpresenter.dialogs.filechooser.FileChooser
 import org.churchpresenter.app.churchpresenter.presenter.Presenting
 import org.churchpresenter.app.churchpresenter.server.ScheduleItemDto
+import org.churchpresenter.app.churchpresenter.utils.addGuardedShutdownHook
 import org.churchpresenter.app.churchpresenter.utils.InstanceLinkLogSide
 import org.churchpresenter.app.churchpresenter.utils.InstanceLinkLogger
 import org.churchpresenter.core.models.schedule.ScheduleItem
@@ -104,7 +105,7 @@ class ScheduleViewModel(
         // exitProcess/System.exit shutdown (e.g. the self-updater relaunching an installer),
         // so this loop could otherwise wake up mid-shutdown and try to classload ScheduleFileV2
         // after the installer has started overwriting the app's own files.
-        Runtime.getRuntime().addShutdownHook(Thread { scope.cancel() })
+        addGuardedShutdownHook("schedule") { scope.cancel() }
         scope.launch {
             while (true) {
                 delay(AUTOSAVE_INTERVAL_MS)

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/PlayerReleaseGateTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/composables/PlayerReleaseGateTest.kt
@@ -1,0 +1,74 @@
+package org.churchpresenter.app.churchpresenter.composables
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The guard that stopped a released VLC handle being paused 200 ms later.
+ *
+ * The production crash was `java.lang.Error: Invalid memory access` raised inside
+ * `libvlc_media_player_pause`, from a `javax.swing.Timer` that outlived the composable — so both
+ * halves matter here: that a released player is never touched, and that an `Error` from one that
+ * slips through does not escape.
+ */
+class PlayerReleaseGateTest {
+
+    @Test
+    fun `runs the block while the player is alive`() {
+        val gate = PlayerReleaseGate()
+        var ran = false
+        assertTrue(gate.ifLive { ran = true })
+        assertTrue(ran)
+        assertFalse(gate.isReleased)
+    }
+
+    @Test
+    fun `does not touch the player once released`() {
+        val gate = PlayerReleaseGate()
+        gate.release()
+        var ran = false
+        assertFalse(gate.ifLive { ran = true })
+        assertFalse(ran, "this is the freed-native-memory dereference the crash came from")
+        assertTrue(gate.isReleased)
+    }
+
+    // The production failure is a bare java.lang.Error out of libvlc; throwing anything narrower
+    // here would not exercise the case that a catch (_: Exception) misses.
+    @Suppress("TooGenericExceptionThrown")
+    @Test
+    fun `swallows an Error thrown by a native call`() {
+        // catch (_: Exception) would let this straight through; the crash was an Error.
+        val gate = PlayerReleaseGate()
+        assertFalse(gate.ifLive { throw Error("Invalid memory access") })
+    }
+
+    @Test
+    fun `swallows an exception thrown by a native call`() {
+        val gate = PlayerReleaseGate()
+        assertFalse(gate.ifLive { error("player is in a bad state") })
+    }
+
+    @Test
+    fun `releasing more than once is safe`() {
+        val gate = PlayerReleaseGate()
+        gate.release()
+        gate.release()
+        assertTrue(gate.isReleased)
+        assertFalse(gate.ifLive { error("must not be called") })
+    }
+
+    @Test
+    fun `a release part way through a sequence stops the calls after it`() {
+        // The real ordering: onDispose releases, and whatever was already queued must go no
+        // further. Anything that ran before the release still counts as having run.
+        val gate = PlayerReleaseGate()
+        val ran = mutableListOf<Int>()
+        gate.ifLive { ran += 1 }
+        gate.release()
+        gate.ifLive { ran += 2 }
+        gate.ifLive { ran += 3 }
+        assertEquals(listOf(1), ran)
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/CefManagerTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/CefManagerTest.kt
@@ -58,41 +58,156 @@ class CefManagerTest {
     }
 
     @Test
-    fun `jcefRootDir on Windows uses a writable ProgramData path`() {
-        val root = CefManager.jcefRootDir(
+    fun `rootCandidates on Windows offers ProgramData first and the home directory second`() {
+        val home = File(dir, "home").apply { mkdirs() }
+        val roots = JcefInstall.rootCandidates(
             osName = "Windows 11",
             programData = dir.absolutePath,
-            homeDir = "/should-not-be-used",
-        )
-        assertEquals(File(dir, "ChurchPresenter").absolutePath, root.absolutePath)
-        assertTrue(root.isDirectory, "jcefRootDir must actually create the ProgramData directory")
-    }
-
-    @Test
-    fun `jcefRootDir on Windows falls back to the home directory when ProgramData is unusable`() {
-        val programData = File(dir, "programdata").apply { mkdirs() }
-        // A plain file blocks mkdirs() at the exact "ChurchPresenter" path, forcing the writable check to fail.
-        File(programData, "ChurchPresenter").writeText("not a directory")
-        val home = File(dir, "home").apply { mkdirs() }
-
-        val root = CefManager.jcefRootDir(
-            osName = "Windows 11",
-            programData = programData.absolutePath,
             homeDir = home.absolutePath,
         )
-
-        assertEquals(File(home, ".churchpresenter").absolutePath, root.absolutePath)
+        assertEquals(
+            listOf(File(dir, "ChurchPresenter").absolutePath, File(home, ".churchpresenter").absolutePath),
+            roots.map { it.absolutePath },
+        )
     }
 
     @Test
-    fun `jcefRootDir on non-Windows always uses the home directory`() {
+    fun `rootCandidates on non-Windows offers only the home directory`() {
         val home = File(dir, "home").apply { mkdirs() }
-        val root = CefManager.jcefRootDir(
+        val roots = JcefInstall.rootCandidates(
             osName = "Mac OS X",
             programData = dir.absolutePath,
             homeDir = home.absolutePath,
         )
-        assertEquals(File(home, ".churchpresenter").absolutePath, root.absolutePath)
+        assertEquals(listOf(File(home, ".churchpresenter").absolutePath), roots.map { it.absolutePath })
+    }
+
+    @Test
+    fun `rootCandidates falls back to the literal ProgramData path when the variable is unset`() {
+        val roots = JcefInstall.rootCandidates(
+            osName = "Windows 10",
+            programData = null,
+            homeDir = File(dir, "home").absolutePath,
+        )
+        assertEquals("ChurchPresenter", roots.first().name)
+        assertTrue(roots.first().absolutePath.contains("ProgramData"))
+    }
+
+    @Test
+    fun `directoryIsWritable is true for a real directory and leaves no probe behind`() {
+        val target = File(dir, "writable")
+        assertTrue(JcefInstall.directoryIsWritable(target))
+        assertTrue(target.isDirectory, "the probe creates the directory it is asked about")
+        assertEquals(emptyList(), target.listFiles()!!.map { it.name }, "the probe file must be removed")
+    }
+
+    @Test
+    fun `directoryIsWritable is false when a plain file sits at the path`() {
+        val target = File(dir, "occupied")
+        target.writeText("not a directory")
+        assertFalse(JcefInstall.directoryIsWritable(target))
+    }
+
+    @Test
+    fun `installIntoFirstUsableRoot installs into the first root when it works`() {
+        val attempted = mutableListOf<File>()
+        val first = File(dir, "first")
+        val outcome = JcefInstall.installIntoFirstUsableRoot(
+            roots = listOf(first, File(dir, "second")),
+            blockerFor = { null },
+            stopRetrying = { false },
+            attempt = { attempted += it },
+        )
+        assertEquals(JcefInstall.Outcome.Installed(first), outcome)
+        assertEquals(listOf(first), attempted, "a working first root must not cost a second attempt")
+    }
+
+    @Test
+    fun `installIntoFirstUsableRoot retries the next root when the first attempt throws`() {
+        val attempted = mutableListOf<File>()
+        val first = File(dir, "programdata")
+        val second = File(dir, "home")
+        val outcome = JcefInstall.installIntoFirstUsableRoot(
+            roots = listOf(first, second),
+            blockerFor = { null },
+            stopRetrying = { false },
+            attempt = { root ->
+                attempted += root
+                if (root == first) throw java.io.FileNotFoundException("chrome_elf.dll (Access is denied)")
+            },
+        )
+        assertEquals(JcefInstall.Outcome.Installed(second), outcome)
+        assertEquals(listOf(first, second), attempted)
+    }
+
+    @Test
+    fun `installIntoFirstUsableRoot skips a blocked root without attempting it`() {
+        val attempted = mutableListOf<File>()
+        val blocked = File(dir, "blocked")
+        val usable = File(dir, "usable")
+        val outcome = JcefInstall.installIntoFirstUsableRoot(
+            roots = listOf(blocked, usable),
+            blockerFor = { if (it == blocked) "permission_denied" else null },
+            stopRetrying = { false },
+            attempt = { attempted += it },
+        )
+        assertEquals(JcefInstall.Outcome.Installed(usable), outcome)
+        assertEquals(listOf(usable), attempted)
+    }
+
+    @Test
+    fun `installIntoFirstUsableRoot reports the last blocker when every root is ruled out`() {
+        val attempted = mutableListOf<File>()
+        val outcome = JcefInstall.installIntoFirstUsableRoot(
+            roots = listOf(File(dir, "a"), File(dir, "b")),
+            blockerFor = { if (it.name == "a") "permission_denied" else "disk_space" },
+            stopRetrying = { false },
+            attempt = { attempted += it },
+        )
+        assertEquals(JcefInstall.Outcome.Blocked("disk_space"), outcome)
+        assertEquals(emptyList(), attempted)
+    }
+
+    @Test
+    fun `installIntoFirstUsableRoot stops after a failure the machine will repeat`() {
+        val attempted = mutableListOf<File>()
+        val first = File(dir, "first")
+        val policy = IllegalStateException("blocked by group policy")
+        val outcome = JcefInstall.installIntoFirstUsableRoot(
+            roots = listOf(first, File(dir, "second")),
+            blockerFor = { null },
+            stopRetrying = { JcefInstall.policyBlock(it.message) != null },
+            attempt = { root ->
+                attempted += root
+                throw policy
+            },
+        )
+        assertEquals(JcefInstall.Outcome.Failed(first, policy), outcome)
+        assertEquals(listOf(first), attempted, "a policy block applies machine-wide; a second root cannot help")
+    }
+
+    @Test
+    fun `installIntoFirstUsableRoot reports the last failure when every root throws`() {
+        val second = File(dir, "second")
+        val last = RuntimeException("second failed")
+        val outcome = JcefInstall.installIntoFirstUsableRoot(
+            roots = listOf(File(dir, "first"), second),
+            blockerFor = { null },
+            stopRetrying = { false },
+            attempt = { root -> throw if (root == second) last else RuntimeException("first failed") },
+        )
+        assertEquals(JcefInstall.Outcome.Failed(second, last), outcome)
+    }
+
+    @Test
+    fun `installIntoFirstUsableRoot reports a blocker when there is nothing to try`() {
+        val outcome = JcefInstall.installIntoFirstUsableRoot(
+            roots = emptyList(),
+            blockerFor = { null },
+            stopRetrying = { false },
+            attempt = { error("must not be called") },
+        )
+        assertEquals(JcefInstall.Outcome.Blocked("no_install_dir"), outcome)
     }
 
     @Test
@@ -151,10 +266,10 @@ class CefManagerTest {
     }
 
     @Test
-    fun `jcefRootDir with no arguments resolves to a churchpresenter directory`() {
-        assertTrue(
-            CefManager.jcefRootDir().name == ".churchpresenter" || CefManager.jcefRootDir().name == "ChurchPresenter",
-        )
+    fun `rootCandidates with no arguments resolves to churchpresenter directories`() {
+        val roots = JcefInstall.rootCandidates()
+        assertTrue(roots.isNotEmpty())
+        assertTrue(roots.all { it.name == ".churchpresenter" || it.name == "ChurchPresenter" }, "got $roots")
     }
 
     @Test
@@ -254,7 +369,7 @@ class CefManagerTest {
         // ProgramData ACLs vary and a locked-down corporate build is normal, not a defect.
         assertEquals(
             "permission_denied",
-            CefManager.jcefInstallBlocker(writable = false, usableSpaceBytes = plentyOfSpace),
+            JcefInstall.installBlocker(writable = false, usableSpaceBytes = plentyOfSpace),
         )
     }
 
@@ -262,13 +377,13 @@ class CefManagerTest {
     fun `a disk without room for a bundled Chromium blocks the install`() {
         assertEquals(
             "disk_space",
-            CefManager.jcefInstallBlocker(writable = true, usableSpaceBytes = 50L * 1024 * 1024),
+            JcefInstall.installBlocker(writable = true, usableSpaceBytes = 50L * 1024 * 1024),
         )
     }
 
     @Test
     fun `a writable directory with room goes ahead`() {
-        assertNull(CefManager.jcefInstallBlocker(writable = true, usableSpaceBytes = plentyOfSpace))
+        assertNull(JcefInstall.installBlocker(writable = true, usableSpaceBytes = plentyOfSpace))
     }
 
     @Test
@@ -276,14 +391,14 @@ class CefManagerTest {
         // File.usableSpace answers 0 when it cannot determine the figure, which is not the same as
         // a full disk — reading it that way would block the install wherever the filesystem does
         // not report one. The real attempt decides instead.
-        assertNull(CefManager.jcefInstallBlocker(writable = true, usableSpaceBytes = 0))
+        assertNull(JcefInstall.installBlocker(writable = true, usableSpaceBytes = 0))
     }
 
     @Test
     fun `permission is answered before space when neither is available`() {
         assertEquals(
             "permission_denied",
-            CefManager.jcefInstallBlocker(writable = false, usableSpaceBytes = 0),
+            JcefInstall.installBlocker(writable = false, usableSpaceBytes = 0),
         )
     }
 
@@ -295,7 +410,7 @@ class CefManagerTest {
         // install a Visual C++ redistributable that would not have helped.
         assertEquals(
             "policy",
-            CefManager.jcefPolicyBlock(
+            JcefInstall.policyBlock(
                 "C:\\ProgramData\\ChurchPresenter\\jcef\\jcef.dll: " +
                     "An Application Control policy has blocked this file"
             ),
@@ -303,8 +418,8 @@ class CefManagerTest {
 
         // Everything else keeps being reported. Matching a message is a weak test and this only
         // ever suppresses an event, so falling through is the safe direction to be wrong in.
-        assertNull(CefManager.jcefPolicyBlock("The specified module could not be found"))
-        assertNull(CefManager.jcefPolicyBlock(null))
+        assertNull(JcefInstall.policyBlock("The specified module could not be found"))
+        assertNull(JcefInstall.policyBlock(null))
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/PictureDecoderTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/PictureDecoderTest.kt
@@ -81,6 +81,55 @@ class PictureDecoderTest {
         assertNull(PictureDecoder.decodeOrNull(broken))
     }
 
+    /**
+     * The smallest valid Photoshop document: a 1x1 8-bit RGB image, uncompressed.
+     *
+     * Hand-built because `imageio-psd` reads PSD and does not write it, so ImageIO cannot produce
+     * this fixture. The layout is the PSD file header (signature, version, channel count, height,
+     * width, depth, colour mode), three empty length-prefixed sections, then the raw image data
+     * preceded by its compression word.
+     */
+    private fun minimalPsdBytes(): ByteArray {
+        val out = java.io.ByteArrayOutputStream()
+        java.io.DataOutputStream(out).use { data ->
+            data.writeBytes("8BPS")
+            data.writeShort(1)                  // version
+            repeat(6) { data.writeByte(0) }     // reserved
+            data.writeShort(3)                  // channels: R, G, B
+            data.writeInt(1)                    // height
+            data.writeInt(1)                    // width
+            data.writeShort(8)                  // bits per channel
+            data.writeShort(3)                  // colour mode: RGB
+            data.writeInt(0)                    // colour mode data
+            data.writeInt(0)                    // image resources
+            data.writeInt(0)                    // layer and mask info
+            data.writeShort(0)                  // compression: raw
+            data.write(byteArrayOf(0x7F, 0x00, 0x00))  // one pixel, one byte per channel
+        }
+        return out.toByteArray()
+    }
+
+    @Test
+    fun `decodes a Photoshop file carrying a jpg name`() {
+        // The field report: an undecodable thumbnail whose leading bytes were 8BPS and whose name
+        // ended .jpg. Skia refuses it and the extension is a lie, so only the ImageIO fallback --
+        // and only with imageio-psd on the classpath -- can read it.
+        val file = File(folder, "renamed-photoshop.jpg")
+        file.writeBytes(minimalPsdBytes())
+
+        assertNotNull(PictureDecoder.decodeOrNull(file), "imageio-psd must be on the classpath")
+    }
+
+    @Test
+    fun `a Photoshop file is claimed by an ImageIO reader`() {
+        // The same file's diagnosis line said "imageio=none" before the reader was added, which is
+        // what made the report look like an unsupported format rather than a missing plugin.
+        val file = File(folder, "photoshop.psd")
+        file.writeBytes(minimalPsdBytes())
+
+        assertContains(PictureDecoder.diagnose(file).lowercase(), "imageio=psd")
+    }
+
     @Test
     fun `transcode returns null for bytes ImageIO cannot read`() {
         assertNull(PictureDecoder.transcodeWithImageIO("not an image".toByteArray()))

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ShutdownHooksTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/ShutdownHooksTest.kt
@@ -1,0 +1,63 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The shutdown-hook guard.
+ *
+ * A hook that throws reaches the default uncaught handler, which is the crash reporter — so a
+ * clean exit gets filed as a fatal crash. The hook itself cannot be run here without ending the
+ * JVM, so what is tested is the body wrapper: it must run the work, and it must not let anything
+ * out. `Thread.getUncaughtExceptionHandler` is what would have seen the escape, so the test drives
+ * the same shape directly.
+ */
+class ShutdownHooksTest {
+
+    /** Runs the real guarded body on its own thread and returns whatever escaped it. */
+    private fun escapedFrom(body: () -> Unit): Throwable? {
+        var escaped: Throwable? = null
+        val thread = Thread(guardedShutdownBody(body), "shutdown-test")
+        thread.setUncaughtExceptionHandler { _, t -> escaped = t }
+        thread.start()
+        thread.join()
+        return escaped
+    }
+
+    @Test
+    fun `the guarded body still does its work`() {
+        val done = mutableListOf<String>()
+        assertEquals(null, escapedFrom { done += "released" })
+        assertEquals(listOf("released"), done)
+    }
+
+    @Test
+    fun `an Error during shutdown does not escape`() {
+        // The reported one: NoClassDefFoundError, raised because the hook was the first thing to
+        // ask for a class that could no longer be loaded.
+        assertEquals(null, escapedFrom { throw NoClassDefFoundError("some/Class") })
+    }
+
+    @Test
+    fun `an exception during shutdown does not escape`() {
+        assertEquals(null, escapedFrom { error("could not release") })
+    }
+
+    @Test
+    fun `the guarded body runs its work exactly once`() {
+        var calls = 0
+        guardedShutdownBody { calls++ }.run()
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `a failure part way through does not undo what already ran`() {
+        val done = mutableListOf<String>()
+        assertEquals(null, escapedFrom {
+            done += "stopped tunnel"
+            error("could not release the rest")
+        })
+        assertTrue(done.contains("stopped tunnel"))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ pdfbox = "2.0.33"
 aircompressor = "2.0.2"
 junitJupiter = "5.10.2"
 filekit = "0.14.1"
+twelvemonkeys-imageio = "3.10.1"
 
 [libraries]
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
@@ -79,6 +80,9 @@ apache-poi = { module = "org.apache.poi:poi", version.ref = "apache-poi" }
 apache-poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "apache-poi" }
 apache-poi-ooxmlFull = { module = "org.apache.poi:poi-ooxml-full", version.ref = "apache-poi" }
 apache-poi-scratchpad = { module = "org.apache.poi:poi-scratchpad", version.ref = "apache-poi" }
+twelvemonkeys-imageio-core = { module = "com.twelvemonkeys.imageio:imageio-core", version.ref = "twelvemonkeys-imageio" }
+twelvemonkeys-imageio-jpeg = { module = "com.twelvemonkeys.imageio:imageio-jpeg", version.ref = "twelvemonkeys-imageio" }
+twelvemonkeys-imageio-psd = { module = "com.twelvemonkeys.imageio:imageio-psd", version.ref = "twelvemonkeys-imageio" }
 pdfbox = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfbox" }
 aircompressor = { module = "io.airlift:aircompressor", version.ref = "aircompressor" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }

--- a/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/DeckRasterizer.kt
+++ b/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/DeckRasterizer.kt
@@ -5,6 +5,7 @@ import org.apache.pdfbox.rendering.ImageType
 import org.apache.pdfbox.rendering.PDFRenderer
 import org.apache.poi.sl.draw.DrawFactory
 import org.apache.poi.sl.draw.Drawable
+import org.apache.poi.sl.usermodel.Slide
 import org.apache.poi.sl.usermodel.SlideShow
 import org.apache.poi.xslf.usermodel.XMLSlideShow
 import org.churchpresenter.presentationengine.fonts.SlideFontRegistry
@@ -20,6 +21,7 @@ import org.churchpresenter.presentationengine.model.RectPt
 import org.churchpresenter.presentationengine.pptx.PowerPointDeckSupport
 import org.churchpresenter.presentationengine.pptx.PptxSlideRasterizer
 import java.awt.Color
+import java.awt.Graphics2D
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
@@ -36,7 +38,18 @@ import kotlin.math.sqrt
  */
 class DeckRasterizer(
     private val deck: Deck,
-    private val targetWidthPx: Int = DEFAULT_TARGET_WIDTH_PX
+    private val targetWidthPx: Int = DEFAULT_TARGET_WIDTH_PX,
+    /**
+     * Called for the **first** slide of this deck that could only be rendered with elements left
+     * out, and not again for the rest of the render.
+     *
+     * A callback rather than a report from in here: this module has no dependency on the crash
+     * reporter and should not gain one, and the caller is what knows whether this render is a
+     * thumbnail, the companion API or the live output. First-only because the cause is nearly
+     * always one asset the whole deck reuses — a hundred-slide deck would otherwise file a
+     * hundred identical events for a single bad picture.
+     */
+    private val onDegraded: (SlideRenderDegradation) -> Unit = {},
 ) : AutoCloseable {
 
     companion object {
@@ -87,6 +100,12 @@ class DeckRasterizer(
     private var slideShow: SlideShow<*, *>? = null
     private var keynoteTempPdf: File? = null
     private var keynoteSceneRasterizer: KeynoteSceneRasterizer? = null
+
+    /** The pixel size a slide renders at, and the scale that gets it there from page points. */
+    private data class SlideCanvas(val width: Int, val height: Int, val scale: Double)
+
+    /** Whether [onDegraded] has already fired for this deck; see its own doc for why once. */
+    private var degradationReported = false
 
     /** Embedded pptx video files extracted to temp files, keyed by relationship id — see
      *  [PptxSlideRasterizer.rasterizeLayer]; deleted in [close], not just `deleteOnExit()`. */
@@ -199,17 +218,43 @@ class DeckRasterizer(
 
     // ── PowerPoint ────────────────────────────────────────────────────────────
 
+    // Throwable is the point: one shape's failure must not cost the slide, and the drawing path
+    // raises Errors (OutOfMemoryError on an absurd declared length) as well as exceptions.
+    @Suppress("TooGenericExceptionCaught")
     private fun renderPowerPointSlide(file: File, slideIndex: Int): BufferedImage {
         val show = slideShow ?: PowerPointDeckSupport.open(file).also { slideShow = it }
         val slide = show.slides[slideIndex]
         val pageSize = show.pageSize
         val scale = boundedRenderScale(pageSize.width.toDouble(), pageSize.height.toDouble(), targetWidthPx)
-        val width = (pageSize.width * scale).toInt().coerceAtLeast(1)
-        val height = (pageSize.height * scale).toInt().coerceAtLeast(1)
-        // ARGB: a slide without an opaque background keeps its transparency instead of the old
-        // pipeline's forced white fill (the slide's own background — from slide, layout or
-        // master — is painted by POI's DrawSlide).
-        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        val canvas = SlideCanvas(
+            width = (pageSize.width * scale).toInt().coerceAtLeast(1),
+            height = (pageSize.height * scale).toInt().coerceAtLeast(1),
+            scale = scale,
+        )
+        return try {
+            slideImage(canvas) { graphics ->
+                DrawFactory.getInstance(graphics).getDrawable(slide).draw(graphics)
+            }
+        } catch (t: Throwable) {
+            // POI's DrawSlide walks every shape itself, so anything one of them throws — an
+            // oversized embedded picture is the one seen in the field — comes out here having
+            // abandoned the rest of the slide. A blank slide mid-service is far worse than a
+            // slide missing one picture, so draw it again the forgiving way. Nothing is retained
+            // from the failed attempt: it is a fresh image, because the first pass may have
+            // painted part of the slide before it threw.
+            renderPowerPointSlideDegraded(slide, slideIndex, canvas, t)
+        }
+    }
+
+    /**
+     * A slide-sized ARGB image with [draw] painted onto it at [scale].
+     *
+     * ARGB: a slide without an opaque background keeps its transparency instead of the old
+     * pipeline's forced white fill (the slide's own background — from slide, layout or master —
+     * is painted by POI's DrawSlide).
+     */
+    private fun slideImage(canvas: SlideCanvas, draw: (Graphics2D) -> Unit): BufferedImage {
+        val image = BufferedImage(canvas.width, canvas.height, BufferedImage.TYPE_INT_ARGB)
         val graphics = image.createGraphics()
         try {
             graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
@@ -218,10 +263,48 @@ class DeckRasterizer(
             graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON)
             graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
             graphics.setRenderingHint(Drawable.FONT_HANDLER, SlideFontRegistry.drawFontManager)
-            graphics.scale(scale, scale)
-            DrawFactory.getInstance(graphics).getDrawable(slide).draw(graphics)
+            graphics.scale(canvas.scale, canvas.scale)
+            draw(graphics)
         } finally {
             graphics.dispose()
+        }
+        return image
+    }
+
+    /**
+     * Re-renders the slide one element at a time, keeping everything that draws.
+     *
+     * This reproduces what `DrawSlide.draw` does — background, then the master sheet when the
+     * slide follows it, then the shapes — with each step on its own, so a failing element costs
+     * only itself. It is not a substitute for the single call: it is slower and it re-implements
+     * an ordering POI owns, which is why it runs only after that call has already failed.
+     */
+    private fun renderPowerPointSlideDegraded(
+        slide: Slide<*, *>,
+        slideIndex: Int,
+        canvas: SlideCanvas,
+        cause: Throwable,
+    ): BufferedImage {
+        val shapes = slide.shapes.toList()
+        var skipped = 0
+        val image = slideImage(canvas) { graphics ->
+            val factory = DrawFactory.getInstance(graphics)
+            runCatching { slide.background?.let { factory.getDrawable(it).draw(graphics) } }
+            if (slide.followMasterGraphics) {
+                runCatching { slide.masterSheet?.let { factory.getDrawable(it).draw(graphics) } }
+            }
+            skipped = drawEachSkippingFailures(shapes) { factory.getDrawable(it).draw(graphics) }
+        }
+        if (!degradationReported) {
+            degradationReported = true
+            onDegraded(
+                SlideRenderDegradation(
+                    slideIndex = slideIndex,
+                    shapesTotal = shapes.size,
+                    shapesSkipped = skipped,
+                    cause = cause.javaClass.simpleName,
+                )
+            )
         }
         return image
     }

--- a/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/SlideRenderDegradation.kt
+++ b/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/SlideRenderDegradation.kt
@@ -1,0 +1,38 @@
+package org.churchpresenter.presentationengine
+
+/**
+ * What a slide lost when it had to be rendered the slow, forgiving way.
+ *
+ * [cause] is the simple class name of the exception that failed the whole-slide draw — not its
+ * message, which can carry a file path. Reported once per slide; see [drawEachSkippingFailures].
+ */
+data class SlideRenderDegradation(
+    val slideIndex: Int,
+    val shapesTotal: Int,
+    val shapesSkipped: Int,
+    val cause: String,
+)
+
+/**
+ * Draws every one of [items], carrying on past the ones that throw, and returns how many were
+ * skipped.
+ *
+ * This is the whole of the recovery policy, kept separate from the POI calls that supply [drawOne]
+ * so it can be tested without a deck, a display or a rasterizer: the interesting behaviour is that
+ * a failure part-way through does not cost the items after it.
+ *
+ * `Throwable` rather than `Exception` on purpose — the failure this exists for,
+ * `RecordFormatException`, is an `Exception`, but the same drawing path also raises
+ * `OutOfMemoryError` on an absurd declared length, and one shape is not worth the slide.
+ */
+internal fun <T> drawEachSkippingFailures(items: List<T>, drawOne: (T) -> Unit): Int {
+    var skipped = 0
+    for (item in items) {
+        try {
+            drawOne(item)
+        } catch (_: Throwable) {
+            skipped++
+        }
+    }
+    return skipped
+}

--- a/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/pptx/PoiLimits.kt
+++ b/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/pptx/PoiLimits.kt
@@ -1,0 +1,51 @@
+package org.churchpresenter.presentationengine.pptx
+
+import org.apache.poi.util.IOUtils
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Raises the ceiling POI puts on a single allocated byte array, once per process.
+ *
+ * POI refuses to allocate more than [DEFAULT_LIMIT_BYTES] for one record and throws
+ * `RecordFormatException` instead. That default is a guard against a corrupt or hostile file
+ * declaring an absurd length, and it is the right shape of protection — but real decks exceed it:
+ * a picture pasted at camera resolution and never downsampled clears 100 MB on its own, and when
+ * `XSLFPictureData.getData` throws, the throw lands inside POI's drawing code and takes the whole
+ * slide with it.
+ *
+ * So the limit is raised rather than removed. [MAX_RECORD_BYTES] is deliberately finite: passing
+ * `-1` disables the check altogether, which trades a blank slide for a declared length large enough
+ * to OOM the app — a worse failure, and one that takes the live service down instead of one image.
+ *
+ * POI exposes only a setter for this — there is no `getByteArrayMaxOverride` to read the current
+ * value back — so the one-shot latch is what keeps this from clobbering a later, deliberate
+ * override rather than a comparison.
+ */
+internal object PoiLimits {
+
+    /** POI's own default, and the number quoted in the exception message when it trips. */
+    const val DEFAULT_LIMIT_BYTES: Int = 100_000_000
+
+    /** Generous enough for an un-downsampled photograph, small enough to stay allocatable. */
+    const val MAX_RECORD_BYTES: Int = 512 * 1024 * 1024
+
+    private val applied = AtomicBoolean(false)
+
+    /** Whether [apply] has already run. The override itself has no getter in POI to read back. */
+    internal val hasApplied: Boolean get() = applied.get()
+
+    /**
+     * Applies the override the first time it is called and does nothing afterwards.
+     *
+     * Idempotent because it is called from [PowerPointDeckSupport.open], which runs once per deck
+     * on whichever thread opened it — the `compareAndSet` is what makes concurrent opens safe, and
+     * it follows the same shape as `SlideFontRegistry.initialize`.
+     */
+    fun apply() {
+        if (!applied.compareAndSet(false, true)) return
+        IOUtils.setByteArrayMaxOverride(MAX_RECORD_BYTES)
+    }
+
+    /** Resets the one-shot latch. Tests only — the override itself is process-global. */
+    internal fun resetForTest() = applied.set(false)
+}

--- a/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/pptx/PowerPointDeckSupport.kt
+++ b/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/pptx/PowerPointDeckSupport.kt
@@ -43,10 +43,19 @@ internal sealed interface PowerPointMetadataResult {
 
 internal object PowerPointDeckSupport {
 
-    /** Opens a slide show with format auto-detection (works for both .pptx and .ppt). */
-    fun open(file: File): SlideShow<*, *> = SlideShowFactory.create(file, null, true)
-        .also { registerEmbeddedFonts(it) }
-        .also { show -> (show as? XMLSlideShow)?.let { stripUnsupportedHighlights(it) } }
+    /**
+     * Opens a slide show with format auto-detection (works for both .pptx and .ppt).
+     *
+     * Every POI `SlideShow` in this module is created here, which is what makes it the place to
+     * apply [PoiLimits] — the alternative, initialising from the app's startup thread, races the
+     * first deck load.
+     */
+    fun open(file: File): SlideShow<*, *> {
+        PoiLimits.apply()
+        return SlideShowFactory.create(file, null, true)
+            .also { registerEmbeddedFonts(it) }
+            .also { show -> (show as? XMLSlideShow)?.let { stripUnsupportedHighlights(it) } }
+    }
 
     /**
      * Registers fonts embedded in the document (the fntdata parts under ppt/fonts — plain TTF

--- a/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/pptx/PptxSlideRasterizer.kt
+++ b/presentation-engine/src/main/kotlin/org/churchpresenter/presentationengine/pptx/PptxSlideRasterizer.kt
@@ -126,9 +126,9 @@ internal object PptxSlideRasterizer {
             graphics.scale(scale, scale)
             if (spec.zIndex == 0) {
                 val factory = DrawFactory.getInstance(graphics)
-                slide.background?.let { factory.getDrawable(it).draw(graphics) }
+                runCatching { slide.background?.let { factory.getDrawable(it).draw(graphics) } }
                 if (slide.followMasterGraphics) {
-                    slide.masterSheet?.let { factory.getDrawable(it).draw(graphics) }
+                    runCatching { slide.masterSheet?.let { factory.getDrawable(it).draw(graphics) } }
                 }
             }
             for (shapeIndex in spec.shapeIndexes) {
@@ -164,9 +164,21 @@ internal object PptxSlideRasterizer {
         return RasterLayer(spec, image, offsetX, offsetY)
     }
 
+    /**
+     * Draws one shape, skipping it if it throws.
+     *
+     * This is the layered playback path, where an unguarded throw costs the caller its whole band
+     * (and through `DeckRasterizer.rasterizeSlideLayers`, the slide's entire layer list) for one
+     * bad element. The same swallow-and-degrade choice the file already makes in
+     * `extractVideoFile`.
+     */
     private fun drawShape(graphics: Graphics2D, shape: XSLFShape) {
-        graphics.setRenderingHint(Drawable.GROUP_TRANSFORM, AffineTransform())
-        DrawFactory.getInstance(graphics).getDrawable(shape).draw(graphics)
+        try {
+            graphics.setRenderingHint(Drawable.GROUP_TRANSFORM, AffineTransform())
+            DrawFactory.getInstance(graphics).getDrawable(shape).draw(graphics)
+        } catch (_: Throwable) {
+            // Left out of this layer; the rest of the band still draws.
+        }
     }
 
     private fun applyHints(graphics: Graphics2D, slide: XSLFSlide) {

--- a/presentation-engine/src/test/kotlin/org/churchpresenter/presentationengine/PresentationLoaderFormatTest.kt
+++ b/presentation-engine/src/test/kotlin/org/churchpresenter/presentationengine/PresentationLoaderFormatTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -62,6 +63,19 @@ class PresentationLoaderFormatTest {
             val file = File(temp, name).apply { writeText("this is not a presentation at all") }
             val result = assertIs<LoadResult.Failure>(PresentationLoader.load(file), "$name should fail")
             assertEquals(DeckLoadError.PARSE_FAILED, result.error, "$name")
+        }
+    }
+
+    @Test
+    fun `a parse failure says why, not just that it failed`() {
+        // PARSE_FAILED on its own is the same event for every cause, which is what made the
+        // companion API's "No slides extracted" report unactionable. The detail is where the
+        // reason lives, so it has to actually be there for the reporting to carry it.
+        for (name in listOf("why.pptx", "why.ppt", "why.pdf")) {
+            val file = File(temp, name).apply { writeText("this is not a presentation at all") }
+            val result = assertIs<LoadResult.Failure>(PresentationLoader.load(file), name)
+            assertNotNull(result.detail, "$name failed with no reason attached")
+            assertTrue(result.detail!!.isNotBlank(), "$name attached a blank reason")
         }
     }
 

--- a/presentation-engine/src/test/kotlin/org/churchpresenter/presentationengine/SlideDrawRecoveryTest.kt
+++ b/presentation-engine/src/test/kotlin/org/churchpresenter/presentationengine/SlideDrawRecoveryTest.kt
@@ -1,0 +1,108 @@
+package org.churchpresenter.presentationengine
+
+import org.churchpresenter.presentationengine.pptx.PoiLimits
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The recovery policy behind a degraded slide render, without a deck or a rasterizer.
+ *
+ * What matters is that a shape failing part-way through does not cost the shapes after it — the
+ * production bug was one oversized picture taking the whole slide with it.
+ */
+class SlideDrawRecoveryTest {
+
+    @Test
+    fun `draws every item and skips none when nothing throws`() {
+        val drawn = mutableListOf<String>()
+        val skipped = drawEachSkippingFailures(listOf("a", "b", "c")) { drawn += it }
+        assertEquals(0, skipped)
+        assertEquals(listOf("a", "b", "c"), drawn)
+    }
+
+    @Test
+    fun `a failing item costs only itself and the rest still draw in order`() {
+        val drawn = mutableListOf<String>()
+        val skipped = drawEachSkippingFailures(listOf("a", "bad", "c")) {
+            if (it == "bad") error("this shape cannot be drawn")
+            drawn += it
+        }
+        assertEquals(1, skipped)
+        assertEquals(listOf("a", "c"), drawn, "the items after the failure must still be drawn")
+    }
+
+    @Test
+    fun `counts every failure, not just the first`() {
+        val drawn = mutableListOf<String>()
+        val skipped = drawEachSkippingFailures(listOf("bad", "bad", "good", "bad")) {
+            if (it == "bad") error("no")
+            drawn += it
+        }
+        assertEquals(3, skipped)
+        assertEquals(listOf("good"), drawn)
+    }
+
+    @Test
+    fun `an Error is skipped too, not propagated`() {
+        // The drawing path raises OutOfMemoryError on an absurd declared length, and an
+        // Exception-only catch would let it through and fail the slide anyway.
+        val drawn = mutableListOf<String>()
+        val skipped = drawEachSkippingFailures(listOf("a", "boom", "b")) {
+            if (it == "boom") throw OutOfMemoryError("declared length")
+            drawn += it
+        }
+        assertEquals(1, skipped)
+        assertEquals(listOf("a", "b"), drawn)
+    }
+
+    @Test
+    fun `an empty list skips nothing`() {
+        assertEquals(0, drawEachSkippingFailures(emptyList<String>()) { error("must not be called") })
+    }
+
+    @Test
+    fun `the POI byte-array ceiling is raised above the default that failed in the field`() {
+        assertTrue(
+            PoiLimits.MAX_RECORD_BYTES > PoiLimits.DEFAULT_LIMIT_BYTES,
+            "the whole point is to clear POI's own default",
+        )
+    }
+
+    @Test
+    fun `the raised POI ceiling stays finite`() {
+        // -1 disables the check outright, which trades a blank slide for an OOM that takes the
+        // live service down. The bound must remain a real, allocatable number.
+        assertTrue(PoiLimits.MAX_RECORD_BYTES > 0)
+    }
+
+    @Test
+    fun `applying the POI limits latches after the first call`() {
+        PoiLimits.resetForTest()
+        assertFalse(PoiLimits.hasApplied)
+        PoiLimits.apply()
+        assertTrue(PoiLimits.hasApplied)
+        // Repeated application is what every deck open relies on being free and safe.
+        PoiLimits.apply()
+        PoiLimits.apply()
+        assertTrue(PoiLimits.hasApplied)
+    }
+
+    @Test
+    fun `opening a deck applies the POI limits`() {
+        // The wiring itself: PowerPointDeckSupport.open is the module's single chokepoint for
+        // creating a SlideShow, and it is what makes the raised ceiling deterministic rather than
+        // dependent on a startup thread winning a race.
+        PoiLimits.resetForTest()
+        val dir = Files.createTempDirectory("cp-poi-limits").toFile()
+        try {
+            val pptx = Fixtures.createPptx(dir, listOf("Slide one" to ""))
+            PresentationLoader.load(pptx)
+        } finally {
+            dir.deleteRecursively()
+        }
+        assertTrue(PoiLimits.hasApplied, "loading a PowerPoint deck must have applied the limits")
+    }
+}


### PR DESCRIPTION
Seven open Sentry issues, triaged against the tree. Four others (`5S`, `5W`, `5N`, `5X`) are warning-level telemetry from paths that already recover and are untouched here; two more are the mobile repo.

## What was broken

**One oversized picture blanks the whole slide** — `DESKTOP-5Z`, `DESKTOP-5Y`

POI refuses to allocate more than 100 MB for one record, and a photograph pasted at camera resolution clears that alone. The throw lands inside `DrawSlide`, which walks every shape itself, so it abandons the rest of the slide — the operator gets a blank slide rather than a slide missing one image.

Two independent defects, both fixed. The ceiling was never configured anywhere in the repo; `PoiLimits` now raises it from `PowerPointDeckSupport.open`, the module's single chokepoint for creating a `SlideShow`, so it is deterministic instead of racing a startup thread. And nothing caught a shape-level failure: `DeckRasterizer` now redraws the slide one element at a time and keeps what draws, and `PptxSlideRasterizer.drawShape` skips a failing shape instead of losing its whole band.

The raised limit stays finite deliberately — `-1` disables the check and trades a blank slide for an OOM that ends the service.

**A released VLC handle is paused 200 ms later** — `DESKTOP-27`, fatal

`playing()` scheduled a `javax.swing.Timer` to auto-pause after the first frame, created inline and never stored, so nothing could stop it. Switching media disposes the composable well inside that window and the callback then called `controls().pause()` on freed native memory. Both copies now hold the timer, stop it on dispose, and route deferred native calls through `PlayerReleaseGate` — set before `releasePlayer()`, and catching `Throwable`, since `catch (_: Exception)` does not catch an `Error`.

**A JCEF install gives up with a usable directory beside it** — `DESKTOP-43`, regressed

`%ProgramData%\ChurchPresenter` is shared between accounts, so a directory this user can create is not one they can extract into. The old code probed `canWrite()` — which reports the read-only attribute, not the ACL — committed to whatever passed, and had no answer when extraction later failed with `Access is denied`. The probe is a real write now, and the install walks candidate roots, falling back to `~/.churchpresenter` before reporting. A policy block still stops the walk, because it applies machine-wide.

**"No slides extracted" said nothing** — `DESKTOP-3T`, regressed

The report dropped `result.detail`, the message the loader had already caught, so every cause filed as the same unactionable `parse_failed`. It goes in extras now — never the context sentence, which is what Sentry groups on. This is the same defect fixed for `EMPTY_DOCUMENT` previously; the sibling branch was missed.

**A clean exit reported as a crash** — `DESKTOP-60`

A shutdown hook that throws reaches the default uncaught handler, which is the crash reporter — so failing to release something while the process ends was filed as `fatal` after the user had already closed the app. All six hooks go through `addGuardedShutdownHook`.

Worth being explicit: the reported instance was a dev build failing to load a class during shutdown, which is a stale build. That is **not** claimed as fixed. What is fixed is it being reported as a crash.

**A Photoshop file named `.jpg`** — `DESKTOP-5T`

The payload named it: `magic=8BPS`, `imageio=none`. `imageio-psd` joins the TwelveMonkeys readers already on the classpath and `PictureDecoder`'s existing ImageIO fallback then reads it, with no change to the decoder. All three TwelveMonkeys coordinates move into the version catalog while adding it.

## Approach

Each unreachable step is a function parameter, so the ordering around it is tested while only the step itself is not: the install attempt in `installIntoFirstUsableRoot`, the per-shape draw in `drawEachSkippingFailures`. The engine reports nothing itself — it has no dependency on the crash reporter and does not gain one; `DeckRasterizer` takes an `onDegraded` callback that fires once per deck, since the cause is nearly always one asset a hundred slides share.

## Not covered

The degraded render is exercised through the recovery policy rather than a >100 MB fixture. The JCEF retry is Windows-ACL-specific and is covered by unit tests rather than reproduced.

## Verification

`:composeApp:check` — 10,401 tests, 0 failed, coverage gate passed. `:presentation-engine:test` green. `detekt` clean on both modules with no baseline entries added. New tests run three consecutive times; slowest new suite is 0.11s. No screenshots affected.