### PR TITLE
Record the GPU behind a renderer crash, and fix three things the Windows pass turned up

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,24 @@ The JVM system property `-Dchurchpresenter.renderApi=OPENGL` does the same. Acce
 skiko's own: `DIRECT3D`, `OPENGL`, `METAL` and `SOFTWARE`. `SOFTWARE` is a last resort — it renders
 on the CPU, which a dual-output presenter app will feel.
 
+On Windows, `OPENGL` can stop a **full-screen presenter output being visible to GDI screen capture**
+— but whether it does is a property of the graphics driver, not of OpenGL, so check it on the
+machine you actually present from. The output renders perfectly either way; it is only the captured
+copy that is affected, and the live preview in the main window keeps showing the real thing.
+
+Measured on one machine, two cards, same build and same workload:
+
+| GPU | full-screen presenter under `OPENGL`, captured with `BitBlt` |
+|---|---|
+| NVIDIA GeForce GTX 1660 Ti | mean brightness **0.000** — solid black |
+| AMD Radeon RX 6500 XT | mean brightness **0.502** — captured normally |
+
+Under the Direct3D default both cards capture fine, and on the NVIDIA card the *main* window
+captured normally at the same moment the presenter came back black. So if something on the machine
+screen-captures the presenter monitor, the default is the safe choice and `OPENGL` is worth
+verifying before a service. Tested against GDI/`BitBlt` only — DXGI Desktop Duplication and Windows
+Graphics Capture, which OBS's Display Capture normally uses, were not tested either way.
+
 ---
 
 ## 📚 Documentation

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -555,36 +555,19 @@ compose.desktop {
             // Bundle ALL dependency JARs into the distribution — critical for standalone mode
             includeAllModules = true
 
-            val commonJvmArgs = listOf(
-                "-Xms512m",
-                "-Xmx3072m",
-                "-XX:+UseG1GC",
-                "-XX:+UnlockExperimentalVMOptions",
-                "-XX:G1NewSizePercent=20",
-                "-XX:G1ReservePercent=20",
-                "-XX:MaxGCPauseMillis=50",
-                "-XX:+UseStringDeduplication",
-                "-Dawt.useSystemAAFontSettings=on",
-                "-Dswing.aatext=true",
-                "--add-opens=java.base/java.lang=ALL-UNNAMED",
-                "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
-                "--add-opens=java.base/java.util=ALL-UNNAMED",
-                "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
-                "--add-opens=java.base/java.io=ALL-UNNAMED",
-                "--add-opens=java.base/java.nio=ALL-UNNAMED",
-                "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
-                "--add-exports=java.desktop/sun.awt=ALL-UNNAMED",
-                "--add-exports=java.desktop/sun.lwawt=ALL-UNNAMED",
-                "--add-exports=java.desktop/sun.lwawt.macosx=ALL-UNNAMED",
-                "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
-                "--add-opens=java.desktop/sun.lwawt=ALL-UNNAMED",
-                "--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED"
-            )
+            // No jvmArgs here or in the platform blocks below. The application-level
+            // jvmArgs(...) above already carries this list, and it reaches every platform:
+            // `jvmArgs` is declared only on JvmApplication, so a call inside macOS { } /
+            // windows { } / linux { } resolves against the enclosing application { } and
+            // applies everywhere. A second copy per platform block therefore did not scope
+            // anything to that platform -- it just wrote the same 24 options into the
+            // artifact four times over (measured in ChurchPresenter.cfg before this was
+            // removed). Anything genuinely platform-specific has to be decided at runtime,
+            // the way MainLogic.preferredRenderApi decides the render API.
 
             macOS {
                 bundleID = "org.churchpresenter.app"
                 iconFile.set(project.file("src/jvmMain/appResources/macos/icon.icns"))
-                jvmArgs(*commonJvmArgs.toTypedArray())
 
                 // ── No renderApi here ─────────────────────────────────────────
                 // A platform block has NO jvmArgs of its own: `jvmArgs` is declared only on
@@ -641,7 +624,6 @@ compose.desktop {
                 dirChooser = true
                 upgradeUuid = "A1B2C3D4-E5F6-4789-A012-3456789ABCDE"
                 iconFile.set(project.file("src/jvmMain/appResources/windows/icon.ico"))
-                jvmArgs(*commonJvmArgs.toTypedArray())
 
                 // ── No renderApi here, deliberately ───────────────────────────
                 // This used to pin OPENGL, overriding skiko's own Direct3D default, and that is
@@ -659,7 +641,6 @@ compose.desktop {
 
             linux {
                 iconFile.set(project.file("src/jvmMain/appResources/linux/icon.png"))
-                jvmArgs(*commonJvmArgs.toTypedArray())
             }
         }
     }

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/main.kt
@@ -38,6 +38,7 @@ import org.churchpresenter.app.churchpresenter.composables.CrashGuardBanner
 import org.churchpresenter.app.churchpresenter.composables.DeckLinkManager
 import org.churchpresenter.app.churchpresenter.utils.addGuardedShutdownHook
 import org.churchpresenter.app.churchpresenter.utils.DevFlags
+import org.churchpresenter.app.churchpresenter.utils.GpuInfo
 import org.churchpresenter.app.churchpresenter.utils.LottieFonts
 import org.churchpresenter.app.churchpresenter.utils.SystemFonts
 import org.churchpresenter.app.churchpresenter.utils.rememberScreenDevices
@@ -275,6 +276,11 @@ fun main() {
     // different evidence. Set here rather than with the availability tags below: a render fault
     // can arrive before those run.
     CrashReporter.setTag("render.api", System.getProperty("skiko.renderApi") ?: "default")
+    // Which renderer ran is only half the fact: whether a GPU driver fault is an NVIDIA, AMD or
+    // Intel problem is the axis such a group has to be split by, and no report carried it at all.
+    // Empty off Windows and on any machine the call fails, so an absent tag means "not known"
+    // rather than a guess. Beside render.api for the same reason: a render fault can arrive early.
+    CrashReporter.setConfigTags(GpuInfo.crashTags())
 
     if (shouldBundleDefaultBible(startupSettings.bibleSettings)) bundleDefaultBible(startupSettings)
 

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/DeviceInfoReport.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/DeviceInfoReport.kt
@@ -42,6 +42,8 @@ object DeviceInfoReport {
         val analyticsEnabled: Boolean,
         /** The skiko render API in force, or "default" when the platform's own choice stands. */
         val renderApi: String,
+        /** The GPU(s) driving the displays, or "unknown" where the OS will not say. */
+        val gpu: String,
     )
 
     internal fun screenLine(index: Int, width: Int, height: Int, refreshRate: Int, primary: Boolean): String =
@@ -93,6 +95,7 @@ object DeviceInfoReport {
             bibleCount = bibleFiles.size,
             analyticsEnabled = CrashReporter.isEnabled(),
             renderApi = System.getProperty("skiko.renderApi") ?: "default",
+            gpu = try { GpuInfo.summary } catch (_: Exception) { "unknown" },
         )
     }
 
@@ -112,6 +115,9 @@ object DeviceInfoReport {
         appendLine("OS: ${System.getProperty("os.name", "unknown")} ${System.getProperty("os.version", "")} (${System.getProperty("os.arch", "unknown")})")
         appendLine("Java: ${System.getProperty("java.version", "unknown")} (${System.getProperty("java.vendor", "unknown")})")
         appendLine("Renderer: ${facts.renderApi}")
+        // Beside the renderer, because the pair is the question a GPU fault asks: which
+        // backend, on whose driver. Either alone has been a reason a report could not be acted on.
+        appendLine("GPU: ${facts.gpu}")
         val runtime = Runtime.getRuntime()
         appendLine("CPU cores: ${runtime.availableProcessors()}")
         val usedMb = (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024)

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/GpuInfo.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/utils/GpuInfo.kt
@@ -1,0 +1,183 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import com.sun.jna.Native
+import com.sun.jna.Structure
+import com.sun.jna.win32.StdCallLibrary
+import com.sun.jna.win32.W32APIOptions
+
+private const val DEVICE_NAME_CHARS = 32
+private const val DEVICE_STRING_CHARS = 128
+private const val DISPLAY_DEVICE_ACTIVE = 0x1
+private const val MAX_ADAPTERS = 16
+private const val NUL = '\u0000'
+
+/**
+ * One display adapter, as the OS reports it for a given display.
+ *
+ * [deviceId] is the PCI identifier (`PCI\VEN_10DE&DEV_2182&...`); [GpuInfo.vendorOf] reads the
+ * vendor out of it. It is the field that matters most: whether a GPU fault is an NVIDIA, AMD or
+ * Intel driver problem is the first question asked of one, and the adapter *name* does not answer
+ * it reliably — "Radeon (TM) RX 480" and "AMD Radeon(TM) RX 6500 XT" share no common prefix.
+ *
+ * **[adapterName] and the vendor behind [deviceId] can legitimately disagree, and both are kept on
+ * purpose.** The name comes from the *driver*, the id from the *hardware*. A machine with no vendor
+ * driver installed falls back to Windows' generic display driver and reports
+ * `Microsoft Basic Display Adapter` while keeping its real PCI id — measured on this hardware as
+ * `Microsoft Basic Display Adapter (Intel)`, an Intel UHD 630 with no Intel driver present. Those
+ * are two different facts, and the second one — that the machine is on an unaccelerated fallback
+ * driver — is a strong diagnosis on its own, so neither half is worth discarding for the other.
+ *
+ * It also means the `1414` (Microsoft) entry in `VENDORS` is narrower than it looks: a
+ * basic-display-adapter machine keeps its hardware's vendor id, so that mapping only fires for
+ * genuinely virtual adapters, not for a driverless physical one.
+ */
+internal data class DisplayAdapter(
+    val displayName: String,
+    val adapterName: String,
+    val deviceId: String,
+    val active: Boolean,
+)
+
+/**
+ * Which GPU is actually driving the screens, for the crash report and the diagnostic dump.
+ *
+ * A renderer fault's first question is which driver it happened on, and until this existed no
+ * report carried it: the crash file recorded OS and Java only, and the Sentry tags stopped at
+ * `render.api`, which says what skiko chose but not what it ran on. So a group of GPU driver
+ * access violations could not be split by vendor — the one axis that decides whether a backend
+ * default is the right one.
+ *
+ * **Read through `EnumDisplayDevices`, deliberately, and not out of the registry.** The obvious
+ * registry source — `Control\Class\{4d36e968-...}\0000` — enumerates every *driver ever installed*
+ * rather than the hardware present: on the machine this was written against it lists five adapters,
+ * the first of which is an AMD card that has not been in the box for years, while the displays are
+ * driven by a GeForce. A report naming the wrong vendor is worse than one naming none, because
+ * nothing downstream can tell that it is wrong. `EnumDisplayDevices` answers per display, and
+ * reports what is actually driving it.
+ */
+object GpuInfo {
+
+    /** Minimal `user32` binding: JNA's own `User32` declares `EnumDisplayMonitors` but not this. */
+    internal interface Display : StdCallLibrary {
+        @Suppress("FunctionNaming")
+        fun EnumDisplayDevicesW(device: String?, devNum: Int, info: DisplayDevice, flags: Int): Boolean
+
+        companion object {
+            val INSTANCE: Display by lazy {
+                Native.load("user32", Display::class.java, W32APIOptions.DEFAULT_OPTIONS)
+            }
+        }
+    }
+
+    @Structure.FieldOrder("cb", "DeviceName", "DeviceString", "StateFlags", "DeviceID", "DeviceKey")
+    @Suppress("VariableNaming")
+    internal class DisplayDevice : Structure() {
+        @JvmField var cb: Int = 0
+        @JvmField var DeviceName: CharArray = CharArray(DEVICE_NAME_CHARS)
+        @JvmField var DeviceString: CharArray = CharArray(DEVICE_STRING_CHARS)
+        @JvmField var StateFlags: Int = 0
+        @JvmField var DeviceID: CharArray = CharArray(DEVICE_STRING_CHARS)
+        @JvmField var DeviceKey: CharArray = CharArray(DEVICE_STRING_CHARS)
+    }
+
+    /** PCI vendor ids. Virtual adapters are named because "no real GPU" is itself the diagnosis. */
+    private val VENDORS = mapOf(
+        "10de" to "NVIDIA", "1002" to "AMD", "1022" to "AMD", "8086" to "Intel",
+        "1414" to "Microsoft", "15ad" to "VMware", "1ab8" to "Parallels",
+        "80ee" to "VirtualBox", "1b36" to "QEMU", "1af4" to "virtio", "5333" to "S3",
+    )
+
+    /** The vendor [deviceId] names, or "unknown" when it carries no `VEN_xxxx`. */
+    internal fun vendorOf(deviceId: String): String {
+        val ven = Regex("VEN_([0-9A-Fa-f]{4})").find(deviceId)?.groupValues?.get(1)?.lowercase()
+            ?: return "unknown"
+        return VENDORS[ven] ?: "0x$ven"
+    }
+
+    /** A C string out of a fixed-width JNA char buffer — everything up to the first NUL. */
+    internal fun readCString(buf: CharArray): String {
+        val end = buf.indexOf(NUL).let { if (it < 0) buf.size else it }
+        return String(buf, 0, end)
+    }
+
+    /**
+     * The active adapters, deduplicated by name.
+     *
+     * Four displays on one card report the same adapter four times, so the list is distinct rather
+     * than per-display: the report wants "which GPUs", not "how many cables".
+     */
+    internal fun distinctActive(adapters: List<DisplayAdapter>): List<DisplayAdapter> =
+        adapters.filter { it.active && it.adapterName.isNotBlank() }.distinctBy { it.adapterName }
+
+    /** One line for the diagnostic report, e.g. `NVIDIA GeForce GTX 1660 Ti (NVIDIA)`. */
+    internal fun summarise(adapters: List<DisplayAdapter>): String {
+        val active = distinctActive(adapters)
+        if (active.isEmpty()) return "unknown"
+        return active.joinToString(" + ") { "${it.adapterName} (${vendorOf(it.deviceId)})" }
+    }
+
+    /**
+     * The tags a crash report carries. Empty when nothing could be read, so a platform without this
+     * call sends no tag at all rather than one saying "unknown" — an absent tag and a tag whose
+     * value is a guess are very different things to group a crash by.
+     */
+    internal fun tags(adapters: List<DisplayAdapter>): Map<String, String> {
+        val active = distinctActive(adapters)
+        if (active.isEmpty()) return emptyMap()
+        return mapOf(
+            "gpu.vendor" to active.joinToString("+") { vendorOf(it.deviceId) },
+            "gpu.adapter" to active.joinToString(" + ") { it.adapterName },
+            "gpu.count" to active.size.toString(),
+        )
+    }
+
+    /** Whether this platform has the call at all. */
+    internal fun isSupported(osName: String = System.getProperty("os.name", "")): Boolean =
+        osName.lowercase().contains("win")
+
+    /**
+     * Walks `EnumDisplayDevices`, which is the one step that needs the real OS.
+     *
+     * [fill] is taken as a parameter for the reason `WindowsWindowCapture.listWindowsWith` takes its
+     * `User32`: the loop, the NUL-trimming and the active-flag test are ordinary logic and are
+     * tested with a stand-in, leaving only the call itself uncovered.
+     */
+    internal fun enumerateWith(
+        newDevice: () -> DisplayDevice = { DisplayDevice() },
+        fill: (Int, DisplayDevice) -> Boolean,
+    ): List<DisplayAdapter> {
+        val out = mutableListOf<DisplayAdapter>()
+        for (i in 0 until MAX_ADAPTERS) {
+            val d = newDevice()
+            d.cb = d.size()
+            if (!fill(i, d)) break
+            out.add(
+                DisplayAdapter(
+                    displayName = readCString(d.DeviceName),
+                    adapterName = readCString(d.DeviceString),
+                    deviceId = readCString(d.DeviceID),
+                    active = (d.StateFlags and DISPLAY_DEVICE_ACTIVE) != 0,
+                )
+            )
+        }
+        return out
+    }
+
+    private fun enumerate(): List<DisplayAdapter> {
+        if (!isSupported()) return emptyList()
+        return try {
+            enumerateWith { i, d -> Display.INSTANCE.EnumDisplayDevicesW(null, i, d, 0) }
+        } catch (_: Throwable) {
+            emptyList()   // a missing user32 export must never stop the app starting
+        }
+    }
+
+    /** Read once per process: the adapters do not change under a running app. */
+    private val adapters: List<DisplayAdapter> by lazy { enumerate() }
+
+    /** The `GPU:` line for the diagnostic report. */
+    val summary: String get() = summarise(adapters)
+
+    /** The GPU tags for the crash reporter, empty when nothing could be read. */
+    fun crashTags(): Map<String, String> = tags(adapters)
+}

--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/QAManager.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/QAManager.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -18,6 +19,7 @@ import org.churchpresenter.core.models.qa.toDto
 import java.io.File
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 
 private const val MILLIS_PER_SECOND = 1000L
 
@@ -292,18 +294,56 @@ class QAManager {
 
     // ── Persistence ─────────────────────────────────────────────────
 
+    /** The most recently requested save, or null when every save has finished. */
+    private val pendingSave = AtomicReference<Job?>(null)
+
+    /**
+     * Writes the session to disk after every action that changes it.
+     *
+     * Two things here are load-bearing, and this used to do neither.
+     *
+     * The snapshot is taken **on the calling thread**, not inside the coroutine. Taken inside, it
+     * described whatever the state happened to be when the coroutine was scheduled, so the file
+     * could record a moment that never corresponded to the action that triggered the save.
+     *
+     * The writes are then **chained**, so they land in the order they were requested. Each save
+     * used to be an independent `launch`, and two actions in quick succession put two writes in
+     * flight with nothing ordering them: if the older one landed last, the file kept a stale
+     * snapshot for good. That is not only a test problem — moderating quickly during a live
+     * session could persist a state the operator had already moved on from, and because the write
+     * is wrapped in a `try`/`catch` that swallows everything, it failed silently and only showed
+     * up after a restart.
+     */
     private fun saveState() {
-        scope.launch(Dispatchers.IO) {
+        val state = QAState(
+            questions = _questions.map { it.toDto() },
+            history = _history.map { it.toDto() },
+            votedIps = _votedIps.mapValues { entry -> entry.value.toMap() }
+        )
+        val previous = pendingSave.get()
+        val job = scope.launch(Dispatchers.IO) {
+            previous?.join()
             try {
-                val state = QAState(
-                    questions = _questions.map { it.toDto() },
-                    history = _history.map { it.toDto() },
-                    votedIps = _votedIps.mapValues { entry -> entry.value.toMap() }
-                )
                 stateFile.parentFile?.mkdirs()
                 stateFile.writeTextAtomically(json.encodeToString(QAState.serializer(), state))
             } catch (_: Exception) { }
         }
+        // Only clear the chain head when it is still the job we put there, so a save started on
+        // another thread in the meantime keeps its place in the order.
+        pendingSave.set(job)
+        job.invokeOnCompletion { pendingSave.compareAndSet(job, null) }
+    }
+
+    /**
+     * Suspends until every requested save has been written.
+     *
+     * For tests: the state file is written off-thread, so without this a test has to poll for the
+     * shape it expects and time out when it guesses wrong — which is what made
+     * `QAManagerStateTest` flaky. Joining the chain head is enough because each save waits for its
+     * predecessor. Nothing in the app waits for a save; it is fire-and-forget by design.
+     */
+    internal suspend fun awaitPendingSave() {
+        pendingSave.get()?.join()
     }
 
     private fun loadState() {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/DeviceInfoReportTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/DeviceInfoReportTest.kt
@@ -155,6 +155,7 @@ class DeviceInfoReportTest {
         bibleCount: Int = 0,
         analyticsEnabled: Boolean = false,
         renderApi: String = "default",
+        gpu: String = "NVIDIA GeForce GTX 1660 Ti (NVIDIA)",
     ) = DeviceInfoReport.DeviceFacts(
         appVersion = "1.2.3", buildType = "release", installId = "inst-id",
         didCrashLastRun = false, consecutiveCrashes = 0, videoBackgroundsDisabled = false,
@@ -162,7 +163,7 @@ class DeviceInfoReportTest {
         vlcAvailable = vlcAvailable, vlcReason = vlcReason,
         jcefInitialized = jcefInitialized, jcefMacUnsupported = jcefMacUnsupported,
         songFolderCount = songFolderCount, totalSongs = totalSongs, bibleCount = bibleCount,
-        analyticsEnabled = analyticsEnabled, renderApi = renderApi,
+        analyticsEnabled = analyticsEnabled, renderApi = renderApi, gpu = gpu,
     )
 
     private fun render(f: DeviceInfoReport.DeviceFacts) = DeviceInfoReport.render(AppSettings(), f, fixedTime)
@@ -173,6 +174,18 @@ class DeviceInfoReportTest {
         // carried nothing about rendering at all before.
         assertTrue("Renderer: DIRECT3D" in render(facts(renderApi = "DIRECT3D")))
         assertTrue("Renderer: default" in render(facts()), "the platform's own choice is itself a fact")
+    }
+
+    @Test
+    fun `the report says which GPU was driving the displays`() {
+        // The backend alone cannot say whether a driver fault is an NVIDIA, AMD or Intel problem,
+        // which is the axis such a crash has to be grouped by.
+        assertTrue("GPU: AMD Radeon RX 6500 XT (AMD)" in render(facts(gpu = "AMD Radeon RX 6500 XT (AMD)")))
+    }
+
+    @Test
+    fun `an unknown GPU is still reported, rather than the line going missing`() {
+        assertTrue("GPU: unknown" in render(facts(gpu = "unknown")))
     }
 
     @Test

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/GpuInfoTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/utils/GpuInfoTest.kt
@@ -1,0 +1,179 @@
+package org.churchpresenter.app.churchpresenter.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * [GpuInfo] without a GPU.
+ *
+ * Everything here goes through [GpuInfo.enumerateWith], which takes the one call that needs a real
+ * `user32` as a parameter — so the walk, the NUL-trimming and the active-flag test are exercised
+ * for real and only the `EnumDisplayDevicesW` call itself stays uncovered.
+ */
+class GpuInfoTest {
+
+    private fun device(
+        display: String = "\\\\.\\DISPLAY1",
+        adapter: String = "NVIDIA GeForce GTX 1660 Ti",
+        id: String = "PCI\\VEN_10DE&DEV_2182&SUBSYS_375E1462&REV_A1",
+        active: Boolean = true,
+    ) = GpuInfo.DisplayDevice().apply {
+        fun fill(buf: CharArray, s: String) {
+            s.forEachIndexed { i, c -> buf[i] = c }
+        }
+        fill(DeviceName, display)
+        fill(DeviceString, adapter)
+        fill(DeviceID, id)
+        StateFlags = if (active) 1 else 0
+    }
+
+    /** Hands [GpuInfo.enumerateWith] a fixed list, the way the real call hands it the OS's. */
+    private fun enumerate(devices: List<GpuInfo.DisplayDevice>): List<DisplayAdapter> {
+        var next = 0
+        return GpuInfo.enumerateWith(newDevice = { devices.getOrElse(next) { GpuInfo.DisplayDevice() } }) { i, _ ->
+            next = i + 1
+            i < devices.size
+        }
+    }
+
+    // ── vendorOf ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `reads the vendor out of a PCI device id`() {
+        assertEquals("NVIDIA", GpuInfo.vendorOf("PCI\\VEN_10DE&DEV_2182&SUBSYS_375E1462&REV_A1"))
+        assertEquals("AMD", GpuInfo.vendorOf("PCI\\VEN_1002&DEV_743F"))
+        assertEquals("Intel", GpuInfo.vendorOf("PCI\\VEN_8086&DEV_3E9B"))
+    }
+
+    @Test
+    fun `names virtual adapters, because no real GPU is itself the diagnosis`() {
+        assertEquals("Microsoft", GpuInfo.vendorOf("PCI\\VEN_1414&DEV_008C"))
+        assertEquals("VMware", GpuInfo.vendorOf("PCI\\VEN_15AD&DEV_0405"))
+    }
+
+    @Test
+    fun `keeps an unrecognised vendor id rather than discarding it`() {
+        assertEquals("0xbeef", GpuInfo.vendorOf("PCI\\VEN_BEEF&DEV_0001"))
+    }
+
+    @Test
+    fun `is unknown when the id carries no vendor at all`() {
+        assertEquals("unknown", GpuInfo.vendorOf(""))
+        assertEquals("unknown", GpuInfo.vendorOf("ROOT\\BasicDisplay"))
+    }
+
+    @Test
+    fun `matches the vendor id case-insensitively`() {
+        assertEquals("NVIDIA", GpuInfo.vendorOf("PCI\\VEN_10de&DEV_2182"))
+    }
+
+    // ── enumerateWith ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `stops at the first device the OS declines to fill`() {
+        val found = enumerate(listOf(device(), device(display = "\\\\.\\DISPLAY2")))
+        assertEquals(2, found.size)
+        assertEquals("NVIDIA GeForce GTX 1660 Ti", found[0].adapterName)
+    }
+
+    @Test
+    fun `trims each fixed-width buffer at its NUL`() {
+        val found = enumerate(listOf(device(adapter = "Intel UHD Graphics 630")))
+        assertEquals("Intel UHD Graphics 630", found.single().adapterName)
+        // The buffer is 128 chars wide; untrimmed the name would carry 106 NULs after it.
+        assertEquals(22, found.single().adapterName.length)
+    }
+
+    @Test
+    fun `reads the active flag`() {
+        val found = enumerate(listOf(device(active = true), device(active = false)))
+        assertTrue(found[0].active)
+        assertFalse(found[1].active)
+    }
+
+    @Test
+    fun `returns nothing when the OS reports no devices`() {
+        assertEquals(emptyList(), enumerate(emptyList()))
+    }
+
+    // ── distinctActive / summarise ────────────────────────────────────────────
+
+    @Test
+    fun `collapses four displays on one card into one adapter`() {
+        val found = enumerate(
+            listOf(
+                device(display = "\\\\.\\DISPLAY1"),
+                device(display = "\\\\.\\DISPLAY2"),
+                device(display = "\\\\.\\DISPLAY3", active = false),
+            )
+        )
+        assertEquals("NVIDIA GeForce GTX 1660 Ti (NVIDIA)", GpuInfo.summarise(found))
+    }
+
+    @Test
+    fun `names both adapters on a hybrid machine`() {
+        val found = enumerate(
+            listOf(
+                device(adapter = "Intel UHD Graphics 630", id = "PCI\\VEN_8086&DEV_3E9B"),
+                device(display = "\\\\.\\DISPLAY2"),
+            )
+        )
+        assertEquals(
+            "Intel UHD Graphics 630 (Intel) + NVIDIA GeForce GTX 1660 Ti (NVIDIA)",
+            GpuInfo.summarise(found),
+        )
+    }
+
+    @Test
+    fun `an inactive adapter is not reported as driving anything`() {
+        val found = enumerate(listOf(device(active = false)))
+        assertEquals("unknown", GpuInfo.summarise(found))
+    }
+
+    @Test
+    fun `summarises to unknown rather than throwing when nothing was read`() {
+        assertEquals("unknown", GpuInfo.summarise(emptyList()))
+    }
+
+    // ── tags ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `sends no tag at all when nothing could be read`() {
+        assertEquals(emptyMap(), GpuInfo.tags(emptyList()))
+    }
+
+    @Test
+    fun `tags carry the vendor, the adapter and the count`() {
+        val tags = GpuInfo.tags(enumerate(listOf(device())))
+        assertEquals("NVIDIA", tags["gpu.vendor"])
+        assertEquals("NVIDIA GeForce GTX 1660 Ti", tags["gpu.adapter"])
+        assertEquals("1", tags["gpu.count"])
+    }
+
+    @Test
+    fun `a hybrid machine tags both vendors, which is the axis a GPU fault is grouped by`() {
+        val tags = GpuInfo.tags(
+            enumerate(
+                listOf(
+                    device(adapter = "Intel UHD Graphics 630", id = "PCI\\VEN_8086&DEV_3E9B"),
+                    device(display = "\\\\.\\DISPLAY2"),
+                )
+            )
+        )
+        assertEquals("Intel+NVIDIA", tags["gpu.vendor"])
+        assertEquals("2", tags["gpu.count"])
+    }
+
+    // ── isSupported ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `only Windows has EnumDisplayDevices`() {
+        assertTrue(GpuInfo.isSupported("Windows 11"))
+        assertTrue(GpuInfo.isSupported("Windows Server 2022"))
+        assertFalse(GpuInfo.isSupported("Mac OS X"))
+        assertFalse(GpuInfo.isSupported("Linux"))
+        assertFalse(GpuInfo.isSupported(""))
+    }
+}

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/QAManagerStateTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/viewmodel/QAManagerStateTest.kt
@@ -3,6 +3,7 @@ package org.churchpresenter.app.churchpresenter.viewmodel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
@@ -33,6 +34,15 @@ import kotlin.test.assertTrue
  *
  * `user.home` is swapped per test, as in [QAManagerTest]: the manager resolves its state file at
  * construction, so a "restart" here is just a second manager built against the same temp home.
+ *
+ * Every wait here is a **join**, never a poll. These tests used to watch the file for up to five
+ * seconds after each action and fail on the timeout, because `QAManager.saveState()` fired
+ * unordered, untracked coroutines: a save that had not been scheduled yet was indistinguishable
+ * from one that would never come, and under load the guess went wrong often enough to make the
+ * suite flaky — it failed here on a clean tree one run in one, two the next, three the next.
+ * `saveState` now snapshots on the calling thread and chains its writes, so [joinSaves] can wait
+ * for exactly the writes that were asked for. Do not reintroduce a timeout to "fix" a failure
+ * here; a failure now means the state really is wrong.
  */
 class QAManagerStateTest {
 
@@ -48,41 +58,55 @@ class QAManagerStateTest {
         System.setProperty("user.home", tempHome.absolutePath)
     }
 
+    /**
+     * Every manager built by this test, so [joinSaves] can wait for all of them.
+     *
+     * A restart test has two live managers against one home, and either may have a write in
+     * flight; joining only the newest would still race the older one's.
+     */
+    private val managers = mutableListOf<QAManager>()
+
+    private fun track(manager: QAManager): QAManager = manager.also { managers += it }
+
+    /** Waits for every requested save to reach disk. Returns when the file is final. */
+    private fun joinSaves() = runBlocking { managers.forEach { it.awaitPendingSave() } }
+
     @AfterTest
     fun restoreHome() {
+        // Before deleting the home, not after: a save still in flight would otherwise recreate
+        // `.churchpresenter/` under a directory the next test is about to claim.
+        joinSaves()
         realHome?.let { System.setProperty("user.home", it) }
         tempHome.deleteRecursively()
     }
 
-    private fun awaitUntil(what: String, timeoutMs: Long = 5_000, condition: () -> Boolean) {
-        val deadline = System.currentTimeMillis() + timeoutMs
-        while (System.currentTimeMillis() < deadline) {
-            if (condition()) return
-            Thread.sleep(10)
-        }
-        throw AssertionError("timed out after ${timeoutMs}ms waiting for $what")
+    /**
+     * The saved state, once every in-flight write has landed.
+     *
+     * This used to poll the file for up to five seconds and fail on the timeout, which made the
+     * suite flaky under load: a save that had not been scheduled yet looked identical to one that
+     * was never going to happen. `QAManager` now chains its writes and exposes a join point, so
+     * the state can simply be read once it is final -- no polling, no timeout, no wall-clock cost.
+     */
+    private fun saved(): JsonObject {
+        joinSaves()
+        assertTrue(stateFile.exists(), "no state file was ever written")
+        return Json.parseToJsonElement(stateFile.readText()).jsonObject
     }
 
-    /**
-     * Waits until the saved state satisfies [predicate].
-     *
-     * Every action triggers its own off-thread save, so waiting for a substring is not enough: the
-     * text of a question reaches the file on the save that *created* it, long before the save that
-     * archived or moderated it. Each wait therefore describes the shape it is expecting. A torn
-     * half-written file simply fails to parse and the poll continues.
-     *
-     * These tests also wait after EVERY action rather than only at the end. `QAManager.saveState()`
-     * launches an independent coroutine that snapshots the state when it runs, so two actions in
-     * quick succession put two writes in flight with no ordering between them — and if the older
-     * one lands last, the file keeps a stale snapshot for good. Letting each save finish before the
-     * next action starts sidesteps that; see the note in the class doc.
-     */
-    private fun awaitState(what: String, predicate: (JsonObject) -> Boolean) =
-        awaitUntil(what) {
-            stateFile.exists() && runCatching {
-                predicate(Json.parseToJsonElement(stateFile.readText()).jsonObject)
-            }.getOrDefault(false)
-        }
+    /** Asserts [predicate] holds of the saved state, described by [what] when it does not. */
+    private fun awaitState(what: String, predicate: (JsonObject) -> Boolean) {
+        val state = saved()
+        assertTrue(predicate(state), "the saved state does not show $what: $state")
+    }
+
+    /** Asserts the saved state contains [marker] -- enough when only one save can produce it. */
+    private fun awaitSaved(marker: String) {
+        joinSaves()
+        assertTrue(stateFile.exists(), "no state file was ever written")
+        val text = stateFile.readText()
+        assertTrue(marker in text, "the saved state does not record \"$marker\": $text")
+    }
 
     private fun JsonObject.entries(name: String): List<JsonObject> =
         this[name]?.jsonArray?.map { it.jsonObject }.orEmpty()
@@ -92,12 +116,6 @@ class QAManagerStateTest {
 
     private fun JsonObject.statuses(): List<String> =
         entries("questions").mapNotNull { it["status"]?.jsonPrimitive?.content }
-
-    /** Waits for the state file to contain [marker] — enough when only one save can produce it. */
-    private fun awaitSaved(marker: String) =
-        awaitUntil("the state file to record \"$marker\"") {
-            stateFile.exists() && stateFile.readText().contains(marker)
-        }
 
     /** Events are emitted from a coroutine on the Swing event queue; draining it delivers them. */
     private fun settle() = repeat(2) { SwingUtilities.invokeAndWait { } }
@@ -128,9 +146,9 @@ class QAManagerStateTest {
      * queue permanently. The state file does not exist until this first save completes, so its
      * mere existence is the signal.
      */
-    private fun openSession(): QAManager = QAManager().also {
+    private fun openSession(): QAManager = track(QAManager()).also {
         it.toggleSession()
-        awaitUntil("the opened session to be saved") { stateFile.exists() }
+        joinSaves()
     }
 
     /** Submits and approves [text], letting each save land before the next action. */
@@ -148,7 +166,7 @@ class QAManagerStateTest {
     }
 
     /** A second manager against the same home — i.e. the app restarted. */
-    private fun restarted(): QAManager = QAManager()
+    private fun restarted(): QAManager = track(QAManager())
 
     // ── Surviving a restart ─────────────────────────────────────────────────────
 
@@ -362,7 +380,7 @@ class QAManagerStateTest {
 
     @Test
     fun `opening and closing the session is broadcast`() {
-        val qa = QAManager()
+        val qa = track(QAManager())
 
         val opening = qa.eventsDuring { qa.toggleSession() }
         assertEquals(true, opening.filterIsInstance<QAEvent.SessionChanged>().single().active)


### PR DESCRIPTION
Follow-up to #511, which moved Windows off a pinned OpenGL onto skiko's Direct3D default. #514 asked
whether that survives a real presenting load. It does — on three GPU vendors — and the pass turned up
three unrelated problems worth fixing while the machine was set up for it.

Four commits, each independent and readable on its own.

## Record which GPU was driving the displays

A renderer fault's first question is which driver it happened on, and no report carried it: the crash
file recorded OS and Java, and the Sentry tags stopped at `render.api`, which says what skiko chose
but not what it ran on. A group of GPU driver access violations therefore could not be split by
vendor — the axis that decides whether a backend default is right, and the one #497 was waiting on.

Read through `EnumDisplayDevices`, **not** the registry. The obvious registry source,
`Control\Class\{4d36e968-…}\0000`, enumerates every driver ever installed rather than the hardware
present, and it is wrong in a way nothing downstream could detect: on the test machine it names
`Radeon (TM) RX 480 Graphics` first, a card that has not been in the box for years. That entry stayed
first across **two physical GPU swaps**, misreporting the card every time — wrong vendor while a
GeForce drove the displays, then wrong AMD model while a Radeon RX 6500 XT did.

Verified on real hardware in four configurations of one machine:

| configuration | reported |
|---|---|
| NVIDIA GeForce GTX 1660 Ti | `NVIDIA GeForce GTX 1660 Ti (NVIDIA)` |
| AMD Radeon RX 6500 XT | `AMD Radeon(TM) RX 6500 XT (AMD)` |
| Intel UHD 630 | `Intel(R) UHD Graphics 630 (Intel)` |
| same Intel silicon, no driver installed | `Microsoft Basic Display Adapter (Intel)` |

The last one is why the adapter name and the PCI vendor are both kept: same `VEN_8086&DEV_3E98`, two
different driver names. "Intel hardware" and "running the unaccelerated fallback driver" are separate
facts and the second is a strong diagnosis on its own. Tags are empty off Windows and wherever the
call fails, so an absent tag means "not known" rather than a guess.

## Stop writing the same JVM options into the artifact four times

`ChurchPresenter.cfg` carried all 23 application JVM options four times over — 100 `java-options=`
lines where 27 were meant. The list was declared twice: by the application-level `jvmArgs(...)`, and
again as `commonJvmArgs` applied inside each of the macOS, windows and linux blocks.

Those three calls never scoped anything to their platform. `jvmArgs` is declared only on
`JvmApplication`, so a call inside a platform block resolves against the enclosing `application { }`
and applies everywhere — which the comment just above it already says, and which is exactly how a
METAL pin written in `macOS { }` came to reach Windows and stop the app starting. The duplicate flags
were harmless to the JVM; the live mechanism was not.

## Save the Q&A session in the order the actions happened

**The one behavioural change to shipping code, and the one worth the closest review.**

`QAManager.saveState()` launched an independent coroutine per action and took its snapshot *inside*
it, so the snapshot described whatever the state was when that coroutine was scheduled, and nothing
ordered the writes. Two actions in quick succession put two writes in flight; if the older landed
last the file kept a stale snapshot for good. Moderating quickly during a live session could persist
a queue the operator had already moved past — silently, since the write is wrapped in a `catch` that
swallows everything, so it only surfaced after a restart.

The snapshot is now taken on the calling thread, inside the `synchronized` block callers already
hold, and each write joins its predecessor.

That also removes a flake at source rather than papering over it: the test polled the file for up to
five seconds after every action, because a save that had not been scheduled yet was indistinguishable
from one that would never come. On a clean tree it failed one run in one, two the next, three the
next. It now joins the writes instead — 21 tests in 0.287s total, against five seconds per failure
before. Verified with three consecutive `--rerun-tasks` runs, all green.

## Warn that OPENGL can hide the presenter from screen capture

Driver-specific, so the note says so rather than generalising from one card. Measured on one machine,
two cards, same build and workload: the GTX 1660 Ti captured the full-screen presenter at mean
brightness **0.000** under `OPENGL` while its main window captured normally at the same moment; the
RX 6500 XT captured the same scene at **0.502**. Both fine under the Direct3D default. Tested against
GDI/`BitBlt` only — DXGI Desktop Duplication and Windows Graphics Capture were not tested and the
note claims nothing about them.

## One thing CI will see first

`GpuInfoTest` allocates a JNA `Structure` with `CharArray` fields, and **no other JNA structure in
this repo does** — `JnaNdiLibrary` uses String/Int/Boolean. Linux CI is the first place that shape
runs. It works on Windows; on Linux `wchar_t` is 4 bytes rather than 2, but nothing asserts the
struct's size.

It is deliberately **not** guarded to Windows: skipping it there would drop `GpuInfo` to roughly zero
coverage on the very platform where `jacocoTestCoverageVerification` is enforced, which is worse than
the risk. If it does fail, the fix is to feed `enumerateWith` a stand-in needing no native
allocation, keeping `readCString` covered by its own tests — not to weaken the gate.

## Verification

`:composeApp:detekt` clean and `:composeApp:check` green — run on **three different GPUs** (NVIDIA,
AMD, Intel) and once on Microsoft's fallback driver with no acceleration at all. Coverage floor
passed (`check` includes it); `GpuInfo` 96.6% instructions, `QAManager` 214/214 lines. No screenshots
re-recorded — this was a Windows machine and the committed set is a macOS recording.
