### PR TITLE
Show a mirrored path the way the primary wrote it

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PicturesTab.kt
@@ -326,7 +326,7 @@ fun PicturesTab(
                 )
             }
             Text(
-                text = viewModel.selectedFolder?.absolutePath ?: stringResource(Res.string.no_folder_selected),
+                text = viewModel.selectedFolderDisplayPath ?: stringResource(Res.string.no_folder_selected),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
                 modifier = Modifier.weight(1f),
@@ -387,7 +387,7 @@ fun PicturesTab(
                 ) {
                     lazyItems(recentOrdered) { path ->
                         val isPinned = path in RecentPictureFolders.pinned
-                        val isActive = viewModel.selectedFolder?.absolutePath == path
+                        val isActive = viewModel.selectedFolderDisplayPath == path
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(2.dp)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/tabs/PresentationTab.kt
@@ -493,7 +493,8 @@ fun PresentationTab(
                 )
             }
             Text(
-                text = viewModel.selectedPresentation?.name ?: stringResource(Res.string.no_file_selected_presentation),
+                text = viewModel.selectedPresentationDisplayName
+                    ?: stringResource(Res.string.no_file_selected_presentation),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
                 modifier = Modifier.weight(1f),
@@ -626,7 +627,7 @@ fun PresentationTab(
                 ) {
                     lazyItems(recentOrdered) { path ->
                         val isPinned = path in RecentPresentationFiles.pinned
-                        val isActive = viewModel.selectedPresentation?.absolutePath == path
+                        val isActive = viewModel.selectedPresentationDisplayPath == path
                         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(2.dp)) {
                             Box(
                                 modifier = Modifier

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModel.kt
@@ -78,6 +78,31 @@ class PicturesViewModel(
     private val _selectedFolder = mutableStateOf<File?>(null)
     val selectedFolder: File? get() = _selectedFolder.value
 
+    /**
+     * The primary's own folder path when this folder came from [loadPictureFromRemote], against the
+     * [File] it was stored under.
+     *
+     * Kept as the string the primary sent, because a foreign path must not be re-separated by the
+     * local platform: `File("/Volumes/primary-only/Sunday")` renders as `\Volumes\primary-only\Sunday`
+     * on a Windows follower. Keyed by the [File] rather than held loose so it cannot outlive the
+     * selection it describes — a display path is only ever returned for the exact folder it was
+     * recorded against.
+     */
+    private val _remoteFolderPath = mutableStateOf<Pair<File, String>?>(null)
+
+    /**
+     * What the tab shows for the current folder: the primary's path verbatim when this folder is
+     * mirrored over Instance Link, the local absolute path otherwise. Null when nothing is selected.
+     *
+     * Read this rather than [selectedFolder] for anything the operator looks at. [selectedFolder]
+     * stays a [File] because it is also an identity — `stableFileId` derives the folder id this
+     * instance publishes to its own remote clients from it.
+     */
+    val selectedFolderDisplayPath: String?
+        get() = _selectedFolder.value?.let { folder ->
+            _remoteFolderPath.value?.takeIf { it.first == folder }?.second ?: folder.absolutePath
+        }
+
     private val _images: SnapshotStateList<File> = mutableStateListOf()
     val images: List<File> get() = _images
 
@@ -311,7 +336,9 @@ class PicturesViewModel(
      * differently, or not mounted at all, here). Downloads each image's bytes via [fetchBytes] into
      * a cache dir keyed by [folderId] and populates [_images] with the cached files — same public
      * state contract as [selectFolder], so thumbnails, [syncWithPresenter], and navigation all work
-     * unchanged afterward. [folderPath] is only used to build [_selectedFolder]'s display value.
+     * unchanged afterward. [folderPath] is the primary's own path: it is kept verbatim in
+     * [_remoteFolderPath] for [selectedFolderDisplayPath] to show, and the [File] built from it is
+     * an identity for [_selectedFolder], never a path to read from.
      * [presenterManager] — when non-null, explicitly re-synced after every downloaded image (not
      * just once): images arrive one at a time here (unlike the synchronous local-folder path), and
      * PicturesTab's own reactive sync effect only restarts on selectedImageIndex/presentingMode
@@ -327,7 +354,9 @@ class PicturesViewModel(
         fetchBytes: suspend (index: Int) -> ByteArray?
     ) {
         clearImages()
-        _selectedFolder.value = File(folderPath)
+        val displayFolder = File(folderPath)
+        _selectedFolder.value = displayFolder
+        _remoteFolderPath.value = displayFolder to folderPath
         val cacheDir = File(System.getProperty("user.home"), ".churchpresenter/instance-link/cache/picture-folders/$folderId")
         cacheDir.mkdirs()
         remoteLoadJob = scope.launch {
@@ -368,6 +397,9 @@ class PicturesViewModel(
         watchJob = null
         remoteLoadJob?.cancel()
         remoteLoadJob = null
+        // The one choke point for a mirrored folder's display path: selectFolder and
+        // loadPictureFromRemote both come through here, so neither can inherit the other's.
+        _remoteFolderPath.value = null
         synchronized(imagesLock) { _images.clear() }
         _thumbnails.clear()
         _thumbnailFailures.clear()

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModel.kt
@@ -56,6 +56,41 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
     val selectedPresentation: File?
         get() = _selectedPresentation.value
 
+    /**
+     * The primary's own file path when this deck came from [loadPresentationFromRemote], against the
+     * [File] it was stored under.
+     *
+     * Kept as the string the primary sent: a foreign path must not be re-separated by the local
+     * platform, and `absolutePath` additionally prepends a drive letter (Windows) or the working
+     * directory (POSIX, for a path with no leading `/`). Keyed by the [File] so it cannot outlive
+     * the selection it describes.
+     */
+    private val _remotePresentationPath = mutableStateOf<Pair<File, String>?>(null)
+
+    /** The primary's path, but only while it still describes the current selection. */
+    private val remotePathForSelection: String?
+        get() = _selectedPresentation.value?.let { file ->
+            _remotePresentationPath.value?.takeIf { it.first == file }?.second
+        }
+
+    /**
+     * The full path shown for the current deck: the primary's verbatim when mirrored, the local
+     * absolute path otherwise. Null when nothing is selected.
+     */
+    val selectedPresentationDisplayPath: String?
+        get() = remotePathForSelection ?: _selectedPresentation.value?.absolutePath
+
+    /**
+     * The file name shown for the current deck.
+     *
+     * A mirrored path is split on both separators rather than through [File.getName], which knows
+     * only the local one — `File("C:\\Presentations\\Sunday.pptx").name` on a Mac or a Linux box is
+     * the whole string, not `Sunday.pptx`. Same idiom as `data/Songs.kt` and the file pickers.
+     */
+    val selectedPresentationDisplayName: String?
+        get() = remotePathForSelection?.substringAfterLast('/')?.substringAfterLast('\\')
+            ?: _selectedPresentation.value?.name
+
     private val _slideFiles = mutableStateListOf<File>()
     val slideFiles: SnapshotStateList<File> = _slideFiles
 
@@ -190,9 +225,11 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
      * differently, or not mounted at all, here). Downloads each slide's JPEG bytes via [fetchBytes]
      * into a disk cache keyed by [scheduleItemId] (reusing the same cache-dir idiom local rendering
      * uses) and populates [_slideFiles] from the cached files — no new rendering pipeline, just a
-     * remote source of already-cached slides. [filePath] is only used to build a synthetic [File]
-     * so [selectedPresentation] and downstream consumers (recents list, onSlidesLoaded broadcast)
-     * keep working the same as the local-file path — the file itself is never opened.
+     * remote source of already-cached slides. [filePath] is the primary's own path: the synthetic
+     * [File] built from it is an identity, so [selectedPresentation] and downstream consumers
+     * (recents list, onSlidesLoaded broadcast) keep working the same as the local-file path, while
+     * the string itself is kept verbatim for [selectedPresentationDisplayPath] to show. The file is
+     * never opened either way.
      */
     fun loadPresentationFromRemote(
         scheduleItemId: String,
@@ -204,6 +241,7 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
         val existingFile = _presentations.find { it.absolutePath == syntheticFile.absolutePath }
         if (existingFile == null) _presentations.add(syntheticFile)
         _selectedPresentation.value = existingFile ?: syntheticFile
+        _remotePresentationPath.value = (existingFile ?: syntheticFile) to filePath
         _selectedSlideIndex.value = 0
         _loadError.value = null
         activeLoadJob?.cancel()
@@ -273,6 +311,7 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
         if (_selectedPresentation.value?.absolutePath == file.absolutePath) {
             _selectedPresentation.value = _presentations.firstOrNull()
             _selectedPresentation.value?.let { selectPresentation(it) } ?: run {
+                _remotePresentationPath.value = null
                 clearCurrentSlideState()
                 _selectedSlideIndex.value = 0
             }
@@ -283,6 +322,9 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
         val existingFile = _presentations.find { it.absolutePath == file.absolutePath }
         if (existingFile != null) {
             _selectedPresentation.value = existingFile
+            // Only when the selection actually moves elsewhere: re-selecting the mirrored deck
+            // itself must keep showing the primary's path, not fall back to the mangled one.
+            if (_remotePresentationPath.value?.first != existingFile) _remotePresentationPath.value = null
             _selectedSlideIndex.value = 0
             _loadError.value = null
             activeLoadJob?.cancel()
@@ -332,6 +374,7 @@ class PresentationViewModel(private val appSettings: AppSettings? = null) {
         activeLoadJob?.cancel()
         _presentations.clear()
         _selectedPresentation.value = null
+        _remotePresentationPath.value = null
         clearCurrentSlideState()
         _totalSlides.value = 0
         _selectedSlideIndex.value = 0

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModelRemoteTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PicturesViewModelRemoteTest.kt
@@ -100,13 +100,9 @@ class PicturesViewModelRemoteTest {
         awaitUntil("three mirrored images") { vm.images.size == 3 }
         assertEquals(listOf("image_0000.jpg", "image_0001.jpg", "image_0002.jpg"), vm.names)
         assertEquals(listOf(0, 1, 2), asked)
-        // Through File(...) because selectedFolder is a File: it re-separates a foreign path with
-        // the local separator, so a Windows follower of a macOS primary renders the mac path with
-        // backslashes. The point of the assertion is that it is the PRIMARY's folder rather than the
-        // local cache directory, and that still holds either way.
         assertEquals(
-            File("/Volumes/primary-only/Sunday").path,
-            vm.selectedFolder?.path,
+            "/Volumes/primary-only/Sunday",
+            vm.selectedFolderDisplayPath,
             "the folder shown is the primary's path, even though the bytes live in the local cache"
         )
         assertTrue(
@@ -232,6 +228,61 @@ class PicturesViewModelRemoteTest {
         }
     }
 
+    // ── The path shown for a mirrored folder ────────────────────────────────────
+
+    @Test
+    fun `a mirrored folder shows the primary's path exactly as the primary wrote it`() {
+        // Both shapes in one test on purpose. Each is foreign to one platform family, so this fails
+        // on the old `File(folderPath)` code wherever it runs rather than only on a Windows
+        // follower: a POSIX path comes back re-separated with backslashes and a drive letter on
+        // Windows, and a `C:\...` path has no leading slash, so `absolutePath` prepends the working
+        // directory on macOS and Linux.
+        val vm = vm()
+
+        vm.loadPictureFromRemote(folderId = "posix", folderPath = "/Volumes/primary-only/Sunday", imageCount = 0) {
+            pngBytes()
+        }
+        awaitUntil("the posix folder") { vm.selectedFolderDisplayPath != null }
+        assertEquals("/Volumes/primary-only/Sunday", vm.selectedFolderDisplayPath)
+
+        vm.loadPictureFromRemote(
+            folderId = "windows",
+            folderPath = """C:\Presentations\Sunday Pictures""",
+            imageCount = 0,
+        ) { pngBytes() }
+        awaitUntil("the windows folder") {
+            vm.selectedFolderDisplayPath == """C:\Presentations\Sunday Pictures"""
+        }
+        assertEquals("""C:\Presentations\Sunday Pictures""", vm.selectedFolderDisplayPath)
+    }
+
+    @Test
+    fun `a local folder chosen after a mirrored one shows its own path`() {
+        val local = Files.createTempDirectory("cp-pictures-remote-after").toFile()
+        try {
+            ImageIO.write(BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB), "jpg", File(local, "local.jpg"))
+            val vm = vm()
+            vm.loadPictureFromRemote(
+                folderId = "before-local",
+                folderPath = "/Volumes/primary-only/Sunday",
+                imageCount = 0,
+            ) { pngBytes() }
+            awaitUntil("the mirrored folder") { vm.selectedFolderDisplayPath != null }
+
+            vm.selectFolder(local)
+
+            assertEquals(
+                local.absolutePath,
+                vm.selectedFolderDisplayPath,
+                "the primary's path must not survive into a folder chosen here",
+            )
+
+            assertNull(vm().selectedFolderDisplayPath, "nothing selected yet, so there is nothing to show")
+        } finally {
+            local.deleteRecursively()
+        }
+    }
+
     @Test
     fun `each downloaded image is pushed to a screen already showing pictures`() {
         // Images arrive one at a time here, and PicturesTab's own reactive sync only reruns on an
@@ -287,7 +338,7 @@ class PicturesViewModelRemoteTest {
         awaitUntil("the cache directory to be created") { cacheDir("folder-empty").isDirectory }
         assertEquals(0, fetches)
         assertTrue(vm.images.isEmpty())
-        assertEquals(File("/Volumes/primary-only/Empty").path, vm.selectedFolder?.path)
+        assertEquals("/Volumes/primary-only/Empty", vm.selectedFolderDisplayPath)
     }
 
     // ── Thumbnails ──────────────────────────────────────────────────────────────

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModelRemoteTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/PresentationViewModelRemoteTest.kt
@@ -86,10 +86,12 @@ class PresentationViewModelRemoteTest {
         awaitUntil("the download") { !vm.isLoading && vm.slideFiles.size == 3 }
 
         assertEquals(3, vm.totalSlides)
-        // selectedPresentation is a File, so the primary's path is re-rooted with the local
-        // separator (and a drive letter on Windows). Compare through the same conversion: what the
-        // assertion is for is that the deck is identified by the PRIMARY's path, not the cache file.
-        assertEquals(File(remotePath).absolutePath, vm.selectedPresentation?.absolutePath)
+        assertEquals(
+            remotePath,
+            vm.selectedPresentationDisplayPath,
+            "the deck is shown by the PRIMARY's path, not by the cache file it was downloaded into"
+        )
+        assertEquals("Sunday.pptx", vm.selectedPresentationDisplayName)
         assertEquals(1, vm.presentations.size)
         assertNull(vm.loadError)
         assertTrue(vm.slideFiles.all { it.exists() }, "slides are cached to real files")
@@ -233,6 +235,43 @@ class PresentationViewModelRemoteTest {
         assertTrue(vm.presentations.isEmpty())
         assertTrue(vm.slideFiles.isEmpty())
         assertNull(vm.selectedPresentation)
+        assertNull(vm.selectedPresentationDisplayPath, "the primary's path goes with the deck")
+        assertNull(vm.selectedPresentationDisplayName)
+    }
+
+    // ── The path shown for a mirrored deck ──────────────────────────────────────
+
+    @Test
+    fun `a mirrored deck is named by the primary's path, whichever platform wrote it`() {
+        // A Windows primary mirrored onto this machine. `File.name` knows only the local separator,
+        // so on macOS and Linux it returns the whole string rather than the file name — which makes
+        // this red on CI before the fix, not only on a Windows follower.
+        val vm = viewModel()
+        val windowsPath = """C:\Presentations\Sunday.pptx"""
+
+        vm.loadPresentationFromRemote("sched-windows", windowsPath, slideCount = 2) { slideBytes(it) }
+        awaitUntil("download") { !vm.isLoading && vm.slideFiles.size == 2 }
+
+        assertEquals(windowsPath, vm.selectedPresentationDisplayPath)
+        assertEquals("Sunday.pptx", vm.selectedPresentationDisplayName)
+    }
+
+    @Test
+    fun `a local deck opened after a mirrored one is named by its own path`() {
+        val vm = viewModel()
+        vm.loadPresentationFromRemote("sched-before-local", remotePath, slideCount = 2) { slideBytes(it) }
+        awaitUntil("download") { !vm.isLoading && vm.slideFiles.size == 2 }
+
+        val local = pdfFile(pages = 1)
+        vm.addPresentation(local)
+        awaitUntil("the local deck to be selected") { vm.selectedPresentation == local }
+
+        assertEquals(
+            local.absolutePath,
+            vm.selectedPresentationDisplayPath,
+            "the primary's path must not survive into a deck opened here",
+        )
+        assertEquals(local.name, vm.selectedPresentationDisplayName)
     }
 
     // ── Render width from the output configuration ──────────────────────────────


### PR DESCRIPTION
Fixes #513.

## The bug

An Instance Link follower shows the path the primary sent so the operator can recognise the item.
The bytes come from the local cache and that path is never opened. Both follower entry points
stored the string in a `java.io.File`:

```kotlin
_selectedFolder.value = File(folderPath)
```

`File` re-separates a path with the **local** separator, so a Windows follower of a macOS primary
showed `\Volumes\primary-only\Sunday` for `/Volumes/primary-only/Sunday`. The presentation side
additionally gained a drive letter through `absolutePath`, and its name row went through
`File.name`, which on a Mac or Linux box returns `C:\Presentations\Sunday.pptx` whole rather than
`Sunday.pptx`.

Display-only — nothing failed to load.

## Why the File stays

Changing the type, or nulling it for remote loads, would break three things that are not display:

- `stableFileId(folder)` derives the folder id this follower publishes to its **own** Companion and
  web clients (`MainDesktop.kt`), and `RemoteCommandEffects.kt` compares against ids from the same
  derivation. Feeding the raw remote string in would break that agreement.
- `_presentations` dedupes on `absolutePath`.
- The recents and schedule entries are paths meant to be reopened locally.

So the primary's string is kept beside the `File`, **keyed to the `File` it describes**, and one
derived property is what the tabs read:

```kotlin
val selectedFolderDisplayPath: String?
    get() = _selectedFolder.value?.let { folder ->
        _remoteFolderPath.value?.takeIf { it.first == folder }?.second ?: folder.absolutePath
    }
```

Keying it is the point: a display path can only be returned for the exact selection it was recorded
against, so staleness is structurally impossible rather than dependent on every future author
remembering a reset. One derived property rather than a second public field means no call site has
to decide which to read.

One deviation from the issue's sketch: `selectPresentation` clears the remote path **only when the
selection moves to a different file**. Clearing it unconditionally would make re-selecting a
still-mirrored deck fall back to the mangled name.

## The tests were hiding it

`PicturesViewModelRemoteTest` derived its expectation through the same `File(...)` conversion, with
a comment explaining that it therefore tolerated the mangling — added while getting the suite green
on Windows for #511. Both workarounds are now verbatim assertions.

The new tests each assert a **POSIX and a Windows path in the same test**, because each shape is
foreign to one platform family: a POSIX path comes back re-separated on Windows, and a `C:\...` path
has no leading `/` so `absolutePath` prepends the working directory on macOS and Linux. Verified by
holding the new API and restoring the old semantics behind it — both mirrored-path tests fail on
this macOS machine, so they will fail on Linux CI too rather than only on a Windows follower.

## Verification

- `compileKotlinJvm` clean, `:composeApp:detekt` clean (three long lines wrapped, nothing baselined).
- `bash test-changed.sh` — all 60 implicated suites green, including the recents and screenshot ones.
- The two remote suites run three consecutive times with `--rerun-tasks`: 29 tests, 0 failures,
  0.28s and 0.99s.
- No new strings, so no `strings.xml` change and no locale file touched. No screenshot re-record:
  the local-folder rendering is byte-identical, which is every state the committed images cover.

## Known gap, deliberately not fixed here

The multi-file chip row (`PresentationTab.kt:1113`) renders `nameWithoutExtension` off the synthetic
`File`, so a Windows-primary deck mirrored onto macOS still shows the whole string in its chip.
Fixing that means threading display names per open presentation — more than this bug warrants.