### PR TITLE
Retry macOS notarization stapling

### DIFF
--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -286,7 +286,20 @@ jobs:
             --issuer "$API_ISSUER_ID" \
             --wait
           echo "Stapling notarization ticket..."
-          xcrun stapler staple "$DMG"
+          # The ticket is served from Apple's CDN and can lag the "Accepted" verdict by minutes;
+          # stapling too early fails with "Record not found" (exit 65). Retry before giving up.
+          STAPLED=false
+          for attempt in $(seq 1 10); do
+            if xcrun stapler staple "$DMG"; then
+              STAPLED=true
+              break
+            fi
+            echo "Staple attempt $attempt failed — ticket not yet available, retrying in 30s..."
+            sleep 30
+          done
+          if [ "$STAPLED" != "true" ]; then
+            echo "❌ Could not staple notarization ticket after 10 attempts" && exit 1
+          fi
           echo "Notarization complete"
 
       - name: Rename macOS DMG (add MACOS-arm64 label)
@@ -454,7 +467,20 @@ jobs:
             --issuer "$API_ISSUER_ID" \
             --wait
           echo "Stapling notarization ticket..."
-          xcrun stapler staple "$DMG"
+          # The ticket is served from Apple's CDN and can lag the "Accepted" verdict by minutes;
+          # stapling too early fails with "Record not found" (exit 65). Retry before giving up.
+          STAPLED=false
+          for attempt in $(seq 1 10); do
+            if xcrun stapler staple "$DMG"; then
+              STAPLED=true
+              break
+            fi
+            echo "Staple attempt $attempt failed — ticket not yet available, retrying in 30s..."
+            sleep 30
+          done
+          if [ "$STAPLED" != "true" ]; then
+            echo "❌ Could not staple notarization ticket after 10 attempts" && exit 1
+          fi
           echo "Notarization complete"
 
       - name: Rename macOS DMG (add MACOS-x64 label)

--- a/.github/workflows/build-self-hosted.yml
+++ b/.github/workflows/build-self-hosted.yml
@@ -280,11 +280,24 @@ jobs:
 
           DMG=$(find composeApp/build/compose/binaries/main/dmg -name "*.dmg" | head -1)
           echo "Submitting for notarization: $(basename "$DMG")"
-          xcrun notarytool submit "$DMG" \
+          # `--wait` exits 0 on "Invalid" too, so the verdict has to be read from the output;
+          # otherwise the staple below fails with "Record not found" and the real reason — which
+          # file Apple rejected and why — is only in `notarytool log`.
+          SUBMIT_OUT=$( xcrun notarytool submit "$DMG" \
             --key "$RUNNER_TEMP/private_keys/AuthKey.p8" \
             --key-id "$API_KEY_ID" \
             --issuer "$API_ISSUER_ID" \
-            --wait
+            --wait 2>&1 | tee /dev/stderr )
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | grep -m1 -E '^\s*id:' | awk '{print $2}')
+          STATUS=$(echo "$SUBMIT_OUT" | grep -E '^\s*status:' | tail -1 | awk '{print $2}')
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "❌ Notarization ${STATUS:-failed} (submission $SUBMISSION_ID) — Apple's log:"
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --key "$RUNNER_TEMP/private_keys/AuthKey.p8" \
+              --key-id "$API_KEY_ID" \
+              --issuer "$API_ISSUER_ID" || true
+            exit 1
+          fi
           echo "Stapling notarization ticket..."
           # The ticket is served from Apple's CDN and can lag the "Accepted" verdict by minutes;
           # stapling too early fails with "Record not found" (exit 65). Retry before giving up.
@@ -461,11 +474,24 @@ jobs:
 
           DMG=$(find composeApp/build/compose/binaries/main/dmg -name "*.dmg" | head -1)
           echo "Submitting for notarization: $(basename "$DMG")"
-          xcrun notarytool submit "$DMG" \
+          # `--wait` exits 0 on "Invalid" too, so the verdict has to be read from the output;
+          # otherwise the staple below fails with "Record not found" and the real reason — which
+          # file Apple rejected and why — is only in `notarytool log`.
+          SUBMIT_OUT=$( xcrun notarytool submit "$DMG" \
             --key "$RUNNER_TEMP/private_keys/AuthKey.p8" \
             --key-id "$API_KEY_ID" \
             --issuer "$API_ISSUER_ID" \
-            --wait
+            --wait 2>&1 | tee /dev/stderr )
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | grep -m1 -E '^\s*id:' | awk '{print $2}')
+          STATUS=$(echo "$SUBMIT_OUT" | grep -E '^\s*status:' | tail -1 | awk '{print $2}')
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "❌ Notarization ${STATUS:-failed} (submission $SUBMISSION_ID) — Apple's log:"
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --key "$RUNNER_TEMP/private_keys/AuthKey.p8" \
+              --key-id "$API_KEY_ID" \
+              --issuer "$API_ISSUER_ID" || true
+            exit 1
+          fi
           echo "Stapling notarization ticket..."
           # The ticket is served from Apple's CDN and can lag the "Accepted" verdict by minutes;
           # stapling too early fails with "Record not found" (exit 65). Retry before giving up.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,7 +286,20 @@ jobs:
             --issuer "$API_ISSUER_ID" \
             --wait
           echo "Stapling notarization ticket..."
-          xcrun stapler staple "$DMG"
+          # The ticket is served from Apple's CDN and can lag the "Accepted" verdict by minutes;
+          # stapling too early fails with "Record not found" (exit 65). Retry before giving up.
+          STAPLED=false
+          for attempt in $(seq 1 10); do
+            if xcrun stapler staple "$DMG"; then
+              STAPLED=true
+              break
+            fi
+            echo "Staple attempt $attempt failed — ticket not yet available, retrying in 30s..."
+            sleep 30
+          done
+          if [ "$STAPLED" != "true" ]; then
+            echo "❌ Could not staple notarization ticket after 10 attempts" && exit 1
+          fi
           echo "Notarization complete"
 
       - name: Rename macOS DMG (add MACOS-arm64 label)
@@ -456,7 +469,20 @@ jobs:
             --issuer "$API_ISSUER_ID" \
             --wait
           echo "Stapling notarization ticket..."
-          xcrun stapler staple "$DMG"
+          # The ticket is served from Apple's CDN and can lag the "Accepted" verdict by minutes;
+          # stapling too early fails with "Record not found" (exit 65). Retry before giving up.
+          STAPLED=false
+          for attempt in $(seq 1 10); do
+            if xcrun stapler staple "$DMG"; then
+              STAPLED=true
+              break
+            fi
+            echo "Staple attempt $attempt failed — ticket not yet available, retrying in 30s..."
+            sleep 30
+          done
+          if [ "$STAPLED" != "true" ]; then
+            echo "❌ Could not staple notarization ticket after 10 attempts" && exit 1
+          fi
           echo "Notarization complete"
 
       - name: Rename macOS DMG (add MACOS-x64 label)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,11 +280,24 @@ jobs:
 
           DMG=$(find composeApp/build/compose/binaries/main/dmg -name "*.dmg" | head -1)
           echo "Submitting for notarization: $(basename "$DMG")"
-          xcrun notarytool submit "$DMG" \
+          # `--wait` exits 0 on "Invalid" too, so the verdict has to be read from the output;
+          # otherwise the staple below fails with "Record not found" and the real reason — which
+          # file Apple rejected and why — is only in `notarytool log`.
+          SUBMIT_OUT=$( xcrun notarytool submit "$DMG" \
             --key "$RUNNER_TEMP/private_keys/AuthKey.p8" \
             --key-id "$API_KEY_ID" \
             --issuer "$API_ISSUER_ID" \
-            --wait
+            --wait 2>&1 | tee /dev/stderr )
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | grep -m1 -E '^\s*id:' | awk '{print $2}')
+          STATUS=$(echo "$SUBMIT_OUT" | grep -E '^\s*status:' | tail -1 | awk '{print $2}')
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "❌ Notarization ${STATUS:-failed} (submission $SUBMISSION_ID) — Apple's log:"
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --key "$RUNNER_TEMP/private_keys/AuthKey.p8" \
+              --key-id "$API_KEY_ID" \
+              --issuer "$API_ISSUER_ID" || true
+            exit 1
+          fi
           echo "Stapling notarization ticket..."
           # The ticket is served from Apple's CDN and can lag the "Accepted" verdict by minutes;
           # stapling too early fails with "Record not found" (exit 65). Retry before giving up.
@@ -463,11 +476,24 @@ jobs:
 
           DMG=$(find composeApp/build/compose/binaries/main/dmg -name "*.dmg" | head -1)
           echo "Submitting for notarization: $(basename "$DMG")"
-          xcrun notarytool submit "$DMG" \
+          # `--wait` exits 0 on "Invalid" too, so the verdict has to be read from the output;
+          # otherwise the staple below fails with "Record not found" and the real reason — which
+          # file Apple rejected and why — is only in `notarytool log`.
+          SUBMIT_OUT=$( xcrun notarytool submit "$DMG" \
             --key "$RUNNER_TEMP/private_keys/AuthKey.p8" \
             --key-id "$API_KEY_ID" \
             --issuer "$API_ISSUER_ID" \
-            --wait
+            --wait 2>&1 | tee /dev/stderr )
+          SUBMISSION_ID=$(echo "$SUBMIT_OUT" | grep -m1 -E '^\s*id:' | awk '{print $2}')
+          STATUS=$(echo "$SUBMIT_OUT" | grep -E '^\s*status:' | tail -1 | awk '{print $2}')
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "❌ Notarization ${STATUS:-failed} (submission $SUBMISSION_ID) — Apple's log:"
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --key "$RUNNER_TEMP/private_keys/AuthKey.p8" \
+              --key-id "$API_KEY_ID" \
+              --issuer "$API_ISSUER_ID" || true
+            exit 1
+          fi
           echo "Stapling notarization ticket..."
           # The ticket is served from Apple's CDN and can lag the "Accepted" verdict by minutes;
           # stapling too early fails with "Record not found" (exit 65). Retry before giving up.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ than asking anyone to install one. It is **not committed** — `:composeApp:fetc
 downloads the build pinned in `gradle/ffmpeg-builds.properties`, verifies its SHA-256 and writes the
 single `ffmpeg` program into `composeApp/src/jvmMain/appResources/<os>/`, which is what packaging
 and `run` both read. Packaging and `run` depend on that task, so there is nothing to do by hand.
+On macOS, when a signing identity is configured, `:composeApp:signBundledFfmpeg` then codesigns it
+with the hardened runtime and `desktop/macos/ffmpeg.entitlements` before it goes into the bundle —
+Compose never signs anything under `appResources`, and notarization rejects the DMG otherwise.
 
 A target with no URL configured is not an error: the app then falls back to whatever ffmpeg is
 installed on the machine, and Settings → Projection → Camera Capture says which one it is using.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1616,9 +1616,51 @@ fun sha256Of(file: File): String =
         digest.digest().joinToString("") { "%02x".format(it) }
     }
 
+// ── Signing the bundled ffmpeg ────────────────────────────────────────────────
+// Compose signs the launcher, the runtime and the native libraries inside jars, but treats
+// everything under appResources as data and never codesigns it — so the ffmpeg lands in the .app
+// at Contents/app/resources/ffmpeg exactly as the publisher shipped it, and notarization rejects
+// the whole DMG for it: no Developer ID signature, no secure timestamp, no hardened runtime.
+// The signature lives inside the Mach-O file, so signing the fetched copy before
+// prepareAppResources picks it up is enough; Compose does not touch it afterwards.
+val signBundledFfmpeg by tasks.registering {
+    description = "Codesigns the bundled macOS ffmpeg with the Developer ID identity, for notarization."
+    group = "signing"
+    dependsOn(fetchBundledFfmpeg)
+
+    val identity = macSigningProps.getProperty("identityName", "")
+    val keychain = macSigningProps.getProperty("keychain", "")
+    val ffmpeg = layout.projectDirectory.file("src/jvmMain/appResources/macos/ffmpeg").asFile
+    val entitlements = rootProject.file("desktop/macos/ffmpeg.entitlements")
+
+    onlyIf { org.gradle.internal.os.OperatingSystem.current().isMacOsX && identity.isConfigured() && ffmpeg.isFile }
+    // The output is the input, re-signed in place; `--force` makes that idempotent.
+    outputs.upToDateWhen { false }
+
+    doLast {
+        val command = buildList {
+            add("codesign")
+            add("--force")
+            add("--sign"); add(identity)
+            add("--options"); add("runtime")
+            add("--timestamp")
+            add("--entitlements"); add(entitlements.absolutePath)
+            if (keychain.isNotBlank()) { add("--keychain"); add(keychain) }
+            add(ffmpeg.absolutePath)
+        }
+        val process = ProcessBuilder(command).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        check(process.waitFor() == 0) { "codesign failed for the bundled ffmpeg:\n$output" }
+        logger.lifecycle("Signed bundled ffmpeg with \"$identity\"")
+    }
+}
+
 // prepareAppResources copies the per-OS directory into the bundle, and `run` reads the same one.
 tasks.matching { it.name == "prepareAppResources" || it.name == "run" }.configureEach {
     dependsOn(fetchBundledFfmpeg)
+}
+tasks.matching { it.name == "prepareAppResources" }.configureEach {
+    dependsOn(signBundledFfmpeg)
 }
 
 // ── The runtime jpackage will bundle has to be self-contained ─────────────────

--- a/desktop/macos/ffmpeg.entitlements
+++ b/desktop/macos/ffmpeg.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- The bundled ffmpeg is signed with the hardened runtime (notarization requires it), and
+         the hardened runtime denies camera and microphone access to a process that does not
+         carry these entitlements itself — the app's own entitlements do not flow down to a child
+         it spawns. Without them a capture device is listed and delivers no frames, the same
+         symptom as issue #431. -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Apple can take minutes to publish the notarization ticket after the "Accepted" status, and stapling before it is available fails with "Record not found". This change adds retries around `xcrun stapler staple` in both macOS build workflows and fails clearly only after 10 attempts.