### PR TITLE
Explain a camera background that will not draw, and say where a build came from

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -700,6 +700,18 @@ val generateBuildConfig by tasks.registering {
     // would read whatever directory the user happened to launch the app from.
     val repoSlug = gitRepoSlug()
     val buildType = gitBuildType(isRelease)
+    // Whether this build came off CI or somebody's machine. `IS_RELEASE` cannot answer that: it
+    // means "a packaging task ran", so `./gradlew packageDmg` on a laptop produces a build that
+    // calls itself a release and reports `environment=production` to Sentry. Over 30 days that
+    // left 224 of 234 camera reports labelled production, including a tester's, and no way to tell
+    // an operator's build from one built to try a fix out.
+    //
+    // `providers.environmentVariable` and NOT `System.getenv`, for the reason recorded on
+    // `printCoverageLink` below: `System.getenv` reads the Gradle DAEMON's environment, frozen when
+    // the daemon started, which need not be the environment of the build asking.
+    val buildChannel = providers.environmentVariable("GITHUB_ACTIONS")
+        .map { if (it == "true") "ci" else "local" }
+        .getOrElse("local")
     val planningCenterClientId = System.getenv("PLANNING_CENTER_CLIENT_ID") ?: ""
     val planningCenterClientSecret = System.getenv("PLANNING_CENTER_CLIENT_SECRET") ?: ""
     val outputDir = layout.buildDirectory.dir("generated/buildconfig")
@@ -723,6 +735,7 @@ val generateBuildConfig by tasks.registering {
             |    const val IS_RELEASE = $isRelease
             |    const val REPO_SLUG = "$repoSlug"
             |    const val BUILD_TYPE = "$buildType"
+            |    const val BUILD_CHANNEL = "$buildChannel"
             |    const val PLANNING_CENTER_CLIENT_ID = "$planningCenterClientId"
             |    const val PLANNING_CENTER_CLIENT_SECRET = "$planningCenterClientSecret"
             |}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneDeviceEditors.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SceneDeviceEditors.kt
@@ -355,12 +355,7 @@ internal fun CameraProperties(
     // list treats as "say nothing" and must not be flattened into "no cameras found".
     CameraToolHints(osName, known, ffmpegAvailable)
 
-    if (osName.contains("mac") || osName.contains("darwin")) {
-        MacCameraPrivacyHint()
-    }
-    if (osName.contains("win")) {
-        WindowsCameraPrivacyHint()
-    }
+    CameraPrivacyHint(osName)
 }
 
 /** Whatever [cameraHintStringRes] decides is worth saying about this machine's camera tooling. */
@@ -380,46 +375,53 @@ private fun CameraToolHints(osName: String, devices: List<CameraDevice>?, ffmpeg
     }
 }
 
+/** The macOS Camera privacy pane, opened from a panel because a panel is where it can be acted on. */
+internal const val MAC_CAMERA_PRIVACY_URI =
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+
 /** The Windows Camera privacy page, opened for the same reason as [MAC_CAMERA_PRIVACY_URI]. */
 internal const val WINDOWS_CAMERA_PRIVACY_URI = "ms-settings:privacy-webcam"
 
 /**
- * The way out of a privacy refusal on Windows — the twin of [MacCameraPrivacyHint], and there for
- * the same reasons, which are written out at that one.
+ * Where [osName] keeps its camera permission, or null on a platform with no such page to open.
  *
- * Windows has two separate switches on that page (camera access at all, and desktop apps in
- * particular) and blocks with either off, which is why the button leads there rather than the text
- * trying to describe the sequence.
+ * Windows has two separate switches there — camera access at all, and desktop apps in particular —
+ * and blocks with either off, which is why the button leads to the page rather than the text trying
+ * to describe the sequence.
  */
-@Composable
-private fun WindowsCameraPrivacyHint(
-    onOpenPrivacySettings: () -> Unit = { UrlOpener.open(WINDOWS_CAMERA_PRIVACY_URI) },
-) {
-    Button(onClick = onOpenPrivacySettings, modifier = Modifier.fillMaxWidth()) {
-        Text(stringResource(Res.string.canvas_camera_open_privacy_settings), fontSize = 12.sp)
+internal fun cameraPrivacyUri(osName: String): String? {
+    val name = osName.lowercase()
+    return when {
+        name.contains("mac") || name.contains("darwin") -> MAC_CAMERA_PRIVACY_URI
+        name.contains("win") -> WINDOWS_CAMERA_PRIVACY_URI
+        else -> null
     }
 }
 
-/** The macOS Camera privacy pane, opened from here because the canvas is also the live output. */
-internal const val MAC_CAMERA_PRIVACY_URI =
-    "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
-
 /**
- * The way out of a privacy refusal, shown beside the camera picker on macOS.
+ * The way out of a privacy refusal, shown beside a camera picker.
  *
- * It lives in the properties panel rather than on the canvas because the canvas composable is also
- * what the presenter output draws — a button there would be painted onto the screen the
- * congregation is looking at. The canvas says *what* is wrong; this is where it is acted on.
+ * It lives in a panel rather than on the canvas because the canvas composable is also what the
+ * presenter output draws — a button there would be painted onto the screen the congregation is
+ * looking at. The canvas says *what* is wrong; this is where it is acted on.
  *
  * No accompanying warning text: a camera that is working needs no explanation, and a panel that
- * announces macOS is blocking something whenever it is running on macOS is a panel operators learn
- * to read past. The button is a plain affordance, and the canvas carries the diagnosis.
+ * announces the OS is blocking something whenever it runs on that OS is a panel operators learn to
+ * read past. The button is a plain affordance, and the diagnosis is carried beside it.
+ *
+ * Shared with the background camera picker rather than copied to it: a background is opened by the
+ * presenter window before any picker has been looked at, so it is the *more* likely of the two to
+ * be refused, and it had no way out at all.
+ *
+ * [openUri] is a parameter so a test can press the button without launching a browser.
  */
 @Composable
-private fun MacCameraPrivacyHint(
-    onOpenPrivacySettings: () -> Unit = { UrlOpener.open(MAC_CAMERA_PRIVACY_URI) }
+internal fun CameraPrivacyHint(
+    osName: String = System.getProperty("os.name", ""),
+    openUri: (String) -> Unit = { UrlOpener.open(it) },
 ) {
-    Button(onClick = onOpenPrivacySettings, modifier = Modifier.fillMaxWidth()) {
+    val uri = cameraPrivacyUri(osName) ?: return
+    Button(onClick = { openUri(uri) }, modifier = Modifier.fillMaxWidth()) {
         Text(stringResource(Res.string.canvas_camera_open_privacy_settings), fontSize = 12.sp)
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/composables/SharedCameraFrameCache.kt
@@ -70,6 +70,17 @@ object SharedCameraFrameCache {
     )
 
     /**
+     * The failure flow of every capture running right now, by cache key — read-only.
+     *
+     * A property and not a function because this object is at its `TooManyFunctions` threshold;
+     * [cameraFailureFlow] is the thing to call, and is top-level for the same reason
+     * [avfSourceToOpen] is.
+     */
+    @get:Synchronized
+    internal val liveFailures: Map<String, StateFlow<CameraFailure?>>
+        get() = entries.mapValues { (_, entry) -> entry.error }
+
+    /**
      * Acquire a shared frame flow for this camera source.
      * First subscriber starts the capture; subsequent subscribers share it.
      */

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundCameraPicker.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/dialogs/tabs/BackgroundCameraPicker.kt
@@ -28,20 +28,28 @@ import churchpresenter.composeapp.generated.resources.background_camera_device
 import churchpresenter.composeapp.generated.resources.background_camera_format
 import churchpresenter.composeapp.generated.resources.canvas_decklink_device
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.withContext
 import org.churchpresenter.app.churchpresenter.dialogs.PanelCaption
+import org.churchpresenter.app.churchpresenter.composables.cameraFailureStringRes
 import org.churchpresenter.app.churchpresenter.composables.cameraHintStringRes
 import org.churchpresenter.app.churchpresenter.composables.CameraDevice
 import org.churchpresenter.app.churchpresenter.composables.CameraDeviceCatalog
+import org.churchpresenter.app.churchpresenter.composables.CameraFailure
 import org.churchpresenter.app.churchpresenter.composables.CameraFormat
+import org.churchpresenter.app.churchpresenter.composables.CameraPrivacyHint
 import org.churchpresenter.app.churchpresenter.composables.DeckLinkManager
 import org.churchpresenter.app.churchpresenter.composables.DropdownSelector
 import org.churchpresenter.app.churchpresenter.composables.isFfmpegAvailable
 import org.churchpresenter.app.churchpresenter.composables.listCameraFormats
+import org.churchpresenter.app.churchpresenter.composables.SharedCameraFrameCache
 import org.churchpresenter.app.churchpresenter.composables.selectedConnectionName
 import org.churchpresenter.app.churchpresenter.composables.selectedFormatName
 import org.churchpresenter.app.churchpresenter.composables.selectedModeName
 import org.churchpresenter.core.models.camera.CameraDeviceRef
+import org.churchpresenter.core.models.camera.asCameraSource
+import org.churchpresenter.core.models.scene.SceneSource
 import org.churchpresenter.settings.BackgroundConfig
 import org.jetbrains.compose.resources.stringResource
 
@@ -91,24 +99,76 @@ internal fun CameraPickerRow(config: BackgroundConfig, onConfigChange: (Backgrou
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
-        if (found.isEmpty()) return@Column
-
-        DropdownSelector(
-            label = stringResource(Res.string.background_camera_device),
-            items = found.map { it.displayName },
-            selected = selectedBackgroundCameraName(found, config.camera),
-            onSelectedChange = { name ->
-                found.firstOrNull { it.displayName == name }?.let {
-                    onConfigChange(config.copy(camera = cameraRefOn(config.camera, it)))
-                }
-            },
-            modifier = Modifier.fillMaxWidth(),
-        )
-        if (config.camera.isDeckLink && config.camera.deckLinkIndex >= 0) {
-            DeckLinkFormatRows(config, onConfigChange, autoLabel)
-        } else if (config.camera.isSet) {
-            CameraFormatRow(config, onConfigChange, autoLabel)
+        // Wrapped rather than an early `return@Column`, so the failure line and the way out of a
+        // privacy refusal below still render when the list is empty. On macOS empty is *the*
+        // symptom: a TCC denial makes AVFoundation enumerate nothing, so returning here hid the
+        // remedy in precisely the case it exists for.
+        if (found.isNotEmpty()) {
+            DropdownSelector(
+                label = stringResource(Res.string.background_camera_device),
+                items = found.map { it.displayName },
+                selected = selectedBackgroundCameraName(found, config.camera),
+                onSelectedChange = { name ->
+                    found.firstOrNull { it.displayName == name }?.let {
+                        onConfigChange(config.copy(camera = cameraRefOn(config.camera, it)))
+                    }
+                },
+                modifier = Modifier.fillMaxWidth(),
+            )
+            if (config.camera.isDeckLink && config.camera.deckLinkIndex >= 0) {
+                DeckLinkFormatRows(config, onConfigChange, autoLabel)
+            } else if (config.camera.isSet) {
+                CameraFormatRow(config, onConfigChange, autoLabel)
+            }
         }
+        CameraFailureRow(config.camera)
+        CameraPrivacyHint()
+    }
+}
+
+/**
+ * Why [source] is not drawing, if something is drawing it — and null when nothing is.
+ *
+ * Deliberately **not** an acquire: a settings panel that wants to explain a black rectangle must
+ * not be the thing that starts a capture. Acquiring from a dialog would open the device because
+ * someone opened Settings, and the matching release could stop a capture the output is still using.
+ *
+ * Null therefore means "nothing is capturing this camera", which is not the same as "it is fine".
+ * The caller renders that as no diagnosis, never as an all-clear.
+ *
+ * Here rather than beside the cache because that file is already at its `TooManyFunctions`
+ * threshold, and this is its only caller.
+ */
+private fun cameraFailureFlow(source: SceneSource.CameraSource): StateFlow<CameraFailure?>? =
+    SharedCameraFrameCache.liveFailures[SharedCameraFrameCache.keyFor(source)]
+
+/**
+ * Why the chosen camera is not drawing, when something is trying to draw it.
+ *
+ * A camera background renders as black and says nothing — `CameraBackground` documents that as
+ * deliberate, and it is right, because that composable *is* the presenter output and must never
+ * carry troubleshooting text in front of a congregation. But that left the failure explained
+ * nowhere at all: the Canvas layer has its red sentence and this picker had none, so an operator
+ * whose background was refused by macOS saw a black rectangle and no route to the cause. That is
+ * the discoverability half of issue #488.
+ *
+ * Observes through [SharedCameraFrameCache.failureOf] rather than acquiring, so opening Settings
+ * cannot itself start a capture. Nothing capturing means no diagnosis rather than an all-clear —
+ * the camera may simply not be live yet.
+ */
+@Composable
+private fun CameraFailureRow(camera: CameraDeviceRef) {
+    if (!camera.isSet) return
+    val source = remember(camera) { camera.asCameraSource() }
+    val failures = remember(source) { cameraFailureFlow(source) }
+    val failure by (failures ?: remember { MutableStateFlow(null) }).collectAsState()
+
+    failure?.let {
+        Text(
+            text = stringResource(cameraFailureStringRes(it)),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+        )
     }
 }
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -267,6 +267,8 @@ fun main() {
             versionDisplay = BuildConfig.VERSION_DISPLAY,
             appVersion = BuildConfig.APP_VERSION,
             isRelease = BuildConfig.IS_RELEASE,
+            buildType = BuildConfig.BUILD_TYPE,
+            buildChannel = BuildConfig.BUILD_CHANNEL,
         ),
     )
     CrashReporter.breadcrumb("Application started", category = "lifecycle")

--- a/diagnostics/src/main/kotlin/org/churchpresenter/diagnostics/CrashReporter.kt
+++ b/diagnostics/src/main/kotlin/org/churchpresenter/diagnostics/CrashReporter.kt
@@ -37,9 +37,27 @@ data class BuildIdentity(
     val versionDisplay: String = UNKNOWN_VERSION,
     val appVersion: String = UNKNOWN_VERSION,
     val isRelease: Boolean = false,
+    /**
+     * `release`, `dirty`, `snapshot` or `nogit` — what the tree looked like, not merely whether a
+     * packaging task ran. Already computed for the live-map ping; carried here so a report can say
+     * the same thing.
+     */
+    val buildType: String = UNKNOWN_BUILD,
+    /**
+     * `ci` or `local`: where the build was produced.
+     *
+     * [isRelease] cannot answer that — it means "a packaging task ran", so a build packaged on a
+     * developer's machine is indistinguishable from one CI shipped, and both report
+     * `environment=production`. Over 30 days that left 224 of 234 camera reports labelled
+     * production, a tester's among them, with no way to separate them from an operator's.
+     */
+    val buildChannel: String = UNKNOWN_BUILD,
 )
 
 private const val UNKNOWN_VERSION = "unknown"
+
+/** What [BuildIdentity] reports for build provenance it was not told. */
+private const val UNKNOWN_BUILD = "unknown"
 
 /**
  * Global crash reporter that:
@@ -473,18 +491,37 @@ object CrashReporter {
             val dsn = readDsn()
             if (dsn.isBlank()) return   // no DSN → stay disabled, nothing sent
             Sentry.init { options -> configureOptions(options, dsn) }
-            // Static context that helps triage: OS family and arch, and dev/release build.
-            // Both are needed, and arch alone is a trap: Adoptium reports "aarch64" on Apple
-            // Silicon and on ARM Linux alike, and "x86_64" on Intel macOS against "amd64"
-            // elsewhere — so a report carrying only arch cannot say which OS a platform-specific
-            // path was taken on. Diagnosing the HEIC decode failures needed exactly that.
-            setTag("os.family", osFamily(System.getProperty("os.name", "")))
-            setTag("os.arch", System.getProperty("os.arch", "unknown"))
-            setTag("build.type", if (build.isRelease) "release" else "dev")
+            staticTags().forEach { (key, value) -> setTag(key, value) }
         } catch (_: Exception) {
             // Sentry failing to init must never prevent the app from starting
         }
     }
+
+    /**
+     * The context every event carries, whatever it is about.
+     *
+     * A function returning the pairs rather than a run of `setTag` calls inside [initSentry], for
+     * the reason [configureOptions] is split out: `Sentry.init` is the one call a test cannot make,
+     * and these are ordinary decisions about what a report should say. Tags land on the scope and
+     * not on [SentryOptions], so this is the only seam that can check them.
+     *
+     * Arch alone is a trap: Adoptium reports "aarch64" on Apple Silicon and on ARM Linux alike, and
+     * "x86_64" on Intel macOS against "amd64" elsewhere — so a report carrying only arch cannot say
+     * which OS a platform-specific path was taken on. Diagnosing the HEIC decode failures needed
+     * exactly that, which is why the family is sent beside it.
+     *
+     * `build.type` is the tree's own state and not the two-valued `isRelease`, which cannot tell a
+     * CI release from one packaged on a laptop; `build.channel` is what separates those.
+     */
+    internal fun staticTags(
+        osName: String = System.getProperty("os.name", ""),
+        arch: String = System.getProperty("os.arch", "unknown"),
+    ): Map<String, String> = mapOf(
+        "os.family" to osFamily(osName),
+        "os.arch" to arch,
+        "build.type" to build.buildType,
+        "build.channel" to build.buildChannel,
+    )
 
     /**
      * Which OS family [osName] names, as one of "macos", "windows", "linux" or "other".
@@ -513,6 +550,11 @@ object CrashReporter {
         options.dsn = dsn
         options.release = build.appVersion
         // Keep developer test runs out of production release-health stats.
+        //
+        // Deliberately still `isRelease` and not `buildChannel`: builds packaged by hand and passed
+        // to a church are real installs, and relabelling them `development` would hide operator
+        // data to tidy up a tester's. `environment:production build.channel:ci` is the narrower
+        // question, and it can now be asked without redefining this one.
         options.environment = if (build.isRelease) "production" else "development"
         options.isEnableUncaughtExceptionHandler = true
         options.isAttachThreads = false

--- a/diagnostics/src/test/kotlin/org/churchpresenter/diagnostics/CrashReporterStartupTest.kt
+++ b/diagnostics/src/test/kotlin/org/churchpresenter/diagnostics/CrashReporterStartupTest.kt
@@ -210,6 +210,48 @@ class CrashReporterStartupTest {
         assertEquals("26.9.177", options.release, "the release is what groups events in Sentry")
     }
 
+    @Test
+    fun `the static tags carry the build provenance it was given`() {
+        startUp(
+            analyticsReportingEnabled = false,
+            BuildIdentity(isRelease = true, buildType = "release", buildChannel = "ci"),
+        )
+
+        val tags = CrashReporter.staticTags(osName = "Mac OS X", arch = "aarch64")
+
+        assertEquals("release", tags["build.type"])
+        assertEquals("ci", tags["build.channel"])
+        assertEquals("macos", tags["os.family"])
+        assertEquals("aarch64", tags["os.arch"])
+    }
+
+    @Test
+    fun `a locally packaged build is production but not ci`() {
+        // The whole point of build.channel: `isRelease` is "a packaging task ran", so this build
+        // and one CI shipped were indistinguishable, and both reported production.
+        startUp(
+            analyticsReportingEnabled = false,
+            BuildIdentity(isRelease = true, buildType = "dirty", buildChannel = "local"),
+        )
+        val options = SentryOptions()
+
+        CrashReporter.configureOptions(options, "https://key@example.org/1")
+
+        assertEquals("production", options.environment, "a packaged build is still a real install")
+        assertEquals("local", CrashReporter.staticTags()["build.channel"], "but it is not a CI one")
+        assertEquals("dirty", CrashReporter.staticTags()["build.type"])
+    }
+
+    @Test
+    fun `build provenance it was never told reads as unknown, not as a release`() {
+        startUp(analyticsReportingEnabled = false, BuildIdentity())
+
+        val tags = CrashReporter.staticTags()
+
+        assertEquals("unknown", tags["build.type"])
+        assertEquals("unknown", tags["build.channel"])
+    }
+
     // ── Sentry options ──────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
Both halves come out of #488's telemetry review. Findings and the numbers are in [that issue's closing comment](https://github.com/ChurchPresenter/ChurchPresenter/issues/488#issuecomment-5588928674).

## 1. A camera background had no diagnostics anywhere

A camera background renders black and says nothing — `CameraBackground` documents that as deliberate, and it is right, because that composable *is* the presenter output.

But nothing else explained it either. A Canvas camera **layer** gets a red failure sentence in the editor plus a one-click deep link into the OS camera settings beside its picker. The **background** picker in Settings had neither. So an operator whose background was refused saw a black rectangle and no screen anywhere said why.

That is the discoverability finding from #488, where one operator has hit `permission_or_unavailable` 72 times and was still hitting it the day the data was pulled.

- The failure is read through a new `liveFailures` map, **not** by acquiring — a settings panel must not be the thing that starts a capture, and the matching release could stop one the output is still drawing. Nothing capturing means *no diagnosis*, never an all-clear.
- The two private privacy-hint composables differed only in a URI; they are now one `CameraPrivacyHint` shared by both call sites, with the opener as a parameter so it is pressable in a test.
- The device list is **wrapped rather than escaped with an early return**. On macOS an empty list is *the* symptom — a TCC denial makes AVFoundation enumerate nothing — so the old `return@Column` hid the remedy in precisely the case it exists for.

## 2. `environment=production` could not be believed

`IS_RELEASE` means "a task named package/sign/notarize ran", so a build packaged on a laptop is indistinguishable from one CI shipped. Over 30 days that left **224 of 234** camera reports labelled production and 10 development — with a single user id contributing 140 of them while running every build from 26.0.0 to 26.11.74, which is a tester's pattern filed under the same label as the churches.

- `BUILD_TYPE` (release/dirty/snapshot/nogit) already existed for the live-map ping and now reaches Sentry, replacing a `build.type` that was only `isRelease` spelled differently.
- `BUILD_CHANNEL` is new: `ci` or `local`, read with `providers.environmentVariable` and **not** `System.getenv`, for the reason already recorded on `printCoverageLink` — `System.getenv` reads the Gradle daemon's frozen environment.
- `options.environment` is deliberately unchanged. A build packaged by hand and given to a church is a real install; relabelling it `development` would hide operator data to tidy away a tester's. `environment:production build.channel:ci` is the narrower question and can now be asked without redefining the broader one.

The static tags moved into `staticTags()` so they can be tested at all — tags land on the Sentry scope, not on `SentryOptions`, so the existing `configureOptions` seam could not see them. Same split, same reason.

## Testing

- `:diagnostics:test` — three new tests covering the provenance tags, including that a locally packaged build is production but not `ci`, and that provenance never supplied reads `unknown` rather than defaulting to a release.
- `:composeApp:jvmTest` full suite green; `:composeApp:detekt` and `:diagnostics:detekt` clean.
- **No UI tests or screenshots yet, on purpose.** This changes the UI, and AGENT.md says to stop at compiling-and-green and have the look approved first. Those follow once the design is signed off.