### PR TITLE
Confine ComposeScenePump's scene to the event queue

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/ComposeScenePump.kt
+++ b/composeApp/src/jvmMain/kotlin/org/churchpresenter/app/churchpresenter/presenter/ComposeScenePump.kt
@@ -7,14 +7,17 @@ import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.unit.Density
 import com.sun.jna.Pointer
 import kotlinx.coroutines.yield
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.churchpresenter.diagnostics.CrashReporter
 import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorInfo
@@ -64,14 +67,21 @@ typealias OnFrame = suspend (argb: IntArray, width: Int, height: Int, elapsedMs:
  * `remember` in it — survives across frames. Restarting the pump is what discards it, which is why
  * callers `remember` an instance keyed on the dimensions and fps that would invalidate it.
  *
- * **This class is still exposed to the `SnapshotStateObserver` ABBA deadlock — issue #498.**
- * `render` advances the global snapshot, and `advanceGlobalSnapshot` fans out to every registered
- * apply observer, this scene's and the on-screen AWT scene's alike; two threads doing that at once
- * take the two observers' locks in opposite orders. `LowerThirdOffscreenRenderer` was fixed by
- * confining its scene to the event queue and explains the cycle at its own `withSession`;
- * `HungTestReporter` records the proved lock owners. This one was left because it drives a *live*
- * feed, so confining it moves a full-size render onto the event thread for the whole of a service —
- * and nothing here measures what that costs.
+ * **Everything that touches the scene runs on the event queue** — building it, rendering it,
+ * closing it — and only the pixels come back to the worker. That is not a style choice: `render`
+ * advances the global snapshot, `advanceGlobalSnapshot` runs *every* registered apply observer,
+ * this scene's and the on-screen AWT scene's alike, and two threads doing that at once take those
+ * two observers' locks in opposite orders. It was a real deadlock, proved with lock ownership on
+ * 2026-08-29 (CI run 33269248282): `AWT-EventQueue-0` inside a desktop scrollbar's derived state
+ * against a worker inside `sendApplyNotifications`, each holding the lock the other wanted.
+ * `HungTestReporter` records the owners; `LowerThirdOffscreenRenderer` explains the cycle at its
+ * own `withSession` and was confined first. Confining the Compose half to one thread removes the
+ * second lock order, and there is no way to opt a scene out of the global observer list.
+ *
+ * This one was left exposed longer than that one because it drives a *live* feed, so the cost lands
+ * during a service rather than on a bounded pre-render. That cost is now measured rather than
+ * guessed at — see the numbers on issue #498 — and `readInto`/`onFrame`, the expensive half, still
+ * run off the event queue.
  */
 @OptIn(ExperimentalComposeUiApi::class)
 class ComposeScenePump(
@@ -80,6 +90,14 @@ class ComposeScenePump(
     fps: Int,
     private val shouldRender: () -> Boolean = { true },
     private val onPark: () -> Unit = {},
+    /**
+     * Where the scene is built, rendered and closed — one thread, for the reason in the class doc.
+     *
+     * A parameter only so a test can see which thread the scene operations actually land on;
+     * nothing in the app passes anything but the default. Same seam, and the same reason for it, as
+     * [LowerThirdOffscreenRenderer]'s.
+     */
+    private val sceneDispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val content: @Composable () -> Unit,
 ) {
     /**
@@ -135,7 +153,11 @@ class ComposeScenePump(
         if (job != null) return
         job = scope.launch(Dispatchers.Default) {
             val scene = try {
-                sceneCreation.withLock { ImageComposeScene(width, height, Density(1f)) { content() } }
+                sceneCreation.withLock {
+                    withContext(sceneDispatcher) {
+                        ImageComposeScene(width, height, Density(1f)) { content() }
+                    }
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (@Suppress("TooGenericExceptionCaught") t: Throwable) {
@@ -160,7 +182,10 @@ class ComposeScenePump(
             try {
                 runLoop(scene, onFrame)
             } finally {
-                scene.close()
+                // NonCancellable because this `finally` runs on an already-cancelled coroutine —
+                // stopping the pump is the normal way out — and a plain `withContext` would throw
+                // before reaching `close`, leaking the scene for the life of the process.
+                withContext(NonCancellable + sceneDispatcher) { scene.close() }
             }
         }
     }
@@ -193,8 +218,19 @@ class ComposeScenePump(
 
             parked = false
             timeNanos += frameNanos
-            Snapshot.sendApplyNotifications()
-            val img = scene.render(timeNanos)
+            // These two together, in one hop, and not separately: `render` enters the same global
+            // snapshot fan-out three more times per frame on its own (`javap -c` on
+            // `BaseComposeScene`, ui-desktop 1.10.3 — recorded in `HungTestReporter`), so confining
+            // only the explicit `sendApplyNotifications` closes the door the crash dump happened to
+            // record and leaves three open.
+            //
+            // Reading the pixels back and handing them to `onFrame` stay off this thread: they are
+            // the expensive half and they touch no Compose state, so putting them on the event
+            // queue would buy nothing and cost the whole frame.
+            val img = withContext(sceneDispatcher) {
+                Snapshot.sendApplyNotifications()
+                scene.render(timeNanos)
+            }
             val read = try {
                 frame.readInto(img, intBuf)
             } finally {

--- a/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/ComposeScenePumpConfinementTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/churchpresenter/app/churchpresenter/presenter/ComposeScenePumpConfinementTest.kt
@@ -1,0 +1,140 @@
+package org.churchpresenter.app.churchpresenter.presenter
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.SwingUtilities
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+private const val W = 8
+private const val H = 6
+private const val WAIT_MS = 10_000L
+private const val POLL_MS = 20L
+
+/**
+ * Where [ComposeScenePump]'s scene work runs — issue #498.
+ *
+ * `ComposeScene.render` advances the global snapshot and `advanceGlobalSnapshot` runs *every*
+ * registered apply observer, this scene's and the on-screen AWT scene's alike, so two threads doing
+ * it at once take those two observers' locks in opposite orders. That was a real deadlock, proved
+ * with lock ownership on 2026-08-29 (CI run 33269248282): `AWT-EventQueue-0` inside a desktop
+ * scrollbar's derived state against a worker inside `sendApplyNotifications`, each holding the lock
+ * the other wanted. Confining the Compose half to one thread removes the second lock order, and
+ * there is no way to opt a scene out of the global observer list.
+ *
+ * The deadlock itself cannot be tested — it needs two scenes and a lost race. What can be tested is
+ * the property that removes it, which is what this pins: nothing that touches the scene runs
+ * anywhere but the event queue. A change that moves any of it back onto a worker fails here rather
+ * than as an unreproducible freeze in the middle of somebody's service.
+ *
+ * Deliberately *not* asserted: that `readInto` and `onFrame` stay off the event queue. They are the
+ * expensive half and touch no Compose state, so putting them on it would cost the frame budget for
+ * nothing — but they run on the pump's own coroutine rather than through [sceneDispatcher], so this
+ * dispatcher never sees them and their absence here is the evidence.
+ *
+ * Mirrors [LowerThirdOffscreenRendererConfinementTest], which pins the same property for the other
+ * off-screen renderer.
+ */
+class ComposeScenePumpConfinementTest {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    @AfterTest
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    /**
+     * Delegates to [Dispatchers.Main] and records the thread each dispatched block actually ran on.
+     *
+     * Read from *inside* the block, so it records where the work happened rather than merely that a
+     * dispatcher was asked to do it.
+     */
+    private class RecordingDispatcher(private val delegate: CoroutineDispatcher) : CoroutineDispatcher() {
+        val onEventQueue: MutableList<Boolean> = Collections.synchronizedList(mutableListOf())
+        val threads: MutableList<String> = Collections.synchronizedList(mutableListOf())
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            delegate.dispatch(context) {
+                onEventQueue.add(SwingUtilities.isEventDispatchThread())
+                threads.add(Thread.currentThread().name)
+                block.run()
+            }
+        }
+    }
+
+    private fun waitFor(what: String, condition: () -> Boolean) = runBlocking {
+        val deadline = System.nanoTime() + WAIT_MS * 1_000_000
+        while (!condition()) {
+            if (System.nanoTime() > deadline) throw AssertionError("timed out waiting for $what")
+            delay(POLL_MS)
+        }
+    }
+
+    @Test
+    fun `building, rendering and closing the scene all run on the event queue`() {
+        val recorder = RecordingDispatcher(Dispatchers.Main)
+        val frames = AtomicInteger(0)
+        val pump = ComposeScenePump(
+            width = W,
+            height = H,
+            fps = 60,
+            sceneDispatcher = recorder,
+        ) {
+            Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+        }
+
+        pump.start(scope) { _, _, _, _ -> frames.incrementAndGet() }
+        // Several frames, not one: construction and the first render could both be confined while a
+        // later tick quietly was not.
+        waitFor("a few rendered frames") { frames.get() >= 3 }
+        pump.stop()
+        // The close is dispatched from a `finally` on a cancelled coroutine, so it lands after stop
+        // returns; without waiting the last recorded block would be the render, not the close.
+        waitFor("the scene close to be dispatched") { recorder.onEventQueue.size >= frames.get() }
+
+        assertTrue(recorder.onEventQueue.isNotEmpty(), "no scene work was dispatched at all")
+        assertTrue(
+            recorder.onEventQueue.all { it },
+            "every scene operation must run on the event queue, but some ran elsewhere: " +
+                recorder.threads.distinct(),
+        )
+    }
+
+    @Test
+    fun `the scene is still closed when the pump is stopped mid-render`() {
+        // The close runs inside `withContext(NonCancellable + sceneDispatcher)`. Without
+        // NonCancellable that `withContext` throws on the already-cancelled coroutine stopping the
+        // pump is, and the scene leaks for the life of the process -- one per output, every restart.
+        val recorder = RecordingDispatcher(Dispatchers.Main)
+        val frames = AtomicInteger(0)
+        val pump = ComposeScenePump(W, H, fps = 60, sceneDispatcher = recorder) {
+            Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+        }
+
+        pump.start(scope) { _, _, _, _ -> frames.incrementAndGet() }
+        waitFor("the pump to be rendering") { frames.get() >= 2 }
+        val beforeStop = recorder.onEventQueue.size
+        pump.stop()
+
+        waitFor("the close to run despite cancellation") { recorder.onEventQueue.size > beforeStop }
+        assertTrue(
+            recorder.onEventQueue.all { it },
+            "the close must also land on the event queue: " + recorder.threads.distinct(),
+        )
+    }
+}


### PR DESCRIPTION
Closes #498.

`ComposeScene.render` advances the global snapshot, and `advanceGlobalSnapshot` runs **every**
registered apply observer — this off-screen scene's and the on-screen AWT scene's alike — so two
threads doing it at once take those two observers' locks in opposite orders.

It was proved with lock ownership on 2026-08-29 (CI run 33269248282): `AWT-EventQueue-0` inside a
desktop scrollbar's derived state against a worker inside `sendApplyNotifications`, each holding the
lock the other wanted. A first-hand report matches the shape — an NDI sender wedged with the Canvas
tab busy on source discovery, producing no Sentry event, which is what a deadlock looks like.

`LowerThirdOffscreenRenderer` was confined for this reason already. `ComposeScenePump` was left
because it drives a *live* feed, so the cost lands during a service — and nothing in the repo could
measure that cost. **That measurement gap was the actual blocker, so it is what this answers first.**

## The change

Building, rendering and closing the scene all move to the event queue.

- The render hop takes `sendApplyNotifications` and `render` **together**. `javap -c` on
  `BaseComposeScene` (ui-desktop 1.10.3) shows `render` entering the same fan-out three more times
  per frame on its own, so confining only the explicit call would close the one door the crash dump
  happened to record and leave three open.
- `readInto` and `onFrame` stay **off** the event queue — they are the expensive half and touch no
  Compose state.
- The close uses `NonCancellable`, because that `finally` runs on the already-cancelled coroutine
  that stopping the pump is; without it the `withContext` throws before closing and the scene leaks
  — one per output, every restart.
- The `sceneCreation` mutex **stays**. Event-queue construction subsumes it, but it exists for a
  separate production `ArrayIndexOutOfBoundsException`, and removing it would be a second
  behavioural change riding along on a deadlock fix.

## Measured

Two GPUs, six before/after pairs. 1920×1080 Browser Source outputs with a subscriber attached,
bilingual lyrics over a 12.8 Mbps 1080p30 video background, Canvas tab open and busy (the shape of
the first-hand report). EDT scheduling latency sampled **from outside the process** via
`SendMessageTimeout(hwnd, WM_NULL)` at 20 Hz — so it reports what an operator feels rather than what
our own timing code would claim.

| p99 ms, before → after | Intel UHD 630 (1 display) | GTX 1660 Ti (2 displays) |
|---|---|---|
| 1 output @30 fps  | 0.33 → 0.36 | 0.23 → 0.23 |
| 1 output @60 fps  | 0.30 → 0.40 | 0.34 → 0.26 |
| 2 outputs @60 fps | 0.39 → **0.65** | 0.36 → **0.92** |

Throughput is unchanged in all six pairs (~11.5–11.9 fps delivered per output, before and after).
The frame budget at 60 fps is 16.67 ms.

The only reproducible cost is the two-output case, where p99 roughly doubles on both machines — it
reproduces, so it is real — and still lands **~18× under the budget**, with no sample over 100 ms in
any run. The single-output numbers moved within noise and improved as often as not; that is a
coin-flip, not a benefit. `max` is one sample per run and system-dominated: the worst value anywhere
(27.3 ms) is a *baseline* one.

**What bounds this:** delivered throughput is ~12 fps per output against a 60 fps sampling target,
because `onFrame`'s dirty-rect encoding is the bottleneck rather than the render. The event queue is
therefore only asked for ~12 renders a second per output. On hardware where the encoder kept up, and
with more outputs, EDT load rises in proportion — the margin is large, not unlimited.

## Tests

New `ComposeScenePumpConfinementTest`, mirroring `LowerThirdOffscreenRendererConfinementTest`: a
`RecordingDispatcher` reads `SwingUtilities.isEventDispatchThread()` from *inside* each dispatched
block, so it records where the work happened rather than merely that a dispatcher was asked. Two
tests — every scene operation lands on the event queue, and the scene is still closed when the pump
is stopped mid-render (the `NonCancellable` property).

The deadlock itself cannot be tested: it needs two scenes and a lost race. This pins the property
that removes it, so a change moving scene work back onto a worker fails here rather than as an
unreproducible freeze mid-service.

`ComposeScenePumpTest`'s "many pumps starting at once all reach a frame" (eight pumps, 4 s deadline)
was the likely casualty of EDT-serialised construction. It passes, and passed three consecutive
`--rerun-tasks` runs, so it has not been added to `serialTestClasses`.

## Verification

- `:composeApp:check` — 821 test classes, **0 failures**
- `:composeApp:detekt` — clean
- `*ComposeScenePump*` `--rerun-tasks` ×3 — green each time
- `git status --short composeApp/screenshots/` empty (measured on Windows; the committed set is a
  macOS recording)
