### PR TITLE
Say what the per-output Background pane actually offers

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/CustomizeBackgroundPane.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/CustomizeBackgroundPane.kt
@@ -31,11 +31,14 @@ import org.jetbrains.compose.resources.stringResource
 /**
  * The Background pane: what this screen shows behind whatever is live.
  *
- * Type, colour and opacity for the full-screen background and for the lower-third band. The image
- * and video pickers, the stock-photo browser and the gradient controls stay on the global
- * Background tab — those choose a *file*, which is a library decision, where this pane is about how
- * one screen uses what the library already holds. An output set to Image or Video here keeps
- * showing the globally chosen file.
+ * Carries the same controls the global Background tab does — type, colour, the image and video
+ * pickers with the stock-photo browser behind them, the gradient ends, opacity, dim and blur — so a
+ * screen can be given a background of its own rather than only a different treatment of the shared
+ * one. It writes through the same [BackgroundConfig] that tab writes, so the two never disagree
+ * about what a surface means.
+ *
+ * What it does *not* offer is a choice of surface: [BackgroundSurfaceRows] is handed the one this
+ * output actually draws, for the reason given at that call.
  */
 @Composable
 internal fun BackgroundCustomizePane(


### PR DESCRIPTION
## The problem

`BackgroundCustomizePane`'s doc described the state before the image and video pickers landed in it:

> The image and video pickers, the stock-photo browser and the gradient controls stay on the global Background tab … An output set to Image or Video here keeps showing the globally chosen file.

None of that is true any more. `ImagePickerRow`, `VideoPickerRow`, `GradientRows` and both stock-photo API keys are all wired into this pane, so a screen can be given a background of its own — not merely a different treatment of the shared one.

## Why it is worth a commit on its own

A doc that understates a feature is read as a statement of what the code *cannot* do. This one was: the question "can a second screen have its own background image?" was answered from it, and the answer was wrong — including when triaging #474, whose item 2 asked for exactly the capability the doc denied.

## The change

Doc only; no behaviour. It now says what the pane carries and that it writes through the same `BackgroundConfig` the global tab does, and keeps the one restriction that *is* real — a single surface per output, not a choice of six — pointing at the call site that explains why.

`./gradlew :composeApp:detekt` passes.